### PR TITLE
Convert list reverse method

### DIFF
--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -4,6 +4,7 @@ from boa3.model.builtin.classmethod.appendmethod import AppendMethod
 from boa3.model.builtin.classmethod.clearmethod import ClearMethod
 from boa3.model.builtin.classmethod.mapkeysmethod import MapKeysMethod
 from boa3.model.builtin.classmethod.mapvaluesmethod import MapValuesMethod
+from boa3.model.builtin.classmethod.reversemethod import ReverseMethod
 from boa3.model.builtin.decorator.builtindecorator import IBuiltinDecorator
 from boa3.model.builtin.decorator.metadatadecorator import MetadataDecorator
 from boa3.model.builtin.decorator.publicdecorator import PublicDecorator
@@ -39,17 +40,19 @@ class Builtin:
     ByteArray = ByteArrayMethod()
 
     # python class method
-    Append = AppendMethod()
-    Clear = ClearMethod()
-    Keys = MapKeysMethod()
-    Values = MapValuesMethod()
+    SequenceAppend = AppendMethod()
+    SequenceClear = ClearMethod()
+    SequenceReverse = ReverseMethod()
+    DictKeys = MapKeysMethod()
+    DictValues = MapValuesMethod()
 
     _python_builtins: List[IdentifiedSymbol] = [Len,
                                                 ByteArray,
-                                                Append,
-                                                Clear,
-                                                Keys,
-                                                Values]
+                                                SequenceAppend,
+                                                SequenceClear,
+                                                SequenceReverse,
+                                                DictKeys,
+                                                DictValues]
 
     @classmethod
     def interop_symbols(cls, package: str = None) -> Dict[str, IdentifiedSymbol]:

--- a/boa3/model/builtin/classmethod/reversemethod.py
+++ b/boa3/model/builtin/classmethod/reversemethod.py
@@ -1,0 +1,49 @@
+from typing import Any, Dict, List, Optional, Tuple
+
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.expression import IExpression
+from boa3.model.type.collection.sequence.mutable.mutablesequencetype import MutableSequenceType
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class ReverseMethod(IBuiltinMethod):
+    def __init__(self, sequence_type: MutableSequenceType = None):
+        if not isinstance(sequence_type, MutableSequenceType):
+            from boa3.model.type.type import Type
+            sequence_type = Type.mutableSequence
+
+        identifier = 'reverse'
+        args: Dict[str, Variable] = {'self': Variable(sequence_type)}
+        super().__init__(identifier, args)
+
+    @property
+    def _arg_self(self) -> Variable:
+        return self.args['self']
+
+    def validate_parameters(self, *params: IExpression) -> bool:
+        if len(params) != 1:
+            return False
+        return isinstance(params[0], IExpression) and isinstance(params[0].type, MutableSequenceType)
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        return [(Opcode.REVERSEITEMS, b'')]
+
+    def push_self_first(self) -> bool:
+        return self.has_self_argument
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> Optional[str]:
+        return None
+
+    def build(self, value: Any):
+        if type(value) == type(self.args['self'].type):
+            return self
+        if isinstance(value, MutableSequenceType):
+            return ReverseMethod(value)
+        return super().build(value)

--- a/boa3_test/example/built_in_methods_test/ReverseMutableSequence.py
+++ b/boa3_test/example/built_in_methods_test/ReverseMutableSequence.py
@@ -1,0 +1,7 @@
+from typing import MutableSequence
+
+
+def Main() -> MutableSequence[int]:
+    a: MutableSequence[int] = [1, 2, 3]
+    a.reverse()
+    return a

--- a/boa3_test/example/built_in_methods_test/ReverseMutableSequenceBuiltinCall.py
+++ b/boa3_test/example/built_in_methods_test/ReverseMutableSequenceBuiltinCall.py
@@ -1,0 +1,7 @@
+from typing import MutableSequence
+
+
+def Main() -> MutableSequence[int]:
+    a: MutableSequence[int] = bytearray(b'\x01\x02\x03')
+    MutableSequence.reverse(a)
+    return a

