### PR TITLE
Implement Any type

### DIFF
--- a/boa3/analyser/astanalyser.py
+++ b/boa3/analyser/astanalyser.py
@@ -31,12 +31,16 @@ class IAstAnalyser(ABC, ast.NodeVisitor):
         return len(self.errors) > 0
 
     def _log_error(self, error: CompilerError):
-        self.errors.append(error)
-        logging.error(error)
+        if not any(err.message == error.message for err in self.errors):
+            # don't include duplicated errors
+            self.errors.append(error)
+            logging.error(error)
 
     def _log_warning(self, warning: CompilerWarning):
-        self.warnings.append(warning)
-        logging.warning(warning)
+        if not any(warn.message == warning.message for warn in self.errors):
+            # don't include duplicated warnings
+            self.warnings.append(warning)
+            logging.warning(warning)
 
     def get_type(self, value: Any) -> IType:
         """

--- a/boa3/analyser/constructanalyser.py
+++ b/boa3/analyser/constructanalyser.py
@@ -3,7 +3,6 @@ from typing import Optional, Union, Sequence, List
 
 from boa3 import helpers
 from boa3.analyser.astanalyser import IAstAnalyser
-from boa3.exception.CompilerError import CompilerError as Error
 from boa3.model.symbol import ISymbol
 
 

--- a/boa3/model/type/anytype.py
+++ b/boa3/model/type/anytype.py
@@ -1,0 +1,30 @@
+from typing import Any
+
+from boa3.model.type.itype import IType
+from boa3.neo.vm.type.AbiType import AbiType
+
+
+class __AnyType(IType):
+    """
+    A class used to represent Python bool type
+    """
+
+    def __init__(self):
+        identifier = 'any'
+        super().__init__(identifier)
+
+    @property
+    def abi_type(self) -> AbiType:
+        return AbiType.Any
+
+    @classmethod
+    def build(cls, value: Any):
+        from boa3.model.type.type import Type
+        return Type.any
+
+    @classmethod
+    def _is_type_of(cls, value: Any):
+        return True
+
+
+anyType: IType = __AnyType()

--- a/boa3/model/type/genericsequencetype.py
+++ b/boa3/model/type/genericsequencetype.py
@@ -10,7 +10,7 @@ class GenericSequenceType(SequenceType):
     An class used to represent a generic Python sequence type
     """
 
-    def __init__(self, values_type: List[IType]):
+    def __init__(self, values_type: List[IType] = None):
         identifier: str = 'sequence'
         values_type = self.filter_types(values_type)
         super().__init__(identifier, values_type)
@@ -38,4 +38,4 @@ class GenericSequenceType(SequenceType):
         return isinstance(value, SequenceType)
 
     def __hash__(self):
-        return hash(self.identifier + self.value_type.identifier)
+        return hash(self.identifier)

--- a/boa3/model/type/listtype.py
+++ b/boa3/model/type/listtype.py
@@ -43,4 +43,4 @@ class ListType(SequenceType):
         return self.value_type == other.value_type
 
     def __hash__(self):
-        return hash(self.identifier + self.value_type.identifier)
+        return hash(self.identifier)

--- a/boa3/model/type/tupletype.py
+++ b/boa3/model/type/tupletype.py
@@ -43,4 +43,4 @@ class TupleType(SequenceType):
         return self.value_type == other.value_type
 
     def __hash__(self):
-        return hash(self.identifier + self.value_type.identifier)
+        return hash(self.identifier)

--- a/boa3/model/type/type.py
+++ b/boa3/model/type/type.py
@@ -1,5 +1,6 @@
 from typing import Dict, Any
 
+from boa3.model.type.anytype import anyType
 from boa3.model.type.booltype import BoolType
 from boa3.model.type.genericsequencetype import GenericSequenceType
 from boa3.model.type.inttype import IntType
@@ -42,8 +43,9 @@ class Type:
     bool = BoolType()
     str = StrType()
     none = NoneType()
-    tuple = TupleType(none)
-    list = ListType(none)
+    tuple = TupleType()
+    list = ListType()
 
     # Generic types
-    sequence = GenericSequenceType(none)
+    sequence = GenericSequenceType()
+    any = anyType

