### PR TITLE
Sequence get and set with negative index

### DIFF
--- a/boa3/model/type/sequence/tupletype.py
+++ b/boa3/model/type/sequence/tupletype.py
@@ -36,6 +36,10 @@ class TupleType(SequenceType):
     def _is_type_of(cls, value: Any):
         return type(value) is tuple or isinstance(value, TupleType)
 
+    @property
+    def can_reassign_values(self) -> bool:
+        return False
+
     def __eq__(self, other) -> bool:
         if type(self) != type(other):
             return False

--- a/boa3/neo/vm/opcode/Opcode.py
+++ b/boa3/neo/vm/opcode/Opcode.py
@@ -237,6 +237,27 @@ class Opcode(bytes, Enum):
     OVER = b'\x4B'
     # The item n back in the stack is copied to the top.
     PICK = b'\x4D'
+
+    @staticmethod
+    def get_dup(position: int):
+        """
+        Gets the opcode to duplicate the item n back in the stack
+
+        :param position: index of the variable
+        :return: the respective opcode
+        :rtype: Opcode
+        """
+        duplicate_item = {
+            1: Opcode.DUP,
+            2: Opcode.OVER
+        }
+
+        if position > 0:
+            if position in duplicate_item:
+                return duplicate_item[position]
+            else:
+                return Opcode.PICK
+
     # The item at the top of the stack is copied and inserted before the second-to-top item.
     TUCK = b'\x4E'
     # The top two items on the stack are swapped.

--- a/boa3/neo/vm/opcode/OpcodeInfo.py
+++ b/boa3/neo/vm/opcode/OpcodeInfo.py
@@ -90,54 +90,54 @@ class OpcodeInfo:
     JMP_L = OpcodeInformation(Opcode.JMP_L, 4)
     # Transfers control to a target instruction if the value is True, not null, or non-zero. The target instruction
     # is represented as a 1-byte signed offset from the beginning of the current instruction.
-    JMPIF = OpcodeInformation(Opcode.JMPIF, 1)
+    JMPIF = OpcodeInformation(Opcode.JMPIF, 1, stack_items=1)
     # Transfers control to a target instruction if the value is True, not null, or non-zero. The target instruction
     # is represented as a 4-bytes signed offset from the beginning of the current instruction.
-    JMPIF_L = OpcodeInformation(Opcode.JMPIF_L, 4)
+    JMPIF_L = OpcodeInformation(Opcode.JMPIF_L, 4, stack_items=1)
     # Transfers control to a target instruction if the value is False, a null reference,
     # or zero. The target instruction is represented as a 1-byte signed offset from the beginning of the current
     # instruction.
-    JMPIFNOT = OpcodeInformation(Opcode.JMPIFNOT, 1)
+    JMPIFNOT = OpcodeInformation(Opcode.JMPIFNOT, 1, stack_items=1)
     # Transfers control to a target instruction if the value is False, a null reference,
     # or zero. The target instruction is represented as a 4-bytes signed offset from the beginning of the current
     # instruction.
-    JMPIFNOT_L = OpcodeInformation(Opcode.JMPIFNOT_L, 4)
+    JMPIFNOT_L = OpcodeInformation(Opcode.JMPIFNOT_L, 4, stack_items=1)
     # Transfers control to a target instruction if two values are equal. The target instruction is represented as a
     # 1-byte signed offset from the beginning of the current instruction.
-    JMPEQ = OpcodeInformation(Opcode.JMPEQ, 1)
+    JMPEQ = OpcodeInformation(Opcode.JMPEQ, 1, stack_items=2)
     # Transfers control to a target instruction if two values are equal. The target instruction is represented as a
     # 4-bytes signed offset from the beginning of the current instruction.
-    JMPEQ_L = OpcodeInformation(Opcode.JMPEQ_L, 4)
+    JMPEQ_L = OpcodeInformation(Opcode.JMPEQ_L, 4, stack_items=2)
     # Transfers control to a target instruction when two values are not equal. The target instruction is represented
     # as a 1-byte signed offset from the beginning of the current instruction.
-    JMPNE = OpcodeInformation(Opcode.JMPNE, 1)
+    JMPNE = OpcodeInformation(Opcode.JMPNE, 1, stack_items=2)
     # Transfers control to a target instruction when two values are not equal. The target instruction is represented
     # as a 4-bytes signed offset from the beginning of the current instruction.
