### PR TITLE
Convert Function call

### DIFF
--- a/boa3/analyser/moduleanalyser.py
+++ b/boa3/analyser/moduleanalyser.py
@@ -134,13 +134,15 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
         fun_decorators = [self.visit(decorator) for decorator in function.decorator_list]
 
         fun_return: IType = fun_rtype_symbol
+        method = Method(fun_args, fun_return, Builtin.Public.identifier in fun_decorators)
 
         if function.name in ['main', 'Main']:
             arg_types = ', '.join(['{0}: {1}'.format(arg, var.type.identifier) for arg, var in fun_args.items()])
             logging.info("Main method found at {0}:{1}: '{2}({3}) -> {4}'"
                          .format(function.lineno, function.col_offset, function.name, arg_types, fun_return.identifier))
+            # main method is always public
+            method.set_as_main_method()
 
-        method = Method(fun_args, fun_return, Builtin.Public.identifier in fun_decorators)
         self.__current_method = method
 
         for stmt in function.body:
@@ -306,14 +308,15 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
         func_id = self.visit(call.func)
         func_symbol = self.get_symbol(func_id)
 
-        # TODO: change when all user function call is implemented
-        if not isinstance(func_symbol, IBuiltinMethod):
-            # the symbol doesn't exists
-            self._log_error(
-                CompilerError.UnresolvedReference(call.func.lineno, call.func.col_offset, func_id)
-            )
-        if func_symbol.body is not None:
-            self.__builtin_functions_to_visit[func_id] = func_symbol
+        # if func_symbol is None, the called function may be a function written after in the code
+        if func_symbol is not None:
+            if not isinstance(func_symbol, IBuiltinMethod):
+                # the symbol doesn't exists
+                self._log_error(
+                    CompilerError.UnresolvedReference(call.func.lineno, call.func.col_offset, func_id)
+                )
+            elif func_symbol.body is not None:
+                self.__builtin_functions_to_visit[func_id] = func_symbol
 
         return self.get_type(call.func)
 

--- a/boa3/compiler/codegeneratorvisitor.py
+++ b/boa3/compiler/codegeneratorvisitor.py
@@ -271,7 +271,8 @@ class VisitorCodeGenerator(ast.NodeVisitor):
 
         :param call: the python ast function call node
         """
-        for arg in call.args:
+        # the parameters are included into the stack in the reversed order
+        for arg in reversed(call.args):
             self.visit_to_generate(arg)
         function_id = self.visit(call.func)
         self.generator.convert_load_symbol(function_id)

--- a/boa3/compiler/filegenerator.py
+++ b/boa3/compiler/filegenerator.py
@@ -53,7 +53,7 @@ class FileGenerator:
             method_id = 'Main'
 
         if method_id is None:
-            return None
+            raise NotImplementedError
         else:
             return method_id, self.__methods[method_id]
 

--- a/boa3/model/method.py
+++ b/boa3/model/method.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Optional
 
 from boa3.model.expression import IExpression
 from boa3.model.type.itype import IType
@@ -16,12 +16,17 @@ class Method(IExpression):
     """
 
     def __init__(self, args: Dict[str, Variable] = None, return_type: IType = None, is_public: bool = False):
+        from boa3.neo.vm.VMCode import VMCode
         if args is None:
             args = {}
         self.args: Dict[str, Variable] = args
         self.return_type: IType = return_type
+
         self.is_public: bool = is_public
+        self.is_main_method: bool = False
+
         self.locals: Dict[str, Variable] = {}