--- a/boa3_test/example/any_test/AnyList.py
+++ b/boa3_test/example/any_test/AnyList.py
@@ -1,0 +1,2 @@
+def Main():
+    a: List[Any] = [True, 1, 'ok']

--- a/boa3_test/example/any_test/AnySequenceAssignments.py
+++ b/boa3_test/example/any_test/AnySequenceAssignments.py
@@ -1,0 +1,12 @@
+def Main():
+    any_list = [True, 1, 'ok']
+    int_list = [1, 2, 3]
+    any_tuple = (True, 1, 'ok')
+    bool_tuple = True, False
+
+    a: Sequence[Any]
+    a = any_list
+    a = any_tuple
+    a = 'some_string'
+    a = int_list
+    a = bool_tuple

--- a/boa3_test/example/any_test/AnyTuple.py
+++ b/boa3_test/example/any_test/AnyTuple.py
@@ -1,0 +1,2 @@
+def Main():
+    a: Tuple[Any] = (True, 1, 'ok')

--- a/boa3_test/example/any_test/AnyVariableAssignments.py
+++ b/boa3_test/example/any_test/AnyVariableAssignments.py
@@ -1,0 +1,5 @@
+def Main():
+    a: Any = 1
+    a = '2'
+    a = True
+    a = [1, 2, 3]

--- a/boa3_test/example/any_test/FunctionAnyParam.py
+++ b/boa3_test/example/any_test/FunctionAnyParam.py
@@ -1,0 +1,12 @@
+def Main():
+    bool_tuple = True, False
+
+    SequenceFunction(bool_tuple)
+    SequenceFunction([True, 1, 'ok'])
+    SequenceFunction('some_string')
+    SequenceFunction((True, 1, 'ok'))
+    SequenceFunction([1, 2, 3])
+
+
+def SequenceFunction(sequence: Sequence[Any]):
+    a = sequence

--- a/boa3_test/example/any_test/IntSequenceAnyAssignment.py
+++ b/boa3_test/example/any_test/IntSequenceAnyAssignment.py
@@ -1,0 +1,3 @@
+def Main():
+    any_list = [True, 1, 'ok']
+    int_sequence: Sequence[int] = any_list

--- a/boa3_test/example/any_test/OperationWithAny.py
+++ b/boa3_test/example/any_test/OperationWithAny.py
@@ -1,0 +1,3 @@
+def Main():
+    a: Any = 5
+    b = 3 + a

--- a/boa3_test/example/any_test/SequenceOfAnyIntSequence.py
+++ b/boa3_test/example/any_test/SequenceOfAnyIntSequence.py
@@ -1,0 +1,6 @@
+def Main():
+    int_list = [1, 2, 3]
+    any_tuple = (True, 1, 'ok')
+    int_tuple = 10, 9, 8
+
+    a: Sequence[Sequence[int]] = [int_list, any_tuple, int_tuple]

--- a/boa3_test/example/any_test/SequenceOfAnySequence.py
+++ b/boa3_test/example/any_test/SequenceOfAnySequence.py
@@ -1,0 +1,7 @@
+def Main():
+    any_list = [True, 1, 'ok']
+    int_list = [1, 2, 3]
+    any_tuple = (True, 1, 'ok')
+    bool_tuple = True, False
+
+    a: Sequence[Sequence[Any]] = [any_list, int_list, any_tuple, bool_tuple]

--- a/boa3_test/example/any_test/SequenceOfIntSequence.py
+++ b/boa3_test/example/any_test/SequenceOfIntSequence.py
@@ -1,0 +1,5 @@
+def Main():
+    int_list = [1, 2, 3]
+    int_tuple = 10, 9, 8
+
+    a: Sequence[Sequence[int]] = [int_list, int_tuple]

--- a/boa3_test/example/any_test/StrSequenceAnyAssignment.py
+++ b/boa3_test/example/any_test/StrSequenceAnyAssignment.py
@@ -1,0 +1,3 @@
+def Main():
+    any_tuple = (True, 1, 'ok')
+    str_sequence: Sequence[str] = any_tuple

