### PR TITLE
Implement int.to_bytes()

### DIFF
--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -7,6 +7,7 @@ from boa3.model.builtin.classmethod.extendmethod import ExtendMethod
 from boa3.model.builtin.classmethod.mapkeysmethod import MapKeysMethod
 from boa3.model.builtin.classmethod.mapvaluesmethod import MapValuesMethod
 from boa3.model.builtin.classmethod.reversemethod import ReverseMethod
+from boa3.model.builtin.classmethod.tobytesmethod import ToBytes as ToBytesMethod
 from boa3.model.builtin.classmethod.tointmethod import ToInt as ToIntMethod
 from boa3.model.builtin.decorator.eventdecorator import EventDecorator
 from boa3.model.builtin.decorator.metadatadecorator import MetadataDecorator
@@ -54,6 +55,7 @@ class Builtin:
 
     # custom class methods
     ConvertToInt = ToIntMethod
+    ConvertToBytes = ToBytesMethod
 
     _python_builtins: List[IdentifiedSymbol] = [Len,
                                                 ScriptHash,
@@ -64,7 +66,8 @@ class Builtin:
                                                 SequenceReverse,
                                                 DictKeys,
                                                 DictValues,
-                                                ConvertToInt
+                                                ConvertToInt,
+                                                ConvertToBytes
                                                 ]
 
     @classmethod

--- a/boa3_test/example/built_in_methods_test/IntToBytes.py
+++ b/boa3_test/example/built_in_methods_test/IntToBytes.py
@@ -1,0 +1,2 @@
+def int_to_bytes() -> bytes:
+    return (123).to_bytes()

--- a/boa3_test/example/built_in_methods_test/IntToBytesWithBuiltin.py
+++ b/boa3_test/example/built_in_methods_test/IntToBytesWithBuiltin.py
@@ -1,0 +1,2 @@
+def int_to_bytes() -> bytes:
+    return int.to_bytes(123)

--- a/boa3_test/example/built_in_methods_test/ToBytesMismatchedType.py
+++ b/boa3_test/example/built_in_methods_test/ToBytesMismatchedType.py
@@ -1,0 +1,2 @@
+def list_to_bytes() -> bytes:
+    return ['1', '2', '3'].to_bytes()

--- a/boa3_test/tests/test_builtin_method.py
+++ b/boa3_test/tests/test_builtin_method.py
@@ -538,3 +538,45 @@ class TestVariable(BoaTest):
         self.assertCompilerLogs(NotSupportedOperation, path)
 
     # endregion
+
+    # region TestToBytes
+
+    def test_int_to_bytes(self):
+        value = Integer(123).to_byte_array()
+        expected_output = (
+            Opcode.PUSHDATA1        # (123).to_bytes()
+            + Integer(len(value)).to_byte_array(min_length=1)
+            + value
+            + Opcode.CONVERT
+            + Type.int.stack_item
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/built_in_methods_test/IntToBytes.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_int_to_bytes_with_builtin(self):
+        value = Integer(123).to_byte_array()
+        expected_output = (
+            Opcode.PUSHDATA1        # int.to_bytes(123)
+            + Integer(len(value)).to_byte_array(min_length=1)
+            + value
+            + Opcode.CONVERT
+            + Type.int.stack_item
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/built_in_methods_test/IntToBytesWithBuiltin.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_to_bytes_mismatched_types(self):
+        path = '%s/boa3_test/example/built_in_methods_test/ToBytesMismatchedType.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)
+
+    # endregion


### PR DESCRIPTION
Implemented the conversion from int values to bytes values, using `little` byteorder
```python
x1: bytes = (123).to_bytes()  # expected b'\x7b' = b'{'
x2: int = x1.to_int()  # expected 123
y: bytes = int.to_bytes(345)  # expected b'\x59\x01' = b'Y\x01'

```