### PR TITLE
Fix address string to ScriptHash

### DIFF
--- a/boa3/neo/__init__.py
+++ b/boa3/neo/__init__.py
@@ -9,7 +9,16 @@ def to_script_hash(data_bytes: bytes) -> bytes:
     :rtype: bytes
     """
     from boa3.neo import cryptography
-    return cryptography.hash160(data_bytes)
+    from base58 import b58decode
+    try:
+        base58_decoded = b58decode(data_bytes)[1:]  # first byte is the address version
+
+        from boa3.constants import SIZE_OF_INT160
+        if len(base58_decoded) < SIZE_OF_INT160:
+            raise AttributeError
+        return bytes(base58_decoded[:SIZE_OF_INT160])
+    except:
+        return cryptography.hash160(data_bytes)
 
 
 def to_hex_str(data_bytes: bytes) -> str:

--- a/boa3_test/tests/test_constant.py
+++ b/boa3_test/tests/test_constant.py
@@ -306,3 +306,42 @@ class TestConstant(BoaTest):
         output = CodeGenerator.generate_code(analyser)
 
         self.assertEqual(expected_output, output)
+
+    def test_integer_script_hash(self):
+        from boa3.neo import cryptography, to_script_hash
+
+        input = Integer(123).to_byte_array()
+        expected_output = cryptography.hash160(input)
+        output = to_script_hash(input)
+
+        self.assertEqual(expected_output, output)
+
+    def test_string_script_hash(self):
+        from boa3.neo import cryptography, to_script_hash
+
+        input = String('123').to_bytes()
+        expected_output = cryptography.hash160(input)
+        output = to_script_hash(input)
+
+        self.assertEqual(expected_output, output)
+
+    def test_bytes_script_hash(self):
+        from boa3.neo import cryptography, to_script_hash
+
+        input = b'\x01\x02\x03'
+        expected_output = cryptography.hash160(input)
+        output = to_script_hash(input)
+
+        self.assertEqual(expected_output, output)
+
+    def test_address_script_hash(self):
+        from base58 import b58decode
+        from boa3.neo import cryptography, to_script_hash
+
+        input = String('Nd7eAuHsKvvzHzSPyuJQALcYCcUrcwvm5W').to_bytes()
+        expected_output = b58decode(input)[1:21]
+        wrong_output = cryptography.hash160(input)
+        output = to_script_hash(input)
+
+        self.assertNotEqual(wrong_output, output)
+        self.assertEqual(expected_output, output)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 autopep8==1.4.4
+base58==1.0.3
 bitarray==1.0.1
 bitcoin==1.1.42
 coverage==4.5.4


### PR DESCRIPTION
Fixed `to_script_hash()` result when converting account address strings
```python
addr1_script_hash = 'Nd7eAuHsKvvzHzSPyuJQALcYCcUrcwvm5W'.to_script_hash()
addr2_script_hash = str.to_script_hash('NPHivMjKsez5Z8opCkTUr5r8Uqk9uW6sif')
```