### PR TITLE
Implement Python Assert

### DIFF
--- a/boa3/compiler/codegenerator.py
+++ b/boa3/compiler/codegenerator.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from boa3.analyser.analyser import Analyser
 from boa3.compiler.vmcodemapping import VMCodeMapping
@@ -12,6 +12,7 @@ from boa3.model.operation.binaryop import BinaryOp
 from boa3.model.operation.operation import IOperation
 from boa3.model.symbol import ISymbol
 from boa3.model.type.collection.sequence.sequencetype import SequenceType
+from boa3.model.type.primitive.primitivetype import PrimitiveType
 from boa3.model.type.type import IType, Type
 from boa3.model.variable import Variable
 from boa3.neo.vm.VMCode import VMCode
@@ -238,7 +239,7 @@ class CodeGenerator:
         :return: the address of the while first opcode
         """
         # it will be updated when the while ends
-        self._insert_jump(OpcodeInfo.JMP, 0)
+        self._insert_jump(OpcodeInfo.JMP)
         return self.last_code_start_address
 
     def convert_end_while(self, start_address: int, test_address: int):
@@ -299,7 +300,7 @@ class CodeGenerator:
         :return: the address of the if first opcode
         """
         # it will be updated when the if ends
-        self._insert_jump(OpcodeInfo.JMPIFNOT, 0)
+        self._insert_jump(OpcodeInfo.JMPIFNOT)
         return VMCodeMapping.instance().get_start_address(self.last_code)
 
     def convert_begin_else(self, start_address: int) -> int:
@@ -310,7 +311,7 @@ class CodeGenerator:
         :return: the address of the if else first opcode
         """
         # it will be updated when the if ends
-        self._insert_jump(OpcodeInfo.JMP, 0)
+        self._insert_jump(OpcodeInfo.JMP)
 
         # updates the begin jmp with the target address
         self._update_jump(start_address, VMCodeMapping.instance().bytecode_size)
@@ -337,7 +338,7 @@ class CodeGenerator:
         self.convert_literal(-1)
 
         jmp_address = VMCodeMapping.instance().bytecode_size
-        self._insert_jump(OpcodeInfo.JMPNE, 0)     # if index < 0
+        self._insert_jump(OpcodeInfo.JMPNE)     # if index < 0
 
         self.duplicate_stack_item(2)                    # index += len(array)
         self.convert_builtin_method_call(Builtin.Len)
@@ -765,7 +766,7 @@ class CodeGenerator:
             self.__insert1(op_info, data)
 
         if store_opcode is not None:
-            self._insert_jump(OpcodeInfo.JMP, 0)
+            self._insert_jump(OpcodeInfo.JMP)
             jump = self.last_code_start_address
             self.__insert1(store_opcode, store_data)
             self._update_jump(jump, VMCodeMapping.instance().bytecode_size)
@@ -815,6 +816,33 @@ class CodeGenerator:
         for op in range(operation.op_on_stack):
             self._stack.pop()
         self._stack.append(operation.result)
+
+    def convert_assert(self):
+        asserted_type = self._stack[-1] if len(self._stack) > 0 else Type.any
+
+        if not isinstance(asserted_type, PrimitiveType):
+            len_pos = VMCodeMapping.instance().bytecode_size
+            # if the value is an array, a map or a struct, asserts it is not empty
+            self.convert_builtin_method_call(Builtin.Len)
+            len_code = VMCodeMapping.instance().code_map[len_pos]
+
+            if asserted_type is Type.any:
+                # need to check in runtime
+                self.duplicate_stack_top_item()
+                self.__insert1(OpcodeInfo.ISTYPE, StackItemType.Array)
+                self._insert_jump(OpcodeInfo.JMPIF, len_code)
+
+                self.duplicate_stack_top_item()
+                self.__insert1(OpcodeInfo.ISTYPE, StackItemType.Map)
+                self._insert_jump(OpcodeInfo.JMPIF, len_code)
+
+                self.duplicate_stack_top_item()
+                self.__insert1(OpcodeInfo.ISTYPE, StackItemType.Struct)
+                self._insert_jump(OpcodeInfo.JMPIFNOT, 2)
+
+                VMCodeMapping.instance().move_to_end(len_pos, len_pos)
+
+        self.__insert1(OpcodeInfo.ASSERT)
 
     def __insert1(self, op_info: OpcodeInformation, data: bytes = bytes()):
         """
@@ -891,13 +919,16 @@ class CodeGenerator:
                     code.set_target(vm_code)
                 self._missing_target.pop(target_address)
 
