### PR TITLE
Convert multiple expressions in same line

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ def foo(num: int) -> int
 
 - Converts `len()` for `str` and `tuple`
 
+- Converts Multiple Expressions in the same line (`i = i + h; a = 1; b = 3 + a; count = 0`)
+
 #### What it will do...
 
 - `continue`, `break` and `pass`
@@ -97,5 +99,3 @@ def foo(num: int) -> int
 - Convert List type
 
 - Convert String Slicing (`x = 'example'[2:4]`, `x = 'example'[:4]`, `x = 'example'[4:]`, `x = 'example'[:]`, `x = 'example'[2:4:2]`, `x = 'example'[::2]`)
-
-- Convert Multiple Expressions in the same line (`i = i + h; a = 1; b = 3 + a; count = 0`)

--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -198,13 +198,11 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
             self._log_error(
                 CompilerError.NotSupportedOperation(assign.lineno, assign.col_offset, 'Multiple variable assignments')
             )
-
         # multiple assignments with tuples
         elif isinstance(assign.targets[0], ast.Tuple):
             self._log_error(
                 CompilerError.NotSupportedOperation(assign.lineno, assign.col_offset, 'Multiple variable assignments')
             )
-
         else:
             self.validate_type_variable_assign(assign.targets[0], assign.value)
 

--- a/boa3_test/example/arithmetic_test/MultipleExpressionsInLine.py
+++ b/boa3_test/example/arithmetic_test/MultipleExpressionsInLine.py
@@ -1,0 +1,3 @@
+def Main(a: int, b: int) -> int:
+    d = 1; e = 2; c = a + b
+    return c

--- a/boa3_test/example/list_test/MultipleExpressionsInLine.py
+++ b/boa3_test/example/list_test/MultipleExpressionsInLine.py
@@ -1,0 +1,3 @@
+def Main(items1: List[int]) -> int:
+    items2 = [False, '1', 2, 3, '4']; value = items1[0]; count = value + len(items2)
+    return count

--- a/boa3_test/example/logical_test/MultipleExpressionsInLine.py
+++ b/boa3_test/example/logical_test/MultipleExpressionsInLine.py
@@ -1,0 +1,3 @@
+def Main(a: bool, b: bool, c: bool) -> bool:
+    a1 = a and b; b1 = b and c; c1 = a or c
+    return a1 and not b1 and c1

--- a/boa3_test/example/relational_test/MultipleExpressionsInLine.py
+++ b/boa3_test/example/relational_test/MultipleExpressionsInLine.py
@@ -1,0 +1,3 @@
+def Main(a: int, b: int) -> bool:
+    is_equal = a == b; is_greater = a > b; is_less = a < b
+    return not is_equal

--- a/boa3_test/example/tuple_test/MultipleExpressionsInLine.py
+++ b/boa3_test/example/tuple_test/MultipleExpressionsInLine.py
@@ -1,0 +1,3 @@
+def Main(items1: Tuple[int]) -> int:
+    items2 = ('a', 'b', 'c', 'd'); value = items1[0]; count = value + len(items2)
+    return count

