### PR TITLE
Remove entrypoint field from the manifest

### DIFF
--- a/boa3/analyser/moduleanalyser.py
+++ b/boa3/analyser/moduleanalyser.py
@@ -129,14 +129,6 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
 
     # region Log
 
-    def _log_main_method(self, method_id: str, method: Method, node: ast.AST):
-        if self._log:
-            logging.info("Main method found at {0}:{1}: '{2}{3}'"
-                         .format(node.lineno, node.col_offset, method_id, method))
-
-        # main method is always public
-        method.set_as_main_method()
-
     def _log_import(self, import_from: str):
         if self._log:
             logging.info("Importing '{0}'".format(import_from))
@@ -332,8 +324,6 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
             return Builtin.Metadata
 
         method = Method(fun_args, fun_return, Builtin.Public in fun_decorators)
-        if function.name in ['main', 'Main']:
-            self._log_main_method(function.name, method, function)
         self._current_method = method
 
         # don't evaluate constant expression - for example: string for documentation

--- a/boa3/compiler/codegenerator.py
+++ b/boa3/compiler/codegenerator.py
@@ -192,8 +192,6 @@ class CodeGenerator:
 
         if self.last_code.opcode is not Opcode.RET:
             self.insert_return()
-        if self._current_method.is_main_method:
-            self._move_entry_point_to_beginning()
 
         self._current_method = None
         self._stack.clear()
@@ -203,20 +201,6 @@ class CodeGenerator:
         Insert the return statement
         """
         self.__insert1(OpcodeInfo.RET)
-
-    def _move_entry_point_to_beginning(self):
-        """
-        Move the vm codes of the smart contract entry point to the beginning of the bytecode
-        """
-        method = self._current_method
-        if method is not None and method.is_main_method:
-            main_first_code = self._vm_codes_map[method.bytecode_address]
-            main_last_code = self.last_code
-            first_code = self._vm_codes[0]
-
-            if first_code.start_address != main_first_code.start_address:
-                main_first_code._last_code = None
-                first_code._last_code = main_last_code
 
     def convert_begin_while(self) -> int:
         """

--- a/boa3/model/method.py
+++ b/boa3/model/method.py
@@ -28,7 +28,6 @@ class Method(IExpression):
 
         self.is_public: bool = is_public
         self._requires_storage: bool = False
-        self.is_main_method: bool = False
 
         self.locals: Dict[str, Variable] = {}
         self.init_bytecode: Optional[VMCode] = None
@@ -108,7 +107,3 @@ class Method(IExpression):
 
     def set_storage(self):
         self._requires_storage = True
-
-    def set_as_main_method(self):
-        self.is_main_method = True
-        self.is_public = True

--- a/boa3_test/example/generation_test/GenerationWithoutMainAndPublicMethods.py
+++ b/boa3_test/example/generation_test/GenerationWithoutMainAndPublicMethods.py
@@ -1,0 +1,6 @@
+def Add(a: int, b: int) -> int:
+    return a + b
+
+
+def Sub(a: int, b: int) -> int:
+    return a - b

--- a/boa3_test/tests/test_file_generation.py
+++ b/boa3_test/tests/test_file_generation.py
@@ -15,7 +15,6 @@ class TestFileGeneration(BoaTest):
 
     def test_generate_files(self):
         path = '%s/boa3_test/example/generation_test/GenerationWithDecorator.py' % self.dirname
-
         expected_nef_output = path.replace('.py', '.nef')
         expected_manifest_output = path.replace('.py', '.manifest.json')
         Boa3.compile_and_save(path)
@@ -25,7 +24,6 @@ class TestFileGeneration(BoaTest):
 
     def test_generate_nef_file(self):
         path = '%s/boa3_test/example/generation_test/GenerationWithDecorator.py' % self.dirname
-
         expected_nef_output = path.replace('.py', '.nef')
         Boa3.compile_and_save(path)
 
@@ -49,75 +47,66 @@ class TestFileGeneration(BoaTest):
 
     def test_generate_manifest_file_with_decorator(self):
         path = '%s/boa3_test/example/generation_test/GenerationWithDecorator.py' % self.dirname
-
         expected_manifest_output = path.replace('.py', '.manifest.json')
-        Boa3.compile_and_save(path)
+        output, manifest = self.compile_and_save(path)
 
         self.assertTrue(os.path.exists(expected_manifest_output))
-        with open(expected_manifest_output, 'r') as manifest_output:
-            import json
-            manifest = json.loads(manifest_output.read())
-
         self.assertIn('abi', manifest)
         abi = manifest['abi']
 
