### PR TITLE
 Type check values in variable assignment

### DIFF
--- a/boa3/analyser/astanalyser.py
+++ b/boa3/analyser/astanalyser.py
@@ -6,6 +6,7 @@ from typing import List, Dict, Any, Optional
 from boa3.exception.CompilerError import CompilerError
 from boa3.exception.CompilerWarning import CompilerWarning
 from boa3.model.expression import IExpression
+from boa3.model.operation.operation import IOperation
 from boa3.model.symbol import ISymbol
 from boa3.model.type.itype import IType
 from boa3.model.type.type import Type
@@ -50,7 +51,7 @@ class IAstAnalyser(ABC, ast.NodeVisitor):
             if isinstance(fun_rtype_id, ast.Name):
                 fun_rtype_id = fun_rtype_id.id
 
-            if isinstance(fun_rtype_id, str):
+            if isinstance(fun_rtype_id, str) and not isinstance(value, ast.Str):
                 value = self.get_symbol(fun_rtype_id)
             else:
                 value = fun_rtype_id
@@ -59,6 +60,8 @@ class IAstAnalyser(ABC, ast.NodeVisitor):
             return value
         elif isinstance(value, IExpression):
             return value.type
+        elif isinstance(value, IOperation):
+            return value.result
         else:
             return Type.get_type(value)
 

--- a/boa3/model/variable.py
+++ b/boa3/model/variable.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from boa3.model.expression import IExpression
 from boa3.model.type.itype import IType
 
@@ -9,8 +11,8 @@ class Variable(IExpression):
     :ivar var_type: the type of the variable.
     """
 
-    def __init__(self, var_type: IType):
-        self.__var_type: IType = var_type
+    def __init__(self, var_type: Optional[IType]):
+        self.__var_type: Optional[IType] = var_type
 
     @property
     def shadowing_name(self) -> str:
@@ -19,3 +21,12 @@ class Variable(IExpression):
     @property
     def type(self) -> IType:
         return self.__var_type
+
+    def set_type(self, var_type: IType):
+        """
+        Sets a type for the variable if its type is not defined
+
+        :param var_type:
+        """
+        if self.__var_type is None:
+            self.__var_type = var_type

--- a/boa3_test/example/variable_test/MismatchedTypeAssignBinOp.py
+++ b/boa3_test/example/variable_test/MismatchedTypeAssignBinOp.py
@@ -1,0 +1,2 @@
+def Main():
+    a: str = 1 + 2

--- a/boa3_test/example/variable_test/MismatchedTypeAssignMixedOp.py
+++ b/boa3_test/example/variable_test/MismatchedTypeAssignMixedOp.py
@@ -1,0 +1,2 @@
+def Main(a: int, min: int, max: int):
+    b: int = min <= a - 2 <= max

--- a/boa3_test/example/variable_test/MismatchedTypeAssignSequenceGet.py
+++ b/boa3_test/example/variable_test/MismatchedTypeAssignSequenceGet.py
@@ -1,0 +1,2 @@
+def Main(a: Tuple[int]):
+    b: str = a[0]

--- a/boa3_test/example/variable_test/MismatchedTypeAssignSequenceSet.py
+++ b/boa3_test/example/variable_test/MismatchedTypeAssignSequenceSet.py
@@ -1,0 +1,2 @@
+def Main(a: Tuple[int]):
+    a[0] = '1'

--- a/boa3_test/example/variable_test/MismatchedTypeAssignUnOp.py
+++ b/boa3_test/example/variable_test/MismatchedTypeAssignUnOp.py
@@ -1,0 +1,2 @@
+def Main():
+    a: str = -5

--- a/boa3_test/example/variable_test/MismatchedTypeAssignValue.py
+++ b/boa3_test/example/variable_test/MismatchedTypeAssignValue.py
@@ -1,0 +1,2 @@
+def Main():
+    a: int = '1'

--- a/boa3_test/example/variable_test/MismatchedTypeAugAssign.py
+++ b/boa3_test/example/variable_test/MismatchedTypeAugAssign.py
@@ -1,0 +1,3 @@
+def Main():
+    a: int = 1
+    a += '2'

--- a/boa3_test/tests/boa_test.py
+++ b/boa3_test/tests/boa_test.py
@@ -27,6 +27,6 @@ class BoaTest(TestCase):
             except NotLoadedException:
                 # when an compiler error is logged this exception is raised.
                 pass
-        
+
         if len([exception for exception in log.records if isinstance(exception.msg, expected_logged_exception)]) <= 0:
             raise AssertionError('{0} not logged'.format(expected_logged_exception.__name__))

--- a/boa3_test/tests/test_for.py
+++ b/boa3_test/tests/test_for.py
@@ -65,7 +65,7 @@ class TestFor(BoaTest):
 
     def test_for_string_condition(self):
         path = '%s/boa3_test/example/for_test/StringCondition.py' % self.dirname
-        
+
         with self.assertRaises(NotImplementedError):
             output = Boa3.compile(path)
 
@@ -285,10 +285,5 @@ class TestFor(BoaTest):
 
         path = '%s/boa3_test/example/for_test/ForElse.py' % self.dirname
         output = Boa3.compile(path)
-
-        size = min(len(expected_output), len(output))
-        for x in range(0, size - 1):
-            if expected_output[x] != output[x]:
-                print(x, '\texpected: ', expected_output[x], '\tactual: ', output[x])
 
         self.assertEqual(expected_output, output)

--- a/boa3_test/tests/test_variable.py
+++ b/boa3_test/tests/test_variable.py
@@ -3,7 +3,7 @@ from typing import Dict
 
 from boa3.boa3 import Boa3
 from boa3.compiler.compiler import Compiler
-from boa3.exception.CompilerError import NotSupportedOperation, UnresolvedReference
+from boa3.exception.CompilerError import NotSupportedOperation, UnresolvedReference, MismatchedTypes
 from boa3.model.method import Method
 from boa3.model.symbol import ISymbol
 from boa3.model.variable import Variable
@@ -189,3 +189,31 @@ class TestVariable(BoaTest):
     def test_return_undeclared_variable(self):
         path = '%s/boa3_test/example/variable_test/ReturnUndeclaredVariable.py' % self.dirname
         self.assertCompilerLogs(UnresolvedReference, path)
+
+    def test_assign_value_mismatched_type(self):
+        path = '%s/boa3_test/example/variable_test/MismatchedTypeAssignValue.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_assign_binary_operation_mismatched_type(self):
+        path = '%s/boa3_test/example/variable_test/MismatchedTypeAssignBinOp.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_assign_unary_operation_mismatched_type(self):
+        path = '%s/boa3_test/example/variable_test/MismatchedTypeAssignUnOp.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_assign_mixed_operations_mismatched_type(self):
+        path = '%s/boa3_test/example/variable_test/MismatchedTypeAssignMixedOp.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_assign_sequence_get_mismatched_type(self):
+        path = '%s/boa3_test/example/variable_test/MismatchedTypeAssignSequenceGet.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_assign_sequence_set_mismatched_type(self):
+        path = '%s/boa3_test/example/variable_test/MismatchedTypeAssignSequenceSet.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_aug_assign_mismatched_type(self):
+        path = '%s/boa3_test/example/variable_test/MismatchedTypeAugAssign.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)


### PR DESCRIPTION
- Implemented type checking on variables assignments.
Since Neo VM is based on C#, some opcodes only work with specific types. For preventing weird behavior, neo-boa checks variable types on compile-time.
Because of this, the type of a variable can't be changed once defined, unlike standard Python.
- Variable declarations without type hint are only allowed if it is an assignment. In this case, the variable type will be the same as the assigned value type.