### PR TITLE
Implement bytes.to_int()

### DIFF
--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -846,6 +846,9 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
                 call.args.insert(0, arg0)
             if len(call.args) > 0 and isinstance(callable_target, IBuiltinMethod) and callable_target.has_self_argument:
                 self_type: IType = self.get_type(call.args[0])
+                caller = self.get_symbol(arg0_identifier)
+                if isinstance(caller, IType) and not caller.is_type_of(self_type):
+                    self_type = caller
                 callable_target = callable_target.build(self_type)
 
         if not isinstance(callable_target, Callable):

--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -7,6 +7,7 @@ from boa3.model.builtin.classmethod.extendmethod import ExtendMethod
 from boa3.model.builtin.classmethod.mapkeysmethod import MapKeysMethod
 from boa3.model.builtin.classmethod.mapvaluesmethod import MapValuesMethod
 from boa3.model.builtin.classmethod.reversemethod import ReverseMethod
+from boa3.model.builtin.classmethod.tointmethod import ToInt as ToIntMethod
 from boa3.model.builtin.decorator.eventdecorator import EventDecorator
 from boa3.model.builtin.decorator.metadatadecorator import MetadataDecorator
 from boa3.model.builtin.decorator.publicdecorator import PublicDecorator
@@ -51,6 +52,9 @@ class Builtin:
     DictKeys = MapKeysMethod()
     DictValues = MapValuesMethod()
 
+    # custom class methods
+    ConvertToInt = ToIntMethod
+
     _python_builtins: List[IdentifiedSymbol] = [Len,
                                                 ScriptHash,
                                                 ByteArray,
@@ -59,7 +63,9 @@ class Builtin:
                                                 SequenceExtend,
                                                 SequenceReverse,
                                                 DictKeys,
-                                                DictValues]
+                                                DictValues,
+                                                ConvertToInt
+                                                ]
 
     @classmethod
     def interop_symbols(cls, package: str = None) -> Dict[str, IdentifiedSymbol]:
@@ -73,7 +79,8 @@ class Builtin:
     _boa_builtins: List[IdentifiedSymbol] = [Public,
                                              Event,
                                              Metadata,
-                                             NeoMetadataType]
+                                             NeoMetadataType
+                                             ]
 
     @classmethod
     def boa_symbols(cls) -> Dict[str, IdentifiedSymbol]:

--- a/boa3/model/builtin/classmethod/tointmethod.py
+++ b/boa3/model/builtin/classmethod/tointmethod.py
@@ -1,0 +1,80 @@
+from abc import ABC
+from typing import Any, Dict, List, Optional, Tuple
+
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.expression import IExpression
+from boa3.model.identifiedsymbol import IdentifiedSymbol
+from boa3.model.type.itype import IType
+from boa3.model.type.primitive.bytestype import BytesType
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class ToIntMethod(IBuiltinMethod, ABC):
+    def __init__(self, self_type: IType):
+        identifier = 'to_int'
+        if isinstance(self_type, IdentifiedSymbol):
+            identifier = '-{0}_{1}'.format(self_type.identifier, identifier)
+
+        args: Dict[str, Variable] = {'self': Variable(self_type)}
+        from boa3.model.type.type import Type
+        super().__init__(identifier, args, return_type=Type.int)
+
+    @property
+    def _arg_self(self) -> Variable:
+        return self.args['self']
+
+    @property
+    def stores_on_slot(self) -> bool:
+        return True
+
+    def validate_parameters(self, *params: IExpression) -> bool:
+        if len(params) != 1:
+            return False
+        return isinstance(params[0], IExpression) and isinstance(params[0].type, BytesType)
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        from boa3.model.type.type import Type
+        return [
+            (Opcode.CONVERT, Type.int.stack_item)
+        ]
+
+    def push_self_first(self) -> bool:
+        return self.has_self_argument
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> Optional[str]:
+        return None
+
+
+class _ConvertToIntMethod(ToIntMethod):
+    def __init__(self):
+        super().__init__(None)
+
+    def build(self, value: Any):
+        if isinstance(value, BytesType):
+            return BytesToIntMethod(value)
+        return super().build(value)
+
+
+ToInt = _ConvertToIntMethod()
+
+
+class BytesToIntMethod(ToIntMethod):
+    def __init__(self, self_type: IType = None):
+        if not isinstance(self_type, BytesType):
+            from boa3.model.type.type import Type
+            self_type = Type.bytes
+        super().__init__(self_type)
+
+    def build(self, value: Any):
+        if type(value) == type(self.args['self'].type):
+            return self
+        if isinstance(value, BytesType):
+            return BytesToIntMethod(value)
+        return super().build(value)

