### PR TITLE
Convert If Else statement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .idea
-venv/
+venv
 __pycache__
 .nef
 *.nef
@@ -10,4 +10,5 @@ __pycache__
 .abi.json
 *.abi.json
 dist
-/build
+build
+neo3_boa.egg-info

--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -236,6 +236,33 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
 
         :param if_node: the python ast if statement node
         """
+        self.validate_if(if_node)
+        # continue to walk through the tree
+        for stmt in if_node.body:
+            self.visit(stmt)
+
+        if len(if_node.orelse) == 1 and isinstance(if_node.orelse[0], ast.If):
+            # TODO: remove when implement elif statement
+            raise NotImplementedError
+
+        for stmt in if_node.orelse:
+            self.visit(stmt)
+
+    def visit_IfExp(self, if_node: ast.IfExp):
+        """
+        Verifies if the type of if test is valid
+
+        :param if_node: the python ast if expression node
+        """
+        self.validate_if(if_node)
+
+    def validate_if(self, if_node: ast.AST):
+        """
+        Verifies if the type of if test is valid
+
+        :param if_node: the python ast if statement node
+        :type if_node: ast.If or ast.IfExp
+        """
         test = self.visit(if_node.test)
         test_type: IType = self.get_type(test)
 
@@ -246,14 +273,6 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
                     actual_type_id=test_type.identifier,
                     expected_type_id=Type.bool.identifier)
             )
-
-        # continue to walk through the tree
-        for stmt in if_node.body:
-            self.visit(stmt)
-
-        if len(if_node.orelse) > 0:
-            # TODO: remove when implement else statement
-            raise NotImplementedError
 
     def visit_BinOp(self, bin_op: ast.BinOp) -> Optional[IType]:
         """

--- a/boa3/compiler/codegenerator.py
+++ b/boa3/compiler/codegenerator.py
@@ -194,6 +194,22 @@ class CodeGenerator:
         self.__insert_jump(OpcodeInfo.JMPIFNOT, 0)
         return self.__last_code.start_address
 
+    def convert_begin_else(self, start_address: int) -> int:
+        """
+        Converts the beginning of the if else statement
+
+        :param start_address: the address of the if first opcode
+        :return: the address of the if else first opcode
+        """
+        # it will be updated when the if ends
+        self.__insert_jump(OpcodeInfo.JMP, 0)
+
+        # updates the begin jmp with the target address
+        begin_jmp_to: int = self.address - start_address
+        self.__update_jump(start_address, begin_jmp_to)
+
+        return self.__last_code.start_address
+
     def convert_end_if(self, start_address: int):
         """
         Converts the end of the if statement

--- a/boa3/compiler/codegeneratorvisitor.py
+++ b/boa3/compiler/codegeneratorvisitor.py
@@ -211,6 +211,27 @@ class VisitorCodeGenerator(ast.NodeVisitor):
         for stmt in if_node.body:
             self.visit_to_generate(stmt)
 
+        if len(if_node.orelse) > 0:
+            start_addr = self.generator.convert_begin_else(start_addr)
+            for stmt in if_node.orelse:
+                self.visit_to_generate(stmt)
+
+        self.generator.convert_end_if(start_addr)
+
+    def visit_IfExp(self, if_node: ast.IfExp):
+        """
+        Verifies if the type of if test is valid
+
+        :param if_node: the python ast if statement node
+        """
+        self.visit_to_generate(if_node.test)
+
+        start_addr: int = self.generator.convert_begin_if()
+        self.visit_to_generate(if_node.body)
+
+        start_addr = self.generator.convert_begin_else(start_addr)
+        self.visit_to_generate(if_node.orelse)
+
         self.generator.convert_end_if(start_addr)
 
     def visit_Name(self, name: ast.Name) -> str:

--- a/boa3_test/example/if_test/ElseWithoutBody.py
+++ b/boa3_test/example/if_test/ElseWithoutBody.py
@@ -1,0 +1,8 @@
+def Main(condition: bool) -> int:
+    a = 0
+
+    if condition:
+        a = a + 2
+    else:
+
+    return a

--- a/boa3_test/example/if_test/IfElif.py
+++ b/boa3_test/example/if_test/IfElif.py
@@ -1,0 +1,9 @@
+def Main(condition: bool) -> int:
+    a = 0
+
+    if condition:
+        a = a + 2
+    elif condition:
+        a = 10
+
+    return a

--- a/boa3_test/example/if_test/IfExpVariableCondition.py
+++ b/boa3_test/example/if_test/IfExpVariableCondition.py
@@ -1,0 +1,4 @@
+def Main(condition: bool) -> int:
+    a = 2 if condition else 3
+
+    return a

--- a/boa3_test/example/if_test/IfExpWithoutElse.py
+++ b/boa3_test/example/if_test/IfExpWithoutElse.py
@@ -1,0 +1,4 @@
+def Main(condition: bool) -> int:
+    a = 2 if condition
+
+    return a

--- a/boa3_test/example/if_test/IfWithoutBody.py
+++ b/boa3_test/example/if_test/IfWithoutBody.py
@@ -1,0 +1,8 @@
+def Main(condition: bool) -> int:
+    a = 0
+
+    if condition:
+    else:
+        a = 10
+
+    return a


### PR DESCRIPTION
- Implemented else branch to if statement implemented in #10
- Implemented if expressions. If expressions must have both if and else branches.
Ex: `1 if True else 2`.
- `elif` branches will be implemented in another issue.