### PR TITLE
Include limitations when a smart contract is payable

### DIFF
--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -30,7 +30,7 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
     :ivar type_errors: a list with the found type errors. Empty by default.
     :ivar modules: a list with the analysed modules. Empty by default.
     :ivar symbols: a dictionary that maps the global symbols.
-    :cvar __operators: a dictionary that maps each operator from Python ast to its equivalent Boa operator.
+    :cvar _operators: a dictionary that maps each operator from Python ast to its equivalent Boa operator.
     """
 
     def __init__(self, analyser, symbol_table: Dict[str, ISymbol], log: bool = False):
@@ -45,7 +45,7 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
 
         self.visit(self._tree)
 
-    __operators = {
+    _operators = {
         ast.Add: Operator.Plus,
         ast.Sub: Operator.Minus,
         ast.Mult: Operator.Mult,
@@ -75,7 +75,7 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
     }
 
     @property
-    def __current_method_id(self) -> str:
+    def _current_method_id(self) -> str:
         """
         Get the string identifier of the current method
 
@@ -87,7 +87,7 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
             return list(self.symbols.keys())[index]
 
     @property
-    def __modules_symbols(self) -> Dict[str, ISymbol]:
+    def _modules_symbols(self) -> Dict[str, ISymbol]:
         """
         Gets all the symbols in the modules scopes.
 
@@ -192,7 +192,7 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
             # it is returning something, but there is no type hint for return
             elif self._current_method.return_type is Type.none:
                 self._log_error(
-                    CompilerError.TypeHintMissing(ret.lineno, ret.col_offset, symbol_id=self.__current_method_id)
+                    CompilerError.TypeHintMissing(ret.lineno, ret.col_offset, symbol_id=self._current_method_id)
                 )
                 return
         if not self._current_method.return_type.is_type_of(ret_type):
@@ -825,8 +825,8 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
             return node.operator
 
         node_type = type(node)
-        if node_type in self.__operators:
-            return self.__operators[node_type]
+        if node_type in self._operators:
+            return self._operators[node_type]
         else:
             return None
 
@@ -912,7 +912,7 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
                         CompilerError.MetadataInformationMissing(
                             line=call.func.lineno, col=call.func.col_offset,
                             symbol_id=function.identifier,
-                            metadata_attr_id='storage'
+                            metadata_attr_id='has_storage'
                         )
                     )
                 else:

--- a/boa3/compiler/codegeneratorvisitor.py
+++ b/boa3/compiler/codegeneratorvisitor.py
@@ -210,11 +210,11 @@ class VisitorCodeGenerator(ast.NodeVisitor):
                 self.generator.convert_operation(BinaryOp.Sub)
                 self.generator.convert_get_array_ending()
 
-    def __convert_unary_operation(self, operand, op):
+    def _convert_unary_operation(self, operand, op):
         self.visit_to_generate(operand)
         self.generator.convert_operation(op)
 
-    def __convert_binary_operation(self, left, right, op):
+    def _convert_binary_operation(self, left, right, op):
         self.visit_to_generate(left)
         self.visit_to_generate(right)
         self.generator.convert_operation(op)
@@ -226,7 +226,7 @@ class VisitorCodeGenerator(ast.NodeVisitor):
         :param bin_op: the python ast binary operation node
         """
         if isinstance(bin_op.op, BinaryOperation):
-            self.__convert_binary_operation(bin_op.left, bin_op.right, bin_op.op)
+            self._convert_binary_operation(bin_op.left, bin_op.right, bin_op.op)
 
     def visit_UnaryOp(self, un_op: ast.UnaryOp):
         """
@@ -235,7 +235,7 @@ class VisitorCodeGenerator(ast.NodeVisitor):
         :param un_op: the python ast binary operation node
         """
         if isinstance(un_op.op, UnaryOperation):
-            self.__convert_unary_operation(un_op.operand, un_op.op)
+            self._convert_unary_operation(un_op.operand, un_op.op)
 
     def visit_Compare(self, compare: ast.Compare):
         """
@@ -249,12 +249,12 @@ class VisitorCodeGenerator(ast.NodeVisitor):
             right = compare.comparators[index]
             if isinstance(op, IOperation):
                 if isinstance(op, BinaryOperation):
-                    self.__convert_binary_operation(left, right, op)
+                    self._convert_binary_operation(left, right, op)
                 else:
                     operand = left
                     if isinstance(operand, ast.NameConstant) and operand.value is None:
                         operand = right
-                    self.__convert_unary_operation(operand, op)
+                    self._convert_unary_operation(operand, op)
                 # if it's more than two comparators, must include AND between the operations
                 if not converted:
                     converted = True
@@ -432,7 +432,7 @@ class VisitorCodeGenerator(ast.NodeVisitor):
 
         :param tup_node: the python ast tuple node
         """
-        self.__create_array(tup_node.elts, Type.tuple)
+        self._create_array(tup_node.elts, Type.tuple)
 
     def visit_List(self, list_node: ast.List):
         """
@@ -440,7 +440,7 @@ class VisitorCodeGenerator(ast.NodeVisitor):
 
         :param list_node: the python ast list node
         """