-        self.assertIn('entryPoint', abi)
-        self.assertIn('name', abi['entryPoint'])
-        self.assertEqual(abi['entryPoint']['name'], 'Main')
-        self.assertIn('returnType', abi['entryPoint'])
-        self.assertEqual(abi['entryPoint']['returnType'], AbiType.Integer)
-
-        self.assertIn('parameters', abi['entryPoint'])
-        self.assertEqual(len(abi['entryPoint']['parameters']), 2)
-
-        arg0 = abi['entryPoint']['parameters'][0]
-        self.assertIn('name', arg0)
-        self.assertEqual(arg0['name'], 'a')
-        self.assertIn('type', arg0)
-        self.assertEqual(arg0['type'], AbiType.Integer)
-
-        arg1 = abi['entryPoint']['parameters'][1]
-        self.assertIn('name', arg1)
-        self.assertEqual(arg1['name'], 'b')
-        self.assertIn('type', arg1)
-        self.assertEqual(arg1['type'], AbiType.Integer)
-
+        self.assertNotIn('entryPoint', abi)
         self.assertIn('methods', abi)
-        self.assertEqual(len(abi['methods']), 1)
+        self.assertEqual(2, len(abi['methods']))
+
+        # method Main
+        method0 = abi['methods'][0]
+        self.assertIn('returnType', method0)
+        self.assertEqual(AbiType.Integer, method0['returnType'])
+        self.assertIn('parameters', method0)
+        self.assertEqual(2, len(method0['parameters']))
+
+        arg0 = method0['parameters'][0]
+        self.assertIn('name', arg0)
+        self.assertEqual('a', arg0['name'])
+        self.assertIn('type', arg0)
+        self.assertEqual(AbiType.Integer, arg0['type'])
+
+        arg1 = method0['parameters'][1]
+        self.assertIn('name', arg1)
+        self.assertEqual('b', arg1['name'])
+        self.assertIn('type', arg1)
+        self.assertEqual(AbiType.Integer, arg1['type'])
+
+        # method Sub
+        method1 = abi['methods'][1]
+        self.assertIn('returnType', method1)
+        self.assertEqual(AbiType.Integer, method1['returnType'])
+        self.assertIn('parameters', method1)
+        self.assertEqual(2, len(method1['parameters']))
+
+        arg0 = method1['parameters'][0]
+        self.assertIn('name', arg0)
+        self.assertEqual('a', arg0['name'])
+        self.assertIn('type', arg0)
+        self.assertEqual(AbiType.Integer, arg0['type'])
+
+        arg1 = method1['parameters'][1]
+        self.assertIn('name', arg1)
+        self.assertEqual('b', arg1['name'])
+        self.assertIn('type', arg1)
+        self.assertEqual(AbiType.Integer, arg1['type'])
 
         self.assertIn('events', abi)
-        self.assertEqual(len(abi['events']), 0)
+        self.assertEqual(0, len(abi['events']))
 
     def test_generate_manifest_file_without_decorator(self):
         path = '%s/boa3_test/example/generation_test/GenerationWithoutDecorator.py' % self.dirname
-
         expected_manifest_output = path.replace('.py', '.manifest.json')
-        Boa3.compile_and_save(path)
+        output, manifest = self.compile_and_save(path)
 
         self.assertTrue(os.path.exists(expected_manifest_output))
-        with open(expected_manifest_output, 'r') as manifest_output:
-            import json
-            manifest = json.loads(manifest_output.read())
-
         self.assertIn('abi', manifest)
         abi = manifest['abi']
-
-        self.assertIn('entryPoint', abi)
-        self.assertNotEqual(0, len(abi['entryPoint']))  # entry point cannot be empty
-        self.assertIn('parameters', abi['entryPoint'])
-        self.assertEqual(len(abi['entryPoint']['parameters']), 2)
-
-        arg0 = abi['entryPoint']['parameters'][0]
-        self.assertIn('name', arg0)
-        self.assertEqual(arg0['name'], 'a')
-        self.assertIn('type', arg0)
-        self.assertEqual(arg0['type'], AbiType.Integer)
-
-        arg1 = abi['entryPoint']['parameters'][1]
-        self.assertIn('name', arg1)
-        self.assertEqual(arg1['name'], 'b')
-        self.assertIn('type', arg1)
-        self.assertEqual(arg1['type'], AbiType.Integer)
 
         self.assertIn('methods', abi)
         self.assertEqual(0, len(abi['methods']))
@@ -127,9 +116,35 @@ class TestFileGeneration(BoaTest):
 
     def test_generate_without_main(self):
         path = '%s/boa3_test/example/generation_test/GenerationWithoutMain.py' % self.dirname
+        expected_manifest_output = path.replace('.py', '.manifest.json')
+        output, manifest = self.compile_and_save(path)
 
