### PR TITLE
Convert list pop method

### DIFF
--- a/boa3/compiler/codegenerator.py
+++ b/boa3/compiler/codegenerator.py
@@ -91,12 +91,20 @@ class CodeGenerator:
             return None
 
     @property
+    def stack_size(self) -> int:
+        """
+        Gets the size of the stack
+
+        :return: the size of the stack of converted values
+        """
+        return len(self._stack)
+
+    @property
     def last_code_start_address(self) -> int:
         """
         Gets the first address from last code in the bytecode
 
-        :return: the last code. If the bytecode is empty, returns None
-        :rtype: VMCode or None
+        :return: the last code's first address
         """
         instance = VMCodeMapping.instance()
         if len(instance.codes) > 0:
@@ -809,7 +817,7 @@ class CodeGenerator:
 
         for arg in function.args:
             self._stack.pop()
-        if function.return_type is not None:
+        if function.return_type not in (None, Type.none):
             self._stack.append(function.return_type)
 
     def convert_method_call(self, function: Method, num_args: int):
@@ -832,12 +840,14 @@ class CodeGenerator:
         :param event_id: called event identifier
         :param event: called event
         """
-        self.convert_new_array(len(event.args), Type.list.stack_item)
+        self.convert_new_array(len(event.args), Type.list)
         self.convert_literal(event.name)
         from boa3.model.builtin.interop.interop import Interop
         for opcode, data in Interop.Notify.opcode:
             info = OpcodeInfo.get_info(opcode)
             self.__insert1(info, data)
+            self._stack.pop()
+            self._stack.pop()
 
     def convert_operation(self, operation: IOperation):
         """

--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -7,6 +7,7 @@ from boa3.model.builtin.classmethod.clearmethod import ClearMethod
 from boa3.model.builtin.classmethod.extendmethod import ExtendMethod
 from boa3.model.builtin.classmethod.mapkeysmethod import MapKeysMethod
 from boa3.model.builtin.classmethod.mapvaluesmethod import MapValuesMethod
+from boa3.model.builtin.classmethod.popmethod import PopMethod
 from boa3.model.builtin.classmethod.reversemethod import ReverseMethod
 from boa3.model.builtin.classmethod.tobytesmethod import ToBytes as ToBytesMethod
 from boa3.model.builtin.classmethod.tointmethod import ToInt as ToIntMethod
@@ -61,6 +62,7 @@ class Builtin:
     SequenceAppend = AppendMethod()
     SequenceClear = ClearMethod()
     SequenceExtend = ExtendMethod()
+    SequencePop = PopMethod()
     SequenceReverse = ReverseMethod()
     DictKeys = MapKeysMethod()
     DictValues = MapValuesMethod()
@@ -76,6 +78,7 @@ class Builtin:
                                                 SequenceAppend,
                                                 SequenceClear,
                                                 SequenceExtend,
+                                                SequencePop,
                                                 SequenceReverse,
                                                 DictKeys,
                                                 DictValues,

--- a/boa3/model/builtin/classmethod/extendmethod.py
+++ b/boa3/model/builtin/classmethod/extendmethod.py
@@ -43,7 +43,7 @@ class ExtendMethod(IBuiltinMethod):
 
     @property
     def is_supported(self) -> bool:
-        # TODO: remove when bytearray.append() is implemented
+        # TODO: remove when bytearray.extend() is implemented
         from boa3.model.type.type import Type
         return self._arg_self.type is not Type.bytearray
 

