### PR TITLE
Fix error when using a non-existent import

### DIFF
--- a/boa3/analyser/importanalyser.py
+++ b/boa3/analyser/importanalyser.py
@@ -15,7 +15,11 @@ class ImportAnalyser(IAstAnalyser):
         self.can_be_imported: bool = False
         self._import_identifier: str = import_target
 
-        module_origin: str = importlib.util.find_spec(import_target).origin
+        try:
+            module_origin: str = importlib.util.find_spec(import_target).origin
+        except BaseException:
+            return
+
         path: List[str] = module_origin.split(os.sep)
         self.path: str = module_origin.replace(os.sep, '/')
 

--- a/boa3/compiler/compiler.py
+++ b/boa3/compiler/compiler.py
@@ -29,7 +29,7 @@ class Compiler:
         filepath, filename = os.path.split(fullpath)
 
         logging.info('Started compiling\t{0}'.format(filename))
-        self._analyse(path)
+        self._analyse(fullpath)
         return self._compile()
 
     def compile_and_save(self, path: str, output_path: str):

--- a/boa3_test/test_sc/import_test/ImportNonExistantPackage.py
+++ b/boa3_test/test_sc/import_test/ImportNonExistantPackage.py
@@ -1,0 +1,5 @@
+from boa3.interop.runtime import *
+
+
+def Main():
+    x = 'non-existent builtin'

--- a/boa3_test/tests/test_exception.py
+++ b/boa3_test/tests/test_exception.py
@@ -1,6 +1,5 @@
-from boa3.exception.CompilerError import MismatchedTypes
-
 from boa3.boa3 import Boa3
+from boa3.exception.CompilerError import MismatchedTypes
 from boa3.model.builtin.builtin import Builtin
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer

--- a/boa3_test/tests/test_import.py
+++ b/boa3_test/tests/test_import.py
@@ -193,3 +193,7 @@ class TestImport(BoaTest):
 
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
+
+    def test_import_non_existent_package(self):
+        path = '%s/boa3_test/test_sc/import_test/ImportNonExistantPackage.py' % self.dirname
+        self.assertCompilerLogs(UnresolvedReference, path)


### PR DESCRIPTION
When trying to import a non-existent package, the compiler was raising an exception.
![image](https://user-images.githubusercontent.com/19419485/92041042-e052aa00-ed4d-11ea-8510-392a0e906003.png)

Changed to log `UnresolvedReference`:
![image](https://user-images.githubusercontent.com/19419485/92041261-4b9c7c00-ed4e-11ea-96d4-1b47e4b6bcb6.png)
