### PR TITLE
Convert Bytes type

### DIFF
--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -335,7 +335,7 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
             )
             return symbol_type
         # the sequence can't use the given type as index
-        elif not symbol_type.is_valid_key(index_type):
+        if not symbol_type.is_valid_key(index_type):
             self._log_error(
                 CompilerError.MismatchedTypes(
                     subscript.lineno, subscript.col_offset,
@@ -350,9 +350,7 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
                     type_id=symbol_type.identifier,
                     operation_id=Operator.Subscript)
             )
-        else:
-            return symbol_type.value_type
-        return Type.none
+        return symbol_type.value_type
 
     def validate_slice(self, subscript: ast.Subscript, slice_node: ast.Slice) -> IType:
         """
@@ -866,14 +864,23 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
             )
         return num.n
 
-    def visit_Str(self, str: ast.Str) -> str:
+    def visit_Str(self, string: ast.Str) -> str:
         """
         Visitor of literal string node
 
-        :param str: the python ast string node
+        :param string: the python ast string node
         :return: the value of the string
         """
-        return str.s
+        return string.s
+
+    def visit_Bytes(self, bts: ast.Bytes) -> bytes:
+        """
+        Visitor of literal bytes node
+
+        :param bts: the python ast bytes node
+        :return: the value of the bytes
+        """
+        return bts.s
 
     def visit_Tuple(self, tup_node: ast.Tuple) -> Tuple[Any, ...]:
         """

--- a/boa3/compiler/codegeneratorvisitor.py
+++ b/boa3/compiler/codegeneratorvisitor.py
@@ -400,13 +400,22 @@ class VisitorCodeGenerator(ast.NodeVisitor):
         """
         self.generator.convert_literal(num.n)
 
-    def visit_Str(self, str: ast.Str):
+    def visit_Str(self, string: ast.Str):
         """
         Visitor of literal string node
 
-        :param str: the python ast string node
+        :param string: the python ast string node
         """
-        self.generator.convert_literal(str.s)
+        self.generator.convert_literal(string.s)
+
+    def visit_Bytes(self, bts: ast.Bytes):
+        """
+        Visitor of literal bytes node
+
+        :param bts: the python ast bytes node
+        :return: the value of the bytes
+        """
+        self.generator.convert_literal(bts.s)
 
     def visit_Tuple(self, tup_node: ast.Tuple):
         """

--- a/boa3/model/type/itype.py
+++ b/boa3/model/type/itype.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from boa3.model.symbol import ISymbol
 from boa3.neo.vm.type.AbiType import AbiType
+from boa3.neo.vm.type.StackItemType import StackItemType
 
 
 class IType(ISymbol):
