### PR TITLE
Implement toScriptHash()

### DIFF
--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -100,6 +100,8 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
         return symbols
 
     def get_symbol(self, symbol_id: str) -> Optional[ISymbol]:
+        if not isinstance(symbol_id, str):
+            return Variable(self.get_type(symbol_id))
         if self._current_method is not None and symbol_id in self._current_method.symbols:
             # the symbol exists in the local scope
             return self._current_method.symbols[symbol_id]

--- a/boa3/builtin/__init__.py
+++ b/boa3/builtin/__init__.py
@@ -1,3 +1,6 @@
+from typing import Any
+
+
 def event(*args):
     """
     This decorator identifies a method that specifies a Neo event.
@@ -25,6 +28,17 @@ def metadata(*args):
     def metadata_wrapper():
         pass
     return metadata_wrapper
+
+
+def to_script_hash(data_bytes: Any) -> bytes:
+    """
+    Converts a data to a script hash.
+
+    :param data_bytes: data to hash.
+    :return: the script hash of the data
+    :rtype: bytes
+    """
+    pass
 
 
 class NeoMetadata:

--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -14,6 +14,7 @@ from boa3.model.builtin.interop.interop import Interop
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.builtin.method.bytearraymethod import ByteArrayMethod
 from boa3.model.builtin.method.lenmethod import LenMethod
+from boa3.model.builtin.method.toscripthashmethod import ScriptHashMethod
 from boa3.model.builtin.neometadatatype import MetadataTypeSingleton as NeoMetadataType
 from boa3.model.callable import Callable
 from boa3.model.identifiedsymbol import IdentifiedSymbol
@@ -37,6 +38,7 @@ class Builtin:
 
     # builtin method
     Len = LenMethod()
+    ScriptHash = ScriptHashMethod()
 
     # python builtin class constructor
     ByteArray = ByteArrayMethod()
@@ -50,6 +52,7 @@ class Builtin:
     DictValues = MapValuesMethod()
 
     _python_builtins: List[IdentifiedSymbol] = [Len,
+                                                ScriptHash,
                                                 ByteArray,
                                                 SequenceAppend,
                                                 SequenceClear,

--- a/boa3/model/builtin/method/toscripthashmethod.py
+++ b/boa3/model/builtin/method/toscripthashmethod.py
@@ -2,7 +2,6 @@ from typing import Dict, List, Optional, Tuple
 
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.expression import IExpression
-from boa3.model.type.collection.sequence.sequencetype import SequenceType
 from boa3.model.type.primitive.primitivetype import PrimitiveType
 from boa3.model.variable import Variable
 from boa3.neo.vm.opcode.Opcode import Opcode

--- a/boa3/model/builtin/method/toscripthashmethod.py
+++ b/boa3/model/builtin/method/toscripthashmethod.py
@@ -1,0 +1,41 @@
+from typing import Dict, List, Optional, Tuple
+
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.expression import IExpression
+from boa3.model.type.collection.sequence.sequencetype import SequenceType
+from boa3.model.type.primitive.primitivetype import PrimitiveType
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class ScriptHashMethod(IBuiltinMethod):
+
+    def __init__(self):
+        from boa3.model.type.type import Type
+        identifier = 'to_script_hash'
+        args: Dict[str, Variable] = {'data_bytes': Variable(Type.any)}
+        super().__init__(identifier, args, Type.bytes)
+
+    def validate_parameters(self, *params: IExpression) -> bool:
+        if len(params) != 1:
+            return False
+        if not isinstance(params[0], IExpression):
+            return False
+        return isinstance(params[0].type, PrimitiveType)
+
+    @property
+    def is_supported(self) -> bool:
+        # TODO: change when implement variable values conversion to script hash
+        return False
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        return []
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> Optional[str]:
+        return None

--- a/boa3/model/type/primitive/booltype.py
+++ b/boa3/model/type/primitive/booltype.py
@@ -1,11 +1,11 @@
 from typing import Any
 
-from boa3.model.type.itype import IType
+from boa3.model.type.primitive.primitivetype import PrimitiveType
 from boa3.neo.vm.type.AbiType import AbiType
 from boa3.neo.vm.type.StackItemType import StackItemType
 
 
-class BoolType(IType):
+class BoolType(PrimitiveType):
     """
     A class used to represent Python bool type
     """

--- a/boa3/model/type/primitive/bytestype.py
+++ b/boa3/model/type/primitive/bytestype.py
@@ -2,11 +2,12 @@ from typing import Any
 
 from boa3.model.type.collection.sequence.sequencetype import SequenceType
 from boa3.model.type.itype import IType
+from boa3.model.type.primitive.primitivetype import PrimitiveType
 from boa3.neo.vm.type.AbiType import AbiType
 from boa3.neo.vm.type.StackItemType import StackItemType
 
 
-class BytesType(SequenceType):
+class BytesType(SequenceType, PrimitiveType):
     """
     A class used to represent Python bytes type
     """

--- a/boa3/model/type/primitive/inttype.py
+++ b/boa3/model/type/primitive/inttype.py
@@ -1,11 +1,12 @@
 from typing import Any
 
 from boa3.model.type.itype import IType
+from boa3.model.type.primitive.primitivetype import PrimitiveType
 from boa3.neo.vm.type.AbiType import AbiType
 from boa3.neo.vm.type.StackItemType import StackItemType
 
 
-class IntType(IType):
+class IntType(PrimitiveType):
     """
     A class used to represent Python int type
     """

--- a/boa3/model/type/primitive/inttype.py
+++ b/boa3/model/type/primitive/inttype.py
@@ -1,6 +1,5 @@
 from typing import Any
 
-from boa3.model.type.itype import IType
 from boa3.model.type.primitive.primitivetype import PrimitiveType
 from boa3.neo.vm.type.AbiType import AbiType
 from boa3.neo.vm.type.StackItemType import StackItemType

--- a/boa3/model/type/primitive/primitivetype.py
+++ b/boa3/model/type/primitive/primitivetype.py
@@ -1,0 +1,12 @@
+from abc import ABC
+
+from boa3.model.type.itype import IType
+
+
+class PrimitiveType(IType, ABC):
+    """
+    An interface for primitive types
+    """
+
+    def __init__(self, identifier: str):
+        super().__init__(identifier)

--- a/boa3/model/type/primitive/strtype.py
+++ b/boa3/model/type/primitive/strtype.py
@@ -2,11 +2,12 @@ from typing import Any
 
 from boa3.model.type.collection.sequence.sequencetype import SequenceType
 from boa3.model.type.itype import IType
+from boa3.model.type.primitive.primitivetype import PrimitiveType
 from boa3.neo.vm.type.AbiType import AbiType
 from boa3.neo.vm.type.StackItemType import StackItemType
 
 
-class StrType(SequenceType):
+class StrType(SequenceType, PrimitiveType):
     """
     A class used to represent Python str type
     """

--- a/boa3_test/example/built_in_methods_test/ScriptHashBuiltinMismatchedType.py
+++ b/boa3_test/example/built_in_methods_test/ScriptHashBuiltinMismatchedType.py
@@ -1,0 +1,2 @@
+def Main() -> bytes:
+    return bytes.to_script_hash(123)

--- a/boa3_test/example/built_in_methods_test/ScriptHashInt.py
+++ b/boa3_test/example/built_in_methods_test/ScriptHashInt.py
@@ -1,0 +1,2 @@
+def Main() -> bytes:
+    return (123).to_script_hash()

--- a/boa3_test/example/built_in_methods_test/ScriptHashIntBuiltinCall.py
+++ b/boa3_test/example/built_in_methods_test/ScriptHashIntBuiltinCall.py
@@ -1,0 +1,2 @@
+def Main() -> bytes:
+    return int.to_script_hash(123)

--- a/boa3_test/example/built_in_methods_test/ScriptHashMismatchedType.py
+++ b/boa3_test/example/built_in_methods_test/ScriptHashMismatchedType.py
@@ -1,0 +1,2 @@
+def Main() -> bytes:
+    return [1, 2, 3].to_script_hash()

--- a/boa3_test/example/built_in_methods_test/ScriptHashStr.py
+++ b/boa3_test/example/built_in_methods_test/ScriptHashStr.py
@@ -1,0 +1,2 @@
+def Main() -> bytes:
+    return '123'.to_script_hash()

--- a/boa3_test/example/built_in_methods_test/ScriptHashStrBuiltinCall.py
+++ b/boa3_test/example/built_in_methods_test/ScriptHashStrBuiltinCall.py
@@ -1,0 +1,2 @@
+def Main() -> bytes:
+    return str.to_script_hash('123')

--- a/boa3_test/example/built_in_methods_test/ScriptHashTooFewParameters.py
+++ b/boa3_test/example/built_in_methods_test/ScriptHashTooFewParameters.py
@@ -1,0 +1,2 @@
+def Main() -> bytes:
+    return int.to_script_hash()

--- a/boa3_test/example/built_in_methods_test/ScriptHashTooManyParameters.py
+++ b/boa3_test/example/built_in_methods_test/ScriptHashTooManyParameters.py
@@ -1,0 +1,2 @@
+def Main() -> bytes:
+    return (123).to_script_hash(123)

--- a/boa3_test/example/built_in_methods_test/ScriptHashVariable.py
+++ b/boa3_test/example/built_in_methods_test/ScriptHashVariable.py
@@ -1,0 +1,3 @@
+def Main() -> bytes:
+    a = 123
+    return a.to_script_hash()  # only works with literals

--- a/boa3_test/example/built_in_methods_test/ScriptHashVariableBuiltinCall.py
+++ b/boa3_test/example/built_in_methods_test/ScriptHashVariableBuiltinCall.py
@@ -1,0 +1,3 @@
+def Main() -> bytes:
+    a = '123'
+    return str.to_script_hash(a)  # only works with literals

--- a/boa3_test/tests/test_builtin_method.py
+++ b/boa3_test/tests/test_builtin_method.py
@@ -1,5 +1,5 @@
 from boa3.boa3 import Boa3
-from boa3.exception.CompilerError import MismatchedTypes, UnexpectedArgument, UnfilledArgument
+from boa3.exception.CompilerError import MismatchedTypes, NotSupportedOperation, UnexpectedArgument, UnfilledArgument
 from boa3.model.type.type import Type
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
@@ -442,5 +442,99 @@ class TestVariable(BoaTest):
     def test_extend_too_few_parameters(self):
         path = '%s/boa3_test/example/built_in_methods_test/ExtendTooFewParameters.py' % self.dirname
         self.assertCompilerLogs(UnfilledArgument, path)
+
+    # endregion
+
+    # region TestToScriptHash
+
+    def test_script_hash_int(self):
+        from boa3.neo import to_script_hash
+        script_hash = to_script_hash(Integer(123).to_byte_array())
+        expected_output = (
+            Opcode.PUSHDATA1
+            + Integer(len(script_hash)).to_byte_array(min_length=1)
+            + script_hash
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/built_in_methods_test/ScriptHashInt.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_script_hash_int_with_builtin(self):
+        from boa3.neo import to_script_hash
+        script_hash = to_script_hash(Integer(123).to_byte_array())
+        expected_output = (
+            Opcode.PUSHDATA1
+            + Integer(len(script_hash)).to_byte_array(min_length=1)
+            + script_hash
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/built_in_methods_test/ScriptHashIntBuiltinCall.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_script_hash_str(self):
+        from boa3.neo import to_script_hash
+        script_hash = to_script_hash(String('123').to_bytes())
+        expected_output = (
+            Opcode.PUSHDATA1
+            + Integer(len(script_hash)).to_byte_array(min_length=1)
+            + script_hash
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/built_in_methods_test/ScriptHashStr.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_script_hash_str_with_builtin(self):
+        from boa3.neo import to_script_hash
+        script_hash = to_script_hash(String('123').to_bytes())
+        expected_output = (
+            Opcode.PUSHDATA1
+            + Integer(len(script_hash)).to_byte_array(min_length=1)
+            + script_hash
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/built_in_methods_test/ScriptHashStrBuiltinCall.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_script_hash_variable(self):
+        path = '%s/boa3_test/example/built_in_methods_test/ScriptHashVariable.py' % self.dirname
+        self.assertCompilerLogs(NotSupportedOperation, path)
+
+    def test_script_hash_variable_with_builtin(self):
+        path = '%s/boa3_test/example/built_in_methods_test/ScriptHashVariableBuiltinCall.py' % self.dirname
+        self.assertCompilerLogs(NotSupportedOperation, path)
+
+    def test_script_hahs_too_many_parameters(self):
+        path = '%s/boa3_test/example/built_in_methods_test/ScriptHashTooManyParameters.py' % self.dirname
+        self.assertCompilerLogs(UnexpectedArgument, path)
+
+    def test_script_hash_too_few_parameters(self):
+        path = '%s/boa3_test/example/built_in_methods_test/ScriptHashTooFewParameters.py' % self.dirname
+        self.assertCompilerLogs(UnfilledArgument, path)
+
+    def test_script_hash_mismatched_types(self):
+        path = '%s/boa3_test/example/built_in_methods_test/ScriptHashMismatchedType.py' % self.dirname
+        # TODO: change to MismatchedTypes when 'to_script_hash' with variables is implemented
+        self.assertCompilerLogs(NotSupportedOperation, path)
+
+    def test_script_hash_builtin_mismatched_types(self):
+        path = '%s/boa3_test/example/built_in_methods_test/ScriptHashBuiltinMismatchedType.py' % self.dirname
+        # TODO: change to MismatchedTypes when 'to_script_hash' with variables is implemented
+        self.assertCompilerLogs(NotSupportedOperation, path)
 
     # endregion


### PR DESCRIPTION
Implemented a function to convert bytes, string and int values to a script hash value
```python
number_1_script: bytes = 1.to_script_hash()
number_2_script: bytes = int.to_script_hash(1)
string_script: bytes = 'str'.to_script_hash()
bytes_script: bytes = bytes.to_script_hash(b'\x01\x02\x03')

one = 1
script = one.to_script_hash()  # this function only works with literal values
```