--- a/boa3_test/example/built_in_methods_test/ReverseTooFewParameters.py
+++ b/boa3_test/example/built_in_methods_test/ReverseTooFewParameters.py
@@ -1,0 +1,7 @@
+from typing import List
+
+
+def Main() -> List[int]:
+    a: List[int] = [1, 2, 3]
+    list.reverse()
+    return a

--- a/boa3_test/example/built_in_methods_test/ReverseTooManyParameters.py
+++ b/boa3_test/example/built_in_methods_test/ReverseTooManyParameters.py
@@ -1,0 +1,7 @@
+from typing import List
+
+
+def Main() -> List[int]:
+    a: List[int] = [1, 2, 3]
+    a.reverse(a)
+    return a

--- a/boa3_test/example/built_in_methods_test/ReverseTuple.py
+++ b/boa3_test/example/built_in_methods_test/ReverseTuple.py
@@ -1,0 +1,7 @@
+from typing import Tuple
+
+
+def Main() -> Tuple[int]:
+    a: Tuple[int] = (1, 2, 3)
+    a.reverse()
+    return a

--- a/boa3_test/example/bytes_test/BytearrayReverse.py
+++ b/boa3_test/example/bytes_test/BytearrayReverse.py
@@ -1,0 +1,4 @@
+def Main() -> bytearray:
+    a = bytearray(b'\x01\x02\x03')
+    a.reverse()
+    return a

--- a/boa3_test/example/bytes_test/BytesReverse.py
+++ b/boa3_test/example/bytes_test/BytesReverse.py
@@ -1,0 +1,4 @@
+def Main() -> bytes:
+    a = b'\x01\x02\x03\x04'
+    a.reverse()
+    return a

--- a/boa3_test/example/list_test/ReverseList.py
+++ b/boa3_test/example/list_test/ReverseList.py
@@ -1,0 +1,7 @@
+from typing import List
+
+
+def Main() -> List[int]:
+    a: List[int] = [1, 2, 3]
+    a.reverse()
+    return a

--- a/boa3_test/tests/test_builtin_method.py
+++ b/boa3_test/tests/test_builtin_method.py
@@ -233,3 +233,62 @@ class TestVariable(BoaTest):
         self.assertCompilerLogs(UnfilledArgument, path)
 
     # endregion
+
+    # region TestReverse
+
+    def test_reverse_tuple(self):
+        path = '%s/boa3_test/example/built_in_methods_test/ReverseTuple.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_reverse_mutable_sequence(self):
+        expected_output = (
+                Opcode.INITSLOT     # function signature
+                + b'\x01'
+                + b'\x00'
+                + Opcode.PUSH3      # a = [1, 2, 3]
+                + Opcode.PUSH2
+                + Opcode.PUSH1
+                + Opcode.PUSH3
+                + Opcode.PACK
+                + Opcode.STLOC0
+                + Opcode.LDLOC0     # a.reverse()
+                + Opcode.REVERSEITEMS
+                + Opcode.LDLOC0     # return a
+                + Opcode.RET
+        )
+        path = '%s/boa3_test/example/built_in_methods_test/ReverseMutableSequence.py' % self.dirname
+
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_reverse_mutable_sequence_with_builtin(self):
+        data = b'\x01\x02\x03'
+        expected_output = (
+                Opcode.INITSLOT     # function signature
+                + b'\x01'
+                + b'\x00'
+                + Opcode.PUSHDATA1  # a = bytearray(b'\x01\x02\x03')
+                + Integer(len(data)).to_byte_array(min_length=1)
+                + data
+                + Opcode.CONVERT
+                + Type.bytes.stack_item
+                + Opcode.STLOC0
+                + Opcode.LDLOC0     # MutableSequence.reverse(a)
+                + Opcode.REVERSEITEMS
+                + Opcode.LDLOC0     # return a
+                + Opcode.RET
+        )
+        path = '%s/boa3_test/example/built_in_methods_test/ReverseMutableSequenceBuiltinCall.py' % self.dirname
+
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_reverse_too_many_parameters(self):
+        path = '%s/boa3_test/example/built_in_methods_test/ReverseTooManyParameters.py' % self.dirname
+        self.assertCompilerLogs(UnexpectedArgument, path)
+
+    def test_reverse_too_few_parameters(self):
+        path = '%s/boa3_test/example/built_in_methods_test/ReverseTooFewParameters.py' % self.dirname
+        self.assertCompilerLogs(UnfilledArgument, path)
+
+    # endregion