-        with self.assertRaises(NotImplementedError):
-            Boa3.compile_and_save(path)
+        self.assertTrue(os.path.exists(expected_manifest_output))
+        self.assertIn('abi', manifest)
+        abi = manifest['abi']
+
+        self.assertNotIn('entryPoint', abi)
+        self.assertIn('methods', abi)
+        self.assertEqual(2, len(abi['methods']))
+
+        self.assertIn('events', abi)
+        self.assertEqual(0, len(abi['events']))
+
+    def test_generate_without_main_and_public_methods(self):
+        path = '%s/boa3_test/example/generation_test/GenerationWithoutMainAndPublicMethods.py' % self.dirname
+        expected_manifest_output = path.replace('.py', '.manifest.json')
+        output, manifest = self.compile_and_save(path)
+
+        self.assertTrue(os.path.exists(expected_manifest_output))
+        self.assertIn('abi', manifest)
+        abi = manifest['abi']
+
+        self.assertNotIn('entryPoint', abi)
+        self.assertIn('methods', abi)
+        self.assertEqual(0, len(abi['methods']))
+
+        self.assertIn('events', abi)
+        self.assertEqual(0, len(abi['events']))
 
     def test_generate_manifest_file_abi_method_offset(self):
         path = '%s/boa3_test/example/generation_test/GenerationWithDecorator.py' % self.dirname
@@ -144,20 +159,13 @@ class TestFileGeneration(BoaTest):
         }
         self.assertGreater(len(methods), 0)
 
-        Boa3.compile_and_save(path)
+        output, manifest = self.compile_and_save(path)
         self.assertTrue(os.path.exists(manifest_path))
-        with open(manifest_path, 'r') as manifest_output:
-            import json
-            manifest = json.loads(manifest_output.read())
-
         self.assertIn('abi', manifest)
         abi = manifest['abi']
 
-        self.assertIn('entryPoint', abi)
         self.assertIn('methods', abi)
-
-        abi_methods = [abi['entryPoint']]
-        abi_methods.extend(abi['methods'])
+        abi_methods = abi['methods']
         self.assertGreater(len(abi['methods']), 0)
 
         for method in abi_methods:
@@ -170,11 +178,8 @@ class TestFileGeneration(BoaTest):
         path = '%s/boa3_test/example/storage_test/StorageGetBytesKey.py' % self.dirname
         manifest_path = path.replace('.py', '.manifest.json')
 
-        Boa3.compile_and_save(path)
+        output, manifest = self.compile_and_save(path)
         self.assertTrue(os.path.exists(manifest_path))
-        with open(manifest_path, 'r') as manifest_output:
-            import json
-            manifest = json.loads(manifest_output.read())
 
         self.assertIn('features', manifest)
         self.assertIn('storage', manifest['features'])

--- a/boa3_test/tests/test_function.py
+++ b/boa3_test/tests/test_function.py
@@ -319,13 +319,15 @@ class TestFunction(BoaTest):
         self.assertEqual(expected_output, output)
 
     def test_call_function_without_variables(self):
-        main_to_one_address = Integer(13).to_byte_array(min_length=1, signed=True)
-        main_to_two_address = Integer(7).to_byte_array(min_length=1, signed=True)
-        two_to_one_address = Integer(-3).to_byte_array(min_length=1, signed=True)
+        main_to_one_address = Integer(-10).to_byte_array(min_length=1, signed=True)
+        main_to_two_address = Integer(5).to_byte_array(min_length=1, signed=True)
+        two_to_one_address = Integer(-24).to_byte_array(min_length=1, signed=True)
         end_if = Integer(5).to_byte_array(min_length=1, signed=True)
 
         expected_output = (
-            Opcode.INITSLOT     # Main
+            Opcode.PUSH1        # One
+            + Opcode.RET            # return 1
+            + Opcode.INITSLOT   # Main
             + b'\x00'
             + b'\x01'
             + Opcode.LDARG0         # if arg0 == 1
@@ -346,8 +348,6 @@ class TestFunction(BoaTest):
                 + Opcode.RET
             + Opcode.PUSH0          # default return
             + Opcode.RET
-            + Opcode.PUSH1     # One
-            + Opcode.RET            # return 1
             + Opcode.PUSH1     # Two
             + Opcode.CALL           # return 1 + One()
             + two_to_one_address
@@ -361,23 +361,23 @@ class TestFunction(BoaTest):
         self.assertEqual(expected_output, output)
 
     def test_call_function_written_before_caller(self):
-        call_address = Integer(3).to_byte_array(min_length=1, signed=True)
+        call_address = Integer(-12).to_byte_array(min_length=1, signed=True)
 
         expected_output = (
-            Opcode.INITSLOT     # Main
+            Opcode.INITSLOT     # TestFunction
+            + b'\x00'
+            + b'\x02'
+            + Opcode.LDARG0         # return a + b
+            + Opcode.LDARG1
+            + Opcode.ADD
+            + Opcode.RET
+            + Opcode.INITSLOT   # Main
             + b'\x00'
             + b'\x02'
             + Opcode.PUSH2          # return TestAdd(a, b)
             + Opcode.PUSH1
             + Opcode.CALL
             + call_address
-            + Opcode.RET
-            + Opcode.INITSLOT   # TestFunction
-            + b'\x00'
-            + b'\x02'
-            + Opcode.LDARG0         # return a + b
-            + Opcode.LDARG1
-            + Opcode.ADD
             + Opcode.RET
         )
 


### PR DESCRIPTION
In the latest version of Neo, the `entryPoint` field of the manifest was removed.
The former `entryPoint` it's now included in the `methods` field.