+        self.init_bytecode: Optional[VMCode] = None
 
     def include_variable(self, var_id: str, var: Variable):
         """
@@ -48,3 +53,19 @@ class Method(IExpression):
         symbols.update(self.args)
         symbols.update(self.locals)
         return symbols
+
+    @property
+    def bytecode_address(self) -> Optional[int]:
+        """
+        Gets the address where this method starts in the bytecode
+
+        :return: the first address of the method
+        """
+        if self.init_bytecode is None:
+            return None
+        else:
+            return self.init_bytecode.start_address
+
+    def set_as_main_method(self):
+        self.is_main_method = True
+        self.is_public = True

--- a/boa3/model/type/booltype.py
+++ b/boa3/model/type/booltype.py
@@ -25,4 +25,4 @@ class BoolType(IType):
 
     @classmethod
     def is_type_of(cls, value: Any):
-        return type(value) == bool
+        return type(value) in [bool, BoolType]

--- a/boa3/model/type/inttype.py
+++ b/boa3/model/type/inttype.py
@@ -25,4 +25,4 @@ class IntType(IType):
 
     @classmethod
     def is_type_of(cls, value: Any):
-        return type(value) == int
+        return type(value) in [int, IntType]

--- a/boa3/model/type/nonetype.py
+++ b/boa3/model/type/nonetype.py
@@ -25,4 +25,5 @@ class NoneType(IType):
 
     @classmethod
     def is_type_of(cls, value: Any):
-        return value is None
+        from boa3.model.type.type import Type
+        return value is None or value is Type.none

--- a/boa3/model/type/strtype.py
+++ b/boa3/model/type/strtype.py
@@ -31,7 +31,7 @@ class StrType(SequenceType):
 
     @classmethod
     def is_type_of(cls, value: Any):
-        return type(value) == str
+        return type(value) in [str, StrType]
 
     def is_valid_key(self, value_type: IType) -> bool:
         return value_type == self.valid_key

--- a/boa3/model/type/tupletype.py
+++ b/boa3/model/type/tupletype.py
@@ -35,7 +35,7 @@ class TupleType(SequenceType):
 
     @classmethod
     def is_type_of(cls, value: Any):
-        return type(value) == tuple
+        return type(value) in [tuple, TupleType]
 
     def __eq__(self, other) -> bool:
         if type(self) != type(other):

--- a/boa3/neo/vm/VMCode.py
+++ b/boa3/neo/vm/VMCode.py
@@ -19,7 +19,7 @@ class VMCode:
         :type last_code: VMCode or None
         :param data: the data in bytes of the code. Empty byte array by default.
         """
-        self.__last_code = last_code    # type:Optional[VMCode]
+        self._last_code = last_code    # type:Optional[VMCode]
         self.info: OpcodeInformation = op_info
         self.data: bytes = self.__format_data(data)
 
