### PR TITLE
Convert None type

### DIFF
--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -309,6 +309,7 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
                     type_id=symbol_type.identifier,
                     operation_id=Operator.Subscript)
             )
+            return symbol_type
         # the sequence can't use the given type as index
         elif not symbol_type.is_valid_key(index_type):
             self._log_error(
@@ -498,7 +499,7 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
             bin_op.op = operation
             return operation.result
 
-    def validate_binary_operation(self, node: ast.AST, left_op: ast.AST, right_op: ast.AST) -> Optional[BinaryOperation]:
+    def validate_binary_operation(self, node: ast.AST, left_op: ast.AST, right_op: ast.AST) -> Optional[IOperation]:
         """
         Validates a ast node that represents a binary operation
 
@@ -521,7 +522,7 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
             )
 
         try:
-            operation: BinaryOperation = self.get_bin_op(operator, r_operand, l_operand)
+            operation: IOperation = self.get_bin_op(operator, r_operand, l_operand)
             if operation is None:
                 self._log_error(
                     CompilerError.NotSupportedOperation(node.lineno, node.col_offset, operator)
@@ -540,7 +541,7 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
             # raises the exception with the line/col info
             self._log_error(raised_error)
 
-    def get_bin_op(self, operator: Operator, right: Any, left: Any) -> BinaryOperation:
+    def get_bin_op(self, operator: Operator, right: Any, left: Any) -> IOperation:
         """
         Returns the binary operation specified by the operator and the types of the operands
 
@@ -555,7 +556,7 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
         r_type: IType = self.get_type(right)
 
         actual_types = (l_type.identifier, r_type.identifier)
-        operation: BinaryOperation = BinaryOp.validate_type(operator, l_type, r_type)
+        operation: IOperation = BinaryOp.validate_type(operator, l_type, r_type)
 
         if operation is not None:
             return operation
@@ -659,7 +660,7 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
                         CompilerError.UnresolvedReference(line, col, type(op).__name__)
                     )
 