--- a/boa3/neo/__init__.py
+++ b/boa3/neo/__init__.py
@@ -17,7 +17,7 @@ def to_script_hash(data_bytes: bytes) -> bytes:
         if len(base58_decoded) < SIZE_OF_INT160:
             raise AttributeError
         return bytes(base58_decoded[:SIZE_OF_INT160])
-    except:
+    except BaseException:
         return cryptography.hash160(data_bytes)
 
 

--- a/boa3_test/example/bytes_test/BytearrayToInt.py
+++ b/boa3_test/example/bytes_test/BytearrayToInt.py
@@ -1,0 +1,2 @@
+def bytes_to_int() -> int:
+    return bytearray(b'\x01\x02').to_int()

--- a/boa3_test/example/bytes_test/BytearrayToIntWithBuiltin.py
+++ b/boa3_test/example/bytes_test/BytearrayToIntWithBuiltin.py
@@ -1,0 +1,2 @@
+def bytes_to_int() -> int:
+    return bytearray.to_int(bytearray(b'\x01\x02'))

--- a/boa3_test/example/bytes_test/BytearrayToIntWithBytesBuiltin.py
+++ b/boa3_test/example/bytes_test/BytearrayToIntWithBytesBuiltin.py
@@ -1,0 +1,2 @@
+def bytes_to_int() -> int:
+    return bytes.to_int(bytearray(b'\x01\x02'))

--- a/boa3_test/example/bytes_test/BytesToInt.py
+++ b/boa3_test/example/bytes_test/BytesToInt.py
@@ -1,0 +1,2 @@
+def bytes_to_int() -> int:
+    return b'\x01\x02'.to_int()

--- a/boa3_test/example/bytes_test/BytesToIntWithBuiltin.py
+++ b/boa3_test/example/bytes_test/BytesToIntWithBuiltin.py
@@ -1,0 +1,2 @@
+def bytes_to_int() -> int:
+    return bytes.to_int(b'\x01\x02')

--- a/boa3_test/example/bytes_test/BytesToIntWithBuiltinMismatchedTypes.py
+++ b/boa3_test/example/bytes_test/BytesToIntWithBuiltinMismatchedTypes.py
@@ -1,0 +1,2 @@
+def bytes_to_int() -> int:
+    return bytes.to_int('ab')

--- a/boa3_test/example/bytes_test/BytesToIntWithBytearrayBuiltin.py
+++ b/boa3_test/example/bytes_test/BytesToIntWithBytearrayBuiltin.py
@@ -1,0 +1,2 @@
+def bytes_to_int() -> int:
+    return bytearray.to_int(b'\x01\x02')

--- a/boa3_test/tests/test_bytes.py
+++ b/boa3_test/tests/test_bytes.py
@@ -87,6 +87,48 @@ class TestBytes(BoaTest):
         path = '%s/boa3_test/example/bytes_test/BytesReverse.py' % self.dirname
         self.assertCompilerLogs(MismatchedTypes, path)
 
