### PR TITLE
Convert string arithmetic operations

### DIFF
--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -229,7 +229,7 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
         operation = self.validate_binary_operation(aug_assign, aug_assign.target, aug_assign.value)
         if operation is not None:
             # TODO: remove when other augmented assignment operations are implemented
-            if operation.result is not Type.int:
+            if operation.result not in [Type.int, Type.str]:
                 raise NotImplementedError
 
             self.validate_type_variable_assign(aug_assign.target, operation)

--- a/boa3/compiler/codegenerator.py
+++ b/boa3/compiler/codegenerator.py
@@ -569,9 +569,9 @@ class CodeGenerator:
 
         :param operation: the operation that will be converted
         """
-        for opcode in operation.opcode:
+        for opcode, data in operation.opcode:
             op_info: OpcodeInformation = OpcodeInfo.get_info(opcode)
-            self.__insert1(op_info)
+            self.__insert1(op_info, data)
 
         for op in range(operation.op_on_stack):
             self._stack.pop()

--- a/boa3/model/operation/binary/arithmetic/addition.py
+++ b/boa3/model/operation/binary/arithmetic/addition.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Tuple
 
 from boa3.model.operation.binary.binaryoperation import BinaryOperation
 from boa3.model.operation.operator import Operator
@@ -38,5 +38,5 @@ class Addition(BinaryOperation):
             return Type.none
 
     @property
-    def opcode(self) -> List[Opcode]:
-        return [Opcode.ADD]
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        return [(Opcode.ADD, b'')]

--- a/boa3/model/operation/binary/arithmetic/floordivision.py
+++ b/boa3/model/operation/binary/arithmetic/floordivision.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Tuple
 
 from boa3.model.operation.binary.binaryoperation import BinaryOperation
 from boa3.model.operation.operator import Operator
@@ -38,5 +38,5 @@ class FloorDivision(BinaryOperation):
             return Type.none
 
     @property
-    def opcode(self) -> List[Opcode]:
-        return [Opcode.DIV]
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        return [(Opcode.DIV, b'')]

--- a/boa3/model/operation/binary/arithmetic/modulo.py
+++ b/boa3/model/operation/binary/arithmetic/modulo.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Tuple
 
 from boa3.model.operation.binary.binaryoperation import BinaryOperation
 from boa3.model.operation.operator import Operator
@@ -38,5 +38,5 @@ class Modulo(BinaryOperation):
             return Type.none
 
     @property
-    def opcode(self) -> List[Opcode]:
-        return [Opcode.MOD]
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        return [(Opcode.MOD, b'')]

--- a/boa3/model/operation/binary/arithmetic/multiplication.py
+++ b/boa3/model/operation/binary/arithmetic/multiplication.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Tuple
 
 from boa3.model.operation.binary.binaryoperation import BinaryOperation
 from boa3.model.operation.operator import Operator
@@ -38,5 +38,5 @@ class Multiplication(BinaryOperation):
             return Type.none
 
     @property
-    def opcode(self) -> List[Opcode]:
-        return [Opcode.MUL]
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        return [(Opcode.MUL, b'')]

--- a/boa3/model/operation/binary/arithmetic/subtraction.py
+++ b/boa3/model/operation/binary/arithmetic/subtraction.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Tuple
 
 from boa3.model.operation.binary.binaryoperation import BinaryOperation
 from boa3.model.operation.operator import Operator
@@ -38,5 +38,5 @@ class Subtraction(BinaryOperation):
             return Type.none
 
     @property
-    def opcode(self) -> List[Opcode]:
-        return [Opcode.SUB]
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        return [(Opcode.SUB, b'')]

--- a/boa3/model/operation/binary/logical/booleanand.py
+++ b/boa3/model/operation/binary/logical/booleanand.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Tuple
 
 from boa3.model.operation.binary.binaryoperation import BinaryOperation
 from boa3.model.operation.operator import Operator
@@ -37,5 +37,5 @@ class BooleanAnd(BinaryOperation):
             return Type.none
 
     @property
-    def opcode(self) -> List[Opcode]:
-        return [Opcode.BOOLAND]
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        return [(Opcode.BOOLAND, b'')]

--- a/boa3/model/operation/binary/logical/booleanor.py
+++ b/boa3/model/operation/binary/logical/booleanor.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Tuple
 
 from boa3.model.operation.binary.binaryoperation import BinaryOperation
 from boa3.model.operation.operator import Operator
@@ -37,5 +37,5 @@ class BooleanOr(BinaryOperation):
             return Type.none
 
     @property
-    def opcode(self) -> List[Opcode]:
-        return [Opcode.BOOLOR]
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        return [(Opcode.BOOLOR, b'')]

--- a/boa3/model/operation/binary/relational/LessThan.py
+++ b/boa3/model/operation/binary/relational/LessThan.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Tuple
 
 from boa3.model.operation.binary.binaryoperation import BinaryOperation
 from boa3.model.operation.operator import Operator
@@ -37,5 +37,5 @@ class LessThan(BinaryOperation):
             return Type.none
 
     @property
-    def opcode(self) -> List[Opcode]:
-        return [Opcode.LT]
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        return [(Opcode.LT, b'')]

--- a/boa3/model/operation/binary/relational/Lessthanorequal.py
+++ b/boa3/model/operation/binary/relational/Lessthanorequal.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Tuple
 
 from boa3.model.operation.binary.binaryoperation import BinaryOperation
 from boa3.model.operation.operator import Operator
@@ -37,5 +37,5 @@ class LessThanOrEqual(BinaryOperation):
             return Type.none
 
     @property
-    def opcode(self) -> List[Opcode]:
-        return [Opcode.LE]
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        return [(Opcode.LE, b'')]

--- a/boa3/model/operation/binary/relational/greaterthan.py
+++ b/boa3/model/operation/binary/relational/greaterthan.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Tuple
 
 from boa3.model.operation.binary.binaryoperation import BinaryOperation
 from boa3.model.operation.operator import Operator
@@ -37,5 +37,5 @@ class GreaterThan(BinaryOperation):
             return Type.none
 
     @property
-    def opcode(self) -> List[Opcode]:
-        return [Opcode.GT]
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        return [(Opcode.GT, b'')]

--- a/boa3/model/operation/binary/relational/greaterthanorequal.py
+++ b/boa3/model/operation/binary/relational/greaterthanorequal.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Tuple
 
 from boa3.model.operation.binary.binaryoperation import BinaryOperation
 from boa3.model.operation.operator import Operator
@@ -37,5 +37,5 @@ class GreaterThanOrEqual(BinaryOperation):
             return Type.none
 
     @property
-    def opcode(self) -> List[Opcode]:
-        return [Opcode.GE]
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        return [(Opcode.GE, b'')]

--- a/boa3/model/operation/binary/relational/numericequality.py
+++ b/boa3/model/operation/binary/relational/numericequality.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Tuple
 
 from boa3.model.operation.binary.binaryoperation import BinaryOperation
 from boa3.model.operation.operator import Operator
@@ -37,5 +37,5 @@ class NumericEquality(BinaryOperation):
             return Type.none
 
     @property
-    def opcode(self) -> List[Opcode]:
-        return [Opcode.NUMEQUAL]
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        return [(Opcode.NUMEQUAL, b'')]

--- a/boa3/model/operation/binary/relational/numericinequality.py
+++ b/boa3/model/operation/binary/relational/numericinequality.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Tuple
 
 from boa3.model.operation.binary.binaryoperation import BinaryOperation
 from boa3.model.operation.operator import Operator
@@ -37,5 +37,5 @@ class NumericInequality(BinaryOperation):
             return Type.none
 
     @property
-    def opcode(self) -> List[Opcode]:
-        return [Opcode.NUMNOTEQUAL]
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        return [(Opcode.NUMNOTEQUAL, b'')]

--- a/boa3/model/operation/binary/relational/objectequality.py
+++ b/boa3/model/operation/binary/relational/objectequality.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Tuple
 
 from boa3.model.operation.binary.binaryoperation import BinaryOperation
 from boa3.model.operation.operator import Operator
@@ -36,5 +36,5 @@ class ObjectEquality(BinaryOperation):
             return Type.none
 
     @property
-    def opcode(self) -> List[Opcode]:
-        return [Opcode.EQUAL]
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        return [(Opcode.EQUAL, b'')]

--- a/boa3/model/operation/binary/relational/objectinequality.py
+++ b/boa3/model/operation/binary/relational/objectinequality.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Tuple
 
 from boa3.model.operation.binary.binaryoperation import BinaryOperation
 from boa3.model.operation.operator import Operator
@@ -36,5 +36,5 @@ class ObjectInequality(BinaryOperation):
             return Type.none
 
     @property
-    def opcode(self) -> List[Opcode]:
-        return [Opcode.NOTEQUAL]
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        return [(Opcode.NOTEQUAL, b'')]

--- a/boa3/model/operation/binaryop.py
+++ b/boa3/model/operation/binaryop.py
@@ -7,6 +7,7 @@ from boa3.model.operation.binary.arithmetic.floordivision import FloorDivision
 from boa3.model.operation.binary.arithmetic.modulo import Modulo
 from boa3.model.operation.binary.arithmetic.multiplication import Multiplication
 from boa3.model.operation.binary.arithmetic.power import Power
+from boa3.model.operation.binary.arithmetic.strmultiplication import StrMultiplication
 from boa3.model.operation.binary.arithmetic.subtraction import Subtraction
 from boa3.model.operation.binary.binaryoperation import BinaryOperation
 from boa3.model.operation.binary.logical.booleanand import BooleanAnd
@@ -38,6 +39,7 @@ class BinaryOp:
     Mod = Modulo()
     Pow = Power()
     Concat = Concat()
+    StrMul = StrMultiplication()
 
     # Relational operations
     NumEq = NumericEquality()

--- a/boa3/model/operation/operation.py
+++ b/boa3/model/operation/operation.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import List
+from typing import List, Tuple
 
 from boa3.model.operation.operator import Operator
 from boa3.model.type.type import IType
@@ -19,13 +19,25 @@ class IOperation(ABC):
         self.result: IType = result_type
 
     @property
-    def opcode(self) -> List[Opcode]:
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
         """
