### PR TITLE
Implement Interop GetCallingScriptHash

### DIFF
--- a/boa3/builtin/interop/runtime/__init__.py
+++ b/boa3/builtin/interop/runtime/__init__.py
@@ -62,3 +62,6 @@ def is_verification_trigger() -> bool:
     :rtype: bool
     """
     pass
+
+
+calling_script_hash: bytes

--- a/boa3/compiler/codegenerator.py
+++ b/boa3/compiler/codegenerator.py
@@ -10,6 +10,7 @@ from boa3.model.importsymbol import Import
 from boa3.model.method import Method
 from boa3.model.operation.binaryop import BinaryOp
 from boa3.model.operation.operation import IOperation
+from boa3.model.property import Property
 from boa3.model.symbol import ISymbol
 from boa3.model.type.collection.sequence.sequencetype import SequenceType
 from boa3.model.type.type import IType, Type
@@ -665,6 +666,10 @@ class CodeGenerator:
         """
         symbol = self.get_symbol(symbol_id)
         if symbol is not Type.none:
+            if isinstance(symbol, Property):
+                symbol = symbol.getter
+                params_addresses = []
+
             if isinstance(symbol, Variable):
                 self.convert_load_variable(symbol_id, symbol)
             elif isinstance(symbol, IBuiltinMethod) and symbol.body is None:

--- a/boa3/model/builtin/builtinproperty.py
+++ b/boa3/model/builtin/builtinproperty.py
@@ -1,0 +1,11 @@
+from abc import ABC
+
+from boa3.model.identifiedsymbol import IdentifiedSymbol
+from boa3.model.method import Method
+from boa3.model.property import Property
+
+
+class IBuiltinProperty(Property, IdentifiedSymbol, ABC):
+    def __init__(self, identifier: str, getter: Method, setter: Method = None):
+        super().__init__(getter, setter)
+        self._identifier = identifier

--- a/boa3/model/builtin/interop/interop.py
+++ b/boa3/model/builtin/interop/interop.py
@@ -2,6 +2,7 @@ from enum import Enum
 from typing import List, Dict
 
 from boa3.model.builtin.interop.runtime.checkwitnessmethod import CheckWitnessMethod
+from boa3.model.builtin.interop.runtime.getcallingscripthashmethod import CallingScriptHashProperty
 from boa3.model.builtin.interop.runtime.logmethod import LogMethod
 from boa3.model.builtin.interop.runtime.notifymethod import NotifyMethod
 from boa3.model.builtin.interop.runtime.triggermethod import TriggerMethod
@@ -35,6 +36,7 @@ class Interop:
     Log = LogMethod()
     TriggerType = TriggerTyping()
     GetTrigger = TriggerMethod(TriggerType)
+    CallingScriptHash = CallingScriptHashProperty()
 
     # Storage Interops
     StorageGet = StorageGetMethod()
@@ -46,8 +48,11 @@ class Interop:
                                  Notify,
                                  Log,
                                  TriggerType,
-                                 GetTrigger],
+                                 GetTrigger,
+                                 CallingScriptHash
+                                 ],
         InteropPackage.Storage: [StorageGet,
                                  StoragePut,
-                                 StorageDelete]
+                                 StorageDelete
+                                 ]
     }

--- a/boa3/model/builtin/interop/runtime/getcallingscripthashmethod.py
+++ b/boa3/model/builtin/interop/runtime/getcallingscripthashmethod.py
@@ -1,0 +1,32 @@
+from typing import Dict, List, Tuple
+
+from boa3.model.builtin.builtinproperty import IBuiltinProperty
+from boa3.model.builtin.interop.interopmethod import InteropMethod
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class GetCallingScriptHashMethod(InteropMethod):
+    def __init__(self):
+        from boa3.model.type.type import Type
+        identifier = '-get_calling_script_hash'
+        syscall = 'System.Runtime.GetCallingScriptHash'
+        args: Dict[str, Variable] = {}
+        super().__init__(identifier, syscall, args, return_type=Type.bytes)
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        from boa3.model.type.type import Type
+
+        opcodes = super().opcode
+        opcodes.extend([
+            (Opcode.CONVERT, Type.bytes.stack_item)
+        ])
+        return opcodes
+
+
+class CallingScriptHashProperty(IBuiltinProperty):
+    def __init__(self):
+        identifier = 'calling_script_hash'
+        getter = GetCallingScriptHashMethod()
+        super().__init__(identifier, getter)

--- a/boa3/model/property.py
+++ b/boa3/model/property.py
@@ -1,0 +1,38 @@
+import ast
+from typing import Optional
+
+from boa3.model.expression import IExpression
+from boa3.model.method import Method
+from boa3.model.type.itype import IType
+
+
+class Property(IExpression):
+    """
+    A class used to represent a variable
+
+    :ivar var_type: the type of the variable.
+    """
+
+    def __init__(self, getter: Method, setter: Method = None, origin_node: Optional[ast.AST] = None):
+        super().__init__(origin_node)
+        self._getter: Method = getter
+        self._setter: Optional[Method] = setter
+
+    @property
+    def shadowing_name(self) -> str:
+        return 'property'
+
+    @property
+    def type(self) -> IType:
+        return self._getter.type
+
+    @property
+    def getter(self) -> Method:
+        return self._getter
+
+    @property
+    def setter(self) -> Optional[Method]:
+        return self._setter
+
+    def __str__(self) -> str:
+        return str(self.type)

--- a/boa3_test/example/interop_test/CallingScriptHash.py
+++ b/boa3_test/example/interop_test/CallingScriptHash.py
@@ -1,0 +1,5 @@
+from boa3.builtin.interop.runtime import calling_script_hash
+
+
+def Main() -> bytes:
+    return calling_script_hash

--- a/boa3_test/tests/test_interop.py
+++ b/boa3_test/tests/test_interop.py
@@ -214,3 +214,16 @@ class TestInterop(BoaTest):
         path = '%s/boa3_test/example/interop_test/TriggerVerification.py' % self.dirname
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
+
+    def test_get_calling_script_hash(self):
+        expected_output = (
+            Opcode.SYSCALL
+            + Interop.CallingScriptHash.getter.interop_method_hash
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/interop_test/CallingScriptHash.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)


### PR DESCRIPTION
- Implemented a property to call the GetCallingScriptHash Interop
   ```python
   from boa3.builtin.interop.runtime import calling_script_hash


   def example():
       caller = calling_script_hash
   ```