### PR TITLE
Convert For statement

### DIFF
--- a/boa3/analyser/analyser.py
+++ b/boa3/analyser/analyser.py
@@ -1,6 +1,7 @@
 import ast
 from typing import Dict
 
+from boa3.analyser.constructanalyser import ConstructAnalyser
 from boa3.analyser.moduleanalyser import ModuleAnalyser
 from boa3.analyser.typeanalyser import TypeAnalyser
 from boa3.model.symbol import ISymbol
@@ -35,6 +36,7 @@ class Analyser(object):
             ast_tree = ast.parse(source.read())
 
         analyser = Analyser(ast_tree)
+        analyser.__pre_execute()
         # fill symbol table
         if not analyser.__analyse_modules():
             return analyser
@@ -66,6 +68,12 @@ class Analyser(object):
 
         :return: a boolean value that represents if the analysis was successful
         """
-        type_analyser = ModuleAnalyser(self.ast_tree, self.symbol_table)
-        self.symbol_table.update(type_analyser.global_symbols)
-        return not type_analyser.has_errors
+        module_analyser = ModuleAnalyser(self.ast_tree, self.symbol_table)
+        self.symbol_table.update(module_analyser.global_symbols)
+        return not module_analyser.has_errors
+
+    def __pre_execute(self):
+        """
+        Pre executes the instructions of the ast for optimization
+        """
+        self.ast_tree = ConstructAnalyser(self.ast_tree).tree

--- a/boa3/analyser/constructanalyser.py
+++ b/boa3/analyser/constructanalyser.py
@@ -1,0 +1,109 @@
+import ast
+from typing import Optional, Union, Sequence, List
+
+from boa3 import helpers
+from boa3.analyser.astanalyser import IAstAnalyser
+from boa3.exception.CompilerError import CompilerError as Error
+from boa3.model.symbol import ISymbol
+
+
+class ConstructAnalyser(IAstAnalyser, ast.NodeTransformer):
+    """
+    This class is responsible for pre processing Python constructs
+
+    The methods with the name starting with 'visit_' are implementations of methods from the :class:`NodeVisitor` class.
+    These methods are used to walk through the Python abstract syntax tree.
+    """
+
+    def __init__(self, ast_tree: ast.AST):
+        super().__init__(ast_tree)
+        self.visit(self._tree)
+
+    @property
+    def tree(self) -> ast.AST:
+        """
+        Gets the analysed abstract syntax tree
+
+        :return: the analysed ast
+        """
+        return self._tree
+
+    def get_symbol(self, symbol_id: str) -> Optional[ISymbol]:
+        return None
+
+    def visit_For(self, for_node: ast.For):
+        """
+        Includes additional operations for converting the for statement into Neo VM
+
+        :param for_node: the python ast for node
+        """
+        # get auxiliary variables
+        var_iter_id = helpers.get_auxiliary_name(for_node, 'iter')
+        var_index_id = helpers.get_auxiliary_name(for_node, 'index')
+
+        add_instructs: List[ast.AST] = self.parse_to_node('{0} = x; {1} = 0'.format(var_iter_id, var_index_id), for_node)
+        add_instructs[0].value = for_node.iter  # iter auxiliary variable is assigned with the node iter value
+
+        update_target: ast.Assign = self.parse_to_node('x = {0}[{1}]'.format(var_iter_id, var_index_id), for_node)
+        update_target.targets[0] = for_node.target  # target variable is updated each loop iteration
+
+        update_index: ast.Assign = self.parse_to_node('{0} = {0} + 1'.format(var_index_id), for_node)
+        loop_test: ast.Compare = self.parse_to_node('{0} < len({1})'.format(var_index_id, var_iter_id), for_node)
+
+        for_node.body.insert(0, update_target)
+        for_node.body.append(update_index)
+        for_node.body.append(loop_test)
+
+        for node in add_instructs:
+            self.generic_visit(node)
+        self.generic_visit(for_node)
+
+        add_instructs.append(for_node)
+        return add_instructs
+
+    def parse_to_node(self, expression: str, origin: ast.AST = None) -> Union[ast.AST, Sequence[ast.AST]]:
+        """
+        Parses an expression to an ast.
+
+        :param expression: string expression to be parsed
+        :param origin: an existing ast. If not None, the parsed node will have the same location of origin.
+        :return: the parsed node
+        :rtype: ast.AST or Sequence[ast.AST]
+        """
+        node = ast.parse(expression)
+        if origin is not None:
+            self.update_line_and_col(node, origin)
+
+        # get the expression instead of the default root node
+        if hasattr(node, 'body'):
+            node = node.body
+        elif hasattr(node, 'argtypes'):
+            node = node.argtypes
+
+        if isinstance(node, list) and len(node) == 1:
+            # the parsed node has a list of expression and only one expression is found
+            result = node[0]
+        else:
+            result = node
+
+        if isinstance(result, ast.Expr):
+            # an expr node encapsulates another node in its value field.
+            result = result.value
+        return result
+
+    def update_line_and_col(self, target: ast.AST, origin: ast.AST):
+        """
+        Updates the position of a node and its child nodes
+
+        :param target: the node that will have its position updated
+        :param origin: the node with the desired position
+        """
+        ast.copy_location(target, origin)
+        for field, value in ast.iter_fields(target):
+            if isinstance(value, list):
+                for item in value:
+                    if isinstance(item, ast.AST):
+                        ast.copy_location(item, origin)
+            elif isinstance(value, ast.AST):
+                ast.copy_location(value, origin)
+        ast.fix_missing_locations(target)

--- a/boa3/compiler/codegenerator.py
+++ b/boa3/compiler/codegenerator.py
@@ -73,7 +73,7 @@ class CodeGenerator:
         return code_dict
 
     @property
-    def __last_code(self) -> Optional[VMCode]:
+    def last_code(self) -> Optional[VMCode]:
         """
         Gets the last code in the bytecode
 
