### PR TITLE
Convert Static Variable Declarations and Assignments

### DIFF
--- a/boa3/compiler/filegenerator.py
+++ b/boa3/compiler/filegenerator.py
@@ -107,7 +107,8 @@ class FileGenerator:
                 }
             ],
             "trusts": [],
-            "safeMethods": [],
+            "safemethods": [],
+            "supportedstandards": [],
             "extra": self._metadata.extra if len(self._metadata.extra) > 0 else None
         }
 
@@ -145,7 +146,7 @@ class FileGenerator:
                     "type": arg.type.abi_type
                 } for arg_id, arg in method.args.items()
             ],
-            "returnType": method.type.abi_type
+            "returntype": method.type.abi_type
         }
 
     def _get_abi_events(self) -> List[Dict[str, Any]]:

--- a/boa3/constants.py
+++ b/boa3/constants.py
@@ -8,3 +8,5 @@ DEFAULT_UINT32 = 0
 
 ENCODING = 'utf-8'
 BYTEORDER = 'little'
+
+INITIALIZE_METHOD_ID = '_initialize'

--- a/boa3/helpers/__init__.py
+++ b/boa3/helpers/__init__.py
@@ -9,4 +9,4 @@ def get_auxiliary_name(node: ast.AST, aux_symbol_id: str) -> str:
     :param aux_symbol_id: the id name of the auxiliary symbol
     :return: the unique name to the symbol.
     """
-    return "%s_%s" % (aux_symbol_id, id(node))
+    return "{0}_{1}".format(aux_symbol_id, id(node))

--- a/boa3/model/callable.py
+++ b/boa3/model/callable.py
@@ -17,14 +17,15 @@ class Callable(IExpression, ABC):
     :ivar return_type: the return type of the method. None by default.
     """
 
-    def __init__(self, args: Dict[str, Variable] = None, return_type: IType = Type.none,
-                 is_public: bool = False, origin_node: Optional[ast.AST] = None):
+    def __init__(self, args: Dict[str, Variable] = None, return_type: IType = Type.none, is_public: bool = False,
+                 origin_node: Optional[ast.AST] = None):
         if args is None:
             args = {}
         self.args: Dict[str, Variable] = args
         self.return_type: IType = return_type
-        self._origin_node = origin_node
         self.is_public: bool = is_public
+
+        super().__init__(origin_node)
 
         self.init_address: Optional[int] = None
         self.init_bytecode: Optional[VMCode] = None
@@ -42,15 +43,6 @@ class Callable(IExpression, ABC):
         :return: a dictionary that maps each symbol in the module with its name
         """
         return self.args.copy()
-
-    @property
-    def origin(self) -> ast.AST:
-        """
-        Returns the method origin ast node.
-
-        :return: the ast node that describes this method. None if it is not from a ast.
-        """
-        return self._origin_node
 
     @property
     def start_address(self) -> Optional[int]:

--- a/boa3/model/expression.py
+++ b/boa3/model/expression.py
@@ -1,4 +1,6 @@
+import ast
 from abc import abstractmethod
+from typing import Optional
 
 from boa3.model.symbol import ISymbol
 from boa3.model.type.itype import IType
@@ -9,6 +11,9 @@ class IExpression(ISymbol):
     An interface used to represent expressions
     """
 
+    def __init__(self, origin_node: Optional[ast.AST] = None):
+        self._origin_node = origin_node
+
     @property
     @abstractmethod
     def type(self) -> IType:
@@ -18,3 +23,12 @@ class IExpression(ISymbol):
         :return: the resulting type when the expression is evaluated
         """
         pass
+
+    @property
+    def origin(self) -> ast.AST:
+        """
+        Returns the method origin ast node.
+
+        :return: the ast node that describes this method. None if it is not from a ast.
+        """
+        return self._origin_node

--- a/boa3/model/importsymbol.py
+++ b/boa3/model/importsymbol.py
@@ -1,6 +1,7 @@
 import ast
 from typing import Dict
 
+from boa3.analyser.importanalyser import ImportAnalyser
 from boa3.model.method import Method
 from boa3.model.symbol import ISymbol
 from boa3.model.type.itype import IType
@@ -16,9 +17,12 @@ class Import(ISymbol):
     :ivar types: a dictionary that maps each type with its name. Empty by default.
     """
 
