### PR TITLE
Convert bytearray clear method

### DIFF
--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -437,7 +437,7 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
         if (not symbol_type.is_valid_key(lower)
             or not symbol_type.is_valid_key(upper)
             or (step is not Type.none and not symbol_type.is_valid_key(step))
-        ):
+            ):
             actual: Tuple[IType, ...] = (lower, upper) if step is Type.none else (lower, upper, step)
             self._log_error(
                 CompilerError.MismatchedTypes(

--- a/boa3/compiler/filegenerator.py
+++ b/boa3/compiler/filegenerator.py
@@ -107,7 +107,8 @@ class FileGenerator:
                 }
             ],
             "trusts": [],
-            "safeMethods": [],
+            "safemethods": [],
+            "supportedstandards": [],
             "extra": self._metadata.extra if len(self._metadata.extra) > 0 else None
         }
 
@@ -145,7 +146,7 @@ class FileGenerator:
                     "type": arg.type.abi_type
                 } for arg_id, arg in method.args.items()
             ],
-            "returnType": method.type.abi_type
+            "returntype": method.type.abi_type
         }
 
     def _get_abi_events(self) -> List[Dict[str, Any]]:

--- a/boa3/model/builtin/classmethod/appendmethod.py
+++ b/boa3/model/builtin/classmethod/appendmethod.py
@@ -50,7 +50,7 @@ class AppendMethod(IBuiltinMethod):
         return [
             (Opcode.OVER, b''),
             (Opcode.ISTYPE, Type.bytearray.stack_item),     # append opcode only works for array
-            (Opcode.JMPIFNOT, Integer(8).to_byte_array(min_length=1)),  # when it's bytearray, concatenates the value
+            (Opcode.JMPIFNOT, Integer(5).to_byte_array(min_length=1)),  # when it's bytearray, concatenates the value
             (Opcode.CAT, b''),
             (Opcode.JMP, Integer(5).to_byte_array(min_length=1)),
             (Opcode.APPEND, b'')

--- a/boa3/neo3/contracts/nef.py
+++ b/boa3/neo3/contracts/nef.py
@@ -161,7 +161,7 @@ class NEF(serialization.ISerializable):
                 + self.compiler.encode('utf-8')
                 + self.version.to_array()
                 + self.script_hash.to_array())
-        return hashlib.sha256(data).digest()[:4]
+        return hashlib.sha256(hashlib.sha256(data).digest()).digest()[:4]
 
     def compute_script_hash(self) -> types.UInt160:
         hash = hashlib.new('ripemd160', hashlib.sha256(self.script).digest()).digest()

--- a/boa3_test/example/bytes_test/BytearrayClear.py
+++ b/boa3_test/example/bytes_test/BytearrayClear.py
@@ -1,4 +1,4 @@
-def Main(op: str, args: list) -> bytearray:
+def Main() -> bytearray:
     a = bytearray(b'\x01\x02\x03\x04')
-    a.clear()  # not supported yet
+    a.clear()
     return a

--- a/boa3_test/tests/test_builtin_method.py
+++ b/boa3_test/tests/test_builtin_method.py
@@ -139,7 +139,7 @@ class TestVariable(BoaTest):
                 + Opcode.ISTYPE
                 + Type.bytearray.stack_item
                 + Opcode.JMPIFNOT
-                + Integer(8).to_byte_array(min_length=1)
+                + Integer(5).to_byte_array(min_length=1)
                 + Opcode.CAT
                 + Opcode.JMP
                 + Integer(5).to_byte_array(min_length=1)
@@ -172,7 +172,7 @@ class TestVariable(BoaTest):
                 + Opcode.ISTYPE
                 + Type.bytearray.stack_item
                 + Opcode.JMPIFNOT
-                + Integer(8).to_byte_array(min_length=1)
+                + Integer(5).to_byte_array(min_length=1)
                 + Opcode.CAT
                 + Opcode.JMP
                 + Integer(5).to_byte_array(min_length=1)
@@ -216,7 +216,22 @@ class TestVariable(BoaTest):
             + Opcode.PACK
             + Opcode.STLOC0
             + Opcode.LDLOC0     # a.clear()