--- a/boa3_test/example/any_test/StrSequenceStrAssignment.py
+++ b/boa3_test/example/any_test/StrSequenceStrAssignment.py
@@ -1,0 +1,2 @@
+def Main():
+    str_sequence: Sequence[str] = 'some_string'

--- a/boa3_test/example/any_test/VariableAssignmentWithAny.py
+++ b/boa3_test/example/any_test/VariableAssignmentWithAny.py
@@ -1,0 +1,3 @@
+def Main(arg: Any):
+    a: int = 1
+    a = arg

--- a/boa3_test/example/list_test/Nep5Main.py
+++ b/boa3_test/example/list_test/Nep5Main.py
@@ -1,2 +1,2 @@
-def Main(operation: str, args: List[int]) -> int:
+def Main(operation: str, args: List[Any]) -> Any:
     return args[0]

--- a/boa3_test/example/tuple_test/Nep5Main.py
+++ b/boa3_test/example/tuple_test/Nep5Main.py
@@ -1,2 +1,2 @@
-def Main(operation: str, args: Tuple[int]) -> int:
+def Main(operation: str, args: Tuple[Any]) -> Any:
     return args[0]

--- a/boa3_test/tests/test_any.py
+++ b/boa3_test/tests/test_any.py
@@ -1,0 +1,295 @@
+from boa3.boa3 import Boa3
+from boa3.exception.CompilerError import MismatchedTypes
+from boa3.neo.vm.opcode.Opcode import Opcode
+from boa3.neo.vm.type.Integer import Integer
+from boa3.neo.vm.type.String import String
+from boa3_test.tests.boa_test import BoaTest
+
+
+class TestAny(BoaTest):
+
+    def test_any_variable_assignments(self):
+        two = String('2').to_bytes()
+        path = '%s/boa3_test/example/any_test/AnyVariableAssignments.py' % self.dirname
+
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x01'
+            + b'\x00'
+            + Opcode.PUSH1      # a = 1
+            + Opcode.STLOC0
+            + Opcode.PUSHDATA1  # a = '2'
+            + Integer(len(two)).to_byte_array() + two
+            + Opcode.STLOC0
+            + Opcode.PUSH1      # a = True
+            + Opcode.STLOC0
+            + Opcode.PUSH3      # a = [1, 2, 3]
+            + Opcode.PUSH2
+            + Opcode.PUSH1
+            + Opcode.PUSH3
+            + Opcode.PACK
+            + Opcode.STLOC0
+            + Opcode.RET        # return
+        )
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_variable_assignment_with_any(self):
+        path = '%s/boa3_test/example/any_test/VariableAssignmentWithAny.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_any_list(self):
+        ok = String('ok').to_bytes()
+        path = '%s/boa3_test/example/any_test/AnyList.py' % self.dirname
+
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x01'
+            + b'\x00'
+            + Opcode.PUSHDATA1  # a = [True, 1, 'ok']
+            + Integer(len(ok)).to_byte_array() + ok
+            + Opcode.PUSH1
+            + Opcode.PUSH1
+            + Opcode.PUSH3
+            + Opcode.PACK
+            + Opcode.STLOC0
+            + Opcode.RET        # return
+        )
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_any_tuple(self):
+        ok = String('ok').to_bytes()
+        path = '%s/boa3_test/example/any_test/AnyTuple.py' % self.dirname
+
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x01'
+            + b'\x00'
+            + Opcode.PUSHDATA1  # a = [True, 1, 'ok']
+            + Integer(len(ok)).to_byte_array() + ok
+            + Opcode.PUSH1
+            + Opcode.PUSH1
+            + Opcode.PUSH3
+            + Opcode.PACK
+            + Opcode.STLOC0
+            + Opcode.RET        # return
+        )
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_any_operation(self):
+        path = '%s/boa3_test/example/any_test/OperationWithAny.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_function_any_param(self):
+        ok = String('ok').to_bytes()
+        some_string = String('some_string').to_bytes()
+
+        expected_output = (
+            Opcode.INITSLOT   # Main
+            + b'\x01'
+            + b'\x00'
+            + Opcode.PUSH0          # bool_tuple = True, False
+            + Opcode.PUSH1
+            + Opcode.PUSH2
+            + Opcode.PACK
+            + Opcode.STLOC0
+            + Opcode.LDLOC0         # SequenceFunction(bool_tuple)
+            + Opcode.CALL
+            + Integer(45).to_byte_array(min_length=1, signed=True)
+            + Opcode.PUSHDATA1      # SequenceFunction([True, 1, 'ok'])
+            + Integer(len(ok)).to_byte_array() + ok
+            + Opcode.PUSH1
+            + Opcode.PUSH1
+            + Opcode.PUSH3
+            + Opcode.PACK
+            + Opcode.CALL
+            + Integer(35).to_byte_array(min_length=1, signed=True)
+            + Opcode.PUSHDATA1      # SequenceFunction('some_string')
+            + Integer(len(some_string)).to_byte_array()
+            + some_string
+            + Opcode.CALL
+            + Integer(20).to_byte_array(min_length=1, signed=True)
+            + Opcode.PUSHDATA1      # SequenceFunction((True, 1, 'ok'))
+            + Integer(len(ok)).to_byte_array() + ok
+            + Opcode.PUSH1
+            + Opcode.PUSH1
+            + Opcode.PUSH3
+            + Opcode.PACK
+            + Opcode.CALL
+            + Integer(10).to_byte_array(min_length=1, signed=True)
+            + Opcode.PUSH3          # SequenceFunction([1, 2, 3])
+            + Opcode.PUSH2
+            + Opcode.PUSH1
+            + Opcode.PUSH3
+            + Opcode.PACK
+            + Opcode.CALL
+            + Integer(3).to_byte_array(min_length=1, signed=True)
+            + Opcode.RET        # return
+            + Opcode.INITSLOT   # SequenceFunction
+            + b'\x01'
+            + b'\x01'
+            + Opcode.LDARG0         # a = sequence
+            + Opcode.STLOC0
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/any_test/FunctionAnyParam.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_any_sequence_assignments(self):
+        ok = String('ok').to_bytes()
+        some_string = String('some_string').to_bytes()
+
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x05'
+            + b'\x00'
+            + Opcode.PUSHDATA1  # any_list = [True, 1, 'ok']
+            + Integer(len(ok)).to_byte_array() + ok
+            + Opcode.PUSH1
+            + Opcode.PUSH1
+            + Opcode.PUSH3
+            + Opcode.PACK
+            + Opcode.STLOC0
+            + Opcode.PUSH3      # int_list = [1, 2, 3]
+            + Opcode.PUSH2
+            + Opcode.PUSH1
+            + Opcode.PUSH3
+            + Opcode.PACK
+            + Opcode.STLOC1
+            + Opcode.PUSHDATA1  # any_tuple = (True, 1, 'ok')
+            + Integer(len(ok)).to_byte_array() + ok
+            + Opcode.PUSH1
+            + Opcode.PUSH1
+            + Opcode.PUSH3
+            + Opcode.PACK
+            + Opcode.STLOC2
+            + Opcode.PUSH0      # bool_tuple = True, False
+            + Opcode.PUSH1
+            + Opcode.PUSH2
+            + Opcode.PACK
+            + Opcode.STLOC3
+            + Opcode.LDLOC0     # a = any_list
+            + Opcode.STLOC4
+            + Opcode.LDLOC2     # a = any_tuple
+            + Opcode.STLOC4
+            + Opcode.PUSHDATA1  # a = 'some_string'
+            + Integer(len(some_string)).to_byte_array() + some_string
+            + Opcode.STLOC4
+            + Opcode.LDLOC1     # a = int_list
+            + Opcode.STLOC4
+            + Opcode.LDLOC3     # a = bool_tuple
+            + Opcode.STLOC4
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/any_test/AnySequenceAssignments.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_int_sequence_any_assignments(self):
+        path = '%s/boa3_test/example/any_test/IntSequenceAnyAssignment.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_str_sequence_any_assignments(self):
+        path = '%s/boa3_test/example/any_test/StrSequenceAnyAssignment.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_str_sequence_str_assignment(self):
+        some_string = String('some_string').to_bytes()
+
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x01'
+            + b'\x00'
+            + Opcode.PUSHDATA1  # str_sequence = 'some_string'
+            + Integer(len(some_string)).to_byte_array() + some_string
+            + Opcode.STLOC0
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/any_test/StrSequenceStrAssignment.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_sequence_of_any_sequence(self):
+        ok = String('ok').to_bytes()
+
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x05'
+            + b'\x00'
+            + Opcode.PUSHDATA1  # any_list = [True, 1, 'ok']
+            + Integer(len(ok)).to_byte_array() + ok
+            + Opcode.PUSH1
+            + Opcode.PUSH1
+            + Opcode.PUSH3
+            + Opcode.PACK
+            + Opcode.STLOC0
+            + Opcode.PUSH3      # int_list = [1, 2, 3]
+            + Opcode.PUSH2
+            + Opcode.PUSH1
+            + Opcode.PUSH3
+            + Opcode.PACK
+            + Opcode.STLOC1
+            + Opcode.PUSHDATA1  # any_tuple = (True, 1, 'ok')
+            + Integer(len(ok)).to_byte_array() + ok
+            + Opcode.PUSH1
+            + Opcode.PUSH1
+            + Opcode.PUSH3
+            + Opcode.PACK
+            + Opcode.STLOC2
+            + Opcode.PUSH0      # bool_tuple = True, False
+            + Opcode.PUSH1
+            + Opcode.PUSH2
+            + Opcode.PACK
+            + Opcode.STLOC3
+            + Opcode.LDLOC3     # a = [any_list, int_list, any_tuple, bool_tuple]
+            + Opcode.LDLOC2
+            + Opcode.LDLOC1
+            + Opcode.LDLOC0
+            + Opcode.PUSH4
+            + Opcode.PACK
+            + Opcode.STLOC4
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/any_test/SequenceOfAnySequence.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_sequence_of_int_sequence_success(self):
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x03'
+            + b'\x00'
+            + Opcode.PUSH3      # int_list = [1, 2, 3]
+            + Opcode.PUSH2
+            + Opcode.PUSH1
+            + Opcode.PUSH3
+            + Opcode.PACK
+            + Opcode.STLOC0
+            + Opcode.PUSH8      # int_tuple = 10, 9, 8
+            + Opcode.PUSH9
+            + Opcode.PUSH10
+            + Opcode.PUSH3
+            + Opcode.PACK
+            + Opcode.STLOC1
+            + Opcode.LDLOC1     # a = [int_list, int_tuple]
+            + Opcode.LDLOC0
+            + Opcode.PUSH2
+            + Opcode.PACK
+            + Opcode.STLOC2
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/any_test/SequenceOfIntSequence.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_sequence_of_int_sequence_fail(self):
+        path = '%s/boa3_test/example/any_test/SequenceOfAnyIntSequence.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)

--- a/boa3_test/tests/test_types.py
+++ b/boa3_test/tests/test_types.py
@@ -82,7 +82,7 @@ class TestTypes(BoaTest):
     def test_any_tuple_constant(self):
         input = (1, '2', False)
         node = ast.parse(str(input)).body[0].value
-        expected_output = TupleType(Type.none)  # TODO: change to any when implemented
+        expected_output = TupleType(Type.any)
 
         typeanalyser = TypeAnalyser(node, {})
         output = typeanalyser.get_type(input)
@@ -122,7 +122,7 @@ class TestTypes(BoaTest):
     def test_any_list_constant(self):
         input = [1, '2', False]
         node = ast.parse(str(input)).body[0].value
-        expected_output = ListType(Type.none)  # TODO: change to any when implemented
+        expected_output = ListType(Type.any)
 
         typeanalyser = TypeAnalyser(node, {})
         output = typeanalyser.get_type(input)


### PR DESCRIPTION
Included `Any` type to identify which variables can be assigned to multiple values or if a function returns different type values.
In the current implementation of neo-boa, the following statement would cause a compiler error:
```python
a = 1
a = '2'  # raises an error
```
because the variable type is defined as the type of the first value assigned to it. In this case, the type of `a` is `int` and the error occurs when a non-`int` value is assigned to this variable.
But if the variable is explicitly defined with `Any` type, both assignments are allowed:
```python
a: Any = 1
a = '2'  # it doesn't raise an error
```
Currently, `Any` values cannot be used with typed operations without casting.
Type casting is not implemented yet.