@@ -87,8 +87,8 @@ class CodeGenerator:
 
     @property
     def address(self) -> int:
-        if self.__last_code is not None:
-            return self.__last_code.end_address + 1
+        if self.last_code is not None:
+            return self.last_code.end_address + 1
         else:
             return 0
 
@@ -133,10 +133,10 @@ class CodeGenerator:
         :param identifier: id of the symbol
         :return: the symbol if exists. Symbol None otherwise
         """
-        if identifier in self.symbol_table:
-            return self.symbol_table[identifier]
-        elif self.__current_method is not None and identifier in self.__current_method.symbols:
+        if self.__current_method is not None and identifier in self.__current_method.symbols:
             return self.__current_method.symbols[identifier]
+        elif identifier in self.symbol_table:
+            return self.symbol_table[identifier]
 
         # the symbol may be a built in. If not, returns None
         symbol = Builtin.get_symbol(identifier)
@@ -170,7 +170,7 @@ class CodeGenerator:
         """
         # it will be updated when the while ends
         self.__insert_jump(OpcodeInfo.JMP, 0)
-        return self.__last_code.start_address
+        return self.last_code.start_address
 
     def convert_end_while(self, start_address: int, test_address: int):
         """
@@ -197,7 +197,7 @@ class CodeGenerator:
         """
         # it will be updated when the if ends
         self.__insert_jump(OpcodeInfo.JMPIFNOT, 0)
-        return self.__last_code.start_address
+        return self.last_code.start_address
 
     def convert_begin_else(self, start_address: int) -> int:
         """
@@ -213,7 +213,7 @@ class CodeGenerator:
         begin_jmp_to: int = self.address - start_address
         self.__update_jump(start_address, begin_jmp_to)
 
-        return self.__last_code.start_address
+        return self.last_code.start_address
 
     def convert_end_if(self, start_address: int):
         """