-    def _insert_jump(self, op_info: OpcodeInformation, jump_to: int):
+    def _insert_jump(self, op_info: OpcodeInformation, jump_to: Union[int, VMCode] = 0):
         """
         Inserts a jump opcode into the bytecode
 
         :param op_info: info of the opcode  that will be inserted
         :param jump_to: data of the opcode
         """
+        if isinstance(jump_to, VMCode):
+            jump_to = VMCodeMapping.instance().get_start_address(jump_to) - VMCodeMapping.instance().bytecode_size
+
         if self.last_code.opcode is not Opcode.RET:
             data: bytes = self._get_jump_data(op_info, jump_to)
             self.__insert1(op_info, data)

--- a/boa3/compiler/codegeneratorvisitor.py
+++ b/boa3/compiler/codegeneratorvisitor.py
@@ -444,6 +444,15 @@ class VisitorCodeGenerator(ast.NodeVisitor):
 
         self.generator.convert_end_if(start_addr)
 
+    def visit_Assert(self, assert_node: ast.Assert):
+        """
+        Visitor of the assert node
+
+        :param assert_node: the python ast assert node
+        """
+        self.visit_to_generate(assert_node.test)
+        self.generator.convert_assert()
+
     def visit_Call(self, call: ast.Call):
         """
         Visitor of a function call node

--- a/boa3/compiler/vmcodemapping.py
+++ b/boa3/compiler/vmcodemapping.py
@@ -162,7 +162,7 @@ class VMCodeMapping:
                 relative = Integer.from_bytes(code.data)
                 absolute = address + relative
                 if absolute in self.code_map:
-                    code.set_target = self.code_map[absolute]
+                    code.set_target(self.code_map[absolute])
 
     def _update_larger_codes(self):
         """

--- a/boa3/model/builtin/method/lenmethod.py
+++ b/boa3/model/builtin/method/lenmethod.py
@@ -1,18 +1,23 @@
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Sized, Tuple
 
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.expression import IExpression
+from boa3.model.type.collection.icollection import ICollectionType
 from boa3.model.type.collection.sequence.sequencetype import SequenceType
+from boa3.model.type.itype import IType
 from boa3.model.variable import Variable
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
 class LenMethod(IBuiltinMethod):
 
-    def __init__(self):
+    def __init__(self, collection_type: IType = None):
         from boa3.model.type.type import Type
+        if not isinstance(collection_type, ICollectionType):
+            collection_type = Type.sequence
+
         identifier = 'len'
-        args: Dict[str, Variable] = {'__o': Variable(Type.sequence)}
+        args: Dict[str, Variable] = {'__o': Variable(collection_type)}
         super().__init__(identifier, args, return_type=Type.int)
 
     def validate_parameters(self, *params: IExpression) -> bool:
@@ -33,3 +38,13 @@ class LenMethod(IBuiltinMethod):
     @property
     def _body(self) -> Optional[str]:
         return None
+
+    def build(self, value: Any):
+        if type(value) == type(self.args['__o'].type):
+            return self
+
+        if isinstance(value, Sized) and len(value) == 1:
+            value = value[0]
+        if isinstance(value, ICollectionType):
+            return LenMethod(value)
+        return super().build(value)

--- a/boa3_test/example/assert_test/AssertAny.py
+++ b/boa3_test/example/assert_test/AssertAny.py
@@ -1,0 +1,5 @@
+from typing import Any
+
+
+def Main(a: Any):
+    assert a

--- a/boa3_test/example/assert_test/AssertBinaryOperation.py
+++ b/boa3_test/example/assert_test/AssertBinaryOperation.py
@@ -1,0 +1,3 @@
+def Main(a: int, b: int) -> int:
+    assert a != b
+    return a

--- a/boa3_test/example/assert_test/AssertBytes.py
+++ b/boa3_test/example/assert_test/AssertBytes.py
@@ -1,0 +1,3 @@
+def Main(a: bytes) -> bytes:
+    assert a
+    return a

--- a/boa3_test/example/assert_test/AssertDict.py
+++ b/boa3_test/example/assert_test/AssertDict.py
@@ -1,0 +1,3 @@
+def Main(a: dict) -> int:
+    assert a
+    return len(a)

--- a/boa3_test/example/assert_test/AssertInt.py
+++ b/boa3_test/example/assert_test/AssertInt.py
@@ -1,0 +1,3 @@
+def Main(a: int) -> int:
+    assert a
+    return a

--- a/boa3_test/example/assert_test/AssertList.py
+++ b/boa3_test/example/assert_test/AssertList.py
@@ -1,0 +1,3 @@
+def Main(a: list) -> int:
+    assert a
+    return len(a)