-        Gets the operation sequence of opcodes in Neo Vm
+        Gets the operation sequence of opcodes with in Neo Vm
 
         :return: the opcode if exists. Empty list otherwise.
         """
         return []
+
+    @property
+    def bytecode(self) -> bytes:
+        """
+        Gets the operation bytecode
+
+        :return: the bytecode if exists. Empty bytes otherwise.
+        """
+        str_mult_bytes = bytearray()
+        for opcode, data in self.opcode:
+            str_mult_bytes += opcode + data
+        return bytes(str_mult_bytes)
 
     @property
     @abstractmethod

--- a/boa3/model/operation/unary/booleannot.py
+++ b/boa3/model/operation/unary/booleannot.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Tuple
 
 from boa3.model.operation.operator import Operator
 from boa3.model.operation.unary.unaryoperation import UnaryOperation
@@ -34,5 +34,5 @@ class BooleanNot(UnaryOperation):
             return Type.none
 
     @property
-    def opcode(self) -> List[Opcode]:
-        return [Opcode.NOT]
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        return [(Opcode.NOT, b'')]

--- a/boa3/model/operation/unary/negative.py
+++ b/boa3/model/operation/unary/negative.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Tuple
 
 from boa3.model.operation.operator import Operator
 from boa3.model.operation.unary.unaryoperation import UnaryOperation
@@ -34,5 +34,5 @@ class Negative(UnaryOperation):
             return Type.none
 
     @property
-    def opcode(self) -> List[Opcode]:
-        return [Opcode.NEGATE]
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        return [(Opcode.NEGATE, b'')]

--- a/boa3/model/operation/unary/noneidentity.py
+++ b/boa3/model/operation/unary/noneidentity.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Tuple
 
 from boa3.model.operation.operator import Operator
 from boa3.model.operation.unary.unaryoperation import UnaryOperation
@@ -43,5 +43,5 @@ class NoneIdentity(UnaryOperation):
             return Type.none
 
     @property
-    def opcode(self) -> List[Opcode]:
-        return [Opcode.ISNULL]
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        return [(Opcode.ISNULL, b'')]

--- a/boa3/model/operation/unary/nonenotidentity.py
+++ b/boa3/model/operation/unary/nonenotidentity.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Tuple
 
 from boa3.model.operation.operator import Operator
 from boa3.model.operation.unary.unaryoperation import UnaryOperation
@@ -43,5 +43,8 @@ class NoneNotIdentity(UnaryOperation):
             return Type.none
 
     @property
-    def opcode(self) -> List[Opcode]:
-        return [Opcode.ISNULL, Opcode.NOT]
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        return [
+            (Opcode.ISNULL, b''),
+            (Opcode.NOT, b'')
+        ]

--- a/boa3/model/operation/unary/positive.py
+++ b/boa3/model/operation/unary/positive.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Tuple
 
 from boa3.model.operation.operator import Operator
 from boa3.model.operation.unary.unaryoperation import UnaryOperation
@@ -34,6 +34,6 @@ class Positive(UnaryOperation):
             return Type.none
 
     @property
-    def opcode(self) -> List[Opcode]:
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
         # it is the identity function, so there is no need of including another opcode
         return []

--- a/boa3/neo/vm/VMCode.py
+++ b/boa3/neo/vm/VMCode.py
@@ -68,3 +68,6 @@ class VMCode:
             data = data_len[0:max_data_len]
 
         return data
+
+    def __str__(self) -> str:
+        return self.opcode.name + ' ' + self.data.hex()

--- a/boa3_test/example/arithmetic_test/ConcatenationAugmentedAssignment.py
+++ b/boa3_test/example/arithmetic_test/ConcatenationAugmentedAssignment.py
@@ -1,0 +1,2 @@
+def Main(a: str, b: str):
+    a += b

--- a/boa3_test/example/arithmetic_test/StringMultiplication.py
+++ b/boa3_test/example/arithmetic_test/StringMultiplication.py
@@ -1,0 +1,2 @@
+def Main(a: str, b: int) -> str:
+    return a * b

--- a/boa3_test/example/arithmetic_test/StringMultiplicationAugmentedAssignment.py
+++ b/boa3_test/example/arithmetic_test/StringMultiplicationAugmentedAssignment.py
@@ -1,0 +1,2 @@
+def Main(a: str, b: int):
+    a *= b

--- a/boa3_test/tests/test_arithmetic.py
+++ b/boa3_test/tests/test_arithmetic.py
@@ -1,6 +1,9 @@
 from boa3.boa3 import Boa3
 from boa3.exception.CompilerError import MismatchedTypes, NotSupportedOperation
+from boa3.model.operation.binaryop import BinaryOp
 from boa3.neo.vm.opcode.Opcode import Opcode
+from boa3.neo.vm.type.Integer import Integer
+from boa3.neo.vm.type.String import String
 from boa3_test.tests.boa_test import BoaTest
 
 
@@ -120,12 +123,40 @@ class TestArithmetic(BoaTest):
         self.assertEqual(expected_output, output)
 
     def test_concatenation_operation(self):
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x00'
+            + b'\x02'
+            + Opcode.LDARG0
+            + Opcode.LDARG1
+            + Opcode.CAT
+            + Opcode.RET
+        )
+
         path = '%s/boa3_test/example/arithmetic_test/Concatenation.py' % self.dirname
-        self.assertCompilerLogs(NotSupportedOperation, path)
+        output = Boa3.compile(path)
+
+        self.assertEqual(expected_output, output)
 
     def test_power_operation(self):
         path = '%s/boa3_test/example/arithmetic_test/Power.py' % self.dirname
         self.assertCompilerLogs(NotSupportedOperation, path)
+
+    def test_str_multiplication_operation(self):
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x00'
+            + b'\x02'
+            + Opcode.LDARG0
+            + Opcode.LDARG1
+            + BinaryOp.StrMul.bytecode
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/arithmetic_test/StringMultiplication.py' % self.dirname
+        output = Boa3.compile(path)
+
+        self.assertEqual(expected_output, output)
 
     def test_mismatched_type_binary_operation(self):
         path = '%s/boa3_test/example/arithmetic_test/MismatchedOperandBinary.py' % self.dirname
@@ -288,6 +319,40 @@ class TestArithmetic(BoaTest):
 
         self.assertEqual(expected_output, output)
 
+    def test_concatenation_augmented_assignment(self):
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x00'
+            + b'\x02'
+            + Opcode.LDARG0
+            + Opcode.LDARG1
+            + Opcode.CAT
+            + Opcode.STARG0
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/arithmetic_test/ConcatenationAugmentedAssignment.py' % self.dirname
+        output = Boa3.compile(path)
+
+        self.assertEqual(expected_output, output)
+
     def test_power_augmented_assignment(self):
         path = '%s/boa3_test/example/arithmetic_test/PowerAugmentedAssignment.py' % self.dirname
         self.assertCompilerLogs(NotSupportedOperation, path)
+
+    def test_str_multiplication_operation_augmented_assignment(self):
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x00'
+            + b'\x02'
+            + Opcode.LDARG0
+            + Opcode.LDARG1
+            + BinaryOp.StrMul.bytecode
+            + Opcode.STARG0
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/arithmetic_test/StringMultiplicationAugmentedAssignment.py' % self.dirname
+        output = Boa3.compile(path)
+
+        self.assertEqual(expected_output, output)


### PR DESCRIPTION
- Implemented string arithmetic operators:
  - String concatenation:
    ```
    a = 'str1'
    b = 'str2'
    c = a + b
    ```
  - String shallow copy:
    ```
    a = 'str'
    b = a * 3  # result: 'strstrstr'
    ```
- Also implemented these operators on augmented assignments:
    ```
    a = 'str1'
    b = 'str2'
    a += b  # same as a = a + b
    b *= 5  # same as b = b * 5
    ```