@@ -425,7 +425,7 @@ class CodeGenerator:
         :param op_info: info of the opcode  that will be inserted
         :param data: data of the opcode, if needed
         """
-        last_code = self.__last_code
+        last_code = self.last_code
         vm_code = VMCode(op_info, last_code, data)
 
         self.__vm_codes.append(vm_code)
@@ -462,6 +462,6 @@ class CodeGenerator:
                 return op_info, data
 
             op_info = OpcodeInfo.get_info(opcode)
-        data = jmp_data.to_byte_array()
+        data = jmp_data.to_byte_array(min_length=op_info.data_len, signed=True)
 
         return op_info, data

--- a/boa3/exception/CompilerWarning.py
+++ b/boa3/exception/CompilerWarning.py
@@ -15,3 +15,23 @@ class CompilerWarning(ABC):
     @property
     def _warning_message(self) -> Optional[str]:
         return None
+
+    def __str__(self) -> str:
+        return self.message
+
+
+class NameShadowing(CompilerWarning):
+    """
+    An warning raised when a name from an outer scope symbol is used as the name of an inner scope symbol
+    """
+    from boa3.model.symbol import ISymbol
+
+    def __init__(self, line: int, col: int, outer_symbol: ISymbol, symbol_id: str):
+        self.symbol_id: str = symbol_id
+        self.existing_symbol = outer_symbol
+        super().__init__(line, col)
+
+    @property
+    def _warning_message(self) -> Optional[str]:
+        if self.symbol_id is not None:
+            return "Shadowing {0} name '{1}'".format(self.existing_symbol.shadowing_name, self.symbol_id)

--- a/boa3/helpers/__init__.py
+++ b/boa3/helpers/__init__.py
@@ -1,0 +1,12 @@
+import ast
+
+
+def get_auxiliary_name(node: ast.AST, aux_symbol_id: str) -> str:
+    """
+    Generates a name for auxiliary variables.
+
+    :param node: the ast node that originates the auxiliary symbol
+    :param aux_symbol_id: the id name of the auxiliary symbol
+    :return: the unique name to the symbol.
+    """
+    return "%s_%s" % (aux_symbol_id, id(node))

--- a/boa3/model/method.py
+++ b/boa3/model/method.py
@@ -23,6 +23,10 @@ class Method(IExpression):
         self.is_public: bool = is_public
         self.locals: Dict[str, Variable] = {}
 
+    @property
+    def shadowing_name(self) -> str:
+        return 'method'
+
     def include_variable(self, var_id: str, var: Variable):
         """
         Includes a variable into the list of locals

--- a/boa3/model/module.py
+++ b/boa3/model/module.py
@@ -23,6 +23,10 @@ class Module(ISymbol):
             methods = {}
         self.methods = methods
 
+    @property
+    def shadowing_name(self) -> str:
+        return 'module'
+
     def include_variable(self, var_id: str, var: Variable):
         """
         Includes a variable into the scope of the module

--- a/boa3/model/symbol.py
+++ b/boa3/model/symbol.py
@@ -1,5 +1,13 @@
-from abc import ABC
+from abc import ABC, abstractmethod
 
 
 class ISymbol(ABC):
-    pass
+    @property
+    @abstractmethod
+    def shadowing_name(self) -> str:
+        """
+        Gets the type of the evaluated expression
+
+        :return: the resulting type when the expression is evaluated
+        """
+        pass

--- a/boa3/model/type/itype.py
+++ b/boa3/model/type/itype.py
@@ -16,6 +16,10 @@ class IType(ISymbol):
         self.identifier: str = identifier
 
     @property
+    def shadowing_name(self) -> str:
+        return 'type'
+
+    @property
     def abi_type(self) -> AbiType:
         """
         Get the type representation for the abi

--- a/boa3/model/variable.py
+++ b/boa3/model/variable.py
@@ -13,5 +13,9 @@ class Variable(IExpression):
         self.__var_type: IType = var_type
 
     @property
+    def shadowing_name(self) -> str:
+        return 'variable'
+
+    @property
     def type(self) -> IType:
         return self.__var_type

--- a/boa3/neo/vm/type/Integer.py
+++ b/boa3/neo/vm/type/Integer.py
@@ -15,7 +15,8 @@ class Integer(int):
         aux: int = bits_per_byte - 1
         if self < 0:
             signed = True
