### PR TITLE
Convert bytearray append method

### DIFF
--- a/boa3/compiler/codegeneratorvisitor.py
+++ b/boa3/compiler/codegeneratorvisitor.py
@@ -381,16 +381,23 @@ class VisitorCodeGenerator(ast.NodeVisitor):
         # the parameters are included into the stack in the reversed order
         function_id = self.visit(call.func)
         symbol = self.generator.get_symbol(function_id)
+        args_addresses: List[int] = []
 
         if isinstance(symbol, IBuiltinMethod) and symbol.push_self_first():
             args = call.args[1:]
+            args_addresses.append(
+                VMCodeMapping.instance().bytecode_size
+            )
             self.visit_to_generate(call.args[0])
         else:
             args = call.args
 
         for arg in reversed(args):
+            args_addresses.append(
+                VMCodeMapping.instance().bytecode_size
+            )
             self.visit_to_generate(arg)
-        self.generator.convert_load_symbol(function_id)
+        self.generator.convert_load_symbol(function_id, args_addresses)
 
     def visit_Name(self, name: ast.Name) -> str:
         """

--- a/boa3/model/builtin/method/builtinmethod.py
+++ b/boa3/model/builtin/method/builtinmethod.py
@@ -88,6 +88,15 @@ class IBuiltinMethod(IBuiltinDecorator, ABC):
         return 0
 
     @property
+    def stores_on_slot(self) -> bool:
+        """
+        Returns whether this method needs to update the value from a variable
+
+        :return: the number of arguments.
+        """
+        return False
+
+    @property
     def body(self) -> Optional[str]:
         """
         Gets the body of the method.

--- a/boa3/neo/vm/opcode/Opcode.py
+++ b/boa3/neo/vm/opcode/Opcode.py
@@ -32,7 +32,7 @@ class Opcode(bytes, Enum):
         Gets the push opcode to the respective integer
 
         :param integer: value that will be pushed
