### PR TITLE
Resolve py38 SyntaxWarnings

### DIFF
--- a/boa3/analyser/importanalyser.py
+++ b/boa3/analyser/importanalyser.py
@@ -19,7 +19,7 @@ class ImportAnalyser(IAstAnalyser):
         path: List[str] = module_origin.split(os.sep)
 
         super().__init__(ast.Module(body=[]), path[-1])
-        if import_target is 'typing':
+        if import_target == 'typing':
             self.symbols.update(
                 {symbol_id: symbol for symbol_id, symbol in self._get_types_from_typing_lib().items()
                  if symbol_id not in Type.builtin_types()

--- a/boa3/neo3/core/cryptography/ecc.py
+++ b/boa3/neo3/core/cryptography/ecc.py
@@ -714,7 +714,7 @@ class EllipticCurve:
             ysquare_root = None
 
         bit0 = 0
-        if ysquare_root % 2 is not 0:
+        if ysquare_root % 2 != 0:
             bit0 = 1
 
         if bit0 != flag:


### PR DESCRIPTION
Using Python 3.8 shows the following warnings when trying to use the `neo3-boa`  CLI
```bash
(venv) eriks-MacBook-Pro:neo3-boa erik$ neo3-boa
/Users/erik/Documents/code/neo3-boa/boa3/analyser/importanalyser.py:22: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if import_target is 'typing':
/Users/erik/Documents/code/neo3-boa/boa3/neo3/core/cryptography/ecc.py:717: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if ysquare_root % 2 is not 0:
usage: neo3-boa [-h] input
neo3-boa: error: the following arguments are required: input
```