-    def __init__(self, origin: str, syntax_tree: ast.AST, symbols: Dict[str, ISymbol] = None):
-        if symbols is None:
-            symbols = {}
+    def __init__(self, origin: str, syntax_tree: ast.AST, import_analyser: ImportAnalyser,
+                 imported_symbols: Dict[str, ISymbol] = None):
+        if imported_symbols is None:
+            symbols = import_analyser.symbols
+        else:
+            symbols = import_analyser.export_symbols(list(imported_symbols.keys()))
 
         self.variables = {var_id: var for var_id, var in symbols.items() if isinstance(var, Variable)}
         self.methods = {fun_id: fun for fun_id, fun in symbols.items() if isinstance(fun, Method)}
@@ -26,6 +30,9 @@ class Import(ISymbol):
         self.imports = {alias: imprt for alias, imprt in symbols.items() if isinstance(imprt, Import)}
         self._other_symbols = {alias: symbol for alias, symbol in symbols.items()
                                if not isinstance(symbol, (Variable, Method, IType, Import))}
+
+        self._symbols_not_imported = {alias: symbol for alias, symbol in import_analyser.symbols.items()
+                                      if alias not in symbols}
 
         self.origin: str = origin
         self.ast: ast.AST = syntax_tree
@@ -42,4 +49,10 @@ class Import(ISymbol):
         symbol.update(self.types)
         symbol.update(self._other_symbols)
         symbol.update(self.imports)
+        return symbol
+
+    @property
+    def all_symbols(self) -> Dict[str, ISymbol]:
+        symbol = self.symbols.copy()
+        symbol.update(self._symbols_not_imported)
         return symbol

--- a/boa3/model/module.py
+++ b/boa3/model/module.py
@@ -27,6 +27,7 @@ class Module(ISymbol):
         self.callables: Dict[str, Callable] = {}
 
         self.imported_symbols = {}
+        self.assigned_variables = []
 
     @property
     def shadowing_name(self) -> str:
@@ -41,6 +42,24 @@ class Module(ISymbol):
         """
         if var_id not in self.symbols:
             self.variables[var_id] = var
+
+    def is_variable_assigned(self, var_id: str) -> bool:
+        if var_id not in self.variables:
+            return False
+
+        if var_id in self.assigned_variables or var_id in self.imported_symbols:
+            return True
+
+        for imported in self.imported_symbols.values():
+            from boa3.model.importsymbol import Import
+            if isinstance(imported, Import) and self.variables[var_id] in imported.variables.values():
+                return True
+
+        return False
+
+    def assign_variable(self, var_id: str):
+        if var_id in self.variables:
+            self.assigned_variables.append(var_id)
 
     def include_callable(self, method_id: str, method: Callable):
         """

--- a/boa3/model/variable.py
+++ b/boa3/model/variable.py
@@ -1,3 +1,4 @@
+import ast
 from typing import Optional
 
 from boa3.model.expression import IExpression
