### PR TITLE
Include 'public' annotation to methods that should be added to the ABI

### DIFF
--- a/boa3/analyser/moduleanalyser.py
+++ b/boa3/analyser/moduleanalyser.py
@@ -5,7 +5,7 @@ from boa3.analyser.astanalyser import IAstAnalyser
 from boa3.exception import CompilerError
 from boa3.exception.CompilerError import CompilerError as Error
 from boa3.model.builtin.builtin import Builtin
-from boa3.model.builtin.builtinmethod import IBuiltinMethod
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.method import Method
 from boa3.model.module import Module
 from boa3.model.symbol import ISymbol
@@ -135,9 +135,10 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
         """
         fun_args = self.visit(function.args)
         fun_rtype_symbol = self.get_type(function.returns)
+        fun_decorators = [self.visit(decorator) for decorator in function.decorator_list]
 
         fun_return: IType = fun_rtype_symbol
-        method = Method(fun_args, fun_return)
+        method = Method(fun_args, fun_return, Builtin.Public.identifier in fun_decorators)
         self.__current_method = method
 
         for stmt in function.body:

--- a/boa3/compiler/codegenerator.py
+++ b/boa3/compiler/codegenerator.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Any, Optional, Tuple
 from boa3.analyser.analyser import Analyser
 from boa3.constants import ONE_BYTE_MAX_VALUE, TWO_BYTES_MAX_VALUE
 from boa3.model.builtin.builtin import Builtin
-from boa3.model.builtin.builtinmethod import IBuiltinMethod
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.method import Method
 from boa3.model.operation.operation import IOperation
 from boa3.model.symbol import ISymbol

--- a/boa3/compiler/filegenerator.py
+++ b/boa3/compiler/filegenerator.py
@@ -35,11 +35,7 @@ class FileGenerator:
 
         :return: a dictionary that maps each method with its identifier
         """
-        methods: Dict[str, Method] = {}
-        for symbol_id, symbol in self.__symbols.items():
-            if isinstance(symbol, Method):
-                methods[symbol_id] = symbol
-        return methods
+        return {name: method for name, method in self.__symbols.items() if isinstance(method, Method) and method.is_public}
 
     @property
     def __entry_point(self) -> Optional[Tuple[str, Method]]:
@@ -54,8 +50,6 @@ class FileGenerator:
             method_id = 'main'
         elif 'Main' in self.__methods:
             method_id = 'Main'
-        elif len(self.__methods) > 0:
-            method_id = list(self.__methods)[0]
 
         if method_id is None:
             return None

--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -1,14 +1,20 @@
 from typing import Optional
 
-from boa3.model.builtin.builtinmethod import IBuiltinMethod
-from boa3.model.builtin.lenmethod import LenMethod
+from boa3.model.builtin.decorator.builtindecorator import IBuiltinDecorator
+from boa3.model.builtin.decorator.publicdecorator import PublicDecorator
+from boa3.model.builtin.method.lenmethod import LenMethod
+from boa3.model.method import Method
 
 
 class Builtin:
     @classmethod
-    def get_symbol(cls, symbol_id) -> Optional[IBuiltinMethod]:
+    def get_symbol(cls, symbol_id) -> Optional[Method]:
         for name, method in vars(cls).items():
-            if isinstance(method, IBuiltinMethod) and method.identifier == symbol_id:
+            if isinstance(method, IBuiltinDecorator) and method.identifier == symbol_id:
                 return method
 
+    # builtin method
     Len = LenMethod()
+
+    # builtin decorator
+    Public = PublicDecorator()

