### PR TITLE
included type checking on return statements

### DIFF
--- a/boa3/analyser/astanalyser.py
+++ b/boa3/analyser/astanalyser.py
@@ -8,8 +8,7 @@ from boa3.exception.CompilerWarning import CompilerWarning
 from boa3.model.expression import IExpression
 from boa3.model.operation.operation import IOperation
 from boa3.model.symbol import ISymbol
-from boa3.model.type.itype import IType
-from boa3.model.type.type import Type
+from boa3.model.type.type import IType, Type
 
 
 class IAstAnalyser(ABC, ast.NodeVisitor):

--- a/boa3/compiler/codegenerator.py
+++ b/boa3/compiler/codegenerator.py
@@ -8,8 +8,7 @@ from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.method import Method
 from boa3.model.operation.operation import IOperation
 from boa3.model.symbol import ISymbol
-from boa3.model.type.itype import IType
-from boa3.model.type.type import Type
+from boa3.model.type.type import IType, Type
 from boa3.model.variable import Variable
 from boa3.neo.vm.VMCode import VMCode
 from boa3.neo.vm.opcode.Opcode import Opcode
@@ -179,13 +178,19 @@ class CodeGenerator:
         """
         Converts the end of the method
         """
-        self.__insert1(OpcodeInfo.RET)
-
+        if self.last_code.opcode is not Opcode.RET:
+            self.insert_return()
         if self.__current_method.is_main_method:
             self.__move_entry_point_to_beginning()
         self.__current_method = None
 
         self._stack.clear()
+
+    def insert_return(self):
+        """
+        Insert the return statement
+        """
+        self.__insert1(OpcodeInfo.RET)
 
     def __move_entry_point_to_beginning(self):
         """
@@ -596,8 +601,9 @@ class CodeGenerator:
         :param op_info: info of the opcode  that will be inserted
         :param jump_to: data of the opcode
         """
-        op_info, data = self.__get_jump_data(op_info, jump_to)    # type:OpcodeInformation, bytes
-        self.__insert1(op_info, data)
+        if self.last_code.opcode is not Opcode.RET:
+            op_info, data = self.__get_jump_data(op_info, jump_to)    # type:OpcodeInformation, bytes
+            self.__insert1(op_info, data)
 
     def __update_jump(self, jump_address: int, updated_jump_to: int):
         """

--- a/boa3/compiler/codegeneratorvisitor.py
+++ b/boa3/compiler/codegeneratorvisitor.py
@@ -10,8 +10,7 @@ from boa3.model.operation.binaryop import BinaryOp
 from boa3.model.operation.operation import IOperation
 from boa3.model.operation.unary.unaryoperation import UnaryOperation
 from boa3.model.symbol import ISymbol
-from boa3.model.type.itype import IType
-from boa3.model.type.type import Type
+from boa3.model.type.type import IType, Type
 from boa3.model.variable import Variable
 
 
@@ -98,6 +97,7 @@ class VisitorCodeGenerator(ast.NodeVisitor):
         """
         if ret.value is not None:
             self.visit_to_generate(ret.value)
+            self.generator.insert_return()
 
     def store_variable(self, var_id: str, value: ast.AST, index: ast.AST = None):
         # if the value is None, it is a variable declaration

--- a/boa3/model/operation/binary/binaryoperation.py
+++ b/boa3/model/operation/binary/binaryoperation.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from typing import List
 
 from boa3.model.operation.operation import IOperation
-from boa3.model.type.type import IType
+from boa3.model.type.itype import IType
 
 
 class BinaryOperation(IOperation, ABC):

--- a/boa3/model/operation/binaryop.py
+++ b/boa3/model/operation/binaryop.py
@@ -26,7 +26,7 @@ from boa3.model.operation.operation import IOperation
 from boa3.model.operation.operator import Operator
 from boa3.model.operation.unary.noneidentity import NoneIdentity
 from boa3.model.operation.unary.nonenotidentity import NoneNotIdentity
-from boa3.model.type.type import IType
+from boa3.model.type.itype import IType
 
 
 class BinaryOp:

--- a/boa3/model/operation/operation.py
+++ b/boa3/model/operation/operation.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from typing import List, Tuple
 
 from boa3.model.operation.operator import Operator
-from boa3.model.type.type import IType
+from boa3.model.type.itype import IType
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 