-            + Opcode.CLEARITEMS
+                + Opcode.DUP
+                + Opcode.ISTYPE
+                + Type.bytearray.stack_item
+                + Opcode.JMPIFNOT
+                + Integer(9).to_byte_array(min_length=1)
+                + Opcode.DROP
+                + Opcode.PUSHDATA1
+                + Integer(0).to_byte_array(min_length=1)
+                + Opcode.CONVERT
+                + Type.bytearray.stack_item
+                + Opcode.JMP
+                + Integer(5).to_byte_array(min_length=1)
+                + Opcode.CLEARITEMS
+                + Opcode.JMP
+                + Integer(3).to_byte_array(min_length=1)
+                + Opcode.STLOC0
             + Opcode.LDLOC0     # return a
             + Opcode.RET
         )
@@ -237,7 +252,22 @@ class TestVariable(BoaTest):
             + Opcode.PACK
             + Opcode.STLOC0
             + Opcode.LDLOC0     # MutableSequence.clear(a)
-            + Opcode.CLEARITEMS
+                + Opcode.DUP
+                + Opcode.ISTYPE
+                + Type.bytearray.stack_item
+                + Opcode.JMPIFNOT
+                + Integer(9).to_byte_array(min_length=1)
+                + Opcode.DROP
+                + Opcode.PUSHDATA1
+                + Integer(0).to_byte_array(min_length=1)
+                + Opcode.CONVERT
+                + Type.bytearray.stack_item
+                + Opcode.JMP
+                + Integer(5).to_byte_array(min_length=1)
+                + Opcode.CLEARITEMS
+                + Opcode.JMP
+                + Integer(3).to_byte_array(min_length=1)
+                + Opcode.STLOC0
             + Opcode.LDLOC0     # return a
             + Opcode.RET
         )

--- a/boa3_test/tests/test_bytes.py
+++ b/boa3_test/tests/test_bytes.py
@@ -275,7 +275,7 @@ class TestBytes(BoaTest):
                 + Opcode.ISTYPE
                 + Type.bytearray.stack_item
                 + Opcode.JMPIFNOT
-                + Integer(8).to_byte_array(min_length=1)
+                + Integer(5).to_byte_array(min_length=1)
                 + Opcode.CAT
                 + Opcode.JMP
                 + Integer(5).to_byte_array(min_length=1)
@@ -309,7 +309,7 @@ class TestBytes(BoaTest):
                 + Opcode.ISTYPE
                 + Type.bytearray.stack_item
                 + Opcode.JMPIFNOT
-                + Integer(8).to_byte_array(min_length=1)
+                + Integer(5).to_byte_array(min_length=1)
                 + Opcode.CAT
                 + Opcode.JMP
                 + Integer(5).to_byte_array(min_length=1)
@@ -343,7 +343,7 @@ class TestBytes(BoaTest):
                 + Opcode.ISTYPE
                 + Type.bytearray.stack_item
                 + Opcode.JMPIFNOT
-                + Integer(8).to_byte_array(min_length=1)
+                + Integer(5).to_byte_array(min_length=1)
                 + Opcode.CAT
                 + Opcode.JMP
                 + Integer(5).to_byte_array(min_length=1)
@@ -360,8 +360,41 @@ class TestBytes(BoaTest):
         self.assertEqual(expected_output, output)
 
     def test_byte_array_clear(self):
+        data = b'\x01\x02\x03\x04'
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x01'
+            + b'\x00'
+            + Opcode.PUSHDATA1  # a = bytearray(b'\x01\x02\x03\x04')
+            + Integer(len(data)).to_byte_array(min_length=1)
+            + data
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.STLOC0
+            + Opcode.LDLOC0     # a.clear()
+                + Opcode.DUP
+                + Opcode.ISTYPE
+                + Type.bytearray.stack_item
+                + Opcode.JMPIFNOT
+                + Integer(9).to_byte_array(min_length=1)
+                + Opcode.DROP
+                + Opcode.PUSHDATA1
+                + Integer(0).to_byte_array(min_length=1)
+                + Opcode.CONVERT
+                + Type.bytearray.stack_item
+                + Opcode.JMP
+                + Integer(5).to_byte_array(min_length=1)
+                + Opcode.CLEARITEMS
+                + Opcode.JMP
+                + Integer(3).to_byte_array(min_length=1)
+                + Opcode.STLOC0
+            + Opcode.LDLOC0
+            + Opcode.RET        # return a
+        )
+
         path = '%s/boa3_test/example/bytes_test/BytearrayClear.py' % self.dirname