-        :return: the respective opceode
+        :return: the respective opcode
         :rtype: Opcode or None
         """
         if -1 <= integer <= 16:
@@ -366,6 +366,26 @@ class Opcode(bytes, Enum):
                 return Opcode.LDLOC
             else:
                 return Opcode.LDSFLD
+
+    @property
+    def is_load_slot(self) -> bool:
+        return (self.LDSFLD0 <= self <= self.LDSFLD
+                or self.LDLOC0 <= self <= self.LDLOC
+                or self.LDARG0 <= self <= self.LDARG)
+
+    @staticmethod
+    def get_store_from_load(load_opcode):
+        """
+        Gets the store slot opcode equivalent to the given load slot opcode.
+
+        :param load_opcode: load opcode
+        :type load_opcode: Opcode
+        :return: equivalent store opcode if the given opcode is a load slot. Otherwise, returns None
+        :rtype: Opcode or None
+        """
+        if load_opcode.is_load_slot:
+            opcode_value: int = Integer.from_bytes(load_opcode) + 8
+            return Opcode(Integer(opcode_value).to_byte_array())
 
     # Loads the static field at index 0 onto the evaluation stack.
     LDSFLD0 = b'\x58'

--- a/boa3/neo/vm/opcode/OpcodeInfo.py
+++ b/boa3/neo/vm/opcode/OpcodeInfo.py
@@ -324,8 +324,8 @@ class OpcodeInfo:
 
     # region Splice
 
-    NEWBUFFER = OpcodeInformation(Opcode.NEWBUFFER),
-    MEMCPY = OpcodeInformation(Opcode.MEMCPY),
+    NEWBUFFER = OpcodeInformation(Opcode.NEWBUFFER)
+    MEMCPY = OpcodeInformation(Opcode.MEMCPY)
     # Concatenates two strings.
     CAT = OpcodeInformation(Opcode.CAT)
     # Returns a section of a string.

--- a/boa3_test/example/bytes_test/BytearrayAppendWithBuiltin.py
+++ b/boa3_test/example/bytes_test/BytearrayAppendWithBuiltin.py
@@ -1,4 +1,4 @@
 def Main() -> bytearray:
     a = bytearray(b'\x01\x02\x03')
-    a.append(4)
+    bytearray.append(a, 4)
     return a

--- a/boa3_test/example/bytes_test/BytearrayAppendWithMutableSequence.py
+++ b/boa3_test/example/bytes_test/BytearrayAppendWithMutableSequence.py
@@ -1,4 +1,7 @@
+from typing import MutableSequence
+
+
 def Main() -> bytearray:
     a = bytearray(b'\x01\x02\x03')
-    a.append(4)
+    MutableSequence.append(a, 4)
     return a

--- a/boa3_test/tests/test_builtin_method.py
+++ b/boa3_test/tests/test_builtin_method.py
@@ -135,7 +135,18 @@ class TestVariable(BoaTest):
             + Opcode.STLOC0
             + Opcode.LDLOC0     # a.append(4)
             + Opcode.PUSH4
-            + Opcode.APPEND
+                + Opcode.OVER
+                + Opcode.ISTYPE
+                + Type.bytearray.stack_item
+                + Opcode.JMPIFNOT
+                + Integer(8).to_byte_array(min_length=1)
+                + Opcode.CAT
+                + Opcode.JMP
+                + Integer(5).to_byte_array(min_length=1)
+                + Opcode.APPEND
+                + Opcode.JMP
+                + Integer(2).to_byte_array(min_length=1)
+                + Opcode.STLOC0
             + Opcode.LDLOC0     # return a
             + Opcode.RET
         )
@@ -157,7 +168,18 @@ class TestVariable(BoaTest):
             + Opcode.STLOC0
             + Opcode.LDLOC0     # a.append(4)
             + Opcode.PUSH4
-            + Opcode.APPEND
+                + Opcode.OVER
+                + Opcode.ISTYPE
+                + Type.bytearray.stack_item
+                + Opcode.JMPIFNOT
+                + Integer(8).to_byte_array(min_length=1)
+                + Opcode.CAT
+                + Opcode.JMP
+                + Integer(5).to_byte_array(min_length=1)
+                + Opcode.APPEND
+                + Opcode.JMP
+                + Integer(2).to_byte_array(min_length=1)
+                + Opcode.STLOC0
             + Opcode.LDLOC0     # return a
             + Opcode.RET
         )

--- a/boa3_test/tests/test_bytes.py
+++ b/boa3_test/tests/test_bytes.py
@@ -258,8 +258,106 @@ class TestBytes(BoaTest):
         self.assertCompilerLogs(NotSupportedOperation, path)
 
     def test_byte_array_append(self):
+        data = b'\x01\x02\x03'
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x01'
+            + b'\x00'
+            + Opcode.PUSHDATA1  # a = bytearray(b'\x01\x02\x03')
+            + Integer(len(data)).to_byte_array(min_length=1)
+            + data
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.STLOC0
+            + Opcode.LDLOC0     # a.append(4)
+            + Opcode.PUSH4
+                + Opcode.OVER
+                + Opcode.ISTYPE
+                + Type.bytearray.stack_item
+                + Opcode.JMPIFNOT
+                + Integer(8).to_byte_array(min_length=1)
+                + Opcode.CAT
+                + Opcode.JMP
+                + Integer(5).to_byte_array(min_length=1)
+                + Opcode.APPEND
+                + Opcode.JMP
+                + Integer(2).to_byte_array(min_length=1)
+                + Opcode.STLOC0
+            + Opcode.LDLOC0
+            + Opcode.RET        # return a
+        )
+
         path = '%s/boa3_test/example/bytes_test/BytearrayAppend.py' % self.dirname
-        self.assertCompilerLogs(NotSupportedOperation, path)
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_byte_array_append_with_builtin(self):
+        data = b'\x01\x02\x03'
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x01'
+            + b'\x00'
+            + Opcode.PUSHDATA1  # a = bytearray(b'\x01\x02\x03')
+            + Integer(len(data)).to_byte_array(min_length=1)
+            + data
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.STLOC0
+            + Opcode.LDLOC0     # bytearray.append(a, 4)
+            + Opcode.PUSH4
+                + Opcode.OVER
+                + Opcode.ISTYPE
+                + Type.bytearray.stack_item
+                + Opcode.JMPIFNOT
+                + Integer(8).to_byte_array(min_length=1)
+                + Opcode.CAT
+                + Opcode.JMP
+                + Integer(5).to_byte_array(min_length=1)
+                + Opcode.APPEND
+                + Opcode.JMP
+                + Integer(2).to_byte_array(min_length=1)
+                + Opcode.STLOC0
+            + Opcode.LDLOC0
+            + Opcode.RET        # return a
+        )
+
+        path = '%s/boa3_test/example/bytes_test/BytearrayAppendWithBuiltin.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_byte_array_append_mutable_sequence_with_builtin(self):
+        data = b'\x01\x02\x03'
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x01'
+            + b'\x00'
+            + Opcode.PUSHDATA1  # a = bytearray(b'\x01\x02\x03')
+            + Integer(len(data)).to_byte_array(min_length=1)
+            + data
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.STLOC0
+            + Opcode.LDLOC0     # MutableSequence.append(a, 4)
+            + Opcode.PUSH4
+                + Opcode.OVER
+                + Opcode.ISTYPE
+                + Type.bytearray.stack_item
+                + Opcode.JMPIFNOT
+                + Integer(8).to_byte_array(min_length=1)
+                + Opcode.CAT
+                + Opcode.JMP
+                + Integer(5).to_byte_array(min_length=1)
+                + Opcode.APPEND
+                + Opcode.JMP
+                + Integer(2).to_byte_array(min_length=1)
+                + Opcode.STLOC0
+            + Opcode.LDLOC0
+            + Opcode.RET        # return a
+        )
+
+        path = '%s/boa3_test/example/bytes_test/BytearrayAppendWithMutableSequence.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
 
     def test_byte_array_clear(self):
         path = '%s/boa3_test/example/bytes_test/BytearrayClear.py' % self.dirname

--- a/boa3_test/tests/test_function.py
+++ b/boa3_test/tests/test_function.py
@@ -1,6 +1,7 @@
 from boa3.boa3 import Boa3
 from boa3.constants import ENCODING
 from boa3.exception.CompilerError import MismatchedTypes, MissingReturnStatement, TooManyReturns, TypeHintMissing
+from boa3.model.type.type import Type
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3_test.tests.boa_test import BoaTest
@@ -677,12 +678,12 @@ class TestFunction(BoaTest):
             + Opcode.PUSH2
             + Opcode.GE
             + Opcode.BOOLAND
-            + Opcode.JMPIFNOT + b'\x2e'
+            + Opcode.JMPIFNOT + b'\x39'
             + Opcode.NEWARRAY0          # operands: List[int] = []
             + Opcode.STLOC0
             + Opcode.PUSH1              # i = 1
             + Opcode.STLOC1
-            + Opcode.JMP + b'\x13'      # begin while i < len(arg):
+            + Opcode.JMP + b'\x1e'      # begin while i < len(arg):
             + Opcode.LDLOC0                 # operands.append(arg[i])
             + Opcode.LDARG1                 # arg[i]
             + Opcode.LDLOC1
@@ -693,8 +694,19 @@ class TestFunction(BoaTest):
             + Opcode.OVER
             + Opcode.SIZE
             + Opcode.ADD
-            + Opcode.PICKITEM
-            + Opcode.APPEND
+            + Opcode.PICKITEM               # append(args[i])
+                + Opcode.OVER
+                + Opcode.ISTYPE
+                + Type.bytearray.stack_item
+                + Opcode.JMPIFNOT
+                + Integer(8).to_byte_array(min_length=1)
+                + Opcode.CAT
+                + Opcode.JMP
+                + Integer(5).to_byte_array(min_length=1)
+                + Opcode.APPEND
+                + Opcode.JMP
+                + Integer(2).to_byte_array(min_length=1)
+                + Opcode.STLOC0
             + Opcode.LDLOC1                 # i += 1
             + Opcode.PUSH1
             + Opcode.ADD
@@ -703,7 +715,7 @@ class TestFunction(BoaTest):
             + Opcode.LDARG1
             + Opcode.SIZE
             + Opcode.LT
-            + Opcode.JMPIF + b'\xeb'
+            + Opcode.JMPIF + b'\xe0'
             + Opcode.LDLOC0             # return calculate(arg[0], operands)
             + Opcode.LDARG1             # arg[0]
             + Opcode.PUSH0
@@ -897,5 +909,4 @@ class TestFunction(BoaTest):
 
         path = '%s/boa3_test/example/function_test/MultipleFunctionLargeCall.py' % self.dirname
         output = Boa3.compile(path)
-
         self.assertEqual(expected_output, output)

--- a/boa3_test/tests/test_list.py
+++ b/boa3_test/tests/test_list.py
@@ -1,5 +1,6 @@
 from boa3.boa3 import Boa3
 from boa3.exception.CompilerError import MismatchedTypes, UnresolvedOperation
+from boa3.model.type.type import Type
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.String import String
@@ -318,7 +319,18 @@ class TestList(BoaTest):
             + Opcode.STLOC0
             + Opcode.LDLOC0     # a.append(4)
             + Opcode.PUSH4
-            + Opcode.APPEND
+                + Opcode.OVER
+                + Opcode.ISTYPE
+                + Type.bytearray.stack_item
+                + Opcode.JMPIFNOT
+                + Integer(8).to_byte_array(min_length=1)
+                + Opcode.CAT
+                + Opcode.JMP
+                + Integer(5).to_byte_array(min_length=1)
+                + Opcode.APPEND
+                + Opcode.JMP
+                + Integer(2).to_byte_array(min_length=1)
+                + Opcode.STLOC0
             + Opcode.LDLOC0     # return a
             + Opcode.RET
         )
@@ -343,7 +355,18 @@ class TestList(BoaTest):
             + Opcode.PUSHDATA1
             + Integer(len(four)).to_byte_array()
             + four
-            + Opcode.APPEND
+                + Opcode.OVER
+                + Opcode.ISTYPE
+                + Type.bytearray.stack_item
+                + Opcode.JMPIFNOT
+                + Integer(8).to_byte_array(min_length=1)
+                + Opcode.CAT
+                + Opcode.JMP
+                + Integer(5).to_byte_array(min_length=1)
+                + Opcode.APPEND
+                + Opcode.JMP
+                + Integer(2).to_byte_array(min_length=1)
+                + Opcode.STLOC0
             + Opcode.LDLOC0     # return a
             + Opcode.RET
         )
@@ -369,7 +392,18 @@ class TestList(BoaTest):
             + Opcode.STLOC0
             + Opcode.LDLOC0     # list.append(a, 4)
             + Opcode.PUSH4
-            + Opcode.APPEND
+                + Opcode.OVER
+                + Opcode.ISTYPE
+                + Type.bytearray.stack_item
+                + Opcode.JMPIFNOT
+                + Integer(8).to_byte_array(min_length=1)
+                + Opcode.CAT
+                + Opcode.JMP
+                + Integer(5).to_byte_array(min_length=1)
+                + Opcode.APPEND
+                + Opcode.JMP
+                + Integer(2).to_byte_array(min_length=1)
+                + Opcode.STLOC0
             + Opcode.LDLOC0     # return a
             + Opcode.RET
         )


### PR DESCRIPTION
Implemented Python `bytearray` append function
```
a = bytearray(b'\x01\x02\x03')

a.append(4)
bytearray.append(a, 5)
MutableSequence.append(a, 6)

a.append('7')  # compiler error - the list is defined as a list of ints and here it's trying to append a non-int value
```