-        self.__create_array(list_node.elts, Type.list)
+        self._create_array(list_node.elts, Type.list)
 
     def visit_Dict(self, dict_node: ast.Dict):
         """
@@ -456,7 +456,7 @@ class VisitorCodeGenerator(ast.NodeVisitor):
             self.visit_to_generate(dict_node.values[key_value])
             self.generator.convert_set_item()
 
-    def __create_array(self, values: List[ast.AST], array_type: IType):
+    def _create_array(self, values: List[ast.AST], array_type: IType):
         """
         Creates a new array from a literal sequence
 

--- a/boa3/compiler/filegenerator.py
+++ b/boa3/compiler/filegenerator.py
@@ -94,14 +94,6 @@ class FileGenerator:
             "extra": self._metadata.extra if len(self._metadata.extra) > 0 else None
         }
 
-    def _uses_storage_feature(self) -> bool:
-        """
-        Returns whether the smart contract uses the storage feature
-
-        :return: True if there is any method that uses storage. False otherwise.
-        """
-        return any(method.requires_storage for method in self._methods.values())
-
     def generate_abi_file(self) -> bytes:
         """
         Generates the .abi metadata file
@@ -137,16 +129,15 @@ class FileGenerator:
         return methods
 
     def _construct_abi_method(self, method_id: str, method: Method) -> Dict[str, Any]:
-        params = []
-        for arg_id, arg in method.args.items():
-            params.append({
-                "name": arg_id,
-                "type": arg.type.abi_type
-            })
         return {
             "name": method_id,
             "offset": method.bytecode_address if method.bytecode_address is not None else 0,
-            "parameters": params,
+            "parameters": [
+                {
+                    "name": arg_id,
+                    "type": arg.type.abi_type
+                } for arg_id, arg in method.args.items()
+            ],
             "returnType": method.type.abi_type
         }
 

--- a/boa3/exception/CompilerError.py
+++ b/boa3/exception/CompilerError.py
@@ -61,6 +61,41 @@ class InvalidType(CompilerError):
         return message
 
 
+class MetadataImplementationMissing(CompilerError):
+    """
+    An error raised when the metadata required functions aren't implemented
+    """
+
+    def __init__(self, line: int, col: int, symbol_id: str, metadata_attr_id: str):
+        self.symbol_id: str = symbol_id
+        self.metadata_attr_id: str = metadata_attr_id
+        super().__init__(line, col)
+
+    @property
+    def _error_message(self) -> Optional[str]:
+        return "'{0}' requires '{1}' implementation".format(self.metadata_attr_id, self.symbol_id)
+
+
+class MetadataIncorrectImplementation(CompilerError):
+    """
+    An error raised when a metadata required function is incorrectly implemented
+    """
+    from boa3.model.symbol import ISymbol
+
+    def __init__(self, line: int, col: int, symbol_id: str, expected_symbol: ISymbol, actual_symbol: ISymbol):
+        from boa3.model.symbol import ISymbol
+
+        self.symbol_id: str = symbol_id
+        self.expected_symbol: ISymbol = expected_symbol
+        self.actual_symbol: ISymbol = actual_symbol
+        super().__init__(line, col)
+
+    @property
+    def _error_message(self) -> Optional[str]:
+        return ("'{0}' is not correctly implemented. Expecting '{1}', got '{2}' instead"
+                .format(self.symbol_id, self.expected_symbol, self.actual_symbol))
+
+
 class MetadataInformationMissing(CompilerError):
     """
     An error raised when the metadata info doesn't match with the functions requirements
@@ -73,7 +108,7 @@ class MetadataInformationMissing(CompilerError):
 
     @property
     def _error_message(self) -> Optional[str]:
-        return "'{0}' requires {1}, which is missing in the metadata".format(self.symbol_id, self.metadata_attr_id)
+        return "'{0}' requires '{1}' attribute, which is missing in the metadata".format(self.symbol_id, self.metadata_attr_id)
 
 
 class MismatchedTypes(CompilerError):

--- a/boa3_test/example/metadata_test/MetadataInfoPayableIncorrectVerify.py
+++ b/boa3_test/example/metadata_test/MetadataInfoPayableIncorrectVerify.py
@@ -6,8 +6,8 @@ def Main() -> int:
 
 
 @public
-def verify() -> bool:
-    return False
+def verify() -> int:
+    return 10
 
 
 @metadata

--- a/boa3_test/example/metadata_test/MetadataInfoPayableMissingVerify.py
+++ b/boa3_test/example/metadata_test/MetadataInfoPayableMissingVerify.py
@@ -1,13 +1,8 @@
-from boa3.builtin import metadata, NeoMetadata, public
+from boa3.builtin import metadata, NeoMetadata
 
 
 def Main() -> int:
     return 5
-
-
-@public
-def verify() -> bool:
-    return False
 
 
 @metadata

--- a/boa3_test/example/metadata_test/MetadataInfoPayablePrivateVerify.py
+++ b/boa3_test/example/metadata_test/MetadataInfoPayablePrivateVerify.py
@@ -1,11 +1,10 @@
-from boa3.builtin import metadata, NeoMetadata, public
+from boa3.builtin import metadata, NeoMetadata
 
 
 def Main() -> int:
     return 5
 
 
-@public
 def verify() -> bool:
     return False
 


### PR DESCRIPTION
A payable smart contract must have a `verify` function.
If `verify` is not implemented or if its signature isn't correct the compiler will raise an error.

The `verify` function must implement the following signature:
```python
@public
def verify() -> bool
```
- `verify` can have arguments as well, but they're not been checked in this pull request. It will be implemented when the stared parameters (`*args`) is implemented