@@ -11,7 +12,8 @@ class Variable(IExpression):
     :ivar var_type: the type of the variable.
     """
 
-    def __init__(self, var_type: Optional[IType]):
+    def __init__(self, var_type: Optional[IType], origin_node: Optional[ast.AST] = None):
+        super().__init__(origin_node)
         self._var_type: Optional[IType] = var_type
 
     @property

--- a/boa3/neo3/contracts/nef.py
+++ b/boa3/neo3/contracts/nef.py
@@ -161,7 +161,7 @@ class NEF(serialization.ISerializable):
                 + self.compiler.encode('utf-8')
                 + self.version.to_array()
                 + self.script_hash.to_array())
-        return hashlib.sha256(data).digest()[:4]
+        return hashlib.sha256(hashlib.sha256(data).digest()).digest()[:4]
 
     def compute_script_hash(self) -> types.UInt160:
         hash = hashlib.new('ripemd160', hashlib.sha256(self.script).digest()).digest()

--- a/boa3_test/example/import_test/FromImportTyping.py
+++ b/boa3_test/example/import_test/FromImportTyping.py
@@ -3,3 +3,6 @@ from typing import Any, List
 
 def EmptyList() -> List[Any]:
     return []
+
+
+empty_list = []

--- a/boa3_test/example/import_test/FromImportVariable.py
+++ b/boa3_test/example/import_test/FromImportVariable.py
@@ -1,0 +1,7 @@
+from typing import Any, List
+
+from boa3_test.example.import_test.FromImportTyping import empty_list
+
+
+def Main():
+    b: List[Any] = empty_list

--- a/boa3_test/example/import_test/FromImportWithGlobalVariables.py
+++ b/boa3_test/example/import_test/FromImportWithGlobalVariables.py
@@ -1,0 +1,9 @@
+from typing import Any, List
+
+from boa3_test.example.import_test.FromImportTyping import EmptyList
+
+a = EmptyList()
+
+
+def Main():
+    b: List[Any] = a

--- a/boa3_test/example/variable_test/AssignLocalWithArgumentShadowingGlobal.py
+++ b/boa3_test/example/variable_test/AssignLocalWithArgumentShadowingGlobal.py
@@ -1,0 +1,6 @@
+b: int = 0
+
+
+def Main(a: int) -> int:
+    b = a
+    return b

--- a/boa3_test/example/variable_test/GetGlobalValueWrittenAfter.py
+++ b/boa3_test/example/variable_test/GetGlobalValueWrittenAfter.py
@@ -1,0 +1,16 @@
+from typing import List
+
+a = 0
+b = 1
+c = 2
+d = 3
+e = 4
+f = 5
+
+
+def Main() -> List[int]:
+    return [a, b, c, d, e, f, g, h]
+
+
+g = 6
+h = 7

--- a/boa3_test/example/variable_test/GlobalAssignmentBetweenFunctions.py
+++ b/boa3_test/example/variable_test/GlobalAssignmentBetweenFunctions.py
@@ -1,0 +1,12 @@
+a = 10
+
+
+def Main() -> int:
+    return a
+
+
+b = 5
+
+
+def example() -> int:
+    return b

--- a/boa3_test/example/variable_test/GlobalAssignmentInFunctionWithArgument.py
+++ b/boa3_test/example/variable_test/GlobalAssignmentInFunctionWithArgument.py
@@ -1,0 +1,7 @@
+b: int = 0
+
+
+def Main(a: int) -> int:
+    global b  # not implemented yet
+    b = a
+    return b

--- a/boa3_test/example/variable_test/GlobalAssignmentWithTuples.py
+++ b/boa3_test/example/variable_test/GlobalAssignmentWithTuples.py
@@ -1,0 +1,9 @@
+a, b = 2, '3'
+
+
+def get_a() -> int:
+    return a
+
+
+def get_b() -> str:
+    return b

--- a/boa3_test/example/variable_test/GlobalAssignmentWithType.py
+++ b/boa3_test/example/variable_test/GlobalAssignmentWithType.py
@@ -1,0 +1,5 @@
+a: int = 10
+
+
+def Main() -> int:
+    return a

--- a/boa3_test/example/variable_test/GlobalAssignmentWithoutType.py
+++ b/boa3_test/example/variable_test/GlobalAssignmentWithoutType.py
@@ -1,0 +1,5 @@
+a = 10
+
+
+def Main() -> int:
+    return a

--- a/boa3_test/example/variable_test/GlobalDeclarationWithArgumentWrittenAfter.py
+++ b/boa3_test/example/variable_test/GlobalDeclarationWithArgumentWrittenAfter.py
@@ -1,0 +1,8 @@
+a: int
+
+
+def Main() -> int:
+    return a
+
+
+a = 10

--- a/boa3_test/example/variable_test/GlobalDeclarationWithoutAssignment.py
+++ b/boa3_test/example/variable_test/GlobalDeclarationWithoutAssignment.py
@@ -1,0 +1,5 @@
+a: int
+
+
+def Main() -> int:
+    return a

--- a/boa3_test/example/variable_test/ManyGlobalAssignments.py
+++ b/boa3_test/example/variable_test/ManyGlobalAssignments.py
@@ -1,0 +1,14 @@
+from typing import List
+
+a = 0
+b = 1
+c = 2
+d = 3
+e = 4
+f = 5
+g = 6
+h = 7
+
+
+def Main() -> List[int]:
+    return [a, b, c, d, e, f, g, h]

--- a/boa3_test/tests/test_constant.py
+++ b/boa3_test/tests/test_constant.py
@@ -3,6 +3,7 @@ import ast
 from boa3.analyser.analyser import Analyser
 from boa3.compiler.codegenerator import CodeGenerator
 from boa3.model.type.type import Type
+from boa3.model.variable import Variable
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.String import String
@@ -111,14 +112,17 @@ class TestConstant(BoaTest):
     def test_integer_tuple_constant(self):
         input = (1, 2, 3)
         expected_output = (
-            Opcode.PUSH3        # 3
+            Opcode.INITSSLOT + b'\x01'
+            + Opcode.PUSH3        # 3
             + Opcode.PUSH2      # 2
             + Opcode.PUSH1      # 1
             + Opcode.PUSH3      # tuple length
             + Opcode.PACK
+            + Opcode.RET
         )
 
         analyser = Analyser(ast.parse(str(input)))
+        analyser.symbol_table['x'] = Variable(Type.any)
         output = CodeGenerator.generate_code(analyser)
 
         self.assertEqual(expected_output, output)
@@ -130,7 +134,8 @@ class TestConstant(BoaTest):
         byte_input2 = String(input[2]).to_bytes()
 
         expected_output = (
-            Opcode.PUSHDATA1    # '3'
+            Opcode.INITSSLOT + b'\x01'
+            + Opcode.PUSHDATA1    # '3'
             + Integer(len(byte_input2)).to_byte_array()
             + byte_input2
             + Opcode.PUSHDATA1  # '2'
@@ -141,9 +146,11 @@ class TestConstant(BoaTest):
             + byte_input0
             + Opcode.PUSH3      # tuple length
             + Opcode.PACK
+            + Opcode.RET
         )
 
         analyser = Analyser(ast.parse(str(input)))
+        analyser.symbol_table['x'] = Variable(Type.any)
         output = CodeGenerator.generate_code(analyser)
 
         self.assertEqual(expected_output, output)
@@ -153,16 +160,19 @@ class TestConstant(BoaTest):
         byte_input1 = String(input[1]).to_bytes()
 
         expected_output = (
-            Opcode.PUSH0        # True
+            Opcode.INITSSLOT + b'\x01'
+            + Opcode.PUSH0        # True
             + Opcode.PUSHDATA1  # '2'
             + Integer(len(byte_input1)).to_byte_array()
             + byte_input1
             + Opcode.PUSH1      # 1
             + Opcode.PUSH3      # tuple length
             + Opcode.PACK
+            + Opcode.RET
         )
 
         analyser = Analyser(ast.parse(str(input)))
+        analyser.symbol_table['x'] = Variable(Type.any)
         output = CodeGenerator.generate_code(analyser)
 
         self.assertEqual(expected_output, output)
@@ -170,8 +180,9 @@ class TestConstant(BoaTest):
     def test_tuple_of_tuple_constant(self):
         input = ((1, 2), (3, 4, 5, 6), (7,))
         expected_output = (
+            Opcode.INITSSLOT + b'\x01'
             # tuple[2]
-            Opcode.PUSH7    # 7
+            + Opcode.PUSH7    # 7
             + Opcode.PUSH1  # tuple length
             + Opcode.PACK
             # tuple[1]
@@ -188,9 +199,11 @@ class TestConstant(BoaTest):
             + Opcode.PACK
             + Opcode.PUSH3  # tuple length
             + Opcode.PACK
+            + Opcode.RET
         )
 
         analyser = Analyser(ast.parse(str(input)))
+        analyser.symbol_table['x'] = Variable(Type.any)
         output = CodeGenerator.generate_code(analyser)
 
         self.assertEqual(expected_output, output)
@@ -198,14 +211,17 @@ class TestConstant(BoaTest):
     def test_integer_list_constant(self):
         input = [1, 2, 3]
         expected_output = (
-            Opcode.PUSH3    # 3
+            Opcode.INITSSLOT + b'\x01'
+            + Opcode.PUSH3    # 3
             + Opcode.PUSH2  # 2
             + Opcode.PUSH1  # 1
             + Opcode.PUSH3  # list length
             + Opcode.PACK
+            + Opcode.RET
         )
 
         analyser = Analyser(ast.parse(str(input)))
+        analyser.symbol_table['x'] = Variable(Type.any)
         output = CodeGenerator.generate_code(analyser)
 
         self.assertEqual(expected_output, output)
@@ -217,7 +233,8 @@ class TestConstant(BoaTest):
         byte_input2 = String(input[2]).to_bytes()
 
         expected_output = (
-            Opcode.PUSHDATA1        # '2'
+            Opcode.INITSSLOT + b'\x01'
+            + Opcode.PUSHDATA1        # '2'
             + Integer(len(byte_input2)).to_byte_array()
             + byte_input2
             + Opcode.PUSHDATA1      # '1'
@@ -228,9 +245,11 @@ class TestConstant(BoaTest):
             + byte_input0
             + Opcode.PUSH3          # list length
             + Opcode.PACK
+            + Opcode.RET
         )
 
         analyser = Analyser(ast.parse(str(input)))
+        analyser.symbol_table['x'] = Variable(Type.any)
         output = CodeGenerator.generate_code(analyser)
 
         self.assertEqual(expected_output, output)
@@ -240,16 +259,19 @@ class TestConstant(BoaTest):
         byte_input1 = String(input[1]).to_bytes()
 
         expected_output = (
-            Opcode.PUSH0        # False
+            Opcode.INITSSLOT + b'\x01'
+            + Opcode.PUSH0        # False
             + Opcode.PUSHDATA1  # '2'
             + Integer(len(byte_input1)).to_byte_array()
             + byte_input1
             + Opcode.PUSH1      # 1
             + Opcode.PUSH3      # list length
             + Opcode.PACK
+            + Opcode.RET
         )
 
         analyser = Analyser(ast.parse(str(input)))
+        analyser.symbol_table['x'] = Variable(Type.any)
         output = CodeGenerator.generate_code(analyser)
 
         self.assertEqual(expected_output, output)
@@ -258,7 +280,8 @@ class TestConstant(BoaTest):
         input = [[1, 2], [3, 4, 5, 6], [7]]
         expected_output = (
             # list[2]
-            Opcode.PUSH7    # 7
+            Opcode.INITSSLOT + b'\x01'
+            + Opcode.PUSH7    # 7
             + Opcode.PUSH1  # list length
             + Opcode.PACK
             # list[1]
@@ -275,9 +298,11 @@ class TestConstant(BoaTest):
             + Opcode.PACK
             + Opcode.PUSH3  # list length
             + Opcode.PACK
+            + Opcode.RET
         )
 
         analyser = Analyser(ast.parse(str(input)))
+        analyser.symbol_table['x'] = Variable(Type.any)
         output = CodeGenerator.generate_code(analyser)
 
         self.assertEqual(expected_output, output)

--- a/boa3_test/tests/test_file_generation.py
+++ b/boa3_test/tests/test_file_generation.py
@@ -84,8 +84,8 @@ class TestFileGeneration(BoaTest):
 
         # method Main
         method0 = abi['methods'][0]
-        self.assertIn('returnType', method0)
-        self.assertEqual(AbiType.Integer, method0['returnType'])
+        self.assertIn('returntype', method0)
+        self.assertEqual(AbiType.Integer, method0['returntype'])
         self.assertIn('parameters', method0)
         self.assertEqual(2, len(method0['parameters']))
 
@@ -103,8 +103,8 @@ class TestFileGeneration(BoaTest):
 
         # method Sub
         method1 = abi['methods'][1]
-        self.assertIn('returnType', method1)
-        self.assertEqual(AbiType.Integer, method1['returnType'])
+        self.assertIn('returntype', method1)
+        self.assertEqual(AbiType.Integer, method1['returntype'])
         self.assertIn('parameters', method1)
         self.assertEqual(2, len(method1['parameters']))
 
@@ -373,3 +373,58 @@ class TestFileGeneration(BoaTest):
                 var_id, var_type = var.split(',')
                 self.assertIn(var_id, actual_method.locals)
                 self.assertEqual(actual_method.locals[var_id].type.abi_type, var_type)
+
+    def test_generate_init_method(self):
+        path = '%s/boa3_test/example/variable_test/GlobalAssignmentWithType.py' % self.dirname
+
+        compiler = Compiler()
+        compiler.compile_and_save(path, path.replace('.py', '.nef'))
+        methods: Dict[str, Method] = {
+            name: method
+            for name, method in self.get_compiler_analyser(compiler).symbol_table.items()
+            if isinstance(method, Method)
+        }
+        from boa3.constants import INITIALIZE_METHOD_ID
+        self.assertGreater(len(methods), 0)
+        self.assertIn(INITIALIZE_METHOD_ID, methods)
+        init_method = methods[INITIALIZE_METHOD_ID]
+
+        output, manifest = self.get_output(path)
+        self.assertIn('abi', manifest)
+        abi = manifest['abi']
+
+        self.assertIn('methods', abi)
+        self.assertGreater(len(abi['methods']), 0)
+
+        abi_init = next(method for method in abi['methods']
+                        if 'name' in method and method['name'] == INITIALIZE_METHOD_ID)
+        self.assertIsNotNone(abi_init)
+        self.assertIn('offset', abi_init)
+        self.assertEqual(init_method.start_address, abi_init['offset'])
+        self.assertIn('parameters', abi_init)
+        self.assertEqual(0, len(abi_init['parameters']))
+        self.assertIn('returntype', abi_init)
+        self.assertEqual(AbiType.Void, abi_init['returntype'])
+
+        debug_info = self.get_debug_info(path)
+        self.assertIn('methods', debug_info)
+        self.assertGreater(len(debug_info['methods']), 0)
+
+        debug_method = next((method for method in debug_info['methods']
+                             if 'id' in method and method['id'] == str(id(init_method))), None)
+        self.assertIsNotNone(debug_method)
+        parsed_name = debug_method['name'].split(',')
+        self.assertEqual(2, len(parsed_name))
+        self.assertIn(parsed_name[-1], methods)
+
+        # validate parameters
+        self.assertIn('params', debug_method)
+        self.assertEqual(0, len(debug_method['params']))
+
+        # validate local variables
+        self.assertIn('variables', debug_method)
+        self.assertEqual(0, len(debug_method['variables']))
+
+        # validate sequence points
+        self.assertIn('sequence-points', debug_method)
+        self.assertEqual(0, len(debug_method['sequence-points']))

--- a/boa3_test/tests/test_import.py
+++ b/boa3_test/tests/test_import.py
@@ -43,9 +43,13 @@ class TestImport(BoaTest):
             + b'\x01'
             + b'\x00'
             + Opcode.CALL
-            + Integer(5).to_byte_array(min_length=1, signed=True)
+            + Integer(10).to_byte_array(min_length=1, signed=True)
             + Opcode.STLOC0
             + Opcode.PUSHNULL
+            + Opcode.RET
+            + Opcode.INITSSLOT + b'\x01'
+            + Opcode.NEWARRAY0
+            + Opcode.STSFLD0
             + Opcode.RET
             + Opcode.NEWARRAY0  # imported function
             + Opcode.RET        # return
@@ -62,14 +66,61 @@ class TestImport(BoaTest):
             + b'\x01'
             + b'\x00'
             + Opcode.CALL
-            + Integer(5).to_byte_array(min_length=1, signed=True)
+            + Integer(10).to_byte_array(min_length=1, signed=True)
             + Opcode.STLOC0
             + Opcode.PUSHNULL
+            + Opcode.RET
+            + Opcode.INITSSLOT + b'\x01'
+            + Opcode.NEWARRAY0
+            + Opcode.STSFLD0
             + Opcode.RET
             + Opcode.NEWARRAY0  # imported function
             + Opcode.RET        # return
         )
 
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_import_user_module_with_global_variables(self):
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x01'
+            + b'\x00'
+            + Opcode.LDSFLD0    # b = a
+            + Opcode.STLOC0
+            + Opcode.PUSHNULL
+            + Opcode.RET
+            + Opcode.INITSSLOT + b'\x01'
+            + Opcode.CALL       # a = UserModule.EmptyList()
+            + Integer(4).to_byte_array(min_length=1, signed=True)
+            + Opcode.STSFLD0
+            + Opcode.RET
+            + Opcode.NEWARRAY0  # imported function
+            + Opcode.RET        # return
+        )
+
+        path = '%s/boa3_test/example/import_test/FromImportWithGlobalVariables.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_import_variable(self):
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x01'
+            + b'\x00'
+            + Opcode.LDSFLD0    # b = a
+            + Opcode.STLOC0
+            + Opcode.PUSHNULL
+            + Opcode.RET
+            + Opcode.INITSSLOT + b'\x01'
+            + Opcode.NEWARRAY0  # imported variable
+            + Opcode.STSFLD0
+            + Opcode.RET
+            + Opcode.NEWARRAY0  # imported function
+            + Opcode.RET        # return
+        )
+
+        path = '%s/boa3_test/example/import_test/FromImportVariable.py' % self.dirname
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -83,6 +134,10 @@ class TestImport(BoaTest):
         expected_output = (
             Opcode.NEWARRAY0
             + Opcode.RET        # return
+            + Opcode.INITSSLOT + b'\x01'
+            + Opcode.NEWARRAY0
+            + Opcode.STSFLD0
+            + Opcode.RET
         )
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)

--- a/boa3_test/tests/test_variable.py
+++ b/boa3_test/tests/test_variable.py
@@ -144,11 +144,11 @@ class TestVariable(BoaTest):
 
     def test_return_arg_value(self):
         expected_output = (
-            Opcode.INITSLOT.value       # function signature
+            Opcode.INITSLOT     # function signature
             + b'\x00'
             + b'\x01'
-            + Opcode.LDARG0.value       # variable address
-            + Opcode.RET.value
+            + Opcode.LDARG0     # variable address
+            + Opcode.RET
         )
 
         path = '%s/boa3_test/example/variable_test/ReturnArgument.py' % self.dirname
@@ -158,13 +158,13 @@ class TestVariable(BoaTest):
 
     def test_return_local_var_value(self):
         expected_output = (
-            Opcode.INITSLOT.value       # function signature
+            Opcode.INITSLOT     # function signature
             + b'\x01'
             + b'\x01'
-            + Opcode.PUSH1.value
-            + Opcode.STLOC0.value
-            + Opcode.LDLOC0.value       # variable address
-            + Opcode.RET.value
+            + Opcode.PUSH1
+            + Opcode.STLOC0
+            + Opcode.LDLOC0     # variable address
+            + Opcode.RET
         )
 
         path = '%s/boa3_test/example/variable_test/ReturnLocalVariable.py' % self.dirname
@@ -174,13 +174,13 @@ class TestVariable(BoaTest):
 
     def test_assign_local_with_arg_value(self):
         expected_output = (
-            Opcode.INITSLOT.value       # function signature
+            Opcode.INITSLOT     # function signature
             + b'\x01'
             + b'\x01'
-            + Opcode.LDARG0.value
-            + Opcode.STLOC0.value
-            + Opcode.LDLOC0.value       # variable address
-            + Opcode.RET.value
+            + Opcode.LDARG0
+            + Opcode.STLOC0
+            + Opcode.LDLOC0     # variable address
+            + Opcode.RET
         )
 
         path = '%s/boa3_test/example/variable_test/AssignLocalWithArgument.py' % self.dirname
@@ -223,3 +223,172 @@ class TestVariable(BoaTest):
     def test_aug_assign_mismatched_type(self):
         path = '%s/boa3_test/example/variable_test/MismatchedTypeAugAssign.py' % self.dirname
         self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_global_declaration_with_assignment(self):
+        expected_output = (
+            Opcode.LDSFLD0
+            + Opcode.RET
+            + Opcode.INITSSLOT  # global variables
+            + b'\x01'           # number of globals
+            + Opcode.PUSH10
+            + Opcode.STSFLD0    # a = 10
+            + Opcode.RET
+        )
+        path = '%s/boa3_test/example/variable_test/GlobalDeclarationWithArgumentWrittenAfter.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_global_declaration_without_assignment(self):
+        path = '%s/boa3_test/example/variable_test/GlobalDeclarationWithoutAssignment.py' % self.dirname
+        self.assertCompilerLogs(UnresolvedReference, path)
+
+    def test_global_assignment_with_type(self):
+        expected_output = (
+            Opcode.LDSFLD0
+            + Opcode.RET
+            + Opcode.INITSSLOT  # global variables
+            + b'\x01'           # number of globals
+            + Opcode.PUSH10
+            + Opcode.STSFLD0    # a = 10
+            + Opcode.RET
+        )
+        path = '%s/boa3_test/example/variable_test/GlobalAssignmentWithType.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_global_assignment_without_type(self):
+        expected_output = (
+            Opcode.LDSFLD0
+            + Opcode.RET
+            + Opcode.INITSSLOT  # global variables
+            + b'\x01'           # number of globals
+            + Opcode.PUSH10
+            + Opcode.STSFLD0    # a = 10
+            + Opcode.RET
+        )
+        path = '%s/boa3_test/example/variable_test/GlobalAssignmentWithoutType.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_global_tuple_multiple_assignments(self):
+        path = '%s/boa3_test/example/variable_test/GlobalAssignmentWithTuples.py' % self.dirname
+        self.assertCompilerLogs(NotSupportedOperation, path)
+
+    def test_many_global_assignments(self):
+        expected_output = (
+            Opcode.LDSFLD + b'\x07'
+            + Opcode.LDSFLD6    # [a, b, c, d, e, f, g, h]
+            + Opcode.LDSFLD5
+            + Opcode.LDSFLD4
+            + Opcode.LDSFLD3
+            + Opcode.LDSFLD2
+            + Opcode.LDSFLD1
+            + Opcode.LDSFLD0
+            + Opcode.PUSH8
+            + Opcode.PACK       # return [a, b, c, d, e, f, g, h]
+            + Opcode.RET
+            + Opcode.INITSSLOT  # global variables
+            + b'\x08'           # number of globals
+            + Opcode.PUSH0      # a = 0
+            + Opcode.STSFLD0
+            + Opcode.PUSH1      # b = 1
+            + Opcode.STSFLD1
+            + Opcode.PUSH2      # c = 2
+            + Opcode.STSFLD2
+            + Opcode.PUSH3      # d = 3
+            + Opcode.STSFLD3
+            + Opcode.PUSH4      # e = 4
+            + Opcode.STSFLD4
+            + Opcode.PUSH5      # f = 5
+            + Opcode.STSFLD5
+            + Opcode.PUSH6      # g = 6
+            + Opcode.STSFLD6
+            + Opcode.PUSH7      # h = 7
+            + Opcode.STSFLD + b'\x07'   # variable index greater than 6 uses another opcode
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/variable_test/ManyGlobalAssignments.py' % self.dirname
+        output = Boa3.compile(path)
+
+        self.assertEqual(expected_output, output)
+
+    def test_global_assignment_between_functions(self):
+        expected_output = (
+            Opcode.LDSFLD0
+            + Opcode.RET
+            + Opcode.LDSFLD1
+            + Opcode.RET
+            + Opcode.INITSSLOT  # global variables
+            + b'\x02'           # number of globals
+            + Opcode.PUSH10     # a = 10
+            + Opcode.STSFLD0
+            + Opcode.PUSH5      # b = 5
+            + Opcode.STSFLD1
+            + Opcode.RET
+        )
+        path = '%s/boa3_test/example/variable_test/GlobalAssignmentBetweenFunctions.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_get_global_variable_value_written_after(self):
+        expected_output = (
+            Opcode.LDSFLD + b'\x07'
+            + Opcode.LDSFLD6    # [a, b, c, d, e, f, g, h]
+            + Opcode.LDSFLD5
+            + Opcode.LDSFLD4
+            + Opcode.LDSFLD3
+            + Opcode.LDSFLD2
+            + Opcode.LDSFLD1
+            + Opcode.LDSFLD0
+            + Opcode.PUSH8
+            + Opcode.PACK       # return [a, b, c, d, e, f, g, h]
+            + Opcode.RET
+            + Opcode.INITSSLOT  # global variables
+            + b'\x08'           # number of globals
+            + Opcode.PUSH0      # a = 0
+            + Opcode.STSFLD0
+            + Opcode.PUSH1      # b = 1
+            + Opcode.STSFLD1
+            + Opcode.PUSH2      # c = 2
+            + Opcode.STSFLD2
+            + Opcode.PUSH3      # d = 3
+            + Opcode.STSFLD3
+            + Opcode.PUSH4      # e = 4
+            + Opcode.STSFLD4
+            + Opcode.PUSH5      # f = 5
+            + Opcode.STSFLD5
+            + Opcode.PUSH6      # g = 6
+            + Opcode.STSFLD6
+            + Opcode.PUSH7      # h = 7
+            + Opcode.STSFLD + b'\x07'   # variable index greater than 6 uses another opcode
+            + Opcode.RET
+        )
+        path = '%s/boa3_test/example/variable_test/GetGlobalValueWrittenAfter.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_assign_local_shadowing_global_with_arg_value(self):
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x01'
+            + b'\x01'
+            + Opcode.LDARG0     # b = a  // this b is not the global b
+            + Opcode.STLOC0
+            + Opcode.LDLOC0     # variable address
+            + Opcode.RET
+            + Opcode.INITSSLOT  # global variables
+            + b'\x01'           # number of globals
+            + Opcode.PUSH0      # b = 0
+            + Opcode.STSFLD0
+            + Opcode.RET
+        )
+        path = '%s/boa3_test/example/variable_test/AssignLocalWithArgumentShadowingGlobal.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_assign_global_in_function(self):
+        path = '%s/boa3_test/example/variable_test/GlobalAssignmentInFunctionWithArgument.py' % self.dirname
+
+        with self.assertRaises(NotImplementedError):
+            output = Boa3.compile(path)


### PR DESCRIPTION
Implemented variable declarations and assignments outside the scope of a function
```
from typing import Any


owner: bytes = b'\x01\x02\x03'
empty_bytes = b''


def Main(operation: str) -> Any:
    if operation == 'owner':
        return owner
    return empty_bytes
```
- Variables outside functions must be initialized with a value.
```
var_1: int
var_2: str


def foo() -> int:
    return var_1


var_1 = 10
# the compiler will raise an exception because var_2 is not initialized
```