--- a/boa3/model/builtin/classmethod/popmethod.py
+++ b/boa3/model/builtin/classmethod/popmethod.py
@@ -1,0 +1,99 @@
+import ast
+from typing import Any, Dict, List, Optional, Tuple, Iterable
+
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.expression import IExpression
+from boa3.model.type.collection.sequence.mutable.mutablesequencetype import MutableSequenceType
+from boa3.model.type.itype import IType
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class PopMethod(IBuiltinMethod):
+    def __init__(self, sequence_type: MutableSequenceType = None):
+        if not isinstance(sequence_type, MutableSequenceType):
+            from boa3.model.type.type import Type
+            sequence_type = Type.mutableSequence
+
+        identifier = 'pop'
+        args: Dict[str, Variable] = {'self': Variable(sequence_type),
+                                     'index': Variable(sequence_type.valid_key)
+                                     }
+        # TODO: change when dict.pop is implemented
+        index_default = ast.parse("-1").body[0].value.operand
+        index_default.n = -1
+        super().__init__(identifier, args, defaults=[index_default], return_type=sequence_type.value_type)
+
+    @property
+    def is_supported(self) -> bool:
+        """
+        Verifies if the builtin method is supported by the compiler
+
+        :return: True if it is supported. False otherwise.
+        """
+        # TODO: remove when bytearray.pop() is implemented
+        from boa3.model.type.type import Type
+        return not Type.bytearray.is_type_of(self._arg_self.type)
+
+    @property
+    def _arg_self(self) -> Variable:
+        return self.args['self']
+
+    def validate_parameters(self, *params: IExpression) -> bool:
+        if len(params) < 0 or len(params) > 2:
+            return False
+
+        if any(not isinstance(param, (IExpression, IType)) for param in params):
+            return False
+
+        sequence = params[0].type if isinstance(params[0], IExpression) else params[0]
+        if not isinstance(sequence, MutableSequenceType):
+            return False
+
+        if len(params) > 1:
+            value = params[1].type if isinstance(params[1], IExpression) else params[1]
+            return sequence.valid_key.is_type_of(value)
+        return True
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        from boa3.neo.vm.type.Integer import Integer
+        return [
+            (Opcode.DUP, b''),
+            (Opcode.SIGN, b''),
+            (Opcode.PUSHM1, b''),
+            (Opcode.JMPNE, Integer(5).to_byte_array(min_length=1, signed=True)),
+            (Opcode.OVER, b''),
+            (Opcode.SIZE, b''),
+            (Opcode.ADD, b''),
+            (Opcode.OVER, b''),
+            (Opcode.OVER, b''),
+            (Opcode.PICKITEM, b''),
+            (Opcode.REVERSE3, b''),
+            (Opcode.SWAP, b''),
+            (Opcode.REMOVE, b''),
+        ]
+
+    def push_self_first(self) -> bool:
+        return self.has_self_argument
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> Optional[str]:
+        return None
+
+    def build(self, value: Any):
+        if isinstance(value, Iterable) and len(value) > 0:
+            if len(value) == 1:
+                value = value[0]
+            elif self.validate_parameters(*value):
+                return PopMethod(value[0])
+
+        if type(value) == type(self.args['self'].type):
+            return self
+        if isinstance(value, MutableSequenceType):
+            return PopMethod(value)
+        return super().build(value)

--- a/boa3_test/test_sc/list_test/PopList.py
+++ b/boa3_test/test_sc/list_test/PopList.py
@@ -1,0 +1,8 @@
+from boa3.builtin import public
+
+
+@public
+def pop_test() -> int:
+    a = [1, 2, 3, 4, 5]
+    b = a.pop()
+    return b

--- a/boa3_test/test_sc/list_test/PopListLiteralArgument.py
+++ b/boa3_test/test_sc/list_test/PopListLiteralArgument.py
@@ -1,0 +1,4 @@
+def pop_test() -> int:
+    a = [1, 2, 3, 4, 5]
+    b = a.pop(2)
+    return b

--- a/boa3_test/test_sc/list_test/PopListLiteralNegativeArgument.py
+++ b/boa3_test/test_sc/list_test/PopListLiteralNegativeArgument.py
@@ -1,0 +1,4 @@
+def pop_test() -> int:
+    a = [1, 2, 3, 4, 5]
+    b = a.pop(-2)
+    return b

--- a/boa3_test/test_sc/list_test/PopListMismatchedTypeArgument.py
+++ b/boa3_test/test_sc/list_test/PopListMismatchedTypeArgument.py
@@ -1,0 +1,4 @@
+def pop_test() -> int:
+    a = [1, 2, 3, 4, 5]
+    b = a.pop('2')
+    return b