--- a/boa3/model/operation/unary/noneidentity.py
+++ b/boa3/model/operation/unary/noneidentity.py
@@ -29,6 +29,8 @@ class NoneIdentity(UnaryOperation):
         return super().number_of_operands
 
     def validate_type(self, *types: IType) -> bool:
+        if len(types) == self.op_on_stack:
+            return True
         if len(types) != self.number_of_operands:
             return False
         left: IType = types[0]
@@ -38,7 +40,7 @@ class NoneIdentity(UnaryOperation):
 
     def _get_result(self, operand: IType) -> IType:
         if self.validate_type(operand):
-            return operand
+            return Type.bool
         else:
             return Type.none
 

--- a/boa3/model/operation/unary/nonenotidentity.py
+++ b/boa3/model/operation/unary/nonenotidentity.py
@@ -29,6 +29,8 @@ class NoneNotIdentity(UnaryOperation):
         return super().number_of_operands
 
     def validate_type(self, *types: IType) -> bool:
+        if len(types) == self.op_on_stack:
+            return True
         if len(types) != self.number_of_operands:
             return False
         left: IType = types[0]
@@ -38,7 +40,7 @@ class NoneNotIdentity(UnaryOperation):
 
     def _get_result(self, operand: IType) -> IType:
         if self.validate_type(operand):
-            return operand
+            return Type.bool
         else:
             return Type.none
 

--- a/boa3/model/operation/unary/unaryoperation.py
+++ b/boa3/model/operation/unary/unaryoperation.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from typing import List
 
 from boa3.model.operation.operation import IOperation
-from boa3.model.type.type import IType
+from boa3.model.type.itype import IType
 
 
 class UnaryOperation(IOperation, ABC):

--- a/boa3/model/operation/unaryop.py
+++ b/boa3/model/operation/unaryop.py
@@ -5,7 +5,7 @@ from boa3.model.operation.unary.booleannot import BooleanNot
 from boa3.model.operation.unary.negative import Negative
 from boa3.model.operation.unary.positive import Positive
 from boa3.model.operation.unary.unaryoperation import UnaryOperation
-from boa3.model.type.type import IType
+from boa3.model.type.itype import IType
 
 
 class UnaryOp:

--- a/boa3/model/type/itype.py
+++ b/boa3/model/type/itype.py
@@ -24,6 +24,10 @@ class IType(ISymbol):
         return self._identifier
 
     @property