-    JMPNE_L = OpcodeInformation(Opcode.JMPNE_L, 4)
+    JMPNE_L = OpcodeInformation(Opcode.JMPNE_L, 4, stack_items=2)
     # Transfers control to a target instruction if the first value is greater than the second value. The target
     # instruction is represented as a 1-byte signed offset from the beginning of the current instruction.
-    JMPGT = OpcodeInformation(Opcode.JMPGT, 1)
+    JMPGT = OpcodeInformation(Opcode.JMPGT, 1, stack_items=2)
     # Transfers control to a target instruction if the first value is greater than the second value. The target
     # instruction is represented as a 4-bytes signed offset from the beginning of the current instruction.
-    JMPGT_L = OpcodeInformation(Opcode.JMPGT_L, 4)
+    JMPGT_L = OpcodeInformation(Opcode.JMPGT_L, 4, stack_items=2)
     # Transfers control to a target instruction if the first value is greater than or equal to the second value. The
     # target instruction is represented as a 1-byte signed offset from the beginning of the current instruction.
-    JMPGE = OpcodeInformation(Opcode.JMPGE, 1)
+    JMPGE = OpcodeInformation(Opcode.JMPGE, 1, stack_items=2)
     # Transfers control to a target instruction if the first value is greater than or equal to the second value. The
     # target instruction is represented as a 4-bytes signed offset from the beginning of the current instruction.
-    JMPGE_L = OpcodeInformation(Opcode.JMPGE_L, 4)
+    JMPGE_L = OpcodeInformation(Opcode.JMPGE_L, 4, stack_items=2)
     # Transfers control to a target instruction if the first value is less than the second value. The target
     # instruction is represented as a 1-byte signed offset from the beginning of the current instruction.
-    JMPLT = OpcodeInformation(Opcode.JMPLT, 1)
+    JMPLT = OpcodeInformation(Opcode.JMPLT, 1, stack_items=2)
     # Transfers control to a target instruction if the first value is less than the second value. The target
     # instruction is represented as a 4-bytes signed offset from the beginning of the current instruction.
-    JMPLT_L = OpcodeInformation(Opcode.JMPLT_L, 4)
+    JMPLT_L = OpcodeInformation(Opcode.JMPLT_L, 4, stack_items=2)
     # Transfers control to a target instruction if the first value is less than or equal to the second value. The
     # target instruction is represented as a 1-byte signed offset from the beginning of the current instruction.
-    JMPLE = OpcodeInformation(Opcode.JMPLE, 1)
+    JMPLE = OpcodeInformation(Opcode.JMPLE, 1, stack_items=2)
     # Transfers control to a target instruction if the first value is less than or equal to the second value. The
     # target instruction is represented as a 4-bytes signed offset from the beginning of the current instruction.
-    JMPLE_L = OpcodeInformation(Opcode.JMPLE_L, 4)
+    JMPLE_L = OpcodeInformation(Opcode.JMPLE_L, 4, stack_items=2)
     # Calls the function at the target address which is represented as a 1-byte signed offset from the beginning of
     # the current instruction.
     CALL = OpcodeInformation(Opcode.CALL, 1)
@@ -185,7 +185,7 @@ class OpcodeInfo:
     # Removes the second-to-top stack item.
     NIP = OpcodeInformation(Opcode.NIP)
     # The item n back in the main stack is removed.
-    XDROP = OpcodeInformation(Opcode.XDROP)
+    XDROP = OpcodeInformation(Opcode.XDROP, stack_items=1)
     # Clear the stack
     CLEAR = OpcodeInformation(Opcode.CLEAR)
     # Duplicates the top stack item.
@@ -193,7 +193,7 @@ class OpcodeInfo:
     # Copies the second-to-top stack item to the top.
     OVER = OpcodeInformation(Opcode.OVER)
     # The item n back in the stack is copied to the top.
-    PICK = OpcodeInformation(Opcode.PICK)
+    PICK = OpcodeInformation(Opcode.PICK, stack_items=1)
     # The item at the top of the stack is copied and inserted before the second-to-top item.
     TUCK = OpcodeInformation(Opcode.TUCK)
     # The top two items on the stack are swapped.
@@ -207,7 +207,7 @@ class OpcodeInfo:
     # Reverse the order of the top 4 items on the stack.
     REVERSE4 = OpcodeInformation(Opcode.REVERSE4)
     # Pop the number N on the stack, and reverse the order of the top N items on the stack.