@@ -30,10 +30,10 @@ class VMCode:
 
         :return: the first address of the code
         """
-        if self.__last_code is None:
+        if self._last_code is None:
             return 0
         else:
-            return self.__last_code.end_address + 1
+            return self._last_code.end_address + 1
 
     @property
     def end_address(self) -> int:

--- a/boa3_test/example/function_test/CallFunctionWrittenBefore.py
+++ b/boa3_test/example/function_test/CallFunctionWrittenBefore.py
@@ -1,0 +1,6 @@
+def TestAdd(a: int, b: int) -> int:
+    return a + b
+
+
+def Main(operation: str, args: Tuple[int]) -> int:
+    return TestAdd(1, 2)

--- a/boa3_test/example/function_test/CallReturnFunctionOnReturn.py
+++ b/boa3_test/example/function_test/CallReturnFunctionOnReturn.py
@@ -1,0 +1,8 @@
+def Main(operation: str, args: Tuple[int]) -> int:
+    a = 1
+    b = 2
+    return TestAdd(a, b)
+
+
+def TestAdd(a: int, b: int) -> int:
+    return a + b

--- a/boa3_test/example/function_test/CallReturnFunctionWithLiteralArgs.py
+++ b/boa3_test/example/function_test/CallReturnFunctionWithLiteralArgs.py
@@ -1,0 +1,7 @@
+def Main(operation: str, args: Tuple[int]) -> int:
+    a = TestAdd(1, 2)
+    return a
+
+
+def TestAdd(a: int, b: int) -> int:
+    return a + b

--- a/boa3_test/example/function_test/CallReturnFunctionWithVariableArgs.py
+++ b/boa3_test/example/function_test/CallReturnFunctionWithVariableArgs.py
@@ -1,0 +1,9 @@
+def Main(operation: str, args: Tuple[int]) -> int:
+    a = 1
+    b = 2
+    c = TestAdd(a, b)
+    return c
+
+
+def TestAdd(a: int, b: int) -> int:
+    return a + b

--- a/boa3_test/example/function_test/CallReturnFunctionWithoutArgs.py
+++ b/boa3_test/example/function_test/CallReturnFunctionWithoutArgs.py
@@ -1,0 +1,7 @@
+def Main(operation: str, args: Tuple[int]) -> int:
+    a = TestFunction()
+    return a
+
+
+def TestFunction() -> int:
+    return 1

--- a/boa3_test/example/function_test/CallVoidFunctionWithLiteralArgs.py
+++ b/boa3_test/example/function_test/CallVoidFunctionWithLiteralArgs.py
@@ -1,0 +1,7 @@
+def Main(operation: str, args: Tuple[int]) -> bool:
+    TestAdd(1, 2)
+    return True
+
+
+def TestAdd(a: int, b: int):
+    c = a + b

--- a/boa3_test/example/function_test/CallVoidFunctionWithVariableArgs.py
+++ b/boa3_test/example/function_test/CallVoidFunctionWithVariableArgs.py
@@ -1,0 +1,9 @@
+def Main(operation: str, args: Tuple[int]) -> bool:
+    a = 1
+    b = 2
+    TestAdd(a, b)
+    return True
+
+
+def TestAdd(a: int, b: int):
+    c = a + b

--- a/boa3_test/example/function_test/CallVoidFunctionWithoutArgs.py
+++ b/boa3_test/example/function_test/CallVoidFunctionWithoutArgs.py
@@ -1,0 +1,7 @@
+def Main(operation: str, args: Tuple[int]) -> bool:
+    TestFunction()
+    return True
+
+
+def TestFunction():
+    a = 1

--- a/boa3_test/example/generation_test/GenerationWithoutMain.py
+++ b/boa3_test/example/generation_test/GenerationWithoutMain.py
@@ -1,0 +1,8 @@
+@public
+def Add(a: int, b: int) -> int:
+    return a + b
+
+
+@public
+def Sub(a: int, b: int) -> int:
+    return a - b

--- a/boa3_test/tests/test_file_generation.py
+++ b/boa3_test/tests/test_file_generation.py
@@ -105,10 +105,30 @@ class TestFileGeneration(BoaTest):
         abi = manifest['abi']
 
         self.assertIn('entryPoint', abi)
-        self.assertEqual(len(abi['entryPoint']), 0)
+        self.assertNotEqual(0, len(abi['entryPoint']))  # entry point cannot be empty
+        self.assertIn('parameters', abi['entryPoint'])
+        self.assertEqual(len(abi['entryPoint']['parameters']), 2)
+
+        arg0 = abi['entryPoint']['parameters'][0]
+        self.assertIn('name', arg0)
+        self.assertEqual(arg0['name'], 'a')
+        self.assertIn('type', arg0)
+        self.assertEqual(arg0['type'], AbiType.Integer)
+
+        arg1 = abi['entryPoint']['parameters'][1]
+        self.assertIn('name', arg1)
+        self.assertEqual(arg1['name'], 'b')
+        self.assertIn('type', arg1)
+        self.assertEqual(arg1['type'], AbiType.Integer)
 
         self.assertIn('methods', abi)
-        self.assertEqual(len(abi['methods']), 0)
+        self.assertEqual(0, len(abi['methods']))
 
         self.assertIn('events', abi)
-        self.assertEqual(len(abi['events']), 0)
+        self.assertEqual(0, len(abi['events']))
+
+    def test_generate_without_main(self):
+        path = '%s/boa3_test/example/generation_test/GenerationWithoutMain.py' % self.dirname
+
+        with self.assertRaises(NotImplementedError):
+            Boa3.compile_and_save(path)

--- a/boa3_test/tests/test_function.py
+++ b/boa3_test/tests/test_function.py
@@ -1,6 +1,7 @@
 from boa3.boa3 import Boa3
 from boa3.exception.CompilerError import MismatchedTypes, TypeHintMissing, TooManyReturns
 from boa3.neo.vm.opcode.Opcode import Opcode
+from boa3.neo.vm.type.Integer import Integer
 from boa3_test.tests.boa_test import BoaTest
 
 
@@ -97,3 +98,227 @@ class TestFunction(BoaTest):
     def test_tuple_function(self):
         path = '%s/boa3_test/example/function_test/TupleFunction.py' % self.dirname
         self.assertCompilerLogs(TooManyReturns, path)
+
+    def test_call_void_function_without_args(self):
+        called_function_address = Integer(4).to_byte_array(min_length=1, signed=True)
+
+        expected_output = (
+            Opcode.INITSLOT     # Main
+            + b'\x00'
+            + b'\x02'
+            + Opcode.CALL           # TestFunction()
+            + called_function_address
+            + Opcode.PUSH1          # return True
+            + Opcode.RET
+            + Opcode.INITSLOT   # TestFunction
+            + b'\x01'
+            + b'\x00'
+            + Opcode.PUSH1          # a = 1
+            + Opcode.STLOC0
+            + Opcode.RET            # return
+        )
+
+        path = '%s/boa3_test/example/function_test/CallVoidFunctionWithoutArgs.py' % self.dirname
+        output = Boa3.compile(path)
+
+        self.assertEqual(expected_output, output)
+
+    def test_call_function_without_args(self):
+        called_function_address = Integer(5).to_byte_array(min_length=1, signed=True)
+
+        expected_output = (
+            Opcode.INITSLOT     # Main
+            + b'\x01'
+            + b'\x02'
+            + Opcode.CALL           # a = TestFunction()
+            + called_function_address
+            + Opcode.STLOC0
+            + Opcode.LDLOC0         # return a
+            + Opcode.RET
+            + Opcode.INITSLOT   # TestFunction
+            + b'\x00'
+            + b'\x00'
+            + Opcode.PUSH1          # return 1
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/function_test/CallReturnFunctionWithoutArgs.py' % self.dirname
+        output = Boa3.compile(path)
+
+        self.assertEqual(expected_output, output)
+
+    def test_call_void_function_with_literal_args(self):
+        called_function_address = Integer(4).to_byte_array(min_length=1, signed=True)
+
+        expected_output = (
+            Opcode.INITSLOT     # Main
+            + b'\x00'
+            + b'\x02'
+            + Opcode.PUSH2          # TestAdd(1, 2)
+            + Opcode.PUSH1
+            + Opcode.CALL
+            + called_function_address
+            + Opcode.PUSH1          # return True
+            + Opcode.RET
+            + Opcode.INITSLOT   # TestFunction
+            + b'\x01'
+            + b'\x02'
+            + Opcode.LDARG0         # c = a + b
+            + Opcode.LDARG1
+            + Opcode.ADD
+            + Opcode.STLOC0
+            + Opcode.RET            # return
+        )
+
+        path = '%s/boa3_test/example/function_test/CallVoidFunctionWithLiteralArgs.py' % self.dirname
+        output = Boa3.compile(path)
+
+        self.assertEqual(expected_output, output)
+
+    def test_call_function_with_literal_args(self):
+        called_function_address = Integer(5).to_byte_array(min_length=1, signed=True)
+
+        expected_output = (
+            Opcode.INITSLOT     # Main
+            + b'\x01'
+            + b'\x02'
+            + Opcode.PUSH2          # a = TestAdd(1, 2)
+            + Opcode.PUSH1
+            + Opcode.CALL
+            + called_function_address
+            + Opcode.STLOC0
+            + Opcode.LDLOC0         # return a
+            + Opcode.RET
+            + Opcode.INITSLOT   # TestFunction
+            + b'\x00'
+            + b'\x02'
+            + Opcode.LDARG0         # return a + b
+            + Opcode.LDARG1
+            + Opcode.ADD
+            + Opcode.RET            # return
+        )
+
+        path = '%s/boa3_test/example/function_test/CallReturnFunctionWithLiteralArgs.py' % self.dirname
+        output = Boa3.compile(path)
+
+        self.assertEqual(expected_output, output)
+
+    def test_call_void_function_with_variable_args(self):
+        called_function_address = Integer(4).to_byte_array(min_length=1, signed=True)
+
+        expected_output = (
+            Opcode.INITSLOT     # Main
+            + b'\x02'
+            + b'\x02'
+            + Opcode.PUSH1          # a = 1
+            + Opcode.STLOC0
+            + Opcode.PUSH2          # b = 2
+            + Opcode.STLOC1
+            + Opcode.LDLOC1         # TestAdd(a, b)
+            + Opcode.LDLOC0
+            + Opcode.CALL
+            + called_function_address
+            + Opcode.PUSH1          # return True
+            + Opcode.RET
+            + Opcode.INITSLOT   # TestFunction
+            + b'\x01'
+            + b'\x02'
+            + Opcode.LDARG0         # c = a + b
+            + Opcode.LDARG1
+            + Opcode.ADD
+            + Opcode.STLOC0
+            + Opcode.RET            # return
+        )
+
+        path = '%s/boa3_test/example/function_test/CallVoidFunctionWithVariableArgs.py' % self.dirname
+        output = Boa3.compile(path)
+
+        self.assertEqual(expected_output, output)
+
+    def test_call_function_with_variable_args(self):
+        called_function_address = Integer(5).to_byte_array(min_length=1, signed=True)
+
+        expected_output = (
+            Opcode.INITSLOT     # Main
+            + b'\x03'
+            + b'\x02'
+            + Opcode.PUSH1          # a = 1
+            + Opcode.STLOC0
+            + Opcode.PUSH2          # b = 2
+            + Opcode.STLOC1
+            + Opcode.LDLOC1         # c = TestAdd(a, b)
+            + Opcode.LDLOC0
+            + Opcode.CALL
+            + called_function_address
+            + Opcode.STLOC2
+            + Opcode.LDLOC2         # return c
+            + Opcode.RET
+            + Opcode.INITSLOT   # TestFunction
+            + b'\x00'
+            + b'\x02'
+            + Opcode.LDARG0         # return a + b
+            + Opcode.LDARG1
+            + Opcode.ADD
+            + Opcode.RET            # return
+        )
+
+        path = '%s/boa3_test/example/function_test/CallReturnFunctionWithVariableArgs.py' % self.dirname
+        output = Boa3.compile(path)
+
+        self.assertEqual(expected_output, output)
+
+    def test_call_function_with_on_return(self):
+        called_function_address = Integer(3).to_byte_array(min_length=1, signed=True)
+
+        expected_output = (
+            Opcode.INITSLOT     # Main
+            + b'\x02'
+            + b'\x02'
+            + Opcode.PUSH1          # a = 1
+            + Opcode.STLOC0
+            + Opcode.PUSH2          # b = 2
+            + Opcode.STLOC1
+            + Opcode.LDLOC1         # return TestAdd(a, b)
+            + Opcode.LDLOC0
+            + Opcode.CALL
+            + called_function_address
+            + Opcode.RET
+            + Opcode.INITSLOT   # TestFunction
+            + b'\x00'
+            + b'\x02'
+            + Opcode.LDARG0         # return a + b
+            + Opcode.LDARG1
+            + Opcode.ADD
+            + Opcode.RET            # return
+        )
+
+        path = '%s/boa3_test/example/function_test/CallReturnFunctionOnReturn.py' % self.dirname
+        output = Boa3.compile(path)
+
+        self.assertEqual(expected_output, output)
+
+    def test_call_function_written_before_caller(self):
+        called_function_address = Integer(3).to_byte_array(min_length=1, signed=True)
+
+        expected_output = (
+            Opcode.INITSLOT     # Main
+            + b'\x00'
+            + b'\x02'
+            + Opcode.PUSH2          # return TestAdd(a, b)
+            + Opcode.PUSH1
+            + Opcode.CALL
+            + called_function_address
+            + Opcode.RET
+            + Opcode.INITSLOT   # TestFunction
+            + b'\x00'
+            + b'\x02'
+            + Opcode.LDARG0         # return a + b
+            + Opcode.LDARG1
+            + Opcode.ADD
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/function_test/CallFunctionWrittenBefore.py' % self.dirname
+        output = Boa3.compile(path)
+
+        self.assertEqual(expected_output, output)


### PR DESCRIPTION
- Implemented user-created function calls.
- Converts the function calls independently of the order of the functions. Converts both:
```python
def Main(a: int, b: int) -> int:
    return Add(a, b)

def Add(a: int, b: int) -> int:
    return a + b
```
and
```python
def Add(a: int, b: int) -> int:
    return a + b

def Main(a: int, b: int) -> int:
    return Add(a, b)
```
- Raise a compiler error if there's no main method.