### PR TITLE
Change metadata to define manifest 'extra' field information

### DIFF
--- a/boa3/analyser/moduleanalyser.py
+++ b/boa3/analyser/moduleanalyser.py
@@ -215,10 +215,17 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
                 for expected, actual in [(Builtin.metadata_fields[attr], type(v_type))
                                          for attr, v_type in attributes.items()
                                          if not isinstance(v_type, Builtin.metadata_fields[attr])]:
+                    if isinstance(expected, Iterable):
+                        expected_id = 'Union[{0}]'.format(', '.join([tpe.__name__ for tpe in expected]))
+                    elif hasattr(expected, '__name__'):
+                        expected_id = expected.__name__
+                    else:
+                        expected_id = str(expected)
+
                     self._log_error(
                         CompilerError.MismatchedTypes(
                             line=node.lineno, col=node.col_offset,
-                            expected_type_id=expected.__name__,
+                            expected_type_id=expected_id,
                             actual_type_id=actual.__name__
                         )
                     )

--- a/boa3/builtin/__init__.py
+++ b/boa3/builtin/__init__.py
@@ -25,8 +25,40 @@ class NeoMetadata:
     :type has_storage: bool
     :ivar is_payable: is a boolean value indicating whether the contract accepts transfers. False by default.
     :type is_payable: bool