--- a/boa3_test/test_sc/list_test/PopListMismatchedTypeResult.py
+++ b/boa3_test/test_sc/list_test/PopListMismatchedTypeResult.py
@@ -1,0 +1,4 @@
+def pop_test() -> str:
+    a = [1, 2, 3, 4, 5]
+    b: str = a.pop(2)
+    return b

--- a/boa3_test/test_sc/list_test/PopListTooManyArguments.py
+++ b/boa3_test/test_sc/list_test/PopListTooManyArguments.py
@@ -1,0 +1,4 @@
+def pop_test() -> int:
+    a = [1, 2, 3, 4, 5]
+    b = a.pop(2, 3)
+    return b

--- a/boa3_test/test_sc/list_test/PopListVariableArgument.py
+++ b/boa3_test/test_sc/list_test/PopListVariableArgument.py
@@ -1,0 +1,4 @@
+def pop_test(x: int) -> int:
+    a = [1, 2, 3, 4, 5]
+    b = a.pop(x)
+    return b

--- a/boa3_test/test_sc/list_test/PopListWithoutAssignment.py
+++ b/boa3_test/test_sc/list_test/PopListWithoutAssignment.py
@@ -1,0 +1,8 @@
+from boa3.builtin import public
+
+
+@public
+def pop_test() -> list:
+    a = [1, 2, 3, 4, 5]
+    a.pop()
+    return a

--- a/boa3_test/tests/test_any.py
+++ b/boa3_test/tests/test_any.py
@@ -100,7 +100,8 @@ class TestAny(BoaTest):
             + Opcode.STLOC0
             + Opcode.LDLOC0         # SequenceFunction(bool_tuple)
             + Opcode.CALL
-            + Integer(46).to_byte_array(min_length=1, signed=True)
+            + Integer(51).to_byte_array(min_length=1, signed=True)
+            + Opcode.DROP
             + Opcode.PUSHDATA1      # SequenceFunction([True, 1, 'ok'])
             + Integer(len(ok)).to_byte_array() + ok
             + Opcode.PUSH1
@@ -108,12 +109,14 @@ class TestAny(BoaTest):
             + Opcode.PUSH3
             + Opcode.PACK
             + Opcode.CALL
-            + Integer(36).to_byte_array(min_length=1, signed=True)
+            + Integer(40).to_byte_array(min_length=1, signed=True)
+            + Opcode.DROP
             + Opcode.PUSHDATA1      # SequenceFunction('some_string')
             + Integer(len(some_string)).to_byte_array()
             + some_string
             + Opcode.CALL
-            + Integer(21).to_byte_array(min_length=1, signed=True)
+            + Integer(24).to_byte_array(min_length=1, signed=True)
+            + Opcode.DROP
             + Opcode.PUSHDATA1      # SequenceFunction((True, 1, 'ok'))
             + Integer(len(ok)).to_byte_array() + ok
             + Opcode.PUSH1
@@ -121,14 +124,16 @@ class TestAny(BoaTest):
             + Opcode.PUSH3
             + Opcode.PACK
             + Opcode.CALL
-            + Integer(11).to_byte_array(min_length=1, signed=True)
+            + Integer(13).to_byte_array(min_length=1, signed=True)
+            + Opcode.DROP
             + Opcode.PUSH3          # SequenceFunction([1, 2, 3])
             + Opcode.PUSH2
             + Opcode.PUSH1
             + Opcode.PUSH3
             + Opcode.PACK
             + Opcode.CALL
-            + Integer(4).to_byte_array(min_length=1, signed=True)
+            + Integer(5).to_byte_array(min_length=1, signed=True)
+            + Opcode.DROP
             + Opcode.PUSHNULL
             + Opcode.RET        # return
             + Opcode.INITSLOT   # SequenceFunction

--- a/boa3_test/tests/test_constant.py
+++ b/boa3_test/tests/test_constant.py
@@ -156,6 +156,7 @@ class TestConstant(BoaTest):
             + Opcode.PUSH1      # 1
             + Opcode.PUSH3      # tuple length
             + Opcode.PACK