--- a/boa3_test/tests/test_bytes.py
+++ b/boa3_test/tests/test_bytes.py
@@ -79,6 +79,14 @@ class TestBytes(BoaTest):
         path = '%s/boa3_test/example/bytes_test/BytesSetValue.py' % self.dirname
         self.assertCompilerLogs(UnresolvedOperation, path)
 
+    def test_bytes_clear(self):
+        path = '%s/boa3_test/example/bytes_test/BytesClear.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_bytes_reverse(self):
+        path = '%s/boa3_test/example/bytes_test/BytesReverse.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)
+
     def test_bytes_from_byte_array(self):
         data = b'\x01\x02\x03'
         expected_output = (
@@ -253,10 +261,28 @@ class TestBytes(BoaTest):
         path = '%s/boa3_test/example/bytes_test/BytearrayAppend.py' % self.dirname
         self.assertCompilerLogs(NotSupportedOperation, path)
 
-    def test_bytes_clear(self):
-        path = '%s/boa3_test/example/bytes_test/BytesClear.py' % self.dirname
-        self.assertCompilerLogs(MismatchedTypes, path)
-
     def test_byte_array_clear(self):
         path = '%s/boa3_test/example/bytes_test/BytearrayClear.py' % self.dirname
         self.assertCompilerLogs(NotSupportedOperation, path)
+
+    def test_byte_array_reverse(self):
+        data = b'\x01\x02\x03'
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x01'
+            + b'\x00'
+            + Opcode.PUSHDATA1  # a = bytearray(b'\x01\x02\x03')
+            + Integer(len(data)).to_byte_array(min_length=1)
+            + data
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.STLOC0
+            + Opcode.LDLOC0     # a.reverse()
+            + Opcode.REVERSEITEMS
+            + Opcode.LDLOC0
+            + Opcode.RET        # return a
+        )
+
+        path = '%s/boa3_test/example/bytes_test/BytearrayReverse.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)

--- a/boa3_test/tests/test_list.py
+++ b/boa3_test/tests/test_list.py
@@ -400,3 +400,24 @@ class TestList(BoaTest):
         )
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
+
+    def test_list_reverse(self):
+        path = '%s/boa3_test/example/list_test/ReverseList.py' % self.dirname
+
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x01'
+            + b'\x00'
+            + Opcode.PUSH3      # a = [1, 2, 3]
+            + Opcode.PUSH2
+            + Opcode.PUSH1
+            + Opcode.PUSH3
+            + Opcode.PACK
+            + Opcode.STLOC0
+            + Opcode.LDLOC0     # a.reverse()
+            + Opcode.REVERSEITEMS
+            + Opcode.LDLOC0     # return a
+            + Opcode.RET
+        )
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)


### PR DESCRIPTION
Implemented Python `reverse` function to `list` and `bytearray` types
```
a: List[int] = [1, 2, 3]
a.reverse()  # a = [3, 2, 1]

b = [1, 2]
list.reverse(b)  # b = [2, 1]

c = [3, 2, 1]
MutableSequence.reverse(c)  # c = [1, 2, 3]

d = bytearray(b'\x01\x02\x03')
d.reverse()  # d = bytearray(b'\x03\x02\x01')
```