-    REVERSEN = OpcodeInformation(Opcode.REVERSEN)
+    REVERSEN = OpcodeInformation(Opcode.REVERSEN, stack_items=1)
 
     # endregion
 

--- a/boa3/neo/vm/opcode/OpcodeInformation.py
+++ b/boa3/neo/vm/opcode/OpcodeInformation.py
@@ -10,7 +10,7 @@ class OpcodeInformation:
     :ivar max_data_len: the max size in bytes of the operand. Same value as data_len if size is constant.
     """
 
-    def __init__(self, opcode: Opcode, min_data_len: int = 0, extra_data_max_len: int = 0):
+    def __init__(self, opcode: Opcode, min_data_len: int = 0, extra_data_max_len: int = 0, stack_items: int = 0):
         self.opcode: Opcode = opcode
 
         if min_data_len < 0:
@@ -20,6 +20,10 @@ class OpcodeInformation:
         if extra_data_max_len < 0:
             extra_data_max_len = 0
         self.max_data_len: int = min_data_len + extra_data_max_len
+
+        if stack_items < 0:
+            stack_items = 0
+        self.stack_items: int = stack_items
 
     def get_large(self):
         large_op = self.opcode.get_large

--- a/boa3_test/example/list_test/GetValueNegativeIndex.py
+++ b/boa3_test/example/list_test/GetValueNegativeIndex.py
@@ -1,0 +1,2 @@
+def Main(a: List[int]) -> int:
+    return a[-1]

--- a/boa3_test/example/list_test/SetValueNegativeIndex.py
+++ b/boa3_test/example/list_test/SetValueNegativeIndex.py
@@ -1,0 +1,3 @@
+def Main(a: List[int]) -> list:
+    a[-1] = 1
+    return a

--- a/boa3_test/tests/test_for.py
+++ b/boa3_test/tests/test_for.py
@@ -8,8 +8,8 @@ from boa3_test.tests.boa_test import BoaTest
 class TestFor(BoaTest):
 
     def test_for_tuple_condition(self):
-        jmpif_address = Integer(14).to_byte_array(min_length=1, signed=True)
-        jmp_address = Integer(-16).to_byte_array(min_length=1, signed=True)
+        jmpif_address = Integer(22).to_byte_array(min_length=1, signed=True)
+        jmp_address = Integer(-24).to_byte_array(min_length=1, signed=True)
 
         expected_output = (
             Opcode.INITSLOT
@@ -29,6 +29,14 @@ class TestFor(BoaTest):
             + jmpif_address
                 + Opcode.LDLOC1         # x = for_sequence[for_index]
                 + Opcode.LDLOC2
+                    + Opcode.DUP
+                    + Opcode.SIGN
+                    + Opcode.PUSHM1
+                    + Opcode.JMPNE
+                    + Integer(5).to_byte_array(min_length=1, signed=True)
+                    + Opcode.OVER
+                    + Opcode.SIZE
+                    + Opcode.ADD
                 + Opcode.PICKITEM
                 + Opcode.STLOC3
                 + Opcode.LDLOC0         # a = a + x
@@ -61,8 +69,8 @@ class TestFor(BoaTest):
             output = Boa3.compile(path)
 
     def test_for_variable_condition(self):
-        jmpif_address = Integer(14).to_byte_array(min_length=1, signed=True)
-        jmp_address = Integer(-16).to_byte_array(min_length=1, signed=True)
+        jmpif_address = Integer(22).to_byte_array(min_length=1, signed=True)
+        jmp_address = Integer(-24).to_byte_array(min_length=1, signed=True)
 
         expected_output = (
             Opcode.INITSLOT
@@ -84,6 +92,14 @@ class TestFor(BoaTest):
             + jmpif_address
                 + Opcode.LDLOC2         # x = for_sequence[for_index]
                 + Opcode.LDLOC3
+                    + Opcode.DUP
+                    + Opcode.SIGN
+                    + Opcode.PUSHM1
+                    + Opcode.JMPNE
+                    + Integer(5).to_byte_array(min_length=1, signed=True)
+                    + Opcode.OVER
+                    + Opcode.SIZE
+                    + Opcode.ADD
                 + Opcode.PICKITEM
                 + Opcode.STLOC4
                 + Opcode.LDLOC0         # a = a + x
@@ -120,11 +136,11 @@ class TestFor(BoaTest):
             output = Boa3.compile(path)
 
     def test_nested_for(self):
-        outer_jmpif_address = Integer(38).to_byte_array(min_length=1, signed=True)
-        outer_jmp_address = Integer(-40).to_byte_array(min_length=1, signed=True)
+        outer_jmpif_address = Integer(54).to_byte_array(min_length=1, signed=True)
+        outer_jmp_address = Integer(-56).to_byte_array(min_length=1, signed=True)
 
-        inner_jmpif_address = Integer(18).to_byte_array(min_length=1, signed=True)
-        inner_jmp_address = Integer(-20).to_byte_array(min_length=1, signed=True)
+        inner_jmpif_address = Integer(26).to_byte_array(min_length=1, signed=True)
+        inner_jmp_address = Integer(-28).to_byte_array(min_length=1, signed=True)
 
         expected_output = (
             Opcode.INITSLOT
@@ -146,6 +162,14 @@ class TestFor(BoaTest):
             + outer_jmpif_address
                 + Opcode.LDLOC2         # x = outer_for_sequence[outer_for_index]
                 + Opcode.LDLOC3
+                    + Opcode.DUP
+                    + Opcode.SIGN
+                    + Opcode.PUSHM1
+                    + Opcode.JMPNE
+                    + Integer(5).to_byte_array(min_length=1, signed=True)
+                    + Opcode.OVER
+                    + Opcode.SIZE
+                    + Opcode.ADD
                 + Opcode.PICKITEM
                 + Opcode.STLOC4
                     + Opcode.LDLOC1     # inner_for_sequence = sequence
@@ -156,6 +180,14 @@ class TestFor(BoaTest):
                 + inner_jmpif_address
                     + Opcode.LDLOC5         # y = inner_for_sequence[inner_for_index]
                     + Opcode.LDLOC6
+                        + Opcode.DUP
+                        + Opcode.SIGN
+                        + Opcode.PUSHM1
+                        + Opcode.JMPNE
+                        + Integer(5).to_byte_array(min_length=1, signed=True)
+                        + Opcode.OVER
+                        + Opcode.SIZE
+                        + Opcode.ADD
                     + Opcode.PICKITEM
                     + Opcode.STLOC
                     + Integer(7).to_byte_array()
@@ -196,8 +228,8 @@ class TestFor(BoaTest):
         self.assertEqual(expected_output, output)
 
     def test_for_else(self):
-        jmpif_address = Integer(14).to_byte_array(min_length=1, signed=True)
-        jmp_address = Integer(-16).to_byte_array(min_length=1, signed=True)
+        jmpif_address = Integer(22).to_byte_array(min_length=1, signed=True)
+        jmp_address = Integer(-24).to_byte_array(min_length=1, signed=True)
 
         expected_output = (
             Opcode.INITSLOT
@@ -219,6 +251,14 @@ class TestFor(BoaTest):
             + jmpif_address
                 + Opcode.LDLOC2         # x = for_sequence[for_index]
                 + Opcode.LDLOC3
+                    + Opcode.DUP
+                    + Opcode.SIGN
+                    + Opcode.PUSHM1
+                    + Opcode.JMPNE
+                    + Integer(5).to_byte_array(min_length=1, signed=True)
+                    + Opcode.OVER
+                    + Opcode.SIZE
+                    + Opcode.ADD
                 + Opcode.PICKITEM
                 + Opcode.STLOC4
                 + Opcode.LDLOC0         # a = a + x

--- a/boa3_test/tests/test_list.py
+++ b/boa3_test/tests/test_list.py
@@ -112,6 +112,38 @@ class TestList(BoaTest):
             + b'\x01'
             + Opcode.LDARG0     # arg[0]
             + Opcode.PUSH0
+                + Opcode.DUP
+                + Opcode.SIGN
+                + Opcode.PUSHM1
+                + Opcode.JMPNE
+                + Integer(5).to_byte_array(min_length=1, signed=True)
+                + Opcode.OVER
+                + Opcode.SIZE
+                + Opcode.ADD
+            + Opcode.PICKITEM
+            + Opcode.RET        # return
+        )
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_list_get_value_with_negative_index(self):
+        path = '%s/boa3_test/example/list_test/GetValueNegativeIndex.py' % self.dirname
+
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x00'
+            + b'\x01'
+            + Opcode.LDARG0     # arg[-1]
+            + Opcode.PUSH1
+            + Opcode.NEGATE
+                + Opcode.DUP
+                + Opcode.SIGN
+                + Opcode.PUSHM1
+                + Opcode.JMPNE
+                + Integer(5).to_byte_array(min_length=1, signed=True)
+                + Opcode.OVER
+                + Opcode.SIZE
+                + Opcode.ADD
             + Opcode.PICKITEM
             + Opcode.RET        # return
         )
@@ -146,9 +178,43 @@ class TestList(BoaTest):
             + b'\x01'
             + Opcode.LDARG0     # arg[0] = 1
             + Opcode.PUSH0
+                + Opcode.DUP
+                + Opcode.SIGN
+                + Opcode.PUSHM1
+                + Opcode.JMPNE
+                + Integer(5).to_byte_array(min_length=1, signed=True)
+                + Opcode.OVER
+                + Opcode.SIZE
+                + Opcode.ADD
             + Opcode.PUSH1
             + Opcode.SETITEM
             + Opcode.PUSH1      # return 1
+            + Opcode.RET
+        )
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_list_set_value_with_negative_index(self):
+        path = '%s/boa3_test/example/list_test/SetValueNegativeIndex.py' % self.dirname
+
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x00'
+            + b'\x01'
+            + Opcode.LDARG0     # arg[-1] = 1
+            + Opcode.PUSH1
+            + Opcode.NEGATE
+                + Opcode.DUP
+                + Opcode.SIGN
+                + Opcode.PUSHM1
+                + Opcode.JMPNE
+                + Integer(5).to_byte_array(min_length=1, signed=True)
+                + Opcode.OVER
+                + Opcode.SIZE
+                + Opcode.ADD
+            + Opcode.PUSH1
+            + Opcode.SETITEM
+            + Opcode.LDARG0     # return a
             + Opcode.RET
         )
         output = Boa3.compile(path)
@@ -171,8 +237,24 @@ class TestList(BoaTest):
             + b'\x01'
             + Opcode.LDARG0     # arg[0][0]
             + Opcode.PUSH0
+                + Opcode.DUP
+                + Opcode.SIGN
+                + Opcode.PUSHM1
+                + Opcode.JMPNE
+                + Integer(5).to_byte_array(min_length=1, signed=True)
+                + Opcode.OVER
+                + Opcode.SIZE
+                + Opcode.ADD
             + Opcode.PICKITEM
             + Opcode.PUSH0
+                + Opcode.DUP
+                + Opcode.SIGN
+                + Opcode.PUSHM1
+                + Opcode.JMPNE
+                + Integer(5).to_byte_array(min_length=1, signed=True)
+                + Opcode.OVER
+                + Opcode.SIZE
+                + Opcode.ADD
             + Opcode.PICKITEM
             + Opcode.RET        # return
         )
@@ -188,6 +270,14 @@ class TestList(BoaTest):
             + b'\x02'
             + Opcode.LDARG1     # args[0]
             + Opcode.PUSH0
+                + Opcode.DUP
+                + Opcode.SIGN
+                + Opcode.PUSHM1
+                + Opcode.JMPNE
+                + Integer(5).to_byte_array(min_length=1, signed=True)
+                + Opcode.OVER
+                + Opcode.SIZE
+                + Opcode.ADD
             + Opcode.PICKITEM
             + Opcode.RET        # return
         )

--- a/boa3_test/tests/test_multiple_expressions.py
+++ b/boa3_test/tests/test_multiple_expressions.py
@@ -110,6 +110,14 @@ class TestMultipleExpressions(BoaTest):
             + Opcode.STLOC0     # items2 = array
             + Opcode.LDARG0     # value = items1[0]
             + Opcode.PUSH0
+                + Opcode.DUP
+                + Opcode.SIGN
+                + Opcode.PUSHM1
+                + Opcode.JMPNE
+                + Integer(5).to_byte_array(min_length=1, signed=True)
+                + Opcode.OVER
+                + Opcode.SIZE
+                + Opcode.ADD
             + Opcode.PICKITEM
             + Opcode.STLOC1
             + Opcode.LDLOC1     # count = value + len(items2)
@@ -146,6 +154,14 @@ class TestMultipleExpressions(BoaTest):
             + Opcode.STLOC0     # items2 = array
             + Opcode.LDARG0     # value = items1[0]
             + Opcode.PUSH0
+                + Opcode.DUP
+                + Opcode.SIGN
+                + Opcode.PUSHM1
+                + Opcode.JMPNE
+                + Integer(5).to_byte_array(min_length=1, signed=True)
+                + Opcode.OVER
+                + Opcode.SIZE
+                + Opcode.ADD
             + Opcode.PICKITEM
             + Opcode.STLOC1
             + Opcode.LDLOC1     # count = value + len(items2)

--- a/boa3_test/tests/test_string.py
+++ b/boa3_test/tests/test_string.py
@@ -17,6 +17,14 @@ class TestString(BoaTest):
             + b'\x01'
             + Opcode.LDARG0     # arg[0]
             + Opcode.PUSH0
+                + Opcode.DUP
+                + Opcode.SIGN
+                + Opcode.PUSHM1
+                + Opcode.JMPNE
+                + Integer(5).to_byte_array(min_length=1, signed=True)
+                + Opcode.OVER
+                + Opcode.SIZE
+                + Opcode.ADD
             + Opcode.PUSH1
             + Opcode.SUBSTR
             + Opcode.RET        # return

--- a/boa3_test/tests/test_tuple.py
+++ b/boa3_test/tests/test_tuple.py
@@ -108,6 +108,14 @@ class TestTuple(BoaTest):
             + b'\x01'
             + Opcode.LDARG0     # arg[0]
             + Opcode.PUSH0
+                + Opcode.DUP
+                + Opcode.SIGN
+                + Opcode.PUSHM1
+                + Opcode.JMPNE
+                + Integer(5).to_byte_array(min_length=1, signed=True)
+                + Opcode.OVER
+                + Opcode.SIZE
+                + Opcode.ADD
             + Opcode.PICKITEM
             + Opcode.RET        # return
         )
@@ -120,20 +128,7 @@ class TestTuple(BoaTest):
 
     def test_tuple_set_value(self):
         path = '%s/boa3_test/example/tuple_test/SetValue.py' % self.dirname
-
-        expected_output = (
-            Opcode.INITSLOT     # function signature
-            + b'\x00'
-            + b'\x01'
-            + Opcode.LDARG0     # arg[0] = 1
-            + Opcode.PUSH0
-            + Opcode.PUSH1
-            + Opcode.SETITEM
-            + Opcode.PUSH1      # return 1
-            + Opcode.RET
-        )
-        output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
+        self.assertCompilerLogs(UnresolvedOperation, path)
 
     def test_non_sequence_set_value(self):
         path = '%s/boa3_test/example/tuple_test/MismatchedTypeSetValue.py' % self.dirname
@@ -152,8 +147,24 @@ class TestTuple(BoaTest):
             + b'\x01'
             + Opcode.LDARG0     # arg[0][0]
             + Opcode.PUSH0
+                + Opcode.DUP
+                + Opcode.SIGN
+                + Opcode.PUSHM1
+                + Opcode.JMPNE
+                + Integer(5).to_byte_array(min_length=1, signed=True)
+                + Opcode.OVER
+                + Opcode.SIZE
+                + Opcode.ADD
             + Opcode.PICKITEM
             + Opcode.PUSH0
+                + Opcode.DUP
+                + Opcode.SIGN
+                + Opcode.PUSHM1
+                + Opcode.JMPNE
+                + Integer(5).to_byte_array(min_length=1, signed=True)
+                + Opcode.OVER
+                + Opcode.SIZE
+                + Opcode.ADD
             + Opcode.PICKITEM
             + Opcode.RET        # return
         )
@@ -169,6 +180,14 @@ class TestTuple(BoaTest):
             + b'\x02'
             + Opcode.LDARG1     # args[0]
             + Opcode.PUSH0
+                + Opcode.DUP
+                + Opcode.SIGN
+                + Opcode.PUSHM1
+                + Opcode.JMPNE
+                + Integer(5).to_byte_array(min_length=1, signed=True)
+                + Opcode.OVER
+                + Opcode.SIZE
+                + Opcode.ADD
             + Opcode.PICKITEM
             + Opcode.RET        # return
         )


### PR DESCRIPTION
Implemented Python feature of getting or setting a value from a sequence with negative index:
```
a = [1, 2, 3]
b = a[-1]  # get last from a
c = a[-4]  # get the position len(a) - 4, which is invalid
```