-        self.assertCompilerLogs(NotSupportedOperation, path)
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
 
     def test_byte_array_reverse(self):
         data = b'\x01\x02\x03'

--- a/boa3_test/tests/test_file_generation.py
+++ b/boa3_test/tests/test_file_generation.py
@@ -84,8 +84,8 @@ class TestFileGeneration(BoaTest):
 
         # method Main
         method0 = abi['methods'][0]
-        self.assertIn('returnType', method0)
-        self.assertEqual(AbiType.Integer, method0['returnType'])
+        self.assertIn('returntype', method0)
+        self.assertEqual(AbiType.Integer, method0['returntype'])
         self.assertIn('parameters', method0)
         self.assertEqual(2, len(method0['parameters']))
 
@@ -103,8 +103,8 @@ class TestFileGeneration(BoaTest):
 
         # method Sub
         method1 = abi['methods'][1]
-        self.assertIn('returnType', method1)
-        self.assertEqual(AbiType.Integer, method1['returnType'])
+        self.assertIn('returntype', method1)
+        self.assertEqual(AbiType.Integer, method1['returntype'])
         self.assertIn('parameters', method1)
         self.assertEqual(2, len(method1['parameters']))
 

--- a/boa3_test/tests/test_function.py
+++ b/boa3_test/tests/test_function.py
@@ -695,7 +695,7 @@ class TestFunction(BoaTest):
                 + Opcode.ISTYPE
                 + Type.bytearray.stack_item
                 + Opcode.JMPIFNOT
-                + Integer(8).to_byte_array(min_length=1)
+                + Integer(5).to_byte_array(min_length=1)
                 + Opcode.CAT
                 + Opcode.JMP
                 + Integer(5).to_byte_array(min_length=1)

--- a/boa3_test/tests/test_list.py
+++ b/boa3_test/tests/test_list.py
@@ -350,7 +350,7 @@ class TestList(BoaTest):
                 + Opcode.ISTYPE
                 + Type.bytearray.stack_item
                 + Opcode.JMPIFNOT
-                + Integer(8).to_byte_array(signed=True, min_length=1)
+                + Integer(5).to_byte_array(signed=True, min_length=1)
                 + Opcode.CAT
                 + Opcode.JMP
                 + Integer(5).to_byte_array(min_length=1)
@@ -427,7 +427,7 @@ class TestList(BoaTest):
                 + Opcode.ISTYPE
                 + Type.bytearray.stack_item
                 + Opcode.JMPIFNOT
-                + Integer(8).to_byte_array(signed=True, min_length=1)
+                + Integer(5).to_byte_array(signed=True, min_length=1)
                 + Opcode.CAT
                 + Opcode.JMP
                 + Integer(5).to_byte_array(min_length=1)
@@ -497,7 +497,7 @@ class TestList(BoaTest):
                 + Opcode.ISTYPE
                 + Type.bytearray.stack_item
                 + Opcode.JMPIFNOT
-                + Integer(8).to_byte_array(signed=True, min_length=1)
+                + Integer(5).to_byte_array(signed=True, min_length=1)
                 + Opcode.CAT
                 + Opcode.JMP
                 + Integer(5).to_byte_array(min_length=1)
@@ -591,7 +591,7 @@ class TestList(BoaTest):
                 + Opcode.ISTYPE
                 + Type.bytearray.stack_item
                 + Opcode.JMPIFNOT
-                + Integer(8).to_byte_array(signed=True, min_length=1)
+                + Integer(5).to_byte_array(signed=True, min_length=1)
                 + Opcode.CAT
                 + Opcode.JMP
                 + Integer(5).to_byte_array(min_length=1)
@@ -643,7 +643,7 @@ class TestList(BoaTest):
                 + Opcode.ISTYPE
                 + Type.bytearray.stack_item
                 + Opcode.JMPIFNOT