+    def test_bytes_to_int(self):
+        data = b'\x01\x02'
+        expected_output = (
+            Opcode.PUSHDATA1    # b'\x01\x02'
+            + Integer(len(data)).to_byte_array(min_length=1)
+            + data
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.CONVERT    # b'\x01\x02'.to_int()
+            + Type.int.stack_item
+            + Opcode.RET        # return
+        )
+
+        path = '%s/boa3_test/example/bytes_test/BytesToInt.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_bytes_to_int_with_builtin(self):
+        data = b'\x01\x02'
+        expected_output = (
+            Opcode.PUSHDATA1    # b'\x01\x02'
+            + Integer(len(data)).to_byte_array(min_length=1)
+            + data
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.CONVERT    # bytes.to_int(b'\x01\x02')
+            + Type.int.stack_item
+            + Opcode.RET        # return
+        )
+
+        path = '%s/boa3_test/example/bytes_test/BytesToIntWithBuiltin.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_bytes_to_int_mismatched_types(self):
+        path = '%s/boa3_test/example/bytes_test/BytesToIntWithBuiltinMismatchedTypes.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_bytes_to_int_with_byte_array_builtin(self):
+        path = '%s/boa3_test/example/bytes_test/BytesToIntWithBytearrayBuiltin.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)
+
     def test_bytes_from_byte_array(self):
         data = b'\x01\x02\x03'
         expected_output = (
@@ -421,3 +463,54 @@ class TestBytes(BoaTest):
     def test_byte_array_extend(self):
         path = '%s/boa3_test/example/bytes_test/BytearrayExtend.py' % self.dirname
         self.assertCompilerLogs(NotSupportedOperation, path)
+
+    def test_byte_array_to_int(self):
+        data = b'\x01\x02'
+        expected_output = (
+            Opcode.PUSHDATA1    # bytearray(b'\x01\x02')
+            + Integer(len(data)).to_byte_array(min_length=1)
+            + data
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.CONVERT    # bytearray(b'\x01\x02').to_int()
+            + Type.int.stack_item
+            + Opcode.RET        # return
+        )
+
+        path = '%s/boa3_test/example/bytes_test/BytearrayToInt.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_byte_array_to_int_with_builtin(self):
+        data = b'\x01\x02'
+        expected_output = (
+            Opcode.PUSHDATA1    # bytearray(b'\x01\x02')
+            + Integer(len(data)).to_byte_array(min_length=1)
+            + data
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.CONVERT    # bytearray.to_int(bytearray(b'\x01\x02'))
+            + Type.int.stack_item
+            + Opcode.RET        # return
+        )
+
+        path = '%s/boa3_test/example/bytes_test/BytearrayToIntWithBuiltin.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_byte_array_to_int_with_bytes_builtin(self):
+        data = b'\x01\x02'
+        expected_output = (
+            Opcode.PUSHDATA1    # bytearray(b'\x01\x02')
+            + Integer(len(data)).to_byte_array(min_length=1)
+            + data
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.CONVERT    # bytes.to_int(bytearray(b'\x01\x02'))
+            + Type.int.stack_item
+            + Opcode.RET        # return
+        )
+
+        path = '%s/boa3_test/example/bytes_test/BytearrayToIntWithBytesBuiltin.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)

--- a/boa3_test/tests/test_tuple.py
+++ b/boa3_test/tests/test_tuple.py
@@ -550,7 +550,6 @@ class TestTuple(BoaTest):
         )
         path = '%s/boa3_test/example/tuple_test/TupleSlicingNegativeEnd.py' % self.dirname
         output = Boa3.compile(path)
-        from boa3.compiler.vmcodemapping import VMCodeMapping
         self.assertEqual(expected_output, output)
 
     def test_tuple_slicing_start_omitted(self):


### PR DESCRIPTION
Implemented the conversion from bytes values to int values, using `little` byteroder
```python
x: int = b'\x01\x02'.to_int()  # expect 512
b = bytearray(b'\x01\x02\x03')
y: int = bytes.to_int(b)  # expect 197121
```