### PR TITLE
Function default argument

### DIFF
--- a/boa3/analyser/moduleanalyser.py
+++ b/boa3/analyser/moduleanalyser.py
@@ -422,7 +422,7 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
                 )
             self.__include_callable(function.name, event)
         else:
-            method = Method(args=fun_args, return_type=fun_return,
+            method = Method(args=fun_args, defaults=function.args.defaults, return_type=fun_return,
                             origin_node=function, is_public=Builtin.Public in fun_decorators)
             self._current_method = method
 

--- a/boa3/compiler/codegenerator.py
+++ b/boa3/compiler/codegenerator.py
@@ -472,7 +472,7 @@ class CodeGenerator:
             self.__insert1(OpcodeInfo.NEWARRAY)
         self._stack.append(array_type)
 
-    def convert_new_array(self, length: int, array_type: IType):
+    def convert_new_array(self, length: int, array_type: IType = Type.list):
         """
         Converts the creation of a new array
 
@@ -653,7 +653,7 @@ class CodeGenerator:
             elif isinstance(symbol, Event):
                 self.convert_event_call(symbol_id, symbol)
             else:
-                self.convert_method_call(symbol)
+                self.convert_method_call(symbol, len(params_addresses))
 
     def convert_load_variable(self, var_id: str, var: Variable):
         """
@@ -756,7 +756,7 @@ class CodeGenerator:
         if function.return_type is not None:
             self._stack.append(function.return_type)
 
-    def convert_method_call(self, function: Method):
+    def convert_method_call(self, function: Method, num_args: int):
         """
         Converts a builtin method function call
 
@@ -765,7 +765,7 @@ class CodeGenerator:
         from boa3.neo.vm.CallCode import CallCode
         self.__insert_code(CallCode(function))
 
-        for arg in function.args:
+        for arg in range(num_args):
             self._stack.pop()
         self._stack.append(function.return_type)
 

--- a/boa3/compiler/filegenerator.py
+++ b/boa3/compiler/filegenerator.py
@@ -137,9 +137,11 @@ class FileGenerator:
         return methods
 
     def _construct_abi_method(self, method_id: str, method: Method) -> Dict[str, Any]:
+        from boa3.compiler.vmcodemapping import VMCodeMapping
         return {
             "name": method_id,
-            "offset": method.start_address if method.start_address is not None else 0,
+            "offset": (VMCodeMapping.instance().get_start_address(method.start_bytecode)
+                       if method.start_bytecode is not None else 0),
             "parameters": [
                 {
                     "name": arg_id,

--- a/boa3/model/builtin/builtincallable.py
+++ b/boa3/model/builtin/builtincallable.py
@@ -1,3 +1,4 @@
+import ast
 from abc import ABC
 from typing import Dict, List, Tuple
 
@@ -9,8 +10,9 @@ from boa3.neo.vm.opcode.Opcode import Opcode
 
 
 class IBuiltinCallable(Callable, IdentifiedSymbol, ABC):
-    def __init__(self, identifier: str, args: Dict[str, Variable] = None, return_type: IType = None):
-        super().__init__(args, return_type)
+    def __init__(self, identifier: str, args: Dict[str, Variable] = None,
+                 defaults: List[ast.AST] = None, return_type: IType = None):
+        super().__init__(args, defaults, return_type)
         self._identifier = identifier
 
     @property

--- a/boa3/model/builtin/classmethod/mapkeysmethod.py
+++ b/boa3/model/builtin/classmethod/mapkeysmethod.py
@@ -19,7 +19,7 @@ class MapKeysMethod(IBuiltinMethod):
 
         identifier = 'keys'
         args: Dict[str, Variable] = {'self': self_arg}
-        super().__init__(identifier, args, return_type)
+        super().__init__(identifier, args, return_type=return_type)
 
     @property
     def _arg_self(self) -> Variable:

--- a/boa3/model/builtin/classmethod/mapvaluesmethod.py
+++ b/boa3/model/builtin/classmethod/mapvaluesmethod.py
@@ -19,7 +19,7 @@ class MapValuesMethod(IBuiltinMethod):
 
         identifier = 'values'
         args: Dict[str, Variable] = {'self': self_arg}
-        super().__init__(identifier, args, return_type)
+        super().__init__(identifier, args, return_type=return_type)
 
     @property
     def _arg_self(self) -> Variable:

--- a/boa3/model/builtin/decorator/builtindecorator.py
+++ b/boa3/model/builtin/decorator/builtindecorator.py
@@ -1,5 +1,6 @@
+import ast
 from abc import ABC, abstractmethod
-from typing import Dict
+from typing import Dict, List
 
 from boa3.model.builtin.builtincallable import IBuiltinCallable
 from boa3.model.expression import IExpression
@@ -9,8 +10,9 @@ from boa3.model.variable import Variable
 
 
 class IBuiltinDecorator(IBuiltinCallable, Method, ABC):
-    def __init__(self, identifier: str, args: Dict[str, Variable] = None, return_type: IType = None):
-        super().__init__(identifier, args, return_type)
+    def __init__(self, identifier: str, args: Dict[str, Variable] = None,
+                 defaults: List[ast.AST] = None, return_type: IType = None):
+        super().__init__(identifier, args, defaults, return_type)
 
     @abstractmethod
     def validate_parameters(self, *params: IExpression) -> bool:

--- a/boa3/model/builtin/interop/interopevent.py
+++ b/boa3/model/builtin/interop/interopevent.py
@@ -1,3 +1,4 @@
+import ast
 from abc import ABC
 from typing import Dict, List, Tuple
 
@@ -8,9 +9,10 @@ from boa3.neo.vm.opcode.Opcode import Opcode
 
 class InteropEvent(IBuiltinEvent, ABC):
 
-    def __init__(self, identifier: str, sys_call: str, args: Dict[str, Variable] = None):
+    def __init__(self, identifier: str, sys_call: str,
+                 args: Dict[str, Variable] = None, defaults: List[ast.AST] = None):
         self._sys_call: str = sys_call
-        super().__init__(identifier, args)
+        super().__init__(identifier, args, defaults)
 
     @property
     def interop_method_hash(self) -> bytes:

--- a/boa3/model/builtin/interop/interopmethod.py
+++ b/boa3/model/builtin/interop/interopmethod.py
@@ -1,3 +1,4 @@
+import ast
 from abc import ABC
 from typing import Dict, List, Optional, Tuple
 
@@ -10,9 +11,10 @@ from boa3.neo.vm.opcode.Opcode import Opcode
 
 class InteropMethod(IBuiltinMethod, ABC):
 
-    def __init__(self, identifier: str, sys_call: str, args: Dict[str, Variable] = None, return_type: IType = None):
+    def __init__(self, identifier: str, sys_call: str, args: Dict[str, Variable] = None,
+                 defaults: List[ast.AST] = None, return_type: IType = None):
         self._sys_call: str = sys_call
-        super().__init__(identifier, args, return_type)
+        super().__init__(identifier, args, defaults, return_type)
 
     def validate_parameters(self, *params: IExpression) -> bool:
         if any(not isinstance(param, IExpression) for param in params):

--- a/boa3/model/builtin/interop/runtime/checkwitnessmethod.py
+++ b/boa3/model/builtin/interop/runtime/checkwitnessmethod.py
@@ -11,4 +11,4 @@ class CheckWitnessMethod(InteropMethod):
         identifier = 'check_witness'
         syscall = 'System.Runtime.CheckWitness'
         args: Dict[str, Variable] = {'hash_or_pubkey': Variable(Type.bytes)}
-        super().__init__(identifier, syscall, args, Type.bool)
+        super().__init__(identifier, syscall, args, return_type=Type.bool)

--- a/boa3/model/builtin/interop/runtime/logmethod.py
+++ b/boa3/model/builtin/interop/runtime/logmethod.py
@@ -11,4 +11,4 @@ class LogMethod(InteropMethod):
         identifier = 'log'
         syscall = 'System.Runtime.Log'
         args: Dict[str, Variable] = {'message': Variable(Type.str)}
-        super().__init__(identifier, syscall, args, Type.none)
+        super().__init__(identifier, syscall, args, return_type=Type.none)

--- a/boa3/model/builtin/interop/runtime/triggermethod.py
+++ b/boa3/model/builtin/interop/runtime/triggermethod.py
@@ -11,4 +11,4 @@ class TriggerMethod(InteropMethod):
         identifier = 'trigger'
         syscall = 'System.Runtime.GetTrigger'
         args: Dict[str, Variable] = {}
-        super().__init__(identifier, syscall, args, trigger_type)
+        super().__init__(identifier, syscall, args, return_type=trigger_type)

--- a/boa3/model/builtin/interop/storage/storagedeletemethod.py
+++ b/boa3/model/builtin/interop/storage/storagedeletemethod.py
@@ -15,7 +15,7 @@ class StorageDeleteMethod(InteropMethod):
         syscall = 'System.Storage.Delete'
         self._storage_context = 'System.Storage.GetContext'  # TODO: refactor when default arguments are implemented
         args: Dict[str, Variable] = {'key': Variable(Type.bytes)}
-        super().__init__(identifier, syscall, args, Type.none)
+        super().__init__(identifier, syscall, args, return_type=Type.none)
 
     @property
     def requires_storage(self) -> bool:

--- a/boa3/model/builtin/interop/storage/storagegetmethod.py
+++ b/boa3/model/builtin/interop/storage/storagegetmethod.py
@@ -15,7 +15,7 @@ class StorageGetMethod(InteropMethod):
         syscall = 'System.Storage.Get'
         self._storage_context = 'System.Storage.GetContext'  # TODO: refactor when default arguments are implemented
         args: Dict[str, Variable] = {'key': Variable(Type.bytes)}
-        super().__init__(identifier, syscall, args, Type.bytes)
+        super().__init__(identifier, syscall, args, return_type=Type.bytes)
 
     @property
     def requires_storage(self) -> bool:

--- a/boa3/model/builtin/interop/storage/storageputmethod.py
+++ b/boa3/model/builtin/interop/storage/storageputmethod.py
@@ -15,7 +15,7 @@ class StoragePutMethod(InteropMethod):
         syscall = 'System.Storage.Put'
         self._storage_context = 'System.Storage.GetContext'  # TODO: refactor when default arguments are implemented
         args: Dict[str, Variable] = {'key': Variable(Type.bytes), 'value': Variable(Type.bytes)}
-        super().__init__(identifier, syscall, args, Type.none)
+        super().__init__(identifier, syscall, args, return_type=Type.none)
 
     @property
     def requires_storage(self) -> bool:

--- a/boa3/model/builtin/method/builtinevent.py
+++ b/boa3/model/builtin/method/builtinevent.py
@@ -1,5 +1,6 @@
+import ast
 from abc import ABC
-from typing import Dict
+from typing import Dict, List
 
 from boa3.model.builtin.builtincallable import IBuiltinCallable
 from boa3.model.event import Event
@@ -7,6 +8,6 @@ from boa3.model.variable import Variable
 
 
 class IBuiltinEvent(IBuiltinCallable, Event, ABC):
-    def __init__(self, identifier: str, args: Dict[str, Variable] = None):
+    def __init__(self, identifier: str, args: Dict[str, Variable] = None, defaults: List[ast.AST] = None):
         from boa3.model.type.type import Type
-        super().__init__(identifier, args, Type.none)
+        super().__init__(identifier, args, defaults, Type.none)

--- a/boa3/model/builtin/method/builtinmethod.py
+++ b/boa3/model/builtin/method/builtinmethod.py
@@ -1,5 +1,6 @@
+import ast
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, List
 
 from boa3.model.builtin.builtincallable import IBuiltinCallable
 from boa3.model.method import Method
@@ -8,8 +9,9 @@ from boa3.model.variable import Variable
 
 
 class IBuiltinMethod(IBuiltinCallable, Method, ABC):
-    def __init__(self, identifier: str, args: Dict[str, Variable] = None, return_type: IType = None):
-        super().__init__(identifier, args, return_type)
+    def __init__(self, identifier: str, args: Dict[str, Variable] = None,
+                 defaults: List[ast.AST] = None, return_type: IType = None):
+        super().__init__(identifier, args, defaults, return_type)
 
     @property
     def is_supported(self) -> bool:

--- a/boa3/model/builtin/method/bytearraymethod.py
+++ b/boa3/model/builtin/method/bytearraymethod.py
@@ -17,7 +17,7 @@ class ByteArrayMethod(IBuiltinMethod):
 
         identifier = 'bytearray'
         args: Dict[str, Variable] = {'object': Variable(argument_type)}
-        super().__init__(identifier, args, Type.bytearray)
+        super().__init__(identifier, args, return_type=Type.bytearray)
 
     @property
     def _arg_object(self) -> Variable:

--- a/boa3/model/builtin/method/lenmethod.py
+++ b/boa3/model/builtin/method/lenmethod.py
@@ -13,7 +13,7 @@ class LenMethod(IBuiltinMethod):
         from boa3.model.type.type import Type
         identifier = 'len'
         args: Dict[str, Variable] = {'__o': Variable(Type.sequence)}
-        super().__init__(identifier, args, Type.int)
+        super().__init__(identifier, args, return_type=Type.int)
 
     def validate_parameters(self, *params: IExpression) -> bool:
         if len(params) != 1:

--- a/boa3/model/event.py
+++ b/boa3/model/event.py
@@ -1,5 +1,5 @@
 import ast
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from boa3.model.callable import Callable
 from boa3.model.type.type import Type
@@ -7,9 +7,9 @@ from boa3.model.variable import Variable
 
 
 class Event(Callable):
-    def __init__(self, args: Dict[str, Variable] = None,
+    def __init__(self, args: Dict[str, Variable] = None, defaults: List[ast.AST] = None,
                  is_public: bool = False, origin_node: Optional[ast.AST] = None):
-        super().__init__(args, Type.none, is_public, origin_node)
+        super().__init__(args, defaults, Type.none, is_public, origin_node)
 
     @property
     def shadowing_name(self) -> str:

--- a/boa3/model/method.py
+++ b/boa3/model/method.py
@@ -19,9 +19,9 @@ class Method(Callable):
     :ivar return_type: the return type of the method. None by default.
     """
 
-    def __init__(self, args: Dict[str, Variable] = None, return_type: IType = Type.none,
-                 is_public: bool = False, origin_node: Optional[ast.AST] = None):
-        super().__init__(args, return_type, is_public, origin_node)
+    def __init__(self, args: Dict[str, Variable] = None, defaults: List[ast.AST] = None,
+                 return_type: IType = Type.none, is_public: bool = False, origin_node: Optional[ast.AST] = None):
+        super().__init__(args, defaults, return_type, is_public, origin_node)
 
         self.imported_symbols = {}
         self._requires_storage: bool = False

--- a/boa3_test/example/function_test/CallFunctionWithKwargs.py
+++ b/boa3_test/example/function_test/CallFunctionWithKwargs.py
@@ -1,0 +1,6 @@
+def Main(number: int) -> int:
+    return negate(number=number)  # not implemented yet
+
+
+def negate(number: int) -> int:
+    return -number

--- a/boa3_test/example/function_test/FunctionWithDefaultArgument.py
+++ b/boa3_test/example/function_test/FunctionWithDefaultArgument.py
@@ -1,0 +1,7 @@
+def Main():
+    add(1, 2, 3)
+    add(5, 6)
+
+
+def add(a: int, b: int, c: int = 0) -> int:
+    return a + b + c

--- a/boa3_test/example/function_test/FunctionWithDefaultArgumentBetweenArgs.py
+++ b/boa3_test/example/function_test/FunctionWithDefaultArgumentBetweenArgs.py
@@ -1,0 +1,7 @@
+def Main():
+    add(1, 2, 3)
+    add(5, 6)
+
+
+def add(a: int, b: int, c: int = 0, d: int) -> int:
+    return a + b + c

--- a/boa3_test/example/function_test/FunctionWithOnlyDefaultArguments.py
+++ b/boa3_test/example/function_test/FunctionWithOnlyDefaultArguments.py
@@ -1,0 +1,9 @@
+def Main():
+    add()
+    add(5, 6)
+    add(9)
+    add(1, 2, 3)
+
+
+def add(a: int = 0, b: int = 0, c: int = 0) -> int:
+    return a + b + c

--- a/boa3_test/tests/test_function.py
+++ b/boa3_test/tests/test_function.py
@@ -906,3 +906,81 @@ class TestFunction(BoaTest):
         path = '%s/boa3_test/example/function_test/MultipleFunctionLargeCall.py' % self.dirname
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
+
+    def test_function_with_default_argument(self):
+        expected_output = (
+            Opcode.PUSH3    # add(1, 2, 3)
+            + Opcode.PUSH2
+            + Opcode.PUSH1
+            + Opcode.CALL
+            + Integer(9).to_byte_array(signed=True, min_length=1)
+            + Opcode.PUSH0
+            + Opcode.PUSH6  # add(5, 6)
+            + Opcode.PUSH5
+            + Opcode.CALL
+            + Integer(4).to_byte_array(signed=True, min_length=1)
+            + Opcode.PUSHNULL
+            + Opcode.RET
+            + Opcode.INITSLOT   # def add(a: int, b: int, c: int = 0)
+            + b'\x00\x03'
+            + Opcode.LDARG0     # return a + b + c
+            + Opcode.LDARG1
+            + Opcode.ADD
+            + Opcode.LDARG2
+            + Opcode.ADD
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/function_test/FunctionWithDefaultArgument.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_function_with_only_default_arguments(self):
+        expected_output = (
+            Opcode.PUSH0        # defaults
+            + Opcode.PUSH0
+            + Opcode.PUSH0
+            + Opcode.CALL   # add()
+            + Integer(19).to_byte_array(signed=True, min_length=1)
+            + Opcode.PUSH0      # defaults
+            + Opcode.PUSH6      # add(5, 6)
+            + Opcode.PUSH5
+            + Opcode.CALL
+            + Integer(14).to_byte_array(signed=True, min_length=1)
+            + Opcode.PUSH0      # defaults
+            + Opcode.PUSH0
+            + Opcode.PUSH9      # add(9)
+            + Opcode.CALL
+            + Integer(9).to_byte_array(signed=True, min_length=1)
+            + Opcode.PUSH3      # add(1, 2, 3)
+            + Opcode.PUSH2
+            + Opcode.PUSH1
+            + Opcode.CALL
+            + Integer(4).to_byte_array(signed=True, min_length=1)
+            + Opcode.PUSHNULL
+            + Opcode.RET
+            + Opcode.INITSLOT   # def add(a: int, b: int, c: int)
+            + b'\x00\x03'
+            + Opcode.LDARG0     # return a + b + c
+            + Opcode.LDARG1
+            + Opcode.ADD
+            + Opcode.LDARG2
+            + Opcode.ADD
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/function_test/FunctionWithOnlyDefaultArguments.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_function_with_default_argument_between_other_args(self):
+        path = '%s/boa3_test/example/function_test/FunctionWithDefaultArgumentBetweenArgs.py' % self.dirname
+
+        with self.assertRaises(SyntaxError):
+            output = Boa3.compile(path)
+
+    def test_call_function_with_kwargs(self):
+        path = '%s/boa3_test/example/function_test/CallFunctionWithKwargs.py' % self.dirname
+
+        with self.assertRaises(NotImplementedError):
+            output = Boa3.compile(path)


### PR DESCRIPTION
Implemented default arguments to functions
```python
def example(a: int = 0, b: int = 0, c: int = 0) -> int:
    return a + b + c

...

add()
add(5, 6)
add(9)
add(1, 2, 3)
```

This is only implemented to functions call inside the same smart contract for now