+            + Opcode.DROP
             + Opcode.RET
         )
 
@@ -184,6 +185,7 @@ class TestConstant(BoaTest):
             + byte_input0
             + Opcode.PUSH3      # tuple length
             + Opcode.PACK
+            + Opcode.DROP
             + Opcode.RET
         )
 
@@ -206,6 +208,7 @@ class TestConstant(BoaTest):
             + Opcode.PUSH1      # 1
             + Opcode.PUSH3      # tuple length
             + Opcode.PACK
+            + Opcode.DROP
             + Opcode.RET
         )
 
@@ -237,6 +240,7 @@ class TestConstant(BoaTest):
             + Opcode.PACK
             + Opcode.PUSH3  # tuple length
             + Opcode.PACK
+            + Opcode.DROP
             + Opcode.RET
         )
 
@@ -255,6 +259,7 @@ class TestConstant(BoaTest):
             + Opcode.PUSH1  # 1
             + Opcode.PUSH3  # list length
             + Opcode.PACK
+            + Opcode.DROP
             + Opcode.RET
         )
 
@@ -283,6 +288,7 @@ class TestConstant(BoaTest):
             + byte_input0
             + Opcode.PUSH3          # list length
             + Opcode.PACK
+            + Opcode.DROP
             + Opcode.RET
         )
 
@@ -305,6 +311,7 @@ class TestConstant(BoaTest):
             + Opcode.PUSH1      # 1
             + Opcode.PUSH3      # list length
             + Opcode.PACK
+            + Opcode.DROP
             + Opcode.RET
         )
 
@@ -336,6 +343,7 @@ class TestConstant(BoaTest):
             + Opcode.PACK
             + Opcode.PUSH3  # list length
             + Opcode.PACK
+            + Opcode.DROP
             + Opcode.RET
         )
 

--- a/boa3_test/tests/test_exception.py
+++ b/boa3_test/tests/test_exception.py
@@ -1,6 +1,5 @@
-from boa3.exception.CompilerError import MismatchedTypes
-
 from boa3.boa3 import Boa3
+from boa3.exception.CompilerError import MismatchedTypes
 from boa3.model.builtin.builtin import Builtin
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer

--- a/boa3_test/tests/test_function.py
+++ b/boa3_test/tests/test_function.py
@@ -122,7 +122,7 @@ class TestFunction(BoaTest):
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_call_void_function_without_args(self):
-        called_function_address = Integer(4).to_byte_array(min_length=1, signed=True)
+        called_function_address = Integer(5).to_byte_array(min_length=1, signed=True)
 
         expected_output = (
             Opcode.INITSLOT     # Main
@@ -130,6 +130,7 @@ class TestFunction(BoaTest):
             + b'\x02'
             + Opcode.CALL           # TestFunction()
             + called_function_address
+            + Opcode.DROP
             + Opcode.PUSH1          # return True
             + Opcode.RET
             + Opcode.INITSLOT   # TestFunction
@@ -168,7 +169,7 @@ class TestFunction(BoaTest):
         self.assertEqual(expected_output, output)
 
     def test_call_void_function_with_literal_args(self):
-        called_function_address = Integer(4).to_byte_array(min_length=1, signed=True)
+        called_function_address = Integer(5).to_byte_array(min_length=1, signed=True)
 
         expected_output = (
             Opcode.INITSLOT     # Main
@@ -178,6 +179,7 @@ class TestFunction(BoaTest):
             + Opcode.PUSH1
             + Opcode.CALL
             + called_function_address
+            + Opcode.DROP
             + Opcode.PUSH1          # return True
             + Opcode.RET
             + Opcode.INITSLOT   # TestFunction
@@ -225,7 +227,7 @@ class TestFunction(BoaTest):
         self.assertEqual(expected_output, output)
 
     def test_call_void_function_with_variable_args(self):
-        called_function_address = Integer(4).to_byte_array(min_length=1, signed=True)
+        called_function_address = Integer(5).to_byte_array(min_length=1, signed=True)
 
         expected_output = (
             Opcode.INITSLOT     # Main
@@ -239,6 +241,7 @@ class TestFunction(BoaTest):
             + Opcode.LDLOC0
             + Opcode.CALL
             + called_function_address
+            + Opcode.DROP
             + Opcode.PUSH1          # return True
             + Opcode.RET
             + Opcode.INITSLOT   # TestFunction
@@ -913,12 +916,14 @@ class TestFunction(BoaTest):
             + Opcode.PUSH2
             + Opcode.PUSH1
             + Opcode.CALL
-            + Integer(9).to_byte_array(signed=True, min_length=1)
+            + Integer(11).to_byte_array(signed=True, min_length=1)
+            + Opcode.DROP
             + Opcode.PUSH0
             + Opcode.PUSH6  # add(5, 6)
             + Opcode.PUSH5
             + Opcode.CALL
-            + Integer(4).to_byte_array(signed=True, min_length=1)
+            + Integer(5).to_byte_array(signed=True, min_length=1)
+            + Opcode.DROP
             + Opcode.PUSHNULL
             + Opcode.RET
             + Opcode.INITSLOT   # def add(a: int, b: int, c: int = 0)
@@ -941,22 +946,26 @@ class TestFunction(BoaTest):
             + Opcode.PUSH0
             + Opcode.PUSH0
             + Opcode.CALL   # add()
-            + Integer(19).to_byte_array(signed=True, min_length=1)
+            + Integer(23).to_byte_array(signed=True, min_length=1)
+            + Opcode.DROP
             + Opcode.PUSH0      # defaults
             + Opcode.PUSH6      # add(5, 6)
             + Opcode.PUSH5
             + Opcode.CALL
-            + Integer(14).to_byte_array(signed=True, min_length=1)
+            + Integer(17).to_byte_array(signed=True, min_length=1)
+            + Opcode.DROP
             + Opcode.PUSH0      # defaults
             + Opcode.PUSH0
             + Opcode.PUSH9      # add(9)
             + Opcode.CALL
-            + Integer(9).to_byte_array(signed=True, min_length=1)
+            + Integer(11).to_byte_array(signed=True, min_length=1)
+            + Opcode.DROP
             + Opcode.PUSH3      # add(1, 2, 3)
             + Opcode.PUSH2
             + Opcode.PUSH1
             + Opcode.CALL
-            + Integer(4).to_byte_array(signed=True, min_length=1)
+            + Integer(5).to_byte_array(signed=True, min_length=1)
+            + Opcode.DROP
             + Opcode.PUSHNULL
             + Opcode.RET
             + Opcode.INITSLOT   # def add(a: int, b: int, c: int)

--- a/boa3_test/tests/test_list.py
+++ b/boa3_test/tests/test_list.py
@@ -1,5 +1,5 @@
 from boa3.boa3 import Boa3
-from boa3.exception.CompilerError import MismatchedTypes, UnresolvedOperation
+from boa3.exception.CompilerError import MismatchedTypes, UnexpectedArgument, UnresolvedOperation
 from boa3.model.type.type import Type
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
@@ -299,6 +299,8 @@ class TestList(BoaTest):
         )
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
+
+    # region TestSlicing
 
     def test_list_slicing(self):
         expected_output = (
@@ -831,6 +833,10 @@ class TestList(BoaTest):
         with self.assertRaises(NotImplementedError):
             output = Boa3.compile(path)
 
+    # endregion
+
+    # region TestAppend
+
     def test_list_append_int_value(self):
         path = '%s/boa3_test/test_sc/list_test/AppendIntValue.py' % self.dirname
 
@@ -941,6 +947,8 @@ class TestList(BoaTest):
         path = '%s/boa3_test/test_sc/list_test/MismatchedTypeAppendWithBuiltin.py' % self.dirname
         self.assertCompilerLogs(MismatchedTypes, path)
 
+    # endregion
+
     def test_list_clear(self):
         path = '%s/boa3_test/test_sc/list_test/ClearList.py' % self.dirname
 
@@ -997,6 +1005,8 @@ class TestList(BoaTest):
         )
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
+
+    # region TestExtend
 
     def test_list_extend_tuple_value(self):
         path = '%s/boa3_test/test_sc/list_test/ExtendTupleValue.py' % self.dirname
@@ -1132,3 +1142,207 @@ class TestList(BoaTest):
     def test_list_extend_with_builtin_mismatched_type(self):
         path = '%s/boa3_test/test_sc/list_test/MismatchedTypeExtendWithBuiltin.py' % self.dirname
         self.assertCompilerLogs(MismatchedTypes, path)
+
+    # endregion
+
+    # region TestPop
+
+    def test_list_pop(self):
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x02'
+            + b'\x00'
+            + Opcode.PUSH5      # a = [1, 2, 3, 4, 5]
+            + Opcode.PUSH4
+            + Opcode.PUSH3
+            + Opcode.PUSH2
+            + Opcode.PUSH1
+            + Opcode.PUSH5
+            + Opcode.PACK
+            + Opcode.STLOC0
+            + Opcode.LDLOC0     # b = a.pop()
+            + Opcode.PUSHM1
+            + Opcode.DUP
+            + Opcode.SIGN
+            + Opcode.PUSHM1
+            + Opcode.JMPNE
+            + Integer(5).to_byte_array(min_length=1, signed=True)
+            + Opcode.OVER
+            + Opcode.SIZE
+            + Opcode.ADD
+            + Opcode.OVER
+            + Opcode.OVER
+            + Opcode.PICKITEM
+            + Opcode.REVERSE3
+            + Opcode.SWAP
+            + Opcode.REMOVE
+            + Opcode.STLOC1
+            + Opcode.LDLOC1     # return b
+            + Opcode.RET
+        )
+        path = '%s/boa3_test/test_sc/list_test/PopList.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_list_pop_without_assignment(self):
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x01'
+            + b'\x00'
+            + Opcode.PUSH5      # a = [1, 2, 3, 4, 5]
+            + Opcode.PUSH4
+            + Opcode.PUSH3
+            + Opcode.PUSH2
+            + Opcode.PUSH1
+            + Opcode.PUSH5
+            + Opcode.PACK
+            + Opcode.STLOC0
+            + Opcode.LDLOC0     # b = a.pop()
+            + Opcode.PUSHM1
+            + Opcode.DUP
+            + Opcode.SIGN
+            + Opcode.PUSHM1
+            + Opcode.JMPNE
+            + Integer(5).to_byte_array(min_length=1, signed=True)
+            + Opcode.OVER
+            + Opcode.SIZE
+            + Opcode.ADD
+            + Opcode.OVER
+            + Opcode.OVER
+            + Opcode.PICKITEM
+            + Opcode.REVERSE3
+            + Opcode.SWAP
+            + Opcode.REMOVE
+            + Opcode.DROP
+            + Opcode.LDLOC0     # return a
+            + Opcode.RET
+        )
+        path = '%s/boa3_test/test_sc/list_test/PopListWithoutAssignment.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_list_pop_literal_argument(self):
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x02'
+            + b'\x00'
+            + Opcode.PUSH5      # a = [1, 2, 3, 4, 5]
+            + Opcode.PUSH4
+            + Opcode.PUSH3
+            + Opcode.PUSH2
+            + Opcode.PUSH1
+            + Opcode.PUSH5
+            + Opcode.PACK
+            + Opcode.STLOC0
+            + Opcode.LDLOC0     # b = a.pop(2)
+            + Opcode.PUSH2
+            + Opcode.DUP
+            + Opcode.SIGN
+            + Opcode.PUSHM1
+            + Opcode.JMPNE
+            + Integer(5).to_byte_array(min_length=1, signed=True)
+            + Opcode.OVER
+            + Opcode.SIZE
+            + Opcode.ADD
+            + Opcode.OVER
+            + Opcode.OVER
+            + Opcode.PICKITEM
+            + Opcode.REVERSE3
+            + Opcode.SWAP
+            + Opcode.REMOVE
+            + Opcode.STLOC1
+            + Opcode.LDLOC1     # return b
+            + Opcode.RET
+        )
+        path = '%s/boa3_test/test_sc/list_test/PopListLiteralArgument.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_list_pop_literal_negative_argument(self):
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x02'
+            + b'\x00'
+            + Opcode.PUSH5      # a = [1, 2, 3, 4, 5]
+            + Opcode.PUSH4
+            + Opcode.PUSH3
+            + Opcode.PUSH2
+            + Opcode.PUSH1
+            + Opcode.PUSH5
+            + Opcode.PACK
+            + Opcode.STLOC0
+            + Opcode.LDLOC0     # b = a.pop(-2)
+            + Opcode.PUSH2
+            + Opcode.NEGATE
+            + Opcode.DUP
+            + Opcode.SIGN
+            + Opcode.PUSHM1
+            + Opcode.JMPNE
+            + Integer(5).to_byte_array(min_length=1, signed=True)
+            + Opcode.OVER
+            + Opcode.SIZE
+            + Opcode.ADD
+            + Opcode.OVER
+            + Opcode.OVER
+            + Opcode.PICKITEM
+            + Opcode.REVERSE3
+            + Opcode.SWAP
+            + Opcode.REMOVE
+            + Opcode.STLOC1
+            + Opcode.LDLOC1     # return b
+            + Opcode.RET
+        )
+        path = '%s/boa3_test/test_sc/list_test/PopListLiteralNegativeArgument.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_list_pop_literal_variable_argument(self):
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x02'
+            + b'\x01'
+            + Opcode.PUSH5      # a = [1, 2, 3, 4, 5]
+            + Opcode.PUSH4
+            + Opcode.PUSH3
+            + Opcode.PUSH2
+            + Opcode.PUSH1
+            + Opcode.PUSH5
+            + Opcode.PACK
+            + Opcode.STLOC0
+            + Opcode.LDLOC0     # b = a.pop(arg0)
+            + Opcode.LDARG0
+            + Opcode.DUP
+            + Opcode.SIGN
+            + Opcode.PUSHM1
+            + Opcode.JMPNE
+            + Integer(5).to_byte_array(min_length=1, signed=True)
+            + Opcode.OVER
+            + Opcode.SIZE
+            + Opcode.ADD
+            + Opcode.OVER
+            + Opcode.OVER
+            + Opcode.PICKITEM
+            + Opcode.REVERSE3
+            + Opcode.SWAP
+            + Opcode.REMOVE
+            + Opcode.STLOC1
+            + Opcode.LDLOC1     # return b
+            + Opcode.RET
+        )
+        path = '%s/boa3_test/test_sc/list_test/PopListVariableArgument.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_list_pop_mismatched_type_argument(self):
+        path = '%s/boa3_test/test_sc/list_test/PopListMismatchedTypeArgument.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_list_pop_mismatched_type_result(self):
+        path = '%s/boa3_test/test_sc/list_test/PopListMismatchedTypeResult.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_list_pop_too_many_arguments(self):
+        path = '%s/boa3_test/test_sc/list_test/PopListTooManyArguments.py' % self.dirname
+        self.assertCompilerLogs(UnexpectedArgument, path)
+
+    # endregion

--- a/boa3_test/tests/test_while.py
+++ b/boa3_test/tests/test_while.py
@@ -288,7 +288,7 @@ class TestWhile(BoaTest):
 
         path = '%s/boa3_test/test_sc/while_test/WhileContinue.py' % self.dirname
         output = Boa3.compile(path)
-        
+
         self.assertEqual(expected_output, output)
 
     def test_boa2_while_test(self):


### PR DESCRIPTION
Implemented pop method for `list` values
```python
from typing import List


def Main(op: str, args: list) -> List[str]:
    a = ['1', '2', '3', '4', '5']
    b = a.pop(4)  # removes '5' and assigns it to b
    c = a.pop(-2)  # removes '3' and assigns it to c
    d = a.pop()  # removes '4' and assigns it to d
    return a  # expected ['1', '2']
```