@@ -35,6 +36,24 @@ class IType(ISymbol):
         :return: the representation for the abi. Any by default.
         """
         return AbiType.Any
+
+    @property
+    def stack_item(self) -> StackItemType:
+        """
+        Get the Neo VM stack item type representation for this type
+
+        :return: the stack item type of this type. Any by default.
+        """
+        return StackItemType.Any
+
+    @property
+    def is_generic(self) -> bool:
+        """
+        Verifies if this is a generic type
+
+        :return: True if this is a generic type. False otherwise.
+        """
+        return False
 
     @classmethod
     @abstractmethod

--- a/boa3/model/type/primitive/booltype.py
+++ b/boa3/model/type/primitive/booltype.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from boa3.model.type.itype import IType
 from boa3.neo.vm.type.AbiType import AbiType
+from boa3.neo.vm.type.StackItemType import StackItemType
 
 
 class BoolType(IType):
@@ -20,6 +21,10 @@ class BoolType(IType):
     @property
     def abi_type(self) -> AbiType:
         return AbiType.Boolean
+
+    @property
+    def stack_item(self) -> StackItemType:
+        return StackItemType.Boolean
 
     @classmethod
     def build(cls, value: Any):

--- a/boa3/model/type/primitive/bytestype.py
+++ b/boa3/model/type/primitive/bytestype.py
@@ -1,0 +1,60 @@
+from typing import Any
+
+from boa3.model.type.itype import IType
+from boa3.model.type.sequence.sequencetype import SequenceType
+from boa3.neo.vm.type.AbiType import AbiType
+from boa3.neo.vm.type.StackItemType import StackItemType
+
+
+class BytesType(SequenceType):
+    """
+    A class used to represent Python bytes type
+    """
+
+    def __init__(self):
+        identifier = 'bytes'
+        from boa3.model.type.primitive.inttype import IntType
+        values_type = [IntType()]
+        super().__init__(identifier, values_type)
+
+    @property
+    def identifier(self) -> str:
+        return self._identifier
+
+    @property
+    def abi_type(self) -> AbiType:
+        return AbiType.ByteArray
+
+    @property
+    def stack_item(self) -> StackItemType:
+        return StackItemType.Buffer
+
+    @property
+    def default_value(self) -> Any:
+        return bytes()
+
+    def is_valid_key(self, value_type: IType) -> bool:
+        return value_type == self.valid_key
+
+    @property
+    def valid_key(self) -> IType:
+        from boa3.model.type.type import Type
+        return Type.int
+
+    @classmethod
+    def build(cls, value: Any):
+        from boa3.model.type.type import Type
+        return Type.bytes
+
+    @classmethod
+    def build_sequence(cls, value_type: IType):
+        from boa3.model.type.type import Type
+        return Type.bytes
+
+    @classmethod
+    def _is_type_of(cls, value: Any):
+        return type(value) is bytes or isinstance(value, BytesType)
+
+    @property
+    def can_reassign_values(self) -> bool:
+        return False

--- a/boa3/model/type/primitive/inttype.py
+++ b/boa3/model/type/primitive/inttype.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from boa3.model.type.itype import IType
 from boa3.neo.vm.type.AbiType import AbiType
+from boa3.neo.vm.type.StackItemType import StackItemType
 
 
 class IntType(IType):
@@ -20,6 +21,10 @@ class IntType(IType):
     @property
     def abi_type(self) -> AbiType:
         return AbiType.Integer
+
+    @property
+    def stack_item(self) -> StackItemType:
+        return StackItemType.Integer
 
     @classmethod
     def build(cls, value: Any):

--- a/boa3/model/type/primitive/strtype.py
+++ b/boa3/model/type/primitive/strtype.py
@@ -3,6 +3,7 @@ from typing import Any
 from boa3.model.type.itype import IType
 from boa3.model.type.sequence.sequencetype import SequenceType
 from boa3.neo.vm.type.AbiType import AbiType
+from boa3.neo.vm.type.StackItemType import StackItemType
 
 
 class StrType(SequenceType):
@@ -25,6 +26,10 @@ class StrType(SequenceType):
     @property
     def abi_type(self) -> AbiType:
         return AbiType.String
+
+    @property
+    def stack_item(self) -> StackItemType:
+        return StackItemType.ByteString
 
     @classmethod
     def build(cls, value: Any):

--- a/boa3/model/type/sequence/genericsequencetype.py
+++ b/boa3/model/type/sequence/genericsequencetype.py
@@ -22,6 +22,10 @@ class GenericSequenceType(SequenceType):
         from boa3.model.type.type import Type
         return Type.int
 
+    @property
+    def is_generic(self) -> bool:
+        return True
+
     @classmethod
     def build(cls, value: Any):
         if cls._is_type_of(value):

--- a/boa3/model/type/sequence/mutable/genericmutablesequencetype.py
+++ b/boa3/model/type/sequence/mutable/genericmutablesequencetype.py
@@ -22,6 +22,10 @@ class GenericMutableSequenceType(MutableSequenceType):
         from boa3.model.type.type import Type
         return Type.int
 
+    @property
+    def is_generic(self) -> bool:
+        return True
+
     @classmethod
     def build(cls, value: Any):
         if cls._is_type_of(value):

--- a/boa3/model/type/sequence/sequencetype.py
+++ b/boa3/model/type/sequence/sequencetype.py
@@ -3,6 +3,7 @@ from typing import List, Any, Iterable
 
 from boa3.model.type.itype import IType
 from boa3.neo.vm.type.AbiType import AbiType
+from boa3.neo.vm.type.StackItemType import StackItemType
 
 
 class SequenceType(IType, ABC):
@@ -44,7 +45,11 @@ class SequenceType(IType, ABC):
 
     @property
     def abi_type(self) -> AbiType:
-        return AbiType.Array  # TODO: change when 'bytes' is implemented
+        return AbiType.Array
+
+    @property
+    def stack_item(self) -> StackItemType:
+        return StackItemType.Array
 
     @abstractmethod
     def is_valid_key(self, value_type: IType) -> bool:

--- a/boa3/model/type/type.py
+++ b/boa3/model/type/type.py
@@ -3,6 +3,7 @@ from typing import Dict, Any
 from boa3.model.type.anytype import anyType
 from boa3.model.type.itype import IType
 from boa3.model.type.primitive.booltype import BoolType
+from boa3.model.type.primitive.bytestype import BytesType
 from boa3.model.type.primitive.inttype import IntType
 from boa3.model.type.primitive.nonetype import NoneType
 from boa3.model.type.primitive.strtype import StrType
@@ -64,6 +65,7 @@ class Type:
     bool = BoolType()
     str = StrType()
     none = NoneType()
+    bytes = BytesType()
     tuple = TupleType()
     list = ListType()
 

--- a/boa3_test/example/built_in_methods_test/LenBytes.py
+++ b/boa3_test/example/built_in_methods_test/LenBytes.py
@@ -1,0 +1,4 @@
+def Main() -> int:
+    a = b'\x01\x02\x03'
+    b = len(a)
+    return b

--- a/boa3_test/example/bytes_test/GetValue.py
+++ b/boa3_test/example/bytes_test/GetValue.py
@@ -1,0 +1,2 @@
+def Main(a: bytes) -> int:
+    return a[0]

--- a/boa3_test/example/bytes_test/GetValueNegativeIndex.py
+++ b/boa3_test/example/bytes_test/GetValueNegativeIndex.py
@@ -1,0 +1,2 @@
+def Main(a: bytes) -> int:
+    return a[-1]

--- a/boa3_test/example/bytes_test/LiteralBytes.py
+++ b/boa3_test/example/bytes_test/LiteralBytes.py
@@ -1,0 +1,2 @@
+def Main():
+    a: bytes = b'\x01\x02\x03'

--- a/boa3_test/example/bytes_test/SetValue.py
+++ b/boa3_test/example/bytes_test/SetValue.py
@@ -1,0 +1,3 @@
+def Main(a: bytes) -> bytes:
+    a[0] = 0x01
+    return a

--- a/boa3_test/tests/test_builtin_method.py
+++ b/boa3_test/tests/test_builtin_method.py
@@ -1,5 +1,6 @@
 from boa3.boa3 import Boa3
 from boa3.exception.CompilerError import MismatchedTypes, UnexpectedArgument, UnfilledArgument
+from boa3.model.type.type import Type
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.String import String
@@ -70,6 +71,29 @@ class TestVariable(BoaTest):
             + Opcode.RET
         )
         path = '%s/boa3_test/example/built_in_methods_test/LenString.py' % self.dirname
+
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_len_of_bytes(self):
+        byte_input = b'\x01\x02\x03'
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x02'
+            + b'\x00'
+            + Opcode.PUSHDATA1            # push the bytes
+            + Integer(len(byte_input)).to_byte_array()
+            + byte_input
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.STLOC0
+            + Opcode.LDLOC0
+            + Opcode.SIZE
+            + Opcode.STLOC1
+            + Opcode.LDLOC1
+            + Opcode.RET
+        )
+        path = '%s/boa3_test/example/built_in_methods_test/LenBytes.py' % self.dirname
 
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)

--- a/boa3_test/tests/test_bytes.py
+++ b/boa3_test/tests/test_bytes.py
@@ -1,0 +1,80 @@
+from boa3.boa3 import Boa3
+from boa3.exception.CompilerError import UnresolvedOperation
+from boa3.model.type.type import Type
+from boa3.neo.vm.opcode.Opcode import Opcode
+from boa3.neo.vm.type.Integer import Integer
+from boa3_test.tests.boa_test import BoaTest
+
+
+class TestBytes(BoaTest):
+
+    def test_bytes_literal_value(self):
+        data = b'\x01\x02\x03'
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x01'
+            + b'\x00'
+            + Opcode.PUSHDATA1  # a = b'\x01\x02\x03'
+            + Integer(len(data)).to_byte_array(min_length=1)
+            + data
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.STLOC0
+            + Opcode.PUSHNULL
+            + Opcode.RET        # return
+        )
+
+        path = '%s/boa3_test/example/bytes_test/LiteralBytes.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_bytes_get_value(self):
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x00'
+            + b'\x01'
+            + Opcode.LDARG0     # arg[0]
+            + Opcode.PUSH0
+                + Opcode.DUP
+                + Opcode.SIGN
+                + Opcode.PUSHM1
+                + Opcode.JMPNE
+                + Integer(5).to_byte_array(min_length=1, signed=True)
+                + Opcode.OVER
+                + Opcode.SIZE
+                + Opcode.ADD
+            + Opcode.PICKITEM
+            + Opcode.RET        # return
+        )
+
+        path = '%s/boa3_test/example/bytes_test/GetValue.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_bytes_get_value_negative_index(self):
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x00'
+            + b'\x01'
+            + Opcode.LDARG0     # arg[0]
+            + Opcode.PUSH1
+            + Opcode.NEGATE
+                + Opcode.DUP
+                + Opcode.SIGN
+                + Opcode.PUSHM1
+                + Opcode.JMPNE
+                + Integer(5).to_byte_array(min_length=1, signed=True)
+                + Opcode.OVER
+                + Opcode.SIZE
+                + Opcode.ADD
+            + Opcode.PICKITEM
+            + Opcode.RET        # return
+        )
+
+        path = '%s/boa3_test/example/bytes_test/GetValueNegativeIndex.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_bytes_set_value(self):
+        path = '%s/boa3_test/example/bytes_test/SetValue.py' % self.dirname
+        self.assertCompilerLogs(UnresolvedOperation, path)

--- a/boa3_test/tests/test_constant.py
+++ b/boa3_test/tests/test_constant.py
@@ -3,9 +3,9 @@ import sys
 
 from boa3.analyser.analyser import Analyser
 from boa3.compiler.codegenerator import CodeGenerator
+from boa3.model.type.type import Type
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
-from boa3.neo.vm.type.StackItemType import StackItemType
 from boa3.neo.vm.type.String import String
 from boa3_test.tests.boa_test import BoaTest
 
@@ -30,7 +30,7 @@ class TestConstant(BoaTest):
             + Integer(len(byte_input)).to_byte_array()
             + byte_input
             + Opcode.CONVERT            # convert to integer
-            + StackItemType.Integer
+            + Type.int.stack_item
         )
 
         generator = CodeGenerator({})
@@ -47,7 +47,7 @@ class TestConstant(BoaTest):
             + Integer(len(byte_input)).to_byte_array(min_length=1)
             + byte_input
             + Opcode.CONVERT            # convert to integer
-            + StackItemType.Integer
+            + Type.int.stack_item
         )
 
         generator = CodeGenerator({})
@@ -64,7 +64,7 @@ class TestConstant(BoaTest):
             + Integer(len(byte_input)).to_byte_array(min_length=2)
             + byte_input
             + Opcode.CONVERT            # convert to integer
-            + StackItemType.Integer
+            + Type.int.stack_item
         )
 
         generator = CodeGenerator({})
@@ -81,7 +81,7 @@ class TestConstant(BoaTest):
             + Integer(len(byte_input)).to_byte_array(min_length=4)
             + byte_input
             + Opcode.CONVERT            # convert to integer
-            + StackItemType.Integer
+            + Type.int.stack_item
         )
 
         generator = CodeGenerator({})

--- a/boa3_test/tests/test_function.py
+++ b/boa3_test/tests/test_function.py
@@ -1,8 +1,8 @@
 from boa3.boa3 import Boa3
 from boa3.exception.CompilerError import MismatchedTypes, TooManyReturns, TypeHintMissing
+from boa3.model.type.type import Type
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
-from boa3.neo.vm.type.StackItemType import StackItemType
 from boa3.neo.vm.type.String import String
 from boa3_test.tests.boa_test import BoaTest
 
@@ -119,7 +119,7 @@ class TestFunction(BoaTest):
                 + Opcode.PUSHDATA1      # return 20
                 + Integer(len(twenty)).to_byte_array() + twenty
                 + Opcode.CONVERT
-                + StackItemType.Integer
+                + Type.int.stack_item
                 + Opcode.RET
             + Opcode.PUSH0          # default return
             + Opcode.RET

--- a/boa3_test/tests/test_if.py
+++ b/boa3_test/tests/test_if.py
@@ -1,8 +1,8 @@
 from boa3.boa3 import Boa3
 from boa3.exception.CompilerError import MismatchedTypes
+from boa3.model.type.type import Type
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
-from boa3.neo.vm.type.StackItemType import StackItemType
 from boa3_test.tests.boa_test import BoaTest
 
 
@@ -252,7 +252,7 @@ class TestIf(BoaTest):
                 + Integer(len(twenty)).to_byte_array()
                 + twenty
                 + Opcode.CONVERT
-                + StackItemType.Integer
+                + Type.int.stack_item
                 + Opcode.STLOC0
             + Opcode.LDLOC0     # return a
             + Opcode.RET


### PR DESCRIPTION
- Implemented conversion of literal `bytes`
- Implemented `get` to bytes indexes. Python's `bytes` object does not support item assignment
- Implemented bytes `len()` method.