### PR TITLE
Implement str.to_bytes()

### DIFF
--- a/boa3/analyser/importanalyser.py
+++ b/boa3/analyser/importanalyser.py
@@ -44,7 +44,6 @@ class ImportAnalyser(IAstAnalyser):
                 self.can_be_imported = True
 
             elif not (inside_python_folder and 'lib' in path):
-                print('Importing with analyser - user modules only')
                 # TODO: only user modules and typing lib imports are implemented
                 try:
                     from boa3.analyser.analyser import Analyser

--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -956,7 +956,7 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
             return '{0}.{1}'.format(attribute.value.id, attribute.attr)
 
         symbol = None
-        if isinstance(value, str):
+        if isinstance(value, str) and not isinstance(attribute.value, ast.Str):
             symbol = self.get_symbol(value)
             if symbol is None:
                 return '{0}.{1}'.format(value, attribute.attr)

--- a/boa3/model/builtin/classmethod/tobytesmethod.py
+++ b/boa3/model/builtin/classmethod/tobytesmethod.py
@@ -7,6 +7,7 @@ from boa3.model.identifiedsymbol import IdentifiedSymbol
 from boa3.model.type.itype import IType
 from boa3.model.type.primitive.bytestype import BytesType
 from boa3.model.type.primitive.inttype import IntType
+from boa3.model.type.primitive.strtype import StrType
 from boa3.model.variable import Variable
 from boa3.neo.vm.opcode.Opcode import Opcode
 
@@ -60,6 +61,8 @@ class _ConvertToBytesMethod(ToBytesMethod):
     def build(self, value: Any):
         if isinstance(value, IntType):
             return IntToBytesMethod(value)
+        elif isinstance(value, StrType):
+            return StrToBytesMethod(value)
         # if it is not a valid type, show mismatched type with int
         return IntToBytesMethod()
 
@@ -77,6 +80,21 @@ class IntToBytesMethod(ToBytesMethod):
     def build(self, value: Any):
         if type(value) == type(self.args['self'].type):
             return self
-        if isinstance(value, BytesType):
+        if isinstance(value, IntType):
             return IntToBytesMethod(value)
+        return super().build(value)
+
+
+class StrToBytesMethod(ToBytesMethod):
+    def __init__(self, self_type: IType = None):
+        if not isinstance(self_type, StrType):
+            from boa3.model.type.type import Type
+            self_type = Type.str
+        super().__init__(self_type)
+
+    def build(self, value: Any):
+        if type(value) == type(self.args['self'].type):
+            return self
+        if isinstance(value, StrType):
+            return StrToBytesMethod(value)
         return super().build(value)

--- a/boa3_test/test_sc/built_in_methods_test/StrToBytes.py
+++ b/boa3_test/test_sc/built_in_methods_test/StrToBytes.py
@@ -1,0 +1,2 @@
+def str_to_bytes() -> bytes:
+    return '123'.to_bytes()

--- a/boa3_test/test_sc/built_in_methods_test/StrToBytesWithBuiltin.py
+++ b/boa3_test/test_sc/built_in_methods_test/StrToBytesWithBuiltin.py
@@ -1,0 +1,2 @@
+def str_to_bytes() -> bytes:
+    return str.to_bytes('123')

--- a/boa3_test/tests/test_builtin_method.py
+++ b/boa3_test/tests/test_builtin_method.py
@@ -575,6 +575,36 @@ class TestVariable(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
+    def test_str_to_bytes(self):
+        value = String('123').to_bytes()
+        expected_output = (
+            Opcode.PUSHDATA1        # '123'.to_bytes()
+            + Integer(len(value)).to_byte_array(min_length=1)
+            + value
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/test_sc/built_in_methods_test/StrToBytes.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_str_to_bytes_with_builtin(self):
+        value = String('123').to_bytes()
+        expected_output = (
+            Opcode.PUSHDATA1        # str.to_bytes('123')
+            + Integer(len(value)).to_byte_array(min_length=1)
+            + value
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/test_sc/built_in_methods_test/StrToBytesWithBuiltin.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
     def test_to_bytes_mismatched_types(self):
         path = '%s/boa3_test/test_sc/built_in_methods_test/ToBytesMismatchedType.py' % self.dirname
         self.assertCompilerLogs(MismatchedTypes, path)


### PR DESCRIPTION
Implemented the conversion from str values to bytes values, using `utf-8` encoding
```python
x1: bytes = '123'.to_bytes()  # expected b'123'
x2: str = x1.to_str()  # expected '123'
y: bytes = str.to_bytes('abc')  # expected b'abc'
```