+    def default_value(self) -> Any:
+        return None
+
+    @property
     def abi_type(self) -> AbiType:
         """
         Get the type representation for the abi

--- a/boa3/model/type/primitive/booltype.py
+++ b/boa3/model/type/primitive/booltype.py
@@ -14,6 +14,10 @@ class BoolType(IType):
         super().__init__(identifier)
 
     @property
+    def default_value(self) -> Any:
+        return bool()
+
+    @property
     def abi_type(self) -> AbiType:
         return AbiType.Boolean
 

--- a/boa3/model/type/primitive/inttype.py
+++ b/boa3/model/type/primitive/inttype.py
@@ -14,6 +14,10 @@ class IntType(IType):
         super().__init__(identifier)
 
     @property
+    def default_value(self) -> Any:
+        return int()
+
+    @property
     def abi_type(self) -> AbiType:
         return AbiType.Integer
 

--- a/boa3/model/type/primitive/strtype.py
+++ b/boa3/model/type/primitive/strtype.py
@@ -19,6 +19,10 @@ class StrType(SequenceType):
         return self._identifier
 
     @property
+    def default_value(self) -> Any:
+        return str()
+
+    @property
     def abi_type(self) -> AbiType:
         return AbiType.String
 

--- a/boa3/model/type/sequence/mutable/listtype.py
+++ b/boa3/model/type/sequence/mutable/listtype.py
@@ -14,6 +14,10 @@ class ListType(MutableSequenceType):
         values_type = self.filter_types(values_type)
         super().__init__(identifier, values_type)
 
+    @property
+    def default_value(self) -> Any:
+        return list()
+
     def is_valid_key(self, value_type: IType) -> bool:
         return value_type == self.valid_key
 

--- a/boa3/model/type/sequence/sequencetype.py
+++ b/boa3/model/type/sequence/sequencetype.py
@@ -18,6 +18,10 @@ class SequenceType(IType, ABC):
     def identifier(self) -> str:
         return '{0}[{1}]'.format(self._identifier, self.value_type.identifier)
 
+    @property
+    def default_value(self) -> Any:
+        return []
+
     def is_type_of(self, value: Any) -> bool:
         if self._is_type_of(value):
             if isinstance(value, SequenceType):

--- a/boa3/model/type/sequence/tupletype.py
+++ b/boa3/model/type/sequence/tupletype.py
@@ -14,6 +14,10 @@ class TupleType(SequenceType):
         values_type = self.filter_types(values_type)
         super().__init__(identifier, values_type)
 
+    @property
+    def default_value(self) -> Any:
+        return tuple()
+
     def is_valid_key(self, value_type: IType) -> bool:
         return value_type == self.valid_key
 
@@ -30,7 +34,7 @@ class TupleType(SequenceType):
 
     @classmethod
     def _is_type_of(cls, value: Any):
-        return type(value) in [tuple, TupleType]
+        return type(value) is tuple or isinstance(value, TupleType)
 
     def __eq__(self, other) -> bool:
         if type(self) != type(other):

--- a/boa3/model/type/type.py
+++ b/boa3/model/type/type.py
@@ -39,6 +39,26 @@ class Type:
             return val
         return cls.none
 
+    @classmethod
+    def get_generic_type(cls, type1: IType, type2: IType) -> IType:
+        """
+        Returns the common generic type between the given values.
+
+        :param type1: first type to be compared
+        :param type2: second type to be compared
+        :return: Returns the common generic type of the values if exist. `Type.any` otherwise.
+        """
+        if type1 == type2 or type1.is_type_of(type2):
+            return type1
+        if type2.is_type_of(type1):
+            return type2
+
+        generic_types = [cls.mutableSequence, cls.sequence]
+        for generic in generic_types:
+            if generic.is_type_of(type1) and generic.is_type_of(type2):
+                return generic
+        return Type.any
+
     # Primitive Types
     int = IntType()
     bool = BoolType()

--- a/boa3_test/example/built_in_methods_test/AppendMutableSequence.py
+++ b/boa3_test/example/built_in_methods_test/AppendMutableSequence.py
@@ -1,4 +1,4 @@
 def Main(op: str, args: List[str]) -> MutableSequence[int]:
-    a: MutableSequence[Any] = [1, 2, 3]
+    a: MutableSequence[int] = [1, 2, 3]
     a.append(4)
     return a

--- a/boa3_test/example/built_in_methods_test/AppendMutableSequenceBuiltinCall.py
+++ b/boa3_test/example/built_in_methods_test/AppendMutableSequenceBuiltinCall.py
@@ -1,4 +1,4 @@
 def Main(op: str, args: List[str]) -> MutableSequence[int]:
-    a: MutableSequence[Any] = [1, 2, 3]
+    a: MutableSequence[int] = [1, 2, 3]
     MutableSequence.append(a, 4)
     return a

--- a/boa3_test/example/function_test/CallFunctionWrittenBefore.py
+++ b/boa3_test/example/function_test/CallFunctionWrittenBefore.py
@@ -3,4 +3,5 @@ def TestAdd(a: int, b: int) -> int:
 
 
 def Main(operation: str, args: Tuple[int]) -> int:
-    return TestAdd(1, 2)
+    if operation == 'TestAdd':
+        return TestAdd(1, 2)

--- a/boa3_test/example/function_test/DefaultReturn.py
+++ b/boa3_test/example/function_test/DefaultReturn.py
@@ -1,0 +1,5 @@
+def Main(condition1: bool, condition2: bool) -> int:
+    if condition1:
+        return 10
+    elif condition2:
+        return 20

--- a/boa3_test/example/function_test/EmptyListReturn.py
+++ b/boa3_test/example/function_test/EmptyListReturn.py
@@ -1,0 +1,2 @@
+def Main() -> List[int]:
+    return []

--- a/boa3_test/example/function_test/MismatchedReturnType.py
+++ b/boa3_test/example/function_test/MismatchedReturnType.py
@@ -1,0 +1,2 @@
+def Main() -> list:
+    return 2

--- a/boa3_test/example/function_test/MismatchedReturnTypeWithIf.py
+++ b/boa3_test/example/function_test/MismatchedReturnTypeWithIf.py
@@ -1,0 +1,5 @@
+def Main(condition: bool) -> int:
+    if condition:
+        return 10
+    else:
+        return '10'

--- a/boa3_test/tests/boa_test.py
+++ b/boa3_test/tests/boa_test.py
@@ -28,5 +28,9 @@ class BoaTest(TestCase):
                 # when an compiler error is logged this exception is raised.
                 pass
 
+        for logger in log.records:
+            import logging
+            logging.log(level=logger.levelno, msg=logger.msg)
+
         if len([exception for exception in log.records if isinstance(exception.msg, expected_logged_exception)]) <= 0:
             raise AssertionError('{0} not logged'.format(expected_logged_exception.__name__))

--- a/boa3_test/tests/test_any.py
+++ b/boa3_test/tests/test_any.py
@@ -29,6 +29,7 @@ class TestAny(BoaTest):
             + Opcode.PUSH3
             + Opcode.PACK
             + Opcode.STLOC0
+            + Opcode.PUSHNULL
             + Opcode.RET        # return
         )
         output = Boa3.compile(path)
@@ -53,6 +54,7 @@ class TestAny(BoaTest):
             + Opcode.PUSH3
             + Opcode.PACK
             + Opcode.STLOC0
+            + Opcode.PUSHNULL
             + Opcode.RET        # return
         )
         output = Boa3.compile(path)
@@ -73,6 +75,7 @@ class TestAny(BoaTest):
             + Opcode.PUSH3
             + Opcode.PACK
             + Opcode.STLOC0
+            + Opcode.PUSHNULL
             + Opcode.RET        # return
         )
         output = Boa3.compile(path)
@@ -97,7 +100,7 @@ class TestAny(BoaTest):
             + Opcode.STLOC0
             + Opcode.LDLOC0         # SequenceFunction(bool_tuple)
             + Opcode.CALL
-            + Integer(45).to_byte_array(min_length=1, signed=True)
+            + Integer(46).to_byte_array(min_length=1, signed=True)
             + Opcode.PUSHDATA1      # SequenceFunction([True, 1, 'ok'])
             + Integer(len(ok)).to_byte_array() + ok
             + Opcode.PUSH1
@@ -105,12 +108,12 @@ class TestAny(BoaTest):
             + Opcode.PUSH3
             + Opcode.PACK
             + Opcode.CALL
-            + Integer(35).to_byte_array(min_length=1, signed=True)
+            + Integer(36).to_byte_array(min_length=1, signed=True)
             + Opcode.PUSHDATA1      # SequenceFunction('some_string')
             + Integer(len(some_string)).to_byte_array()
             + some_string
             + Opcode.CALL
-            + Integer(20).to_byte_array(min_length=1, signed=True)
+            + Integer(21).to_byte_array(min_length=1, signed=True)
             + Opcode.PUSHDATA1      # SequenceFunction((True, 1, 'ok'))
             + Integer(len(ok)).to_byte_array() + ok
             + Opcode.PUSH1
@@ -118,20 +121,22 @@ class TestAny(BoaTest):
             + Opcode.PUSH3
             + Opcode.PACK
             + Opcode.CALL
-            + Integer(10).to_byte_array(min_length=1, signed=True)
+            + Integer(11).to_byte_array(min_length=1, signed=True)
             + Opcode.PUSH3          # SequenceFunction([1, 2, 3])
             + Opcode.PUSH2
             + Opcode.PUSH1
             + Opcode.PUSH3
             + Opcode.PACK
             + Opcode.CALL
-            + Integer(3).to_byte_array(min_length=1, signed=True)
+            + Integer(4).to_byte_array(min_length=1, signed=True)
+            + Opcode.PUSHNULL
             + Opcode.RET        # return
             + Opcode.INITSLOT   # SequenceFunction
             + b'\x01'
             + b'\x01'
             + Opcode.LDARG0         # a = sequence
             + Opcode.STLOC0
+            + Opcode.PUSHNULL
             + Opcode.RET
         )
 
@@ -183,6 +188,7 @@ class TestAny(BoaTest):
             + Opcode.STLOC4
             + Opcode.LDLOC3     # a = bool_tuple
             + Opcode.STLOC4
+            + Opcode.PUSHNULL
             + Opcode.RET
         )
 
@@ -208,6 +214,7 @@ class TestAny(BoaTest):
             + Opcode.PUSHDATA1  # str_sequence = 'some_string'
             + Integer(len(some_string)).to_byte_array() + some_string
             + Opcode.STLOC0
+            + Opcode.PUSHNULL
             + Opcode.RET
         )
 
@@ -254,6 +261,7 @@ class TestAny(BoaTest):
             + Opcode.PUSH4
             + Opcode.PACK
             + Opcode.STLOC4
+            + Opcode.PUSHNULL
             + Opcode.RET
         )
 
@@ -283,6 +291,7 @@ class TestAny(BoaTest):
             + Opcode.PUSH2
             + Opcode.PACK
             + Opcode.STLOC2
+            + Opcode.PUSHNULL
             + Opcode.RET
         )
 

--- a/boa3_test/tests/test_arithmetic.py
+++ b/boa3_test/tests/test_arithmetic.py
@@ -2,8 +2,6 @@ from boa3.boa3 import Boa3
 from boa3.exception.CompilerError import MismatchedTypes, NotSupportedOperation
 from boa3.model.operation.binaryop import BinaryOp
 from boa3.neo.vm.opcode.Opcode import Opcode
-from boa3.neo.vm.type.Integer import Integer
-from boa3.neo.vm.type.String import String
 from boa3_test.tests.boa_test import BoaTest
 
 
@@ -239,6 +237,7 @@ class TestArithmetic(BoaTest):
             + Opcode.LDARG1
             + Opcode.ADD
             + Opcode.STARG0
+            + Opcode.PUSHNULL
             + Opcode.RET
         )
 
@@ -256,6 +255,7 @@ class TestArithmetic(BoaTest):
             + Opcode.LDARG1
             + Opcode.SUB
             + Opcode.STARG0
+            + Opcode.PUSHNULL
             + Opcode.RET
         )
 
@@ -273,6 +273,7 @@ class TestArithmetic(BoaTest):
             + Opcode.LDARG1
             + Opcode.MUL
             + Opcode.STARG0
+            + Opcode.PUSHNULL
             + Opcode.RET
         )
 
@@ -294,6 +295,7 @@ class TestArithmetic(BoaTest):
             + Opcode.LDARG1
             + Opcode.DIV
             + Opcode.STARG0
+            + Opcode.PUSHNULL
             + Opcode.RET
         )
 
@@ -311,6 +313,7 @@ class TestArithmetic(BoaTest):
             + Opcode.LDARG1
             + Opcode.MOD
             + Opcode.STARG0
+            + Opcode.PUSHNULL
             + Opcode.RET
         )
 
@@ -328,6 +331,7 @@ class TestArithmetic(BoaTest):
             + Opcode.LDARG1
             + Opcode.CAT
             + Opcode.STARG0
+            + Opcode.PUSHNULL
             + Opcode.RET
         )
 
@@ -349,6 +353,7 @@ class TestArithmetic(BoaTest):
             + Opcode.LDARG1
             + BinaryOp.StrMul.bytecode
             + Opcode.STARG0
+            + Opcode.PUSHNULL
             + Opcode.RET
         )
 

--- a/boa3_test/tests/test_function.py
+++ b/boa3_test/tests/test_function.py
@@ -2,6 +2,8 @@ from boa3.boa3 import Boa3
 from boa3.exception.CompilerError import MismatchedTypes, TooManyReturns, TypeHintMissing
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
+from boa3.neo.vm.type.StackItemType import StackItemType
+from boa3.neo.vm.type.String import String
 from boa3_test.tests.boa_test import BoaTest
 
 
@@ -79,6 +81,7 @@ class TestFunction(BoaTest):
             Opcode.INITSLOT     # function signature
             + b'\x00'           # num local variables
             + b'\x01'           # num arguments
+            + Opcode.PUSHNULL
             + Opcode.RET        # return
         )
 
@@ -99,6 +102,56 @@ class TestFunction(BoaTest):
         path = '%s/boa3_test/example/function_test/TupleFunction.py' % self.dirname
         self.assertCompilerLogs(TooManyReturns, path)
 
+    def test_default_return(self):
+        twenty = Integer(20).to_byte_array(min_length=1)
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x00'
+            + b'\x02'
+            + Opcode.LDARG0         # if arg0
+            + Opcode.JMPIFNOT
+                + Integer(4).to_byte_array(min_length=1, signed=True)
+                + Opcode.PUSH10         # return 10
+                + Opcode.RET
+            + Opcode.LDARG1         # elif arg1
+            + Opcode.JMPIFNOT
+            + Integer(8).to_byte_array(min_length=1, signed=True)
+                + Opcode.PUSHDATA1      # return 20
+                + Integer(len(twenty)).to_byte_array() + twenty
+                + Opcode.CONVERT
+                + StackItemType.Integer
+                + Opcode.RET
+            + Opcode.PUSH0          # default return
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/function_test/DefaultReturn.py' % self.dirname
+        output = Boa3.compile(path)
+
+        self.assertEqual(expected_output, output)
+
+    def test_empty_list_return(self):
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x00'
+            + b'\x00'
+            + Opcode.NEWARRAY0
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/function_test/EmptyListReturn.py' % self.dirname
+        output = Boa3.compile(path)
+
+        self.assertEqual(expected_output, output)
+
+    def test_mismatched_return_type(self):
+        path = '%s/boa3_test/example/function_test/MismatchedReturnType.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_mismatched_return_type_with_if(self):
+        path = '%s/boa3_test/example/function_test/MismatchedReturnTypeWithIf.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)
+
     def test_call_void_function_without_args(self):
         called_function_address = Integer(4).to_byte_array(min_length=1, signed=True)
 
@@ -115,6 +168,7 @@ class TestFunction(BoaTest):
             + b'\x00'
             + Opcode.PUSH1          # a = 1
             + Opcode.STLOC0
+            + Opcode.PUSHNULL
             + Opcode.RET            # return
         )
 
@@ -167,6 +221,7 @@ class TestFunction(BoaTest):
             + Opcode.LDARG1
             + Opcode.ADD
             + Opcode.STLOC0
+            + Opcode.PUSHNULL
             + Opcode.RET            # return
         )
 
@@ -227,6 +282,7 @@ class TestFunction(BoaTest):
             + Opcode.LDARG1
             + Opcode.ADD
             + Opcode.STLOC0
+            + Opcode.PUSHNULL
             + Opcode.RET            # return
         )
 
@@ -298,16 +354,27 @@ class TestFunction(BoaTest):
         self.assertEqual(expected_output, output)
 
     def test_call_function_written_before_caller(self):
-        called_function_address = Integer(3).to_byte_array(min_length=1, signed=True)
+        test_add: bytes = String('TestAdd').to_bytes()
+        first_call_address = Integer(7).to_byte_array(min_length=1, signed=True)
+        second_call_address = Integer(5).to_byte_array(min_length=1, signed=True)
 
         expected_output = (
             Opcode.INITSLOT     # Main
             + b'\x00'
             + b'\x02'
-            + Opcode.PUSH2          # return TestAdd(a, b)
-            + Opcode.PUSH1
-            + Opcode.CALL
-            + called_function_address
+            + Opcode.LDARG0         # if operation == 'TestAdd'
+            + Opcode.PUSHDATA1
+            + Integer(len(test_add)).to_byte_array(min_length=1)
+            + test_add
+            + Opcode.EQUAL
+            + Opcode.JMPIFNOT
+            + first_call_address
+                + Opcode.PUSH2          # return TestAdd(a, b)
+                + Opcode.PUSH1
+                + Opcode.CALL
+                + second_call_address
+                + Opcode.RET
+            + Opcode.PUSH0
             + Opcode.RET
             + Opcode.INITSLOT   # TestFunction
             + b'\x00'

--- a/boa3_test/tests/test_list.py
+++ b/boa3_test/tests/test_list.py
@@ -21,6 +21,7 @@ class TestList(BoaTest):
             + Opcode.PUSH3      # array length
             + Opcode.PACK
             + Opcode.STLOC0
+            + Opcode.PUSHNULL
             + Opcode.RET        # return
         )
         output = Boa3.compile(path)
@@ -48,6 +49,7 @@ class TestList(BoaTest):
             + Opcode.PUSH3      # array length
             + Opcode.PACK
             + Opcode.STLOC0
+            + Opcode.PUSHNULL
             + Opcode.RET        # return
         )
         output = Boa3.compile(path)
@@ -66,6 +68,7 @@ class TestList(BoaTest):
             + Opcode.PUSH3      # array length
             + Opcode.PACK
             + Opcode.STLOC0
+            + Opcode.PUSHNULL
             + Opcode.RET        # return
         )
         output = Boa3.compile(path)
@@ -90,6 +93,7 @@ class TestList(BoaTest):
             + Opcode.PUSH3      # array length
             + Opcode.PACK
             + Opcode.STLOC3
+            + Opcode.PUSHNULL
             + Opcode.RET        # return
         )
         output = Boa3.compile(path)
@@ -127,6 +131,7 @@ class TestList(BoaTest):
             + Opcode.PUSH3      # list length
             + Opcode.PACK
             + Opcode.STLOC0
+            + Opcode.PUSHNULL
             + Opcode.RET        # return
         )
         output = Boa3.compile(path)

--- a/boa3_test/tests/test_none.py
+++ b/boa3_test/tests/test_none.py
@@ -15,6 +15,7 @@ class TestAny(BoaTest):
             + b'\x00'
             + Opcode.PUSHNULL
             + Opcode.STLOC0
+            + Opcode.PUSHNULL
             + Opcode.RET        # return
         )
         output = Boa3.compile(path)
@@ -33,6 +34,7 @@ class TestAny(BoaTest):
             + Opcode.PUSH3
             + Opcode.PACK
             + Opcode.STLOC0
+            + Opcode.PUSHNULL
             + Opcode.RET        # return
         )
         output = Boa3.compile(path)

--- a/boa3_test/tests/test_tuple.py
+++ b/boa3_test/tests/test_tuple.py
@@ -21,6 +21,7 @@ class TestTuple(BoaTest):
             + Opcode.PUSH3      # tuple length
             + Opcode.PACK
             + Opcode.STLOC0
+            + Opcode.PUSHNULL
             + Opcode.RET        # return
         )
         output = Boa3.compile(path)
@@ -48,6 +49,7 @@ class TestTuple(BoaTest):
             + Opcode.PUSH3      # tuple length
             + Opcode.PACK
             + Opcode.STLOC0
+            + Opcode.PUSHNULL
             + Opcode.RET        # return
         )
         output = Boa3.compile(path)
@@ -66,6 +68,7 @@ class TestTuple(BoaTest):
             + Opcode.PUSH3      # tuple length
             + Opcode.PACK
             + Opcode.STLOC0
+            + Opcode.PUSHNULL
             + Opcode.RET        # return
         )
         output = Boa3.compile(path)
@@ -90,6 +93,7 @@ class TestTuple(BoaTest):
             + Opcode.PUSH3      # tuple length
             + Opcode.PACK
             + Opcode.STLOC3
+            + Opcode.PUSHNULL
             + Opcode.RET        # return
         )
         output = Boa3.compile(path)

--- a/boa3_test/tests/test_variable.py
+++ b/boa3_test/tests/test_variable.py
@@ -24,6 +24,7 @@ class TestVariable(BoaTest):
             Opcode.INITSLOT     # function signature
             + b'\x01'
             + b'\x00'
+            + Opcode.PUSHNULL
             + Opcode.RET        # return
         )
         compiler_output = compiler.compile(path)
@@ -56,6 +57,7 @@ class TestVariable(BoaTest):
             + len(byte_input).to_bytes(1, sys.byteorder)
             + byte_input
             + Opcode.STLOC0     # variable address
+            + Opcode.PUSHNULL
             + Opcode.RET
         )
 
@@ -71,6 +73,7 @@ class TestVariable(BoaTest):
             + b'\x00'
             + Opcode.PUSH1      # assignment value
             + Opcode.STLOC0     # variable address
+            + Opcode.PUSHNULL
             + Opcode.RET
         )
 
@@ -90,6 +93,7 @@ class TestVariable(BoaTest):
             + len(byte_input).to_bytes(1, sys.byteorder)
             + byte_input
             + Opcode.STARG0         # variable address
+            + Opcode.PUSHNULL
             + Opcode.RET
         )
 
@@ -128,6 +132,7 @@ class TestVariable(BoaTest):
             + Opcode.PUSH7
             + Opcode.STLOC          # variable index greater than 6 uses another opcode
             + b'\x07'
+            + Opcode.PUSHNULL
             + Opcode.RET
         )
 


### PR DESCRIPTION
- Include type checking on `return` statements based on the signature of the functions
  ```
  def example(a: int) -> int:
      if a > 10:
          return a
      return [a]  # this will raise a compiler error
  ```
- Included a default return when the last expression in the function's body is not a return statement
  - Because of this, functions with return type hint will always return a value that's the same type from the specified. The Python's behavior, in this case, is different: if there's no return at the end of the function's body, it will return None.
    ```
    def example(a: int) -> int:
        if a > 10:
            return a
        # for a <= 10, Python would return None, but on Neo VM this function returns 0
    ```
  - This decision was made to avoid unexpected behavior from Neo VM