### PR TITLE
Fix error when inserting integer values

### DIFF
--- a/boa3/compiler/codegenerator.py
+++ b/boa3/compiler/codegenerator.py
@@ -389,7 +389,7 @@ class CodeGenerator:
                 op_info: OpcodeInformation = OpcodeInfo.get_info(opcode)
                 self.__insert1(op_info)
         else:
-            array = Integer(value).to_byte_array()
+            array = Integer(value).to_byte_array(signed=True)
             self.insert_push_data(array)
             # cast the value to integer
             self.convert_cast(Type.int)

--- a/boa3/neo/vm/type/Integer.py
+++ b/boa3/neo/vm/type/Integer.py
@@ -15,7 +15,7 @@ class Integer(int):
         aux: int = bits_per_byte - 1
         if self < 0:
             signed = True
-        if signed:
+        if self > 0 and signed:
             aux += 1  # signed numbers uses an additional bit to represent the signal
 
         byte_length: int = ((self.bit_length() + aux) // bits_per_byte)


### PR DESCRIPTION
Fixed a conversion error of integer values. Values that fills the bytes were been converting incorrectly
```python
# both values were converted to b'\x80\x96\x98'
x = 10_000_000  # this now is converted to b'\x80\x96\x98\x00'
y = -6_777_216
``` 