+    :ivar author: the smart contract author. None by default;
+    :type author: str or None
+    :ivar email: the smart contract author email. None by default;
+    :type email: str or None
+    :ivar description: the smart contract description. None by default;
+    :type description: str or None
     """
 
+    from typing import Any, Dict
+
     def __init__(self):
+        from typing import Optional
+
+        # features
         self.has_storage: bool = False
         self.is_payable: bool = False
+
+        # extras
+        self.author: Optional[str] = None
+        self.email: Optional[str] = None
+        self.description: Optional[str] = None
+
+    @property
+    def extra(self) -> Dict[str, Any]:
+        """
+        Gets the metadata extra information
+
+        :return: a dictionary that maps each extra value with its name. Empty by default.
+        """
+        extra = {}
+        if isinstance(self.author, str):
+            extra['Author'] = self.author
+        if isinstance(self.email, str):
+            extra['Email'] = self.email
+        if isinstance(self.description, str):
+            extra['Description'] = self.description
+        return extra

--- a/boa3/compiler/filegenerator.py
+++ b/boa3/compiler/filegenerator.py
@@ -110,7 +110,7 @@ class FileGenerator:
             ],
             "trusts": [],
             "safeMethods": [],
-            "extra": None
+            "extra": self._metadata.extra if len(self._metadata.extra) > 0 else None
         }
 
     def _uses_storage_feature(self) -> bool:

--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple, Union
 
 from boa3.model.builtin.classmethod.appendmethod import AppendMethod
 from boa3.model.builtin.classmethod.mapkeysmethod import MapKeysMethod
@@ -64,5 +64,11 @@ class Builtin:
     def boa_symbols(cls) -> Dict[str, IdentifiedSymbol]:
         return {symbol.identifier: symbol for symbol in cls._boa_builtins}
 
-    metadata_fields: Dict[str, type] = {'has_storage': bool,
-                                        'is_payable': bool}
+    metadata_fields: Dict[str, Union[type, Tuple[type]]] = \
+        {
+            'author': (str, type(None)),
+            'email': (str, type(None)),
+            'description': (str, type(None)),
+            'has_storage': bool,
+            'is_payable': bool
+    }

--- a/boa3_test/example/metadata_test/MetadataInfoAuthor.py
+++ b/boa3_test/example/metadata_test/MetadataInfoAuthor.py
@@ -1,0 +1,12 @@
+from boa3.builtin import metadata, NeoMetadata
+
+
+def Main() -> int:
+    return 5
+
+
+@metadata
+def author_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+    meta.author = 'Test'
+    return meta

--- a/boa3_test/example/metadata_test/MetadataInfoAuthorMismatchedType.py
+++ b/boa3_test/example/metadata_test/MetadataInfoAuthorMismatchedType.py
@@ -1,0 +1,12 @@
+from boa3.builtin import metadata, NeoMetadata
+
+
+def Main() -> int:
+    return 5
+
+
+@metadata
+def author_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+    meta.author = 98
+    return meta

--- a/boa3_test/example/metadata_test/MetadataInfoDescription.py
+++ b/boa3_test/example/metadata_test/MetadataInfoDescription.py
@@ -1,0 +1,12 @@
+from boa3.builtin import metadata, NeoMetadata
+
+
+def Main() -> int:
+    return 5
+
+
+@metadata
+def description_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+    meta.description = 'This is an example'
+    return meta

--- a/boa3_test/example/metadata_test/MetadataInfoDescriptionMismatchedType.py
+++ b/boa3_test/example/metadata_test/MetadataInfoDescriptionMismatchedType.py
@@ -1,0 +1,12 @@
+from boa3.builtin import metadata, NeoMetadata
+
+
+def Main() -> int:
+    return 5
+
+
+@metadata
+def description_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+    meta.description = [0, 4, 8, 12]
+    return meta

--- a/boa3_test/example/metadata_test/MetadataInfoEmail.py
+++ b/boa3_test/example/metadata_test/MetadataInfoEmail.py
@@ -1,0 +1,12 @@
+from boa3.builtin import metadata, NeoMetadata
+
+
+def Main() -> int:
+    return 5
+
+
+@metadata
+def email_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+    meta.email = 'test@test.com'
+    return meta

--- a/boa3_test/example/metadata_test/MetadataInfoEmailMismatchedType.py
+++ b/boa3_test/example/metadata_test/MetadataInfoEmailMismatchedType.py
@@ -1,0 +1,12 @@
+from boa3.builtin import metadata, NeoMetadata
+
+
+def Main() -> int:
+    return 5
+
+
+@metadata
+def email_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+    meta.email = False
+    return meta

--- a/boa3_test/example/metadata_test/MetadataInfoExtras.py
+++ b/boa3_test/example/metadata_test/MetadataInfoExtras.py
@@ -1,0 +1,14 @@
+from boa3.builtin import metadata, NeoMetadata
+
+
+def Main() -> int:
+    return 5
+
+
+@metadata
+def extras_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+    meta.author = 'Test'
+    meta.email = 'test@test.com'
+    meta.description = 'This is an example'
+    return meta

--- a/boa3_test/example/metadata_test/MetadataInfoMultipleMethod.py
+++ b/boa3_test/example/metadata_test/MetadataInfoMultipleMethod.py
@@ -8,10 +8,14 @@ def Main() -> int:
 @metadata
 def manifest_func1() -> NeoMetadata:
     from boa3.builtin import NeoMetadata
-    return NeoMetadata()
+    meta = NeoMetadata()
+    meta.description = 'func1'
+    return meta
 
 
 @metadata  # this decorator can be applied to one function only
 def manifest_func2() -> NeoMetadata:
     from boa3.builtin import NeoMetadata
-    return NeoMetadata()
+    meta = NeoMetadata()
+    meta.description = 'func2'
+    return meta

--- a/boa3_test/tests/test_metadata.py
+++ b/boa3_test/tests/test_metadata.py
@@ -17,11 +17,16 @@ class TestMetadata(BoaTest):
         output, manifest = self.compile_and_save(path)
         self.assertEqual(expected_output, output)
 
+        # test features fields
         self.assertIn('features', manifest)
         self.assertIn('storage', manifest['features'])
         self.assertEqual(False, manifest['features']['storage'])
         self.assertIn('payable', manifest['features'])
         self.assertEqual(False, manifest['features']['payable'])
+
+        # test extra field
+        self.assertIn('extra', manifest)
+        self.assertIsNone(manifest['extra'])
 
     def test_metadata_info_method_mismatched_type(self):
         path = '%s/boa3_test/example/metadata_test/MetadataInfoMethodMismatchedReturn.py' % self.dirname
@@ -38,8 +43,31 @@ class TestMetadata(BoaTest):
         )
 
         path = '%s/boa3_test/example/metadata_test/MetadataInfoMultipleMethod.py' % self.dirname
-        output = self.assertCompilerLogs(RedeclaredSymbol, path)
+        self.assertCompilerLogs(RedeclaredSymbol, path)
+
+        output, manifest = self.compile_and_save(path)
         self.assertEqual(expected_output, output)
+
+        self.assertIn('extra', manifest)
+        self.assertIsNotNone(manifest['extra'])
+        self.assertIn('Description', manifest['extra'])
+        self.assertEqual('func1', manifest['extra']['Description'])
+
+    def test_metadata_method_with_args(self):
+        path = '%s/boa3_test/example/metadata_test/MetadataMethodWithArgs.py' % self.dirname
+        self.assertCompilerLogs(UnexpectedArgument, path)
+
+    def test_metadata_method_called_by_user_method(self):
+        path = '%s/boa3_test/example/metadata_test/MetadataMethodCalledByUserMethod.py' % self.dirname
+        self.assertCompilerLogs(UnresolvedReference, path)
+
+    def test_metadata_object_call_user_method(self):
+        path = '%s/boa3_test/example/metadata_test/MetadataObjectCallUserMethod.py' % self.dirname
+        self.assertCompilerLogs(UnresolvedReference, path)
+
+    def test_metadata_object_type_user_method(self):
+        path = '%s/boa3_test/example/metadata_test/MetadataObjectTypeUserMethod.py' % self.dirname
+        self.assertCompilerLogs(UnresolvedReference, path)
 
     def test_metadata_info_storage(self):
         expected_output = (
@@ -77,18 +105,78 @@ class TestMetadata(BoaTest):
         path = '%s/boa3_test/example/metadata_test/MetadataInfoPayableMismatchedType.py' % self.dirname
         self.assertCompilerLogs(MismatchedTypes, path)
 
-    def test_metadata_method_with_args(self):
-        path = '%s/boa3_test/example/metadata_test/MetadataMethodWithArgs.py' % self.dirname
-        self.assertCompilerLogs(UnexpectedArgument, path)
+    def test_metadata_info_author(self):
+        expected_output = (
+            Opcode.PUSH5        # return 5
+            + Opcode.RET
+        )
 
-    def test_metadata_method_called_by_user_method(self):
-        path = '%s/boa3_test/example/metadata_test/MetadataMethodCalledByUserMethod.py' % self.dirname
-        self.assertCompilerLogs(UnresolvedReference, path)
+        path = '%s/boa3_test/example/metadata_test/MetadataInfoAuthor.py' % self.dirname
+        output, manifest = self.compile_and_save(path)
+        self.assertEqual(expected_output, output)
 
-    def test_metadata_object_call_user_method(self):
-        path = '%s/boa3_test/example/metadata_test/MetadataObjectCallUserMethod.py' % self.dirname
-        self.assertCompilerLogs(UnresolvedReference, path)
+        self.assertIn('extra', manifest)
+        self.assertIsNotNone(manifest['extra'])
+        self.assertIn('Author', manifest['extra'])
+        self.assertEqual('Test', manifest['extra']['Author'])
 
-    def test_metadata_object_type_user_method(self):
-        path = '%s/boa3_test/example/metadata_test/MetadataObjectTypeUserMethod.py' % self.dirname
-        self.assertCompilerLogs(UnresolvedReference, path)
+    def test_metadata_info_author_mismatched_type(self):
+        path = '%s/boa3_test/example/metadata_test/MetadataInfoAuthorMismatchedType.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_metadata_info_email(self):
+        expected_output = (
+            Opcode.PUSH5        # return 5
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/metadata_test/MetadataInfoEmail.py' % self.dirname
+        output, manifest = self.compile_and_save(path)
+        self.assertEqual(expected_output, output)
+
+        self.assertIn('extra', manifest)
+        self.assertIsNotNone(manifest['extra'])
+        self.assertIn('Email', manifest['extra'])
+        self.assertEqual('test@test.com', manifest['extra']['Email'])
+
+    def test_metadata_info_email_mismatched_type(self):
+        path = '%s/boa3_test/example/metadata_test/MetadataInfoEmailMismatchedType.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_metadata_info_description(self):
+        expected_output = (
+            Opcode.PUSH5        # return 5
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/metadata_test/MetadataInfoDescription.py' % self.dirname
+        output, manifest = self.compile_and_save(path)
+        self.assertEqual(expected_output, output)
+
+        self.assertIn('extra', manifest)
+        self.assertIsNotNone(manifest['extra'])
+        self.assertIn('Description', manifest['extra'])
+        self.assertEqual('This is an example', manifest['extra']['Description'])
+
+    def test_metadata_info_description_mismatched_type(self):
+        path = '%s/boa3_test/example/metadata_test/MetadataInfoDescriptionMismatchedType.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_metadata_info_extras(self):
+        expected_output = (
+            Opcode.PUSH5        # return 5
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/metadata_test/MetadataInfoExtras.py' % self.dirname
+        output, manifest = self.compile_and_save(path)
+        self.assertEqual(expected_output, output)
+
+        self.assertIn('extra', manifest)
+        self.assertIsNotNone(manifest['extra'])
+        self.assertIn('Author', manifest['extra'])
+        self.assertEqual('Test', manifest['extra']['Author'])
+        self.assertIn('Email', manifest['extra'])
+        self.assertEqual('test@test.com', manifest['extra']['Email'])
+        self.assertIn('Description', manifest['extra'])
+        self.assertEqual('This is an example', manifest['extra']['Description'])


### PR DESCRIPTION
- Included additional information into the metadata object to be included in the `extra` field of the manifest.
Included data about the smart contract:
https://github.com/CityOfZion/neo3-boa/blob/d25eec059859baf7bf70413e99173b4c5dbeb5b7/boa3/builtin/__init__.py#L28-L33
The new attributes are all optional. If none of them is updated, the `extra` field in the manifest will be `null`, as default.