-            aux += 1  # negative numbers used an additional bit to represent the signal
+        if signed:
+            aux += 1  # signed numbers uses an additional bit to represent the signal
 
         byte_length: int = ((self.bit_length() + aux) // bits_per_byte)
         length = max(min_length, byte_length)

--- a/boa3_test/example/for_test/ForElse.py
+++ b/boa3_test/example/for_test/ForElse.py
@@ -1,0 +1,10 @@
+def Main() -> int:
+    a: int = 0
+    sequence: Tuple[int] = (3, 5, 15)
+
+    for x in sequence:
+        a = a + x
+    else:
+        a = a + 1
+
+    return a

--- a/boa3_test/example/for_test/MismatchedTypeCondition.py
+++ b/boa3_test/example/for_test/MismatchedTypeCondition.py
@@ -1,0 +1,7 @@
+def Main() -> int:
+    a = 0
+
+    for x in a:
+        a = a + 2
+
+    return a

--- a/boa3_test/example/for_test/NestedFor.py
+++ b/boa3_test/example/for_test/NestedFor.py
@@ -1,0 +1,9 @@
+def Main() -> int:
+    a: int = 0
+    sequence: Tuple[int] = (3, 5, 15)
+
+    for x in sequence:
+        for y in sequence:
+            a = a + x * y
+
+    return a

--- a/boa3_test/example/for_test/NoCondition.py
+++ b/boa3_test/example/for_test/NoCondition.py
@@ -1,0 +1,7 @@
+def Main() -> int:
+    a: int = 0
+
+    for x:
+        a = a + x
+
+    return a

--- a/boa3_test/example/for_test/StringCondition.py
+++ b/boa3_test/example/for_test/StringCondition.py
@@ -1,0 +1,9 @@
+def Main() -> str:
+    a: int = 0
+    b: str = ''
+
+    for x in '3515':
+        a = a + 1
+        b = x
+
+    return b

--- a/boa3_test/example/for_test/TupleCondition.py
+++ b/boa3_test/example/for_test/TupleCondition.py
@@ -1,0 +1,7 @@
+def Main() -> int:
+    a: int = 0
+
+    for x in (3, 5, 15):
+        a = a + x
+
+    return a

--- a/boa3_test/example/for_test/VariableCondition.py
+++ b/boa3_test/example/for_test/VariableCondition.py
@@ -1,0 +1,8 @@
+def Main() -> int:
+    a: int = 0
+    sequence: Tuple[int] = (3, 5, 15)
+
+    for x in sequence:
+        a = a + x
+
+    return a

--- a/boa3_test/tests/boa_test.py
+++ b/boa3_test/tests/boa_test.py
@@ -27,6 +27,6 @@ class BoaTest(TestCase):
             except NotLoadedException:
                 # when an compiler error is logged this exception is raised.
                 pass
-
+        
         if len([exception for exception in log.records if isinstance(exception.msg, expected_logged_exception)]) <= 0:
             raise AssertionError('{0} not logged'.format(expected_logged_exception.__name__))

--- a/boa3_test/tests/test_for.py
+++ b/boa3_test/tests/test_for.py
@@ -1,0 +1,294 @@
+from boa3.boa3 import Boa3
+from boa3.exception.CompilerError import MismatchedTypes
+from boa3.neo.vm.opcode.Opcode import Opcode
+from boa3.neo.vm.type.Integer import Integer
+from boa3_test.tests.boa_test import BoaTest
+
+
+class TestFor(BoaTest):
+
+    def test_for_tuple_condition(self):
+        jmpif_address = Integer(14).to_byte_array(min_length=1, signed=True)
+        jmp_address = Integer(-16).to_byte_array(min_length=1, signed=True)
+
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x04'
+            + b'\x00'
+            + Opcode.PUSH0      # a = 0
+            + Opcode.STLOC0
+                + Opcode.PUSH3      # begin for
+                + Opcode.NEWARRAY
+                + Opcode.DUP        # array[0] = 3
+                + Opcode.PUSH0
+                + Opcode.PUSH3
+                + Opcode.SETITEM
+                + Opcode.DUP        # array[1] = 5
+                + Opcode.PUSH1
+                + Opcode.PUSH5
+                + Opcode.SETITEM
+                + Opcode.DUP        # array[2] = 15
+                + Opcode.PUSH2
+                + Opcode.PUSH15
+                + Opcode.SETITEM
+                + Opcode.STLOC1     # for_sequence = array
+                + Opcode.PUSH0
+                + Opcode.STLOC2     # for_index = 0
+            + Opcode.JMP
+            + jmpif_address
+                + Opcode.LDLOC1         # x = for_sequence[for_index]
+                + Opcode.LDLOC2
+                + Opcode.PICKITEM
+                + Opcode.STLOC3
+                + Opcode.LDLOC0         # a = a + x
+                + Opcode.LDLOC3
+                + Opcode.ADD
+                + Opcode.STLOC0
+                + Opcode.LDLOC2         # for_index = for_index + 1
+                + Opcode.PUSH1
+                + Opcode.ADD
+                + Opcode.STLOC2
+            + Opcode.LDLOC2     # if for_index < len(for_sequence)
+            + Opcode.LDLOC1
+            + Opcode.SIZE
+            + Opcode.LT
+            + Opcode.JMPIF      # end for
+            + jmp_address
+            + Opcode.LDLOC0     # return a
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/for_test/TupleCondition.py' % self.dirname
+        output = Boa3.compile(path)
+
+        self.assertEqual(expected_output, output)
+
+    def test_for_string_condition(self):
+        path = '%s/boa3_test/example/for_test/StringCondition.py' % self.dirname
+        
+        with self.assertRaises(NotImplementedError):
+            output = Boa3.compile(path)
+
+    def test_for_variable_condition(self):
+        jmpif_address = Integer(14).to_byte_array(min_length=1, signed=True)
+        jmp_address = Integer(-16).to_byte_array(min_length=1, signed=True)
+
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x05'
+            + b'\x00'
+            + Opcode.PUSH0      # a = 0
+            + Opcode.STLOC0
+                + Opcode.PUSH3  # sequence = (3, 5, 15)
+                + Opcode.NEWARRAY
+                + Opcode.DUP        # sequence[0] = 3
+                + Opcode.PUSH0
+                + Opcode.PUSH3
+                + Opcode.SETITEM
+                + Opcode.DUP        # sequence[1] = 5
+                + Opcode.PUSH1
+                + Opcode.PUSH5
+                + Opcode.SETITEM
+                + Opcode.DUP        # sequence[2] = 15
+                + Opcode.PUSH2
+                + Opcode.PUSH15
+                + Opcode.SETITEM
+            + Opcode.STLOC1
+                + Opcode.LDLOC1     # for_sequence = sequence
+                + Opcode.STLOC2
+                + Opcode.PUSH0      # for_index = 0
+                + Opcode.STLOC3
+            + Opcode.JMP
+            + jmpif_address
+                + Opcode.LDLOC2         # x = for_sequence[for_index]
+                + Opcode.LDLOC3
+                + Opcode.PICKITEM
+                + Opcode.STLOC4
+                + Opcode.LDLOC0         # a = a + x
+                + Opcode.LDLOC4
+                + Opcode.ADD
+                + Opcode.STLOC0
+                + Opcode.LDLOC3         # for_index = for_index + 1
+                + Opcode.PUSH1
+                + Opcode.ADD
+                + Opcode.STLOC3
+            + Opcode.LDLOC3     # if for_index < len(for_sequence)
+            + Opcode.LDLOC2
+            + Opcode.SIZE
+            + Opcode.LT
+            + Opcode.JMPIF      # end for
+            + jmp_address
+            + Opcode.LDLOC0     # return a
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/for_test/VariableCondition.py' % self.dirname
+        output = Boa3.compile(path)
+
+        self.assertEqual(expected_output, output)
+
+    def test_for_mismatched_type_condition(self):
+        path = '%s/boa3_test/example/for_test/MismatchedTypeCondition.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_for_no_condition(self):
+        path = '%s/boa3_test/example/for_test/NoCondition.py' % self.dirname
+
+        with self.assertRaises(SyntaxError):
+            output = Boa3.compile(path)
+
+    def test_nested_for(self):
+        outer_jmpif_address = Integer(38).to_byte_array(min_length=1, signed=True)
+        outer_jmp_address = Integer(-40).to_byte_array(min_length=1, signed=True)
+
+        inner_jmpif_address = Integer(18).to_byte_array(min_length=1, signed=True)
+        inner_jmp_address = Integer(-20).to_byte_array(min_length=1, signed=True)
+
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x08'
+            + b'\x00'
+            + Opcode.PUSH0      # a = 0
+            + Opcode.STLOC0
+                + Opcode.PUSH3  # sequence = (3, 5, 15)
+                + Opcode.NEWARRAY
+                + Opcode.DUP        # sequence[0] = 3
+                + Opcode.PUSH0
+                + Opcode.PUSH3
+                + Opcode.SETITEM
+                + Opcode.DUP        # sequence[1] = 5
+                + Opcode.PUSH1
+                + Opcode.PUSH5
+                + Opcode.SETITEM
+                + Opcode.DUP        # sequence[2] = 15
+                + Opcode.PUSH2
+                + Opcode.PUSH15
+                + Opcode.SETITEM
+            + Opcode.STLOC1
+                + Opcode.LDLOC1     # outer_for_sequence = sequence
+                + Opcode.STLOC2
+                + Opcode.PUSH0      # outer_for_index = 0
+                + Opcode.STLOC3
+            + Opcode.JMP
+            + outer_jmpif_address
+                + Opcode.LDLOC2         # x = outer_for_sequence[outer_for_index]
+                + Opcode.LDLOC3
+                + Opcode.PICKITEM
+                + Opcode.STLOC4
+                    + Opcode.LDLOC1     # inner_for_sequence = sequence
+                    + Opcode.STLOC5
+                    + Opcode.PUSH0      # inner_for_index = 0
+                    + Opcode.STLOC6
+                + Opcode.JMP
+                + inner_jmpif_address
+                    + Opcode.LDLOC5         # y = inner_for_sequence[inner_for_index]
+                    + Opcode.LDLOC6
+                    + Opcode.PICKITEM
+                    + Opcode.STLOC
+                    + Integer(7).to_byte_array()
+                    + Opcode.LDLOC0         # a = a + x * y
+                    + Opcode.LDLOC4
+                    + Opcode.LDLOC
+                    + Integer(7).to_byte_array()
+                    + Opcode.MUL
+                    + Opcode.ADD
+                    + Opcode.STLOC0
+                    + Opcode.LDLOC6         # inner_for_index = inner_for_index + 1
+                    + Opcode.PUSH1
+                    + Opcode.ADD
+                    + Opcode.STLOC6
+                + Opcode.LDLOC6     # if inner_for_index < len(inner_for_sequence)
+                + Opcode.LDLOC5
+                + Opcode.SIZE
+                + Opcode.LT
+                + Opcode.JMPIF      # end inner_for
+                + inner_jmp_address
+                + Opcode.LDLOC3     # outer_for_index = outer_for_index + 1
+                + Opcode.PUSH1
+                + Opcode.ADD
+                + Opcode.STLOC3
+            + Opcode.LDLOC3     # if outer_for_index < len(outer_for_sequence)
+            + Opcode.LDLOC2
+            + Opcode.SIZE
+            + Opcode.LT
+            + Opcode.JMPIF      # end outer_for
+            + outer_jmp_address
+            + Opcode.LDLOC0     # return a
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/for_test/NestedFor.py' % self.dirname
+        output = Boa3.compile(path)
+
+        for x in range(0, min(len(expected_output), len(output) - 1)):
+            if expected_output[x] != output[x]:
+                print(x, '\texpected: ', expected_output[x], '\tactual: ', output[x])
+
+        self.assertEqual(expected_output, output)
+
+    def test_for_else(self):
+        jmpif_address = Integer(14).to_byte_array(min_length=1, signed=True)
+        jmp_address = Integer(-16).to_byte_array(min_length=1, signed=True)
+
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x05'
+            + b'\x00'
+            + Opcode.PUSH0      # a = 0
+            + Opcode.STLOC0
+                + Opcode.PUSH3  # sequence = (3, 5, 15)
+                + Opcode.NEWARRAY
+                + Opcode.DUP        # sequence[0] = 3
+                + Opcode.PUSH0
+                + Opcode.PUSH3
+                + Opcode.SETITEM
+                + Opcode.DUP        # sequence[1] = 5
+                + Opcode.PUSH1
+                + Opcode.PUSH5
+                + Opcode.SETITEM
+                + Opcode.DUP        # sequence[2] = 15
+                + Opcode.PUSH2
+                + Opcode.PUSH15
+                + Opcode.SETITEM
+            + Opcode.STLOC1
+                + Opcode.LDLOC1     # for_sequence = sequence
+                + Opcode.STLOC2
+                + Opcode.PUSH0      # for_index = 0
+                + Opcode.STLOC3
+            + Opcode.JMP
+            + jmpif_address
+                + Opcode.LDLOC2         # x = for_sequence[for_index]
+                + Opcode.LDLOC3
+                + Opcode.PICKITEM
+                + Opcode.STLOC4
+                + Opcode.LDLOC0         # a = a + x
+                + Opcode.LDLOC4
+                + Opcode.ADD
+                + Opcode.STLOC0
+                + Opcode.LDLOC3         # for_index = for_index + 1
+                + Opcode.PUSH1
+                + Opcode.ADD
+                + Opcode.STLOC3
+            + Opcode.LDLOC3     # if for_index < len(for_sequence)
+            + Opcode.LDLOC2
+            + Opcode.SIZE
+            + Opcode.LT
+            + Opcode.JMPIF      # end for
+            + jmp_address
+            + Opcode.LDLOC0     # a = a + 1
+            + Opcode.PUSH1
+            + Opcode.ADD
+            + Opcode.STLOC0
+            + Opcode.LDLOC0     # return a
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/for_test/ForElse.py' % self.dirname
+        output = Boa3.compile(path)
+
+        size = min(len(expected_output), len(output))
+        for x in range(0, size - 1):
+            if expected_output[x] != output[x]:
+                print(x, '\texpected: ', expected_output[x], '\tactual: ', output[x])
+
+        self.assertEqual(expected_output, output)

--- a/boa3_test/tests/test_if.py
+++ b/boa3_test/tests/test_if.py
@@ -17,7 +17,7 @@ class TestIf(BoaTest):
             + Opcode.STLOC0
             + Opcode.PUSH1
             + Opcode.JMPIFNOT   # if True
-            + Integer(6).to_byte_array(min_length=1)
+            + Integer(6).to_byte_array(min_length=1, signed=True)
                 + Opcode.LDLOC0     # a = a + 2
                 + Opcode.PUSH2
                 + Opcode.ADD
@@ -40,7 +40,7 @@ class TestIf(BoaTest):
             + Opcode.STLOC0
             + Opcode.LDARG0
             + Opcode.JMPIFNOT   # if arg0
-            + Integer(6).to_byte_array(min_length=1)
+            + Integer(6).to_byte_array(min_length=1, signed=True)
                 + Opcode.LDLOC0     # a = a + 2
                 + Opcode.PUSH2
                 + Opcode.ADD
@@ -81,14 +81,14 @@ class TestIf(BoaTest):
             + Opcode.STLOC1
             + Opcode.LDARG0
             + Opcode.JMPIFNOT   # if arg0
-            + Integer(17).to_byte_array(min_length=1)
+            + Integer(17).to_byte_array(min_length=1, signed=True)
                 + Opcode.LDLOC0     # c = c + 2
                 + Opcode.PUSH2
                 + Opcode.ADD
                 + Opcode.STLOC0
                 + Opcode.LDARG1
                 + Opcode.JMPIFNOT   # if arg1
-                + Integer(6).to_byte_array(min_length=1)
+                + Integer(6).to_byte_array(min_length=1, signed=True)
                     + Opcode.LDLOC1     # d = d + 3
                     + Opcode.PUSH3
                     + Opcode.ADD
@@ -115,13 +115,13 @@ class TestIf(BoaTest):
             + Opcode.STLOC0
             + Opcode.LDARG0
             + Opcode.JMPIFNOT   # if arg0
-            + Integer(8).to_byte_array(min_length=1)
+            + Integer(8).to_byte_array(min_length=1, signed=True)
                 + Opcode.LDLOC0     # a = a + 2
                 + Opcode.PUSH2
                 + Opcode.ADD
                 + Opcode.STLOC0
             + Opcode.JMP        # else
-            + Integer(4).to_byte_array(min_length=1)
+            + Integer(4).to_byte_array(min_length=1, signed=True)
                 + Opcode.PUSH10     # a = 10
                 + Opcode.STLOC0
             + Opcode.LDLOC0     # return a
@@ -180,7 +180,7 @@ class TestIf(BoaTest):
             output = Boa3.compile(path)
 
     def test_if_relational_condition(self):
-        jmp_address = Integer(6).to_byte_array(min_length=1)
+        jmp_address = Integer(6).to_byte_array(min_length=1, signed=True)
 
         expected_output = (
             Opcode.INITSLOT
@@ -270,10 +270,10 @@ class TestIf(BoaTest):
             + b'\x01'
             + Opcode.LDARG0
             + Opcode.JMPIFNOT   # a = 2 if arg0 else 3
-                + Integer(5).to_byte_array(min_length=1)
+                + Integer(5).to_byte_array(min_length=1, signed=True)
                 + Opcode.PUSH2      # 2
             + Opcode.JMP        # else
-            + Integer(3).to_byte_array(min_length=1)
+            + Integer(3).to_byte_array(min_length=1, signed=True)
                 + Opcode.PUSH3      # 3
             + Opcode.STLOC0
             + Opcode.LDLOC0     # return a

--- a/boa3_test/tests/test_while.py
+++ b/boa3_test/tests/test_while.py
@@ -8,8 +8,8 @@ from boa3_test.tests.boa_test import BoaTest
 class TestWhile(BoaTest):
 
     def test_while_constant_condition(self):
-        jmpif_address = Integer(6).to_byte_array(min_length=1)
-        jmp_address = Integer(-5).to_byte_array(min_length=1)
+        jmpif_address = Integer(6).to_byte_array(min_length=1, signed=True)
+        jmp_address = Integer(-5).to_byte_array(min_length=1, signed=True)
 
         expected_output = (
             Opcode.INITSLOT
@@ -36,8 +36,8 @@ class TestWhile(BoaTest):
         self.assertEqual(expected_output, output)
 
     def test_while_variable_condition(self):
-        jmpif_address = Integer(6).to_byte_array(min_length=1)
-        jmp_address = Integer(-5).to_byte_array(min_length=1)
+        jmpif_address = Integer(6).to_byte_array(min_length=1, signed=True)
+        jmp_address = Integer(-5).to_byte_array(min_length=1, signed=True)
 
         expected_output = (
             Opcode.INITSLOT
@@ -74,11 +74,11 @@ class TestWhile(BoaTest):
             output = Boa3.compile(path)
 
     def test_nested_while(self):
-        outer_jmpif_address = Integer(19).to_byte_array(min_length=1)
-        outer_jmp_address = Integer(-18).to_byte_array(min_length=1)
+        outer_jmpif_address = Integer(19).to_byte_array(min_length=1, signed=True)
+        outer_jmp_address = Integer(-18).to_byte_array(min_length=1, signed=True)
 
-        inner_jmpif_address = Integer(6).to_byte_array(min_length=1)
-        inner_jmp_address = Integer(-5).to_byte_array(min_length=1)
+        inner_jmpif_address = Integer(6).to_byte_array(min_length=1, signed=True)
+        inner_jmp_address = Integer(-5).to_byte_array(min_length=1, signed=True)
 
         expected_output = (
             Opcode.INITSLOT
@@ -120,8 +120,8 @@ class TestWhile(BoaTest):
         self.assertEqual(expected_output, output)
 
     def test_while_else(self):
-        jmpif_address = Integer(6).to_byte_array(min_length=1)
-        jmp_address = Integer(-5).to_byte_array(min_length=1)
+        jmpif_address = Integer(6).to_byte_array(min_length=1, signed=True)
+        jmp_address = Integer(-5).to_byte_array(min_length=1, signed=True)
 
         expected_output = (
             Opcode.INITSLOT
@@ -152,8 +152,8 @@ class TestWhile(BoaTest):
         self.assertEqual(expected_output, output)
 
     def test_while_relational_condition(self):
-        jmpif_address = Integer(10).to_byte_array(min_length=1)
-        jmp_address = Integer(-11).to_byte_array(min_length=1)
+        jmpif_address = Integer(10).to_byte_array(min_length=1, signed=True)
+        jmp_address = Integer(-11).to_byte_array(min_length=1, signed=True)
 
         expected_output = (
             Opcode.INITSLOT
@@ -188,8 +188,8 @@ class TestWhile(BoaTest):
         self.assertEqual(expected_output, output)
 
     def test_while_multiple_relational_condition(self):
-        jmpif_address = Integer(10).to_byte_array(min_length=1)
-        jmp_address = Integer(-15).to_byte_array(min_length=1)
+        jmpif_address = Integer(10).to_byte_array(min_length=1, signed=True)
+        jmp_address = Integer(-15).to_byte_array(min_length=1, signed=True)
 
         expected_output = (
             Opcode.INITSLOT
@@ -235,8 +235,8 @@ class TestWhile(BoaTest):
             output = Boa3.compile(path)
 
     def test_boa2_while_test1(self):
-        jmpif_address = Integer(6).to_byte_array(min_length=1)
-        jmp_address = Integer(-7).to_byte_array(min_length=1)
+        jmpif_address = Integer(6).to_byte_array(min_length=1, signed=True)
+        jmp_address = Integer(-7).to_byte_array(min_length=1, signed=True)
 
         expected_output = (
             Opcode.INITSLOT


### PR DESCRIPTION
- Implemented `for` statements that use a tuple or a variable as its iterator.
If the iterator type is not a sequence, a compiler error will be raised.
- String iteration is not implemented yet, so using a string value in the `for` statement is going to raise an exception.
- The keywords `continue`, `break` and `pass` are not implemented in this issue.