-                operation: BinaryOperation = self.get_bin_op(operator, r_operand, l_operand)
+                operation: IOperation = self.get_bin_op(operator, r_operand, l_operand)
                 if operation is None:
                     self._log_error(
                         CompilerError.NotSupportedOperation(line, col, operator)
@@ -698,7 +699,7 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
         col_offset: int = bool_op.col_offset
         try:
             return_type: IType = None
-            bool_operation: BinaryOperation = None
+            bool_operation: IOperation = None
             operator: Operator = self.get_operator(bool_op.op)
 
             if not isinstance(operator, Operator):
@@ -711,7 +712,7 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
             for index, operand in enumerate(bool_op.values[1:]):
                 r_operand = self.visit(operand)
 
-                operation: BinaryOperation = self.get_bin_op(operator, r_operand, l_operand)
+                operation: IOperation = self.get_bin_op(operator, r_operand, l_operand)
                 if operation is None:
                     self._log_error(
                         CompilerError.NotSupportedOperation(lineno, col_offset, operator)

--- a/boa3/compiler/codegenerator.py
+++ b/boa3/compiler/codegenerator.py
@@ -282,6 +282,8 @@ class CodeGenerator:
             self.convert_integer_literal(value)
         elif isinstance(value, str):
             self.convert_string_literal(value)
+        elif value is None:
+            self.insert_none()
         else:
             # TODO: convert other python literals as they are implemented
             raise NotImplementedError
@@ -344,6 +346,13 @@ class CodeGenerator:
         data = Integer(data_len).to_byte_array(min_length=op_info.data_len) + array
         self.__insert1(op_info, data)
         self._stack.append(Type.none)  # TODO: change to bytearray when implemented
+
+    def insert_none(self):
+        """
+        Converts None literal
+        """
+        self.__insert1(OpcodeInfo.PUSHNULL)
+        self._stack.append(Type.none)
 
     def convert_new_empty_array(self, length: int, array_type: IType):
         """
@@ -560,13 +569,11 @@ class CodeGenerator:
 
         :param operation: the operation that will be converted
         """
-        opcode: Opcode = operation.opcode
-
-        if opcode is not None:
+        for opcode in operation.opcode:
             op_info: OpcodeInformation = OpcodeInfo.get_info(opcode)
             self.__insert1(op_info)
 
-        for op in range(0, operation.number_of_operands):
+        for op in range(0, operation.op_on_stack):
             self._stack.pop()
         self._stack.append(operation.result)
 

--- a/boa3/model/operation/binary/arithmetic/addition.py
+++ b/boa3/model/operation/binary/arithmetic/addition.py
@@ -38,5 +38,5 @@ class Addition(BinaryOperation):
             return Type.none
 
     @property
-    def opcode(self) -> Optional[Opcode]:
-        return Opcode.ADD
+    def opcode(self) -> List[Opcode]:
+        return [Opcode.ADD]

--- a/boa3/model/operation/binary/arithmetic/concat.py
+++ b/boa3/model/operation/binary/arithmetic/concat.py
@@ -36,8 +36,8 @@ class Concat(BinaryOperation):
             return Type.none
 
     @property
-    def opcode(self) -> Optional[Opcode]:
-        return Opcode.CAT
+    def opcode(self) -> List[Opcode]:
+        return [Opcode.CAT]
 
     @property
     def is_supported(self) -> bool:

--- a/boa3/model/operation/binary/arithmetic/floordivision.py
+++ b/boa3/model/operation/binary/arithmetic/floordivision.py
@@ -38,5 +38,5 @@ class FloorDivision(BinaryOperation):
             return Type.none
 
     @property
-    def opcode(self) -> Optional[Opcode]:
-        return Opcode.DIV
+    def opcode(self) -> List[Opcode]:
+        return [Opcode.DIV]

--- a/boa3/model/operation/binary/arithmetic/modulo.py
+++ b/boa3/model/operation/binary/arithmetic/modulo.py
@@ -38,5 +38,5 @@ class Modulo(BinaryOperation):
             return Type.none
 
     @property
-    def opcode(self) -> Optional[Opcode]:
-        return Opcode.MOD
+    def opcode(self) -> List[Opcode]:
+        return [Opcode.MOD]

--- a/boa3/model/operation/binary/arithmetic/multiplication.py
+++ b/boa3/model/operation/binary/arithmetic/multiplication.py
@@ -38,5 +38,5 @@ class Multiplication(BinaryOperation):
             return Type.none
 
     @property
-    def opcode(self) -> Optional[Opcode]:
-        return Opcode.MUL
+    def opcode(self) -> List[Opcode]:
+        return [Opcode.MUL]

--- a/boa3/model/operation/binary/arithmetic/subtraction.py
+++ b/boa3/model/operation/binary/arithmetic/subtraction.py
@@ -38,5 +38,5 @@ class Subtraction(BinaryOperation):
             return Type.none
 
     @property
-    def opcode(self) -> Optional[Opcode]:
-        return Opcode.SUB
+    def opcode(self) -> List[Opcode]:
+        return [Opcode.SUB]

--- a/boa3/model/operation/binary/logical/booleanand.py
+++ b/boa3/model/operation/binary/logical/booleanand.py
@@ -37,5 +37,5 @@ class BooleanAnd(BinaryOperation):
             return Type.none
 
     @property
-    def opcode(self) -> Optional[Opcode]:
-        return Opcode.BOOLAND
+    def opcode(self) -> List[Opcode]:
+        return [Opcode.BOOLAND]

--- a/boa3/model/operation/binary/logical/booleanor.py
+++ b/boa3/model/operation/binary/logical/booleanor.py
@@ -37,5 +37,5 @@ class BooleanOr(BinaryOperation):
             return Type.none
 
     @property
-    def opcode(self) -> Optional[Opcode]:
-        return Opcode.BOOLOR
+    def opcode(self) -> List[Opcode]:
+        return [Opcode.BOOLOR]

--- a/boa3/model/operation/binary/relational/LessThan.py
+++ b/boa3/model/operation/binary/relational/LessThan.py
@@ -37,5 +37,5 @@ class LessThan(BinaryOperation):
             return Type.none
 
     @property
-    def opcode(self) -> Optional[Opcode]:
-        return Opcode.LT
+    def opcode(self) -> List[Opcode]:
+        return [Opcode.LT]

--- a/boa3/model/operation/binary/relational/Lessthanorequal.py
+++ b/boa3/model/operation/binary/relational/Lessthanorequal.py
@@ -37,5 +37,5 @@ class LessThanOrEqual(BinaryOperation):
             return Type.none
 
     @property
-    def opcode(self) -> Optional[Opcode]:
-        return Opcode.LE
+    def opcode(self) -> List[Opcode]:
+        return [Opcode.LE]

--- a/boa3/model/operation/binary/relational/greaterthan.py
+++ b/boa3/model/operation/binary/relational/greaterthan.py
@@ -37,5 +37,5 @@ class GreaterThan(BinaryOperation):
             return Type.none
 
     @property
-    def opcode(self) -> Optional[Opcode]:
-        return Opcode.GT
+    def opcode(self) -> List[Opcode]:
+        return [Opcode.GT]

--- a/boa3/model/operation/binary/relational/greaterthanorequal.py
+++ b/boa3/model/operation/binary/relational/greaterthanorequal.py
@@ -37,5 +37,5 @@ class GreaterThanOrEqual(BinaryOperation):
             return Type.none
 
     @property
-    def opcode(self) -> Optional[Opcode]:
-        return Opcode.GE
+    def opcode(self) -> List[Opcode]:
+        return [Opcode.GE]

--- a/boa3/model/operation/binary/relational/numericequality.py
+++ b/boa3/model/operation/binary/relational/numericequality.py
@@ -37,5 +37,5 @@ class NumericEquality(BinaryOperation):
             return Type.none
 
     @property
-    def opcode(self) -> Optional[Opcode]:
-        return Opcode.NUMEQUAL
+    def opcode(self) -> List[Opcode]:
+        return [Opcode.NUMEQUAL]

--- a/boa3/model/operation/binary/relational/numericinequality.py
+++ b/boa3/model/operation/binary/relational/numericinequality.py
@@ -37,5 +37,5 @@ class NumericInequality(BinaryOperation):
             return Type.none
 
     @property
-    def opcode(self) -> Optional[Opcode]:
-        return Opcode.NUMNOTEQUAL
+    def opcode(self) -> List[Opcode]:
+        return [Opcode.NUMNOTEQUAL]

--- a/boa3/model/operation/binary/relational/objectequality.py
+++ b/boa3/model/operation/binary/relational/objectequality.py
@@ -36,5 +36,5 @@ class ObjectEquality(BinaryOperation):
             return Type.none
 
     @property
-    def opcode(self) -> Optional[Opcode]:
-        return Opcode.EQUAL
+    def opcode(self) -> List[Opcode]:
+        return [Opcode.EQUAL]

--- a/boa3/model/operation/binary/relational/objectinequality.py
+++ b/boa3/model/operation/binary/relational/objectinequality.py
@@ -36,5 +36,5 @@ class ObjectInequality(BinaryOperation):
             return Type.none
 
     @property
-    def opcode(self) -> Optional[Opcode]:
-        return Opcode.NOTEQUAL
+    def opcode(self) -> List[Opcode]:
+        return [Opcode.NOTEQUAL]

--- a/boa3/model/operation/binaryop.py
+++ b/boa3/model/operation/binaryop.py
@@ -21,7 +21,10 @@ from boa3.model.operation.binary.relational.numericequality import NumericEquali
 from boa3.model.operation.binary.relational.numericinequality import NumericInequality
 from boa3.model.operation.binary.relational.objectequality import ObjectEquality
 from boa3.model.operation.binary.relational.objectinequality import ObjectInequality
+from boa3.model.operation.operation import IOperation
 from boa3.model.operation.operator import Operator
+from boa3.model.operation.unary.noneidentity import NoneIdentity
+from boa3.model.operation.unary.nonenotidentity import NoneNotIdentity
 from boa3.model.type.type import IType
 
 
@@ -43,6 +46,8 @@ class BinaryOp:
     LtE = LessThanOrEqual()
     Gt = GreaterThan()
     GtE = GreaterThanOrEqual()
+    IsNone = NoneIdentity()
+    IsNotNone = NoneNotIdentity()
     Is = Identity()
     IsNot = NotIdentity()
     Eq = ObjectEquality()
@@ -64,8 +69,13 @@ class BinaryOp:
         :rtype: BinaryOperation or None
         """
         for id, op in vars(cls).items():
-            if isinstance(op, BinaryOperation) and op.is_valid(operator, left, right):
-                return op.build(left, right)
+            if isinstance(op, IOperation) and op.is_valid(operator, left, right):
+                if isinstance(op, BinaryOperation):
+                    return op.build(left, right)
+                else:
+                    from boa3.model.type.type import Type
+                    operand = right if left is Type.none else left
+                    return op.build(operand)
 
     @classmethod
     def get_operation_by_operator(cls, operator: Operator) -> Optional[BinaryOperation]:

--- a/boa3/model/operation/operation.py
+++ b/boa3/model/operation/operation.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Optional, List
 
 from boa3.model.operation.operator import Operator
 from boa3.model.type.type import IType
@@ -19,13 +19,13 @@ class IOperation(ABC):
         self.result: IType = result_type
 
     @property
-    def opcode(self) -> Optional[Opcode]:
+    def opcode(self) -> List[Opcode]:
         """
-        Gets the operation opcode in Neo Vm
+        Gets the operation sequence of opcodes in Neo Vm
 
-        :return: the opcode if exists. None otherwise.
+        :return: the opcode if exists. Empty list otherwise.
         """
-        return None
+        return []
 
     @property
     @abstractmethod
@@ -36,6 +36,15 @@ class IOperation(ABC):
         :return: Number of operands
         """
         pass
+
+    @property
+    def op_on_stack(self) -> int:
+        """
+        Gets the number of arguments that must be on stack before the opcode is called.
+
+        :return: the number of arguments. Same from `number_of_operands` by default.
+        """
+        return self.number_of_operands
 
     @abstractmethod
     def validate_type(self, *types: IType) -> bool:
@@ -68,3 +77,15 @@ class IOperation(ABC):
         :return: True if it is supported. False otherwise.
         """
         return True
+
+    @classmethod
+    @abstractmethod
+    def build(cls, *operands: IType):
+        """
+        Creates an operation with the given operands types
+
+        :param operands: operands types
+        :return: The built operation if the operands are valid. None otherwise
+        :rtype: IOperation or None
+        """
+        return None

--- a/boa3/model/operation/unary/negative.py
+++ b/boa3/model/operation/unary/negative.py
@@ -34,5 +34,5 @@ class Negative(UnaryOperation):
             return Type.none
 
     @property
-    def opcode(self) -> Optional[Opcode]:
-        return Opcode.NEGATE
+    def opcode(self) -> List[Opcode]:
+        return [Opcode.NEGATE]

--- a/boa3/model/operation/unary/noneidentity.py
+++ b/boa3/model/operation/unary/noneidentity.py
@@ -6,26 +6,35 @@ from boa3.model.type.type import IType, Type
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
-class BooleanNot(UnaryOperation):
+class NoneIdentity(UnaryOperation):
     """
-    A class used to represent a numeric negative operation
+    A class used to represent an 'is None' comparison
 
     :ivar operator: the operator of the operation. Inherited from :class:`IOperation`
     :ivar operand: the operand type. Inherited from :class:`UnaryOperation`
     :ivar result: the result type of the operation.  Inherited from :class:`IOperation`
     """
-    _valid_types: List[IType] = [Type.bool]
 
-    def __init__(self, operand: IType = Type.bool):
-        self.operator: Operator = Operator.Not
+    def __init__(self, operand: IType = Type.int):
+        self.operator: Operator = Operator.Is
         super().__init__(operand)
+
+    @property
+    def number_of_operands(self) -> int:
+        # it is a Python binary operation that is equivalent to a Neo VM unary operation
+        return 2
+
+    @property
+    def op_on_stack(self) -> int:
+        return super().number_of_operands
 
     def validate_type(self, *types: IType) -> bool:
         if len(types) != self.number_of_operands:
             return False
-        operand: IType = types[0]
+        left: IType = types[0]
+        right: IType = types[1]
 
-        return operand in self._valid_types
+        return left is Type.none or right is Type.none
 
     def _get_result(self, operand: IType) -> IType:
         if self.validate_type(operand):
@@ -35,4 +44,4 @@ class BooleanNot(UnaryOperation):
 
     @property
     def opcode(self) -> List[Opcode]:
-        return [Opcode.NOT]
+        return [Opcode.ISNULL]

--- a/boa3/model/operation/unary/nonenotidentity.py
+++ b/boa3/model/operation/unary/nonenotidentity.py
@@ -6,26 +6,35 @@ from boa3.model.type.type import IType, Type
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
-class BooleanNot(UnaryOperation):
+class NoneNotIdentity(UnaryOperation):
     """
-    A class used to represent a numeric negative operation
+    A class used to represent an 'is not None' comparison
 
     :ivar operator: the operator of the operation. Inherited from :class:`IOperation`
     :ivar operand: the operand type. Inherited from :class:`UnaryOperation`
     :ivar result: the result type of the operation.  Inherited from :class:`IOperation`
     """
-    _valid_types: List[IType] = [Type.bool]
 
-    def __init__(self, operand: IType = Type.bool):
-        self.operator: Operator = Operator.Not
+    def __init__(self, operand: IType = Type.int):
+        self.operator: Operator = Operator.IsNot
         super().__init__(operand)
+
+    @property
+    def number_of_operands(self) -> int:
+        # it is a Python binary operation that is equivalent to a Neo VM unary operation
+        return 2
+
+    @property
+    def op_on_stack(self) -> int:
+        return super().number_of_operands
 
     def validate_type(self, *types: IType) -> bool:
         if len(types) != self.number_of_operands:
             return False
-        operand: IType = types[0]
+        left: IType = types[0]
+        right: IType = types[1]
 
-        return operand in self._valid_types
+        return left is Type.none or right is Type.none
 
     def _get_result(self, operand: IType) -> IType:
         if self.validate_type(operand):
@@ -35,4 +44,4 @@ class BooleanNot(UnaryOperation):
 
     @property
     def opcode(self) -> List[Opcode]:
-        return [Opcode.NOT]
+        return [Opcode.ISNULL, Opcode.NOT]

--- a/boa3/model/operation/unary/positive.py
+++ b/boa3/model/operation/unary/positive.py
@@ -34,6 +34,6 @@ class Positive(UnaryOperation):
             return Type.none
 
     @property
-    def opcode(self) -> Optional[Opcode]:
+    def opcode(self) -> List[Opcode]:
         # it is the identity function, so there is no need of including another opcode
-        return None
+        return []

--- a/boa3/model/type/sequencetype.py
+++ b/boa3/model/type/sequencetype.py
@@ -73,6 +73,10 @@ class SequenceType(IType, ABC):
             values_type = [values_type]
 
         if len(values_type) > 1:
+            from boa3.model.type.type import Type
+            if any(t is Type.any or t is Type.none for t in values_type):
+                return [Type.any]
+
             # verifies if all the types are the same sequence with different arguments
             if all(isinstance(x, SequenceType) for x in values_type):
                 sequence_type = type(values_type[0])  # first sequence type
@@ -85,11 +89,9 @@ class SequenceType(IType, ABC):
                 elif all(isinstance(x.value_type, value_type) for x in values_type):
                     # the sequences doesn't have the same type but the value type is the same
                     # for example: Tuple[int] and List[int]
-                    from boa3.model.type.type import Type
                     values_type = [Type.sequence.build_sequence(values_type[0].value_type)]
                 else:
                     # otherwise, built a generic sequence with any as parameters
-                    from boa3.model.type.type import Type
                     values_type = [Type.sequence]
         return values_type
 

--- a/boa3_test/example/any_test/SequenceOfAnySequence.py
+++ b/boa3_test/example/any_test/SequenceOfAnySequence.py
@@ -1,7 +1,7 @@
 def Main():
     any_list = [True, 1, 'ok']
     int_list = [1, 2, 3]
-    any_tuple = (True, 1, 'ok')
+    any_tuple = (None, 1, 'ok')
     bool_tuple = True, False
 
     a: Sequence[Sequence[Any]] = [any_list, int_list, any_tuple, bool_tuple]

--- a/boa3_test/example/none_test/MismatchedTypesAfterReassign.py
+++ b/boa3_test/example/none_test/MismatchedTypesAfterReassign.py
@@ -1,0 +1,4 @@
+def Main():
+    a = None
+    a = 2
+    b = a * 2

--- a/boa3_test/example/none_test/MismatchedTypesAssign.py
+++ b/boa3_test/example/none_test/MismatchedTypesAssign.py
@@ -1,0 +1,4 @@
+def Main():
+    a = 2
+    a = None
+    b = a * 2

--- a/boa3_test/example/none_test/MismatchedTypesInOperation.py
+++ b/boa3_test/example/none_test/MismatchedTypesInOperation.py
@@ -1,0 +1,4 @@
+def Main():
+    a = None
+    b = 2
+    c = a + b

--- a/boa3_test/example/none_test/NoneEquality.py
+++ b/boa3_test/example/none_test/NoneEquality.py
@@ -1,0 +1,3 @@
+def Main(a: str) -> bool:
+    b = None
+    return a == b

--- a/boa3_test/example/none_test/NoneIdentity.py
+++ b/boa3_test/example/none_test/NoneIdentity.py
@@ -1,0 +1,2 @@
+def Main(a: Any) -> bool:
+    return a is None

--- a/boa3_test/example/none_test/NoneNotIdentity.py
+++ b/boa3_test/example/none_test/NoneNotIdentity.py
@@ -1,0 +1,2 @@
+def Main(a: Any) -> bool:
+    return a is not None

--- a/boa3_test/example/none_test/NoneTuple.py
+++ b/boa3_test/example/none_test/NoneTuple.py
@@ -1,0 +1,2 @@
+def Main():
+    a = (None, None, None)

--- a/boa3_test/example/none_test/VariableNone.py
+++ b/boa3_test/example/none_test/VariableNone.py
@@ -1,0 +1,2 @@
+def Main():
+    a = None

--- a/boa3_test/tests/test_any.py
+++ b/boa3_test/tests/test_any.py
@@ -235,10 +235,10 @@ class TestAny(BoaTest):
             + Opcode.PUSH3
             + Opcode.PACK
             + Opcode.STLOC1
-            + Opcode.PUSHDATA1  # any_tuple = (True, 1, 'ok')
+            + Opcode.PUSHDATA1  # any_tuple = (None, 1, 'ok')
             + Integer(len(ok)).to_byte_array() + ok
             + Opcode.PUSH1
-            + Opcode.PUSH1
+            + Opcode.PUSHNULL
             + Opcode.PUSH3
             + Opcode.PACK
             + Opcode.STLOC2

--- a/boa3_test/tests/test_multiple_expressions.py
+++ b/boa3_test/tests/test_multiple_expressions.py
@@ -1,5 +1,4 @@
 from boa3.boa3 import Boa3
-from boa3.exception.CompilerError import MismatchedTypes, TypeHintMissing, TooManyReturns
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.String import String

--- a/boa3_test/tests/test_none.py
+++ b/boa3_test/tests/test_none.py
@@ -1,0 +1,84 @@
+from boa3.boa3 import Boa3
+from boa3.exception.CompilerError import MismatchedTypes
+from boa3.neo.vm.opcode.Opcode import Opcode
+from boa3_test.tests.boa_test import BoaTest
+
+
+class TestAny(BoaTest):
+
+    def test_variable_none(self):
+        path = '%s/boa3_test/example/none_test/VariableNone.py' % self.dirname
+
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x01'
+            + b'\x00'
+            + Opcode.PUSHNULL
+            + Opcode.STLOC0
+            + Opcode.RET        # return
+        )
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_none_tuple(self):
+        path = '%s/boa3_test/example/none_test/NoneTuple.py' % self.dirname
+
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x01'
+            + b'\x00'
+            + Opcode.PUSHNULL   # a = (None, None, None)
+            + Opcode.PUSHNULL
+            + Opcode.PUSHNULL
+            + Opcode.PUSH3
+            + Opcode.PACK
+            + Opcode.STLOC0
+            + Opcode.RET        # return
+        )
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_none_identity(self):
+        path = '%s/boa3_test/example/none_test/NoneIdentity.py' % self.dirname
+
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x00'
+            + b'\x01'
+            + Opcode.LDARG0
+            + Opcode.ISNULL
+            + Opcode.RET        # return
+        )
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_none_not_identity(self):
+        path = '%s/boa3_test/example/none_test/NoneNotIdentity.py' % self.dirname
+
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x00'
+            + b'\x01'
+            + Opcode.LDARG0
+            + Opcode.ISNULL
+            + Opcode.NOT
+            + Opcode.RET        # return
+        )
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_none_equality(self):
+        path = '%s/boa3_test/example/none_test/NoneEquality.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_mismatched_type_int_operation(self):
+        path = '%s/boa3_test/example/none_test/MismatchedTypesInOperation.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_mismatched_type_assign(self):
+        path = '%s/boa3_test/example/none_test/MismatchedTypesAssign.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_mismatched_type_after_reassign(self):
+        path = '%s/boa3_test/example/none_test/MismatchedTypesAfterReassign.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)


### PR DESCRIPTION
- Implemented None value conversion.
  - Variables assigned with `None` value are typed with `Any` type
    ```python
    x = None  # because of this, x is any
    x = 1
    ```
  - Variables which type is not `Any` cannot be assigned with `None`
    ```python
    x = 1  # typed as int
    x = None  # this will raise a compile error
    ```
- Implemented `is None` and `is not None` operations
    ```python
    x = None
    y = 'some_string'
    x1: bool = x is None
    y1: bool = y is not None
    ```