--- a/boa3_test/example/assert_test/AssertStr.py
+++ b/boa3_test/example/assert_test/AssertStr.py
@@ -1,0 +1,3 @@
+def Main(a: str) -> str:
+    assert a
+    return a

--- a/boa3_test/example/assert_test/AssertUnaryOperation.py
+++ b/boa3_test/example/assert_test/AssertUnaryOperation.py
@@ -1,0 +1,3 @@
+def Main(a: bool, b: int) -> int:
+    assert not a
+    return b

--- a/boa3_test/example/assert_test/AssertWithMessage.py
+++ b/boa3_test/example/assert_test/AssertWithMessage.py
@@ -1,0 +1,3 @@
+def Main(a: int) -> int:
+    assert a > 0, 'a must be greater than zero'
+    return a

--- a/boa3_test/tests/test_assert.py
+++ b/boa3_test/tests/test_assert.py
@@ -1,0 +1,162 @@
+from boa3.boa3 import Boa3
+from boa3.neo.vm.opcode.Opcode import Opcode
+from boa3.neo.vm.type.Integer import Integer
+from boa3.neo.vm.type.StackItemType import StackItemType
+from boa3_test.tests.boa_test import BoaTest
+
+
+class TestAssert(BoaTest):
+
+    def test_assert_unary_boolean_operation(self):
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x00'
+            + b'\x02'
+            + Opcode.LDARG0     # assert not a
+            + Opcode.NOT
+            + Opcode.ASSERT
+            + Opcode.LDARG1     # return b
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/assert_test/AssertUnaryOperation.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_assert_binary_boolean_operation(self):
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x00'
+            + b'\x02'
+            + Opcode.LDARG0     # assert a != b
+            + Opcode.LDARG1
+            + Opcode.NUMNOTEQUAL
+            + Opcode.ASSERT
+            + Opcode.LDARG0     # return a
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/assert_test/AssertBinaryOperation.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_assert_with_message(self):
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x00'
+            + b'\x01'
+            + Opcode.LDARG0     # assert a > 0, 'a must be greater than zero'
+            + Opcode.PUSH0
+            + Opcode.GT
+            + Opcode.ASSERT         # neo assert doesn't receive messages yet
+            + Opcode.LDARG0     # return a
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/assert_test/AssertWithMessage.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_assert_int(self):
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x00'
+            + b'\x01'
+            + Opcode.LDARG0     # assert a
+            + Opcode.ASSERT
+            + Opcode.LDARG0     # return a
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/assert_test/AssertInt.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_assert_str(self):
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x00'
+            + b'\x01'
+            + Opcode.LDARG0     # assert a
+            + Opcode.ASSERT
+            + Opcode.LDARG0     # return a
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/assert_test/AssertStr.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_assert_bytes(self):
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x00'
+            + b'\x01'
+            + Opcode.LDARG0     # assert a
+            + Opcode.ASSERT
+            + Opcode.LDARG0     # return a
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/assert_test/AssertBytes.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_assert_list(self):
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x00'
+            + b'\x01'
+            + Opcode.LDARG0     # assert a
+            + Opcode.SIZE
+            + Opcode.ASSERT
+            + Opcode.LDARG0     # return len(a)
+            + Opcode.SIZE
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/assert_test/AssertList.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_assert_dict(self):
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x00'
+            + b'\x01'
+            + Opcode.LDARG0     # assert a
+            + Opcode.SIZE
+            + Opcode.ASSERT
+            + Opcode.LDARG0     # return len(a)
+            + Opcode.SIZE
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/assert_test/AssertDict.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_assert_any(self):
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x00'
+            + b'\x01'
+            + Opcode.LDARG0     # assert a
+            + Opcode.DUP
+            + Opcode.ISTYPE + StackItemType.Array
+            + Opcode.JMPIF + Integer(12).to_byte_array(signed=True, min_length=1)
+            + Opcode.DUP
+            + Opcode.ISTYPE + StackItemType.Map
+            + Opcode.JMPIF + Integer(7).to_byte_array(signed=True, min_length=1)
+            + Opcode.DUP
+            + Opcode.ISTYPE + StackItemType.Struct
+            + Opcode.JMPIFNOT + Integer(3).to_byte_array(signed=True, min_length=1)
+            + Opcode.SIZE
+            + Opcode.ASSERT
+            + Opcode.PUSHNULL
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/example/assert_test/AssertAny.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)


### PR DESCRIPTION
Implemented Python `assert` keyword
```python
assert x % 2 == 0
assert x % 3 != 2, 'error message'
```
- `assert` has optional messages. These messages are allowed, but they are not shown when running the smart contract