--- a/boa3_test/tests/test_multiple_expressions.py
+++ b/boa3_test/tests/test_multiple_expressions.py
@@ -1,0 +1,164 @@
+from boa3.boa3 import Boa3
+from boa3.exception.CompilerError import MismatchedTypes, TypeHintMissing, TooManyReturns
+from boa3.neo.vm.opcode.Opcode import Opcode
+from boa3.neo.vm.type.Integer import Integer
+from boa3.neo.vm.type.String import String
+from boa3_test.tests.boa_test import BoaTest
+
+
+class TestMultipleExpressions(BoaTest):
+
+    def test_multiple_arithmetic_expressions(self):
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x03'
+            + b'\x02'
+            + Opcode.PUSH1      # d = 1
+            + Opcode.STLOC0
+            + Opcode.PUSH2      # e = 2
+            + Opcode.STLOC1
+            + Opcode.LDARG0     # c = a + b
+            + Opcode.LDARG1
+            + Opcode.ADD
+            + Opcode.STLOC2
+            + Opcode.LDLOC2     # return c
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/arithmetic_test/MultipleExpressionsInLine.py' % self.dirname
+        output = Boa3.compile(path)
+
+        self.assertEqual(expected_output, output)
+
+    def test_multiple_relational_expressions(self):
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x03'
+            + b'\x02'
+            + Opcode.LDARG0     # is_equal = a == b
+            + Opcode.LDARG1
+            + Opcode.NUMEQUAL
+            + Opcode.STLOC0
+            + Opcode.LDARG0     # is_greater = a > b
+            + Opcode.LDARG1
+            + Opcode.GT
+            + Opcode.STLOC1
+            + Opcode.LDARG0     # is_less = a < b
+            + Opcode.LDARG1
+            + Opcode.LT
+            + Opcode.STLOC2
+            + Opcode.LDLOC0     # return not is_equal
+            + Opcode.NOT
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/relational_test/MultipleExpressionsInLine.py' % self.dirname
+        output = Boa3.compile(path)
+
+        self.assertEqual(expected_output, output)
+
+    def test_multiple_logic_expressions(self):
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x03'
+            + b'\x03'
+            + Opcode.LDARG0     # a1 = a and b
+            + Opcode.LDARG1
+            + Opcode.BOOLAND
+            + Opcode.STLOC0
+            + Opcode.LDARG1     # b1 = b and c
+            + Opcode.LDARG2
+            + Opcode.BOOLAND
+            + Opcode.STLOC1
+            + Opcode.LDARG0     # c1 = a or c
+            + Opcode.LDARG2
+            + Opcode.BOOLOR
+            + Opcode.STLOC2
+            + Opcode.LDLOC0     # return a1 and not b1 and c1
+            + Opcode.LDLOC1
+            + Opcode.NOT
+            + Opcode.BOOLAND
+            + Opcode.LDLOC2
+            + Opcode.BOOLAND
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/logical_test/MultipleExpressionsInLine.py' % self.dirname
+        output = Boa3.compile(path)
+
+        self.assertEqual(expected_output, output)
+
+    def test_multiple_tuple_expressions(self):
+        a = String('a').to_bytes()
+        b = String('b').to_bytes()
+        c = String('c').to_bytes()
+        d = String('d').to_bytes()
+
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x03'
+            + b'\x01'
+            + Opcode.PUSHDATA1  # items2 = ('a', 'b', 'c', 'd')
+            + Integer(len(d)).to_byte_array() + d
+            + Opcode.PUSHDATA1
+            + Integer(len(c)).to_byte_array() + c
+            + Opcode.PUSHDATA1
+            + Integer(len(b)).to_byte_array() + b
+            + Opcode.PUSHDATA1
+            + Integer(len(a)).to_byte_array() + a
+            + Opcode.PUSH4
+            + Opcode.PACK
+            + Opcode.STLOC0     # items2 = array
+            + Opcode.LDARG0     # value = items1[0]
+            + Opcode.PUSH0
+            + Opcode.PICKITEM
+            + Opcode.STLOC1
+            + Opcode.LDLOC1     # count = value + len(items2)
+            + Opcode.LDLOC0
+            + Opcode.SIZE
+            + Opcode.ADD
+            + Opcode.STLOC2
+            + Opcode.LDLOC2     # return count
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/tuple_test/MultipleExpressionsInLine.py' % self.dirname
+        output = Boa3.compile(path)
+
+        self.assertEqual(expected_output, output)
+
+    def test_multiple_list_expressions(self):
+        one = String('1').to_bytes()
+        four = String('4').to_bytes()
+
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x03'
+            + b'\x01'
+            + Opcode.PUSHDATA1  # items2 = [False, '1', 2, 3, '4']
+            + Integer(len(four)).to_byte_array() + four
+            + Opcode.PUSH3
+            + Opcode.PUSH2
+            + Opcode.PUSHDATA1
+            + Integer(len(one)).to_byte_array() + one
+            + Opcode.PUSH0
+            + Opcode.PUSH5
+            + Opcode.PACK
+            + Opcode.STLOC0     # items2 = array
+            + Opcode.LDARG0     # value = items1[0]
+            + Opcode.PUSH0
+            + Opcode.PICKITEM
+            + Opcode.STLOC1
+            + Opcode.LDLOC1     # count = value + len(items2)
+            + Opcode.LDLOC0
+            + Opcode.SIZE
+            + Opcode.ADD
+            + Opcode.STLOC2
+            + Opcode.LDLOC2     # return count
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/list_test/MultipleExpressionsInLine.py' % self.dirname
+        output = Boa3.compile(path)
+
+        self.assertEqual(expected_output, output)


### PR DESCRIPTION
Because of the way the Python abstract syntax tree is built, multiple expressions written in the same line were already converted correctly.
I included some unit tests to make sure that the expressions in the same line are working as expected.