-                + Integer(8).to_byte_array(min_length=1)
+                + Integer(5).to_byte_array(min_length=1)
                 + Opcode.CAT
                 + Opcode.JMP
                 + Integer(5).to_byte_array(min_length=1)
@@ -679,7 +679,7 @@ class TestList(BoaTest):
                 + Opcode.ISTYPE
                 + Type.bytearray.stack_item
                 + Opcode.JMPIFNOT
-                + Integer(8).to_byte_array(min_length=1)
+                + Integer(5).to_byte_array(min_length=1)
                 + Opcode.CAT
                 + Opcode.JMP
                 + Integer(5).to_byte_array(min_length=1)
@@ -716,7 +716,7 @@ class TestList(BoaTest):
                 + Opcode.ISTYPE
                 + Type.bytearray.stack_item
                 + Opcode.JMPIFNOT
-                + Integer(8).to_byte_array(min_length=1)
+                + Integer(5).to_byte_array(min_length=1)
                 + Opcode.CAT
                 + Opcode.JMP
                 + Integer(5).to_byte_array(min_length=1)
@@ -748,7 +748,22 @@ class TestList(BoaTest):
             + Opcode.PACK
             + Opcode.STLOC0
             + Opcode.LDLOC0     # a.clear()
-            + Opcode.CLEARITEMS
+                + Opcode.DUP
+                + Opcode.ISTYPE
+                + Type.bytearray.stack_item
+                + Opcode.JMPIFNOT
+                + Integer(9).to_byte_array(min_length=1)
+                + Opcode.DROP
+                + Opcode.PUSHDATA1
+                + Integer(0).to_byte_array(min_length=1)
+                + Opcode.CONVERT
+                + Type.bytearray.stack_item
+                + Opcode.JMP
+                + Integer(5).to_byte_array(min_length=1)
+                + Opcode.CLEARITEMS
+                + Opcode.JMP
+                + Integer(3).to_byte_array(min_length=1)
+                + Opcode.STLOC0
             + Opcode.LDLOC0     # return a
             + Opcode.RET
         )

--- a/boa3_test/tests/test_tuple.py
+++ b/boa3_test/tests/test_tuple.py
@@ -260,7 +260,7 @@ class TestTuple(BoaTest):
                 + Opcode.ISTYPE
                 + Type.bytearray.stack_item
                 + Opcode.JMPIFNOT
-                + Integer(8).to_byte_array(signed=True, min_length=1)
+                + Integer(5).to_byte_array(signed=True, min_length=1)
                 + Opcode.CAT
                 + Opcode.JMP
                 + Integer(5).to_byte_array(min_length=1)
@@ -337,7 +337,7 @@ class TestTuple(BoaTest):
                 + Opcode.ISTYPE
                 + Type.bytearray.stack_item
                 + Opcode.JMPIFNOT
-                + Integer(8).to_byte_array(signed=True, min_length=1)
+                + Integer(5).to_byte_array(signed=True, min_length=1)
                 + Opcode.CAT
                 + Opcode.JMP
                 + Integer(5).to_byte_array(min_length=1)
@@ -407,7 +407,7 @@ class TestTuple(BoaTest):
                 + Opcode.ISTYPE
                 + Type.bytearray.stack_item
                 + Opcode.JMPIFNOT
-                + Integer(8).to_byte_array(signed=True, min_length=1)
+                + Integer(5).to_byte_array(signed=True, min_length=1)
                 + Opcode.CAT
                 + Opcode.JMP
                 + Integer(5).to_byte_array(min_length=1)
@@ -501,7 +501,7 @@ class TestTuple(BoaTest):
                 + Opcode.ISTYPE
                 + Type.bytearray.stack_item
                 + Opcode.JMPIFNOT
-                + Integer(8).to_byte_array(signed=True, min_length=1)
+                + Integer(5).to_byte_array(signed=True, min_length=1)
                 + Opcode.CAT
                 + Opcode.JMP
                 + Integer(5).to_byte_array(min_length=1)


### PR DESCRIPTION
Implemented Python `bytearray` clear function
```
a = bytearray(b'\x01\x02\x03')
b = bytearray(b'\x03\x02\x01')
c = bytearray(b'\x0a\x0b\x0c')

a.clear()
MutableSequence.clear(b)
bytearray.clear(c)
```