--- a/boa3/model/builtin/decorator/builtindecorator.py
+++ b/boa3/model/builtin/decorator/builtindecorator.py
@@ -1,0 +1,23 @@
+from abc import ABC, abstractmethod
+from typing import Dict
+
+from boa3.model.expression import IExpression
+from boa3.model.method import Method
+from boa3.model.type.itype import IType
+from boa3.model.variable import Variable
+
+
+class IBuiltinDecorator(Method, ABC):
+    def __init__(self, identifier: str, args: Dict[str, Variable] = None, return_type: IType = None):
+        self.identifier = identifier
+        super().__init__(args, return_type)
+
+    @abstractmethod
+    def validate_parameters(self, *params: IExpression) -> bool:
+        """
+        Verifies if the given parameters are valid to the method
+
+        :param params: arguments of the method
+        :return: True if all arguments are valid. False otherwise.
+        """
+        pass

--- a/boa3/model/builtin/decorator/publicdecorator.py
+++ b/boa3/model/builtin/decorator/publicdecorator.py
@@ -1,0 +1,11 @@
+from boa3.model.builtin.decorator.builtindecorator import IBuiltinDecorator
+from boa3.model.expression import IExpression
+
+
+class PublicDecorator(IBuiltinDecorator):
+    def __init__(self):
+        identifier = 'public'
+        super().__init__(identifier)
+
+    def validate_parameters(self, *params: IExpression) -> bool:
+        return len(params) == len(self.args)

--- a/boa3/model/builtin/method/builtinmethod.py
+++ b/boa3/model/builtin/method/builtinmethod.py
@@ -1,27 +1,16 @@
 from abc import ABC, abstractmethod
 from typing import Optional, Dict
 
-from boa3.model.expression import IExpression
-from boa3.model.method import Method
+from boa3.model.builtin.decorator.builtindecorator import IBuiltinDecorator
 from boa3.model.type.itype import IType
 from boa3.model.variable import Variable
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
-class IBuiltinMethod(Method, ABC):
+class IBuiltinMethod(IBuiltinDecorator, ABC):
     def __init__(self, identifier: str, args: Dict[str, Variable] = None, return_type: IType = None):
         self.identifier = identifier
-        super().__init__(args, return_type)
-
-    @abstractmethod
-    def validate_parameters(self, *params: IExpression) -> bool:
-        """
-        Verifies if the given parameters are valid to the method
-
-        :param params: arguments of the method
-        :return: True if all arguments are valid. False otherwise.
-        """
-        pass
+        super().__init__(identifier, args, return_type)
 
     @property
     def opcode(self) -> Optional[Opcode]:

--- a/boa3/model/builtin/method/lenmethod.py
+++ b/boa3/model/builtin/method/lenmethod.py
@@ -1,6 +1,6 @@
 from typing import Dict, Optional
 
-from boa3.model.builtin.builtinmethod import IBuiltinMethod
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.expression import IExpression
 from boa3.model.type.sequencetype import SequenceType
 from boa3.model.variable import Variable

--- a/boa3/model/method.py
+++ b/boa3/model/method.py
@@ -11,14 +11,16 @@ class Method(IExpression):
 
     :ivar args: a dictionary that maps each arg with its name. Empty by default.
     :ivar locals: a dictionary that maps each local variable with its name. Empty by default.
