### PR TITLE
Typed collection assign error

### DIFF
--- a/boa3/analyser/moduleanalyser.py
+++ b/boa3/analyser/moduleanalyser.py
@@ -242,7 +242,7 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
                 """
                 Payable smart contracts requires the implementation of a 'verify' function, that must implement the
                 following signature:
-                
+
                 ```
                 @public
                 def verify(*args) -> bool
@@ -252,7 +252,7 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
                 if (verify_id not in self.global_symbols  # couldn't find verify
                     or not isinstance(self.global_symbols[verify_id], Method)  # verify is not a function
                     or self.global_symbols[verify_id].origin is None  # verify is not a user function
-                ):
+                    ):
                     self._log_error(
                         CompilerError.MetadataImplementationMissing(
                             line=self._metadata_node.lineno, col=self._metadata_node.col_offset,
@@ -262,7 +262,7 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
                     )
                 elif (self.global_symbols[verify_id].return_type != Type.bool
                       or not self.global_symbols[verify_id].is_public
-                ):
+                      ):
                     actual = self.global_symbols[verify_id]
                     expected = Method(actual.args, Type.bool, True)
                     self._log_error(

--- a/boa3_test/example/dict_test/EmptyDictAssignment.py
+++ b/boa3_test/example/dict_test/EmptyDictAssignment.py
@@ -1,0 +1,5 @@
+from typing import Dict
+
+
+def Main():
+    a: Dict[int, int] = {}

--- a/boa3_test/example/list_test/EmptyListAssignment.py
+++ b/boa3_test/example/list_test/EmptyListAssignment.py
@@ -1,0 +1,5 @@
+from typing import List
+
+
+def Main():
+    a: List[int] = []

--- a/boa3_test/example/tuple_test/EmptyTupleAssignment.py
+++ b/boa3_test/example/tuple_test/EmptyTupleAssignment.py
@@ -1,0 +1,5 @@
+from typing import Tuple
+
+
+def Main():
+    a: Tuple[int] = ()

--- a/boa3_test/tests/test_dict.py
+++ b/boa3_test/tests/test_dict.py
@@ -154,6 +154,21 @@ class TestDict(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
+    def test_dict_assign_empty_dict(self):
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x01'
+            + b'\x00'
+            + Opcode.NEWMAP  # a = {}
+            + Opcode.STLOC0
+            + Opcode.PUSHNULL
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/dict_test/EmptyDictAssignment.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
     def test_dict_type_hint_assignment(self):
         expected_output = (
             Opcode.INITSLOT

--- a/boa3_test/tests/test_list.py
+++ b/boa3_test/tests/test_list.py
@@ -169,6 +169,21 @@ class TestList(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
+    def test_list_assign_empty_list(self):
+        path = '%s/boa3_test/example/list_test/EmptyListAssignment.py' % self.dirname
+
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x01'
+            + b'\x00'
+            + Opcode.NEWARRAY0
+            + Opcode.STLOC0
+            + Opcode.PUSHNULL
+            + Opcode.RET        # return
+        )
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
     def test_list_set_value(self):
         path = '%s/boa3_test/example/list_test/SetValue.py' % self.dirname
 

--- a/boa3_test/tests/test_tuple.py
+++ b/boa3_test/tests/test_tuple.py
@@ -99,6 +99,21 @@ class TestTuple(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
+    def test_tuple_assign_empty_tuple(self):
+        path = '%s/boa3_test/example/tuple_test/EmptyTupleAssignment.py' % self.dirname
+
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x01'
+            + b'\x00'
+            + Opcode.NEWARRAY0
+            + Opcode.STLOC0
+            + Opcode.PUSHNULL
+            + Opcode.RET        # return
+        )
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
     def test_tuple_get_value(self):
         path = '%s/boa3_test/example/tuple_test/GetValue.py' % self.dirname
 


### PR DESCRIPTION
Fixed an error that was raised when assigning an empty collection to a typed collection.
```python
empty_list: List[int] = []
empty_tuple: Tuple[str] = ()
empty_dict: Dict[str, int] = {}
```