### PR TITLE
Include compiler error when missing return

### DIFF
--- a/boa3/exception/CompilerError.py
+++ b/boa3/exception/CompilerError.py
@@ -144,6 +144,20 @@ class TooManyReturns(CompilerError):
         return "Too many returns"
 
 
+class MissingReturnStatement(CompilerError):
+    """
+    An error raised when a function with a return value is missing a return statement
+    """
+
+    def __init__(self, line: int, col: int, symbol_id: str):
+        self.symbol_id = symbol_id
+        super().__init__(line, col)
+
+    @property
+    def _error_message(self) -> Optional[str]:
+        return "'%s': Missing return statement" % self.symbol_id
+
+
 class IncorrectNumberOfOperands(CompilerError):
     """
     An error raised when an operation is used with the wrong number of operands

--- a/boa3_test/example/function_test/CallFunctionWithoutVariables.py
+++ b/boa3_test/example/function_test/CallFunctionWithoutVariables.py
@@ -7,6 +7,7 @@ def Main(number: int) -> int:
         return One()
     elif number == 2:
         return Two()
+    return 0
 
 
 def Two() -> int:

--- a/boa3_test/example/function_test/CallFunctionWrittenBefore.py
+++ b/boa3_test/example/function_test/CallFunctionWrittenBefore.py
@@ -3,5 +3,4 @@ def TestAdd(a: int, b: int) -> int:
 
 
 def Main(operation: str, args: tuple) -> int:
-    if operation == 'TestAdd':
-        return TestAdd(1, 2)
+    return TestAdd(1, 2)

--- a/boa3_test/example/function_test/DefaultReturn.py
+++ b/boa3_test/example/function_test/DefaultReturn.py
@@ -3,5 +3,5 @@ def Main(condition1: bool, condition2: bool) -> int:
         return 10
     elif condition2:
         return 20
-    # when return type is not None in the signature, returns the default value of the type
-    # in this example, it will return 0 if both `condition1` and `condition2` are False
+    # this will raise a compiler error because there is a execution flow without a return statement
+    # in this example, this flow is when both `condition1` and `condition2` are False

--- a/boa3_test/example/function_test/ReturnElifMissing.py
+++ b/boa3_test/example/function_test/ReturnElifMissing.py
@@ -1,0 +1,7 @@
+def Main(number: int) -> int:
+    if number % 3 == 1:
+        return number - 1
+    elif number % 2 == 1:
+        number += 1  # the function doesn't have return in this case
+    else:
+        return number

--- a/boa3_test/example/function_test/ReturnElseMissing.py
+++ b/boa3_test/example/function_test/ReturnElseMissing.py
@@ -1,0 +1,5 @@
+def Main(number: int) -> int:
+    if number % 2 == 1:
+        return number
+    else:
+        number += 1  # the function doesn't have return in this case

--- a/boa3_test/example/function_test/ReturnFor.py
+++ b/boa3_test/example/function_test/ReturnFor.py
@@ -1,0 +1,8 @@
+from typing import List
+
+
+def Main(iterator: List[int]) -> int:
+    for value in iterator:
+        return value
+    else:
+        return 5

--- a/boa3_test/example/function_test/ReturnForElseMissing.py
+++ b/boa3_test/example/function_test/ReturnForElseMissing.py
@@ -1,0 +1,8 @@
+from typing import List
+
+
+def Main(iterator: List[int]) -> int:
+    for value in iterator:
+        return value
+    else:
+        a = iterator  # the function doesn't have return in this case

--- a/boa3_test/example/function_test/ReturnForOnlyOnElse.py
+++ b/boa3_test/example/function_test/ReturnForOnlyOnElse.py
@@ -1,0 +1,9 @@
+from typing import List
+
+
+def Main(iterator: List[int]) -> int:
+    x = 0
+    for value in iterator:
+        x += value
+    else:
+        return x

--- a/boa3_test/example/function_test/ReturnIf.py
+++ b/boa3_test/example/function_test/ReturnIf.py
@@ -1,0 +1,8 @@
+def Main(number: int) -> int:
+    # the function has a return to each condition
+    if number % 3 == 1:
+        return number - 1
+    elif number % 3 == 2:
+        return number + 1
+    else:
+        return number

--- a/boa3_test/example/function_test/ReturnIfMissing.py
+++ b/boa3_test/example/function_test/ReturnIfMissing.py
@@ -1,0 +1,5 @@
+def Main(number: int) -> int:
+    if number % 2 == 1:
+        number -= 1  # the function doesn't have return in this case
+    else:
+        return number

--- a/boa3_test/example/function_test/ReturnMultipleInnerIf.py
+++ b/boa3_test/example/function_test/ReturnMultipleInnerIf.py
@@ -1,0 +1,23 @@
+def Main(condition: bool) -> int:
+    if condition:
+        if condition:
+            if condition:
+                return 1
+            elif condition:
+                return 2
+            else:
+                return 3
+        elif condition:
+            if condition:
+                return 4
+            else:
+                return 5
+        else:
+            return 6
+    else:
+        if condition:
+            return 7
+        elif condition:
+            return 8
+        else:
+            return 9

--- a/boa3_test/example/function_test/ReturnMultipleInnerIfMissing.py
+++ b/boa3_test/example/function_test/ReturnMultipleInnerIfMissing.py
@@ -1,0 +1,21 @@
+def Main(condition: bool) -> int:
+    if condition:
+        if condition:
+            if condition:
+                return 1
+            elif condition:
+                return 2
+        elif condition:
+            if condition:
+                return 4
+            else:
+                return 5
+        else:
+            return 6
+    else:
+        if condition:
+            return 7
+        elif condition:
+            return 8
+        else:
+            return 9

--- a/boa3_test/example/function_test/ReturnWhile.py
+++ b/boa3_test/example/function_test/ReturnWhile.py
@@ -1,0 +1,7 @@
+def Main(enter: int) -> int:
+    x = enter
+    while x < 10:
+        x += 1
+        return x
+    else:
+        return x

--- a/boa3_test/example/function_test/ReturnWhileOnlyOnElse.py
+++ b/boa3_test/example/function_test/ReturnWhileOnlyOnElse.py
@@ -1,0 +1,6 @@
+def Main(enter: int) -> int:
+    x = enter
+    while x < 10:
+        x += 1
+    else:
+        return x

--- a/boa3_test/example/function_test/ReturnWhileWithoutElse.py
+++ b/boa3_test/example/function_test/ReturnWhileWithoutElse.py
@@ -1,0 +1,6 @@
+def Main(enter: int) -> int:
+    x = enter
+    while x < 10:
+        x += 1
+        return x
+    # missing return when the test if false since the beginning

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-bitcoin==1.1.42
 autopep8==1.4.4
 bitarray==1.0.1
+bitcoin==1.1.42
 coverage==4.5.4
 ecdsa==0.15
 Events==0.3

--- a/setup.py
+++ b/setup.py
@@ -4,14 +4,35 @@ from os import path
 # Always prefer setuptools over distutils
 # To use a consistent encoding
 from setuptools import setup, find_packages
+from pkg_resources import parse_version
+
 
 from boa3 import __version__ as version
 
 here = path.abspath(path.dirname(__file__))
 
+try:
+    from pip._internal.req import parse_requirements
+    from pip import __version__ as __pip_version
+    pip_version = parse_version(__pip_version)
+    if (pip_version >= parse_version("20")):
+        from pip._internal.network.session import PipSession
+    elif (pip_version >= parse_version("10")):
+        from pip._internal.download import PipSession
+except ImportError:  # pip version < 10.0
+    from pip.req import parse_requirements
+    from pip.download import PipSession
+
 # Get the long description from the README file
 with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
+
+# get the requirements from requirements.txt
+install_reqs = parse_requirements('requirements.txt', session=PipSession())
+if pip_version >= parse_version("20"):
+    reqs = [str(ir.requirement) for ir in install_reqs]
+else:
+    reqs = [str(ir.req) for ir in install_reqs]
 
 
 setup(
@@ -72,6 +93,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
+    install_requires=reqs,
 
     python_requires='>=3.6',
 


### PR DESCRIPTION
- Include a compiler error when the return statement is missing in functions with return type hint
  - In #38 it was implemented the inclusion of a default return for this case. As [discussed](https://github.com/CityOfZion/neo3-boa/pull/38#issuecomment-644782772), it was changed to force the user to write all the returns if the return type is specified.
    ```
    def example(a: int) -> int:
        if a > 10:
            return a
        # a compiler error will be raise because for a <= 10 there is no return.
    ```