+    :ivar is_public: a boolean value that specifies if the method is public. False by default.
     :ivar return_type: the return type of the method. None by default.
     """
 
-    def __init__(self, args: Dict[str, Variable] = None, return_type: IType = None):
+    def __init__(self, args: Dict[str, Variable] = None, return_type: IType = None, is_public: bool = False):
         if args is None:
             args = {}
         self.args: Dict[str, Variable] = args
         self.return_type: IType = return_type
+        self.is_public: bool = is_public
         self.locals: Dict[str, Variable] = {}
 
     def include_variable(self, var_id: str, var: Variable):

--- a/boa3_test/example/generation_test/GenerationWithDecorator.py
+++ b/boa3_test/example/generation_test/GenerationWithDecorator.py
@@ -1,0 +1,12 @@
+@public
+def Main(a: int, b: int) -> int:
+    return a + b
+
+
+def Add(a: int, b: int) -> int:
+    return a + b
+
+
+@public
+def Sub(a: int, b: int) -> int:
+    return a - b

--- a/boa3_test/example/generation_test/GenerationWithoutDecorator.py
+++ b/boa3_test/example/generation_test/GenerationWithoutDecorator.py
@@ -1,0 +1,10 @@
+def Main(a: int, b: int) -> int:
+    return a + b
+
+
+def Add(a: int, b: int) -> int:
+    return a + b
+
+
+def Sub(a: int, b: int) -> int:
+    return a - b

--- a/boa3_test/tests/test_file_generation.py
+++ b/boa3_test/tests/test_file_generation.py
@@ -11,7 +11,7 @@ from boa3_test.tests.boa_test import BoaTest
 class TestFileGeneration(BoaTest):
 
     def test_generate_files(self):
-        path = '%s/boa3_test/example/arithmetic_test/Addition.py' % self.dirname
+        path = '%s/boa3_test/example/generation_test/GenerationWithDecorator.py' % self.dirname
 
         expected_nef_output = path.replace('.py', '.nef')
         expected_manifest_output = path.replace('.py', '.manifest.json')
@@ -21,7 +21,7 @@ class TestFileGeneration(BoaTest):
         self.assertTrue(os.path.exists(expected_manifest_output))
 
     def test_generate_nef_file(self):
-        path = '%s/boa3_test/example/arithmetic_test/Addition.py' % self.dirname
+        path = '%s/boa3_test/example/generation_test/GenerationWithDecorator.py' % self.dirname
 
         expected_nef_output = path.replace('.py', '.nef')
         Boa3.compile_and_save(path)
@@ -49,8 +49,8 @@ class TestFileGeneration(BoaTest):
             byte_field = version[begin:begin + constants.SIZE_OF_INT32]
             self.assertEqual(int.from_bytes(byte_field, sys.byteorder), field)
 
-    def test_generate_manifest_file(self):
-        path = '%s/boa3_test/example/arithmetic_test/Addition.py' % self.dirname
+    def test_generate_manifest_file_with_decorator(self):
+        path = '%s/boa3_test/example/generation_test/GenerationWithDecorator.py' % self.dirname
 
         expected_manifest_output = path.replace('.py', '.manifest.json')
         Boa3.compile_and_save(path)
@@ -83,6 +83,29 @@ class TestFileGeneration(BoaTest):
         self.assertEqual(arg1['name'], 'b')
         self.assertIn('type', arg1)
         self.assertEqual(arg1['type'], AbiType.Integer)
+
+        self.assertIn('methods', abi)
+        self.assertEqual(len(abi['methods']), 1)
+
+        self.assertIn('events', abi)
+        self.assertEqual(len(abi['events']), 0)
+
+    def test_generate_manifest_file_without_decorator(self):
+        path = '%s/boa3_test/example/generation_test/GenerationWithoutDecorator.py' % self.dirname
+
+        expected_manifest_output = path.replace('.py', '.manifest.json')
+        Boa3.compile_and_save(path)
+
+        self.assertTrue(os.path.exists(expected_manifest_output))
+        with open(expected_manifest_output, 'r') as manifest_output:
+            import json
+            manifest = json.loads(manifest_output.read())
+
+        self.assertIn('abi', manifest)
+        abi = manifest['abi']
+
+        self.assertIn('entryPoint', abi)
+        self.assertEqual(len(abi['entryPoint']), 0)
 
         self.assertIn('methods', abi)
         self.assertEqual(len(abi['methods']), 0)


### PR DESCRIPTION
- Created a decorator to identify which methods should be included in the `abi` field of the manifest.
For example, in the smart contract below, only the `Main` method will be included in the abi
 ```python
@public
def Main(operation: str, args: Tuple[int]) -> int
    return foo(args[0])

def foo(bar: int) -> int
    return bar
```