### PR TITLE
Convert list clear method

### DIFF
--- a/boa3/analyser/moduleanalyser.py
+++ b/boa3/analyser/moduleanalyser.py
@@ -242,7 +242,7 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
                 """
                 Payable smart contracts requires the implementation of a 'verify' function, that must implement the
                 following signature:
-                
+
                 ```
                 @public
                 def verify(*args) -> bool
@@ -252,7 +252,7 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
                 if (verify_id not in self.global_symbols  # couldn't find verify
                     or not isinstance(self.global_symbols[verify_id], Method)  # verify is not a function
                     or self.global_symbols[verify_id].origin is None  # verify is not a user function
-                ):
+                    ):
                     self._log_error(
                         CompilerError.MetadataImplementationMissing(
                             line=self._metadata_node.lineno, col=self._metadata_node.col_offset,
@@ -262,7 +262,7 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
                     )
                 elif (self.global_symbols[verify_id].return_type != Type.bool
                       or not self.global_symbols[verify_id].is_public
-                ):
+                      ):
                     actual = self.global_symbols[verify_id]
                     expected = Method(actual.args, Type.bool, True)
                     self._log_error(

--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -1,6 +1,7 @@
 from typing import Dict, List, Optional, Tuple, Union
 
 from boa3.model.builtin.classmethod.appendmethod import AppendMethod
+from boa3.model.builtin.classmethod.clearmethod import ClearMethod
 from boa3.model.builtin.classmethod.mapkeysmethod import MapKeysMethod
 from boa3.model.builtin.classmethod.mapvaluesmethod import MapValuesMethod
 from boa3.model.builtin.decorator.builtindecorator import IBuiltinDecorator
@@ -39,12 +40,14 @@ class Builtin:
 
     # python class method
     Append = AppendMethod()
+    Clear = ClearMethod()
     Keys = MapKeysMethod()
     Values = MapValuesMethod()
 
     _python_builtins: List[IdentifiedSymbol] = [Len,
                                                 ByteArray,
                                                 Append,
+                                                Clear,
                                                 Keys,
                                                 Values]
 

--- a/boa3/model/builtin/classmethod/clearmethod.py
+++ b/boa3/model/builtin/classmethod/clearmethod.py
@@ -1,0 +1,55 @@
+from typing import Any, Dict, List, Optional, Tuple
+
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.expression import IExpression
+from boa3.model.type.collection.sequence.mutable.mutablesequencetype import MutableSequenceType
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class ClearMethod(IBuiltinMethod):
+    def __init__(self, sequence_type: MutableSequenceType = None):
+        if not isinstance(sequence_type, MutableSequenceType):
+            from boa3.model.type.type import Type
+            sequence_type = Type.mutableSequence
+
+        identifier = 'clear'
+        args: Dict[str, Variable] = {'self': Variable(sequence_type)}
+        super().__init__(identifier, args)
+
+    @property
+    def _arg_self(self) -> Variable:
+        return self.args['self']
+
+    def validate_parameters(self, *params: IExpression) -> bool:
+        if len(params) != 1:
+            return False
+        return isinstance(params[0], IExpression) and isinstance(params[0].type, MutableSequenceType)
+
+    @property
+    def is_supported(self) -> bool:
+        # TODO: remove when bytearray.clear() is implemented
+        from boa3.model.type.type import Type
+        return self._arg_self.type is not Type.bytearray
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        return [(Opcode.CLEARITEMS, b'')]
+
+    def push_self_first(self) -> bool:
+        return self.has_self_argument
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> Optional[str]:
+        return None
+
+    def build(self, value: Any):
+        if type(value) == type(self.args['self'].type):
+            return self
+        if isinstance(value, MutableSequenceType):
+            return ClearMethod(value)
+        return super().build(value)

--- a/boa3_test/example/built_in_methods_test/ClearMutableSequence.py
+++ b/boa3_test/example/built_in_methods_test/ClearMutableSequence.py
@@ -1,0 +1,7 @@
+from typing import MutableSequence
+
+
+def Main(op: str, args: list) -> MutableSequence[int]:
+    a: MutableSequence[int] = [1, 2, 3]
+    a.clear()
+    return a

--- a/boa3_test/example/built_in_methods_test/ClearMutableSequenceBuiltinCall.py
+++ b/boa3_test/example/built_in_methods_test/ClearMutableSequenceBuiltinCall.py
@@ -1,0 +1,7 @@
+from typing import MutableSequence
+
+
+def Main(op: str, args: list) -> MutableSequence[int]:
+    a: MutableSequence[int] = [1, 2, 3]
+    MutableSequence.clear(a)
+    return a

--- a/boa3_test/example/built_in_methods_test/ClearTooFewParameters.py
+++ b/boa3_test/example/built_in_methods_test/ClearTooFewParameters.py
@@ -1,0 +1,7 @@
+from typing import List
+
+
+def Main(op: str, args: list) -> List[int]:
+    a = [1, 2, 3]
+    list.clear()
+    return a

--- a/boa3_test/example/built_in_methods_test/ClearTooManyParameters.py
+++ b/boa3_test/example/built_in_methods_test/ClearTooManyParameters.py
@@ -1,0 +1,7 @@
+from typing import List
+
+
+def Main(op: str, args: list) -> List[int]:
+    a = [1, 2, 3]
+    a.clear(a)
+    return a

--- a/boa3_test/example/built_in_methods_test/ClearTuple.py
+++ b/boa3_test/example/built_in_methods_test/ClearTuple.py
@@ -1,0 +1,7 @@
+from typing import Tuple
+
+
+def Main(op: str, args: list) -> Tuple[int]:
+    a = (1, 2, 3)
+    a.clear()
+    return a

--- a/boa3_test/example/bytes_test/BytearrayClear.py
+++ b/boa3_test/example/bytes_test/BytearrayClear.py
@@ -1,0 +1,4 @@
+def Main(op: str, args: list) -> bytearray:
+    a = bytearray(b'\x01\x02\x03\x04')
+    a.clear()  # not supported yet
+    return a

--- a/boa3_test/example/bytes_test/BytesClear.py
+++ b/boa3_test/example/bytes_test/BytesClear.py
@@ -1,0 +1,4 @@
+def Main(op: str, args: list) -> bytes:
+    a = b'\x01\x02\x03\x04'
+    a.clear()
+    return a

--- a/boa3_test/example/list_test/ClearList.py
+++ b/boa3_test/example/list_test/ClearList.py
@@ -1,0 +1,7 @@
+from typing import List
+
+
+def Main(op: str, args: list) -> List[int]:
+    a = [1, 2, 3]
+    a.clear()
+    return a

--- a/boa3_test/tests/test_builtin_method.py
+++ b/boa3_test/tests/test_builtin_method.py
@@ -175,3 +175,61 @@ class TestVariable(BoaTest):
         self.assertCompilerLogs(UnfilledArgument, path)
 
     # endregion
+
+    # region TestClear
+
+    def test_clear_tuple(self):
+        path = '%s/boa3_test/example/built_in_methods_test/ClearTuple.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_clear_mutable_sequence(self):
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x01'
+            + b'\x02'
+            + Opcode.PUSH3      # a = [1, 2, 3]
+            + Opcode.PUSH2
+            + Opcode.PUSH1
+            + Opcode.PUSH3
+            + Opcode.PACK
+            + Opcode.STLOC0
+            + Opcode.LDLOC0     # a.clear()
+            + Opcode.CLEARITEMS
+            + Opcode.LDLOC0     # return a
+            + Opcode.RET
+        )
+        path = '%s/boa3_test/example/built_in_methods_test/ClearMutableSequence.py' % self.dirname
+
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_clear_mutable_sequence_with_builtin(self):
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x01'
+            + b'\x02'
+            + Opcode.PUSH3      # a = [1, 2, 3]
+            + Opcode.PUSH2
+            + Opcode.PUSH1
+            + Opcode.PUSH3
+            + Opcode.PACK
+            + Opcode.STLOC0
+            + Opcode.LDLOC0     # MutableSequence.clear(a)
+            + Opcode.CLEARITEMS
+            + Opcode.LDLOC0     # return a
+            + Opcode.RET
+        )
+        path = '%s/boa3_test/example/built_in_methods_test/ClearMutableSequenceBuiltinCall.py' % self.dirname
+
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_clear_too_many_parameters(self):
+        path = '%s/boa3_test/example/built_in_methods_test/ClearTooManyParameters.py' % self.dirname
+        self.assertCompilerLogs(UnexpectedArgument, path)
+
+    def test_clear_too_few_parameters(self):
+        path = '%s/boa3_test/example/built_in_methods_test/ClearTooFewParameters.py' % self.dirname
+        self.assertCompilerLogs(UnfilledArgument, path)
+
+    # endregion

--- a/boa3_test/tests/test_bytes.py
+++ b/boa3_test/tests/test_bytes.py
@@ -252,3 +252,11 @@ class TestBytes(BoaTest):
     def test_byte_array_append(self):
         path = '%s/boa3_test/example/bytes_test/BytearrayAppend.py' % self.dirname
         self.assertCompilerLogs(NotSupportedOperation, path)
+
+    def test_bytes_clear(self):
+        path = '%s/boa3_test/example/bytes_test/BytesClear.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_byte_array_clear(self):
+        path = '%s/boa3_test/example/bytes_test/BytearrayClear.py' % self.dirname
+        self.assertCompilerLogs(NotSupportedOperation, path)

--- a/boa3_test/tests/test_list.py
+++ b/boa3_test/tests/test_list.py
@@ -364,3 +364,24 @@ class TestList(BoaTest):
     def test_list_append_with_builtin_mismatched_type(self):
         path = '%s/boa3_test/example/list_test/MismatchedTypesAppendWithBuiltin.py' % self.dirname
         self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_list_clear(self):
+        path = '%s/boa3_test/example/list_test/ClearList.py' % self.dirname
+
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x01'
+            + b'\x02'
+            + Opcode.PUSH3      # a = [1, 2, 3]
+            + Opcode.PUSH2
+            + Opcode.PUSH1
+            + Opcode.PUSH3
+            + Opcode.PACK
+            + Opcode.STLOC0
+            + Opcode.LDLOC0     # a.clear()
+            + Opcode.CLEARITEMS
+            + Opcode.LDLOC0     # return a
+            + Opcode.RET
+        )
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)


### PR DESCRIPTION
Implemented Python `list` clear function
```
a: List[int] = [1, 2, 3]
a.clear()

a = [1, 2]
list.clear(a)

a = [3, 2, 1]
MutableSequence.clear(a)

b = bytearray(b'\x01\x02\x03')
b.clear()  # bytearray clear function is not implemented yet
```