### PR TITLE
Implement try except

### DIFF
--- a/boa3/analyser/astanalyser.py
+++ b/boa3/analyser/astanalyser.py
@@ -92,6 +92,6 @@ class IAstAnalyser(ABC, ast.NodeVisitor):
             if (found_symbol is None and isinstance(symbol_id, str)
                     and (symbol_id in globals() or symbol_id in globals()['__builtins__'])):
                 symbol = globals()[symbol_id] if symbol_id in globals() else globals()['__builtins__'][symbol_id]
-                if isclass(symbol) and issubclass(symbol, Exception):
+                if isclass(symbol) and issubclass(symbol, BaseException):
                     found_symbol = Builtin.Exception.return_type
             return found_symbol

--- a/boa3/compiler/vmcodemapping.py
+++ b/boa3/compiler/vmcodemapping.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from boa3.neo.vm.VMCode import VMCode
 from boa3.neo.vm.opcode.OpcodeInformation import OpcodeInformation
@@ -75,9 +75,19 @@ class VMCodeMapping:
         if vm_code not in self._codes.values():
             self._codes[self.bytecode_size] = vm_code
 
-    def get_code(self, address: int):
+    def get_code(self, address: int) -> Optional[VMCode]:
+        """
+        Gets the VM Opcode at the given position
+
+        :param address: the position of the opcode
+        :return: the opcode if it exists. None otherwise
+        :rtype: VMCode or None
+        """
         if address in self._codes:
             return self._codes[address]
+        elif address >= self.bytecode_size:
+            # the address is not in the bytecode
+            return None
         else:
             # if the address is not the start of a instruction, gets the last instruction before given address
             code_address = 0

--- a/boa3/exception/CompilerWarning.py
+++ b/boa3/exception/CompilerWarning.py
@@ -68,3 +68,17 @@ class UnreachableCode(CompilerWarning):
     @property
     def _warning_message(self) -> Optional[str]:
         return "Unreachable code"
+
+
+class UsingSpecificException(CompilerWarning):
+    """
+    An warning raised when a specific exception is used.
+    """
+
+    def __init__(self, line: int, col: int, exception_id: str):
+        self._exception_id: str = exception_id
+        super().__init__(line, col)
+
+    @property
+    def _warning_message(self) -> Optional[str]:
+        return "{0} will be interpreted as BaseException when running in the blockchain".format(self._exception_id)

--- a/boa3/neo/vm/TryCode.py
+++ b/boa3/neo/vm/TryCode.py
@@ -1,0 +1,89 @@
+from typing import Optional
+
+from boa3.neo.vm.VMCode import VMCode
+from boa3.neo.vm.type.Integer import Integer
+
+
+class TryCode(VMCode):
+    """
+    Represents a Neo VM function try code
+
+    :ivar info: the opcode information of the code
+    :ivar data: the data in bytes of the code. Empty byte array by default.
+    """
+
+    def __init__(self, except_start_code: Optional[VMCode] = None, finally_start_code: Optional[VMCode] = None):
+        """
+        :param except_start_code: the first code of the except body
+        :type except_start_code: VMCode or None
+        """
+        self._except_start_code: Optional[VMCode] = except_start_code
+        self._finally_start_code: Optional[VMCode] = finally_start_code
+        from boa3.neo.vm.opcode.OpcodeInfo import OpcodeInfo
+        super().__init__(OpcodeInfo.TRY)
+
+    @property
+    def target(self) -> VMCode:
+        return self._except_start_code if self._finally_start_code is None else self._finally_start_code
+
+    def set_except_code(self, except_code: VMCode):
+        if self._except_start_code is None and except_code is not None:
+            self._except_start_code = except_code
+
+    def set_finally_code(self, finally_code: VMCode):
+        if self._finally_start_code is None and finally_code is not None:
+            self._finally_start_code = finally_code
+
+    @property
+    def data(self) -> bytes:
+        """
+        Gets the Neo VM data of the code
+
+        :return: the formatted data in bytes of the code.
+        """
+        catch_data: bytes = self._get_raw_data(self._except_start_code)
+        finally_data: bytes = self._get_raw_data(self._finally_start_code)
+
+        min_data_len = self._info.data_len // 2
+        max_data_len = self._info.max_data_len // 2
+
+        return (self._format_data(catch_data, min_data_len, max_data_len)
+                + self._format_data(finally_data, min_data_len, max_data_len))
+
+    def _format_data(self, data: bytes, min_data_len: int, max_data_len: int = -1) -> bytes:
+        if max_data_len < min_data_len:
+            max_data_len = min_data_len
+        mutable_data = bytearray(data)
+
+        if len(mutable_data) < min_data_len:
+            mutable_data.extend(bytes(min_data_len))
+        elif len(mutable_data) > max_data_len:
+            mutable_data = mutable_data[:max_data_len]
+        return bytes(mutable_data)
+
+    def _get_raw_data(self, opcode: VMCode) -> bytes:
+        """
+        Gets the Neo VM raw data of the code
+
+        :return: the unformatted data in bytes of the code.
+        """
+        min_len = self._info.data_len // 2  # for try opcode, data_len adds catch and finally addresses
+        if opcode is None:
+            return bytes(min_len)
+        else:
+            from boa3.compiler.vmcodemapping import VMCodeMapping
+            code_mapping = VMCodeMapping.instance()
+            self_start = code_mapping.get_start_address(self)
+            target_start = code_mapping.get_start_address(self.target)
+
+            return (Integer(target_start - self_start)
+                    .to_byte_array(signed=True, min_length=min_len))
+
+    @property
+    def raw_data(self):
+        catch_data: bytes = self._get_raw_data(self._except_start_code)
+        finally_data: bytes = self._get_raw_data(self._finally_start_code)
+
+        size = max(len(catch_data), len(finally_data))
+
+        return self._format_data(catch_data, size) + self._format_data(finally_data, size)

--- a/boa3/neo/vm/VMCode.py
+++ b/boa3/neo/vm/VMCode.py
@@ -13,11 +13,13 @@ class VMCode:
     :ivar data: the data in bytes of the code. Empty byte array by default.
     """
 
-    def __init__(self, op_info: OpcodeInformation, data: bytes = bytes()):
+    def __init__(self, op_info: OpcodeInformation, data: bytes = None):
         """
         :param op_info: information of the opcode of the code
         :param data: the data in bytes of the code. Empty byte array by default.
         """
+        if data is None:
+            data = bytes(op_info.data_len)
         self._info: OpcodeInformation = op_info
         self._target: Optional[VMCode] = None
         self._data: bytes = data
@@ -42,7 +44,7 @@ class VMCode:
         info = self.info
 
         if len(data) < info.data_len:
-            data = data.zfill(info.data_len)
+            data.extend(bytes(info.data_len))
         elif len(data) > info.max_data_len:
             data = data[:info.max_data_len]
         return data

--- a/boa3/neo/vm/opcode/Opcode.py
+++ b/boa3/neo/vm/opcode/Opcode.py
@@ -219,7 +219,7 @@ class Opcode(bytes, Enum):
     SYSCALL = b'\x41'
 
     def has_target(self) -> bool:
-        return self.JMP <= self <= self.CALL_L or self.ENDTRY <= self <= self.ENDFINALLY
+        return self.JMP <= self <= self.CALL_L or self.TRY <= self <= self.ENDFINALLY
 
     # endregion
 

--- a/boa3/neo/vm/opcode/OpcodeInfo.py
+++ b/boa3/neo/vm/opcode/OpcodeInfo.py
@@ -154,18 +154,18 @@ class OpcodeInfo:
     THROW = OpcodeInformation(Opcode.THROW)
     # TRY CatchOffset(sbyte) FinallyOffset(sbyte). If there's no catch body, set CatchOffset 0. If there's no finally
     # body, set FinallyOffset 0.
-    TRY = OpcodeInformation(Opcode.TRY)
+    TRY = OpcodeInformation(Opcode.TRY, 2)
     # TRY_L CatchOffset(int) FinallyOffset(int). If there's no catch body, set CatchOffset 0. If there's no finally
     # body, set FinallyOffset 0.
-    TRY_L = OpcodeInformation(Opcode.TRY_L)
+    TRY_L = OpcodeInformation(Opcode.TRY_L, 8)
     # Ensures that the appropriate surrounding finally blocks are executed. And then unconditionally transfers
     # control to the specific target instruction, represented as a 1-byte signed offset from the beginning of the
     # current instruction.
-    ENDTRY = OpcodeInformation(Opcode.ENDTRY)
+    ENDTRY = OpcodeInformation(Opcode.ENDTRY, 1)
     # Ensures that the appropriate surrounding finally blocks are executed. And then unconditionally transfers
     # control to the specific target instruction, represented as a 4-byte signed offset from the beginning of the
     # current instruction.
-    ENDTRY_L = OpcodeInformation(Opcode.ENDTRY_L)
+    ENDTRY_L = OpcodeInformation(Opcode.ENDTRY_L, 4)
     # End finally, If no exception happen or be catched, vm will jump to the target instruction of ENDTRY/ENDTRY_L.
     # Otherwise vm will rethrow the exception to upper layer.
     ENDFINALLY = OpcodeInformation(Opcode.ENDFINALLY)

--- a/boa3_test/test_sc/exception_test/TryExceptBaseException.py
+++ b/boa3_test/test_sc/exception_test/TryExceptBaseException.py
@@ -1,0 +1,7 @@
+def test_try_except(arg: int) -> int:
+    try:
+        x = arg
+    except BaseException:
+        x = 0
+
+    return x

--- a/boa3_test/test_sc/exception_test/TryExceptFinally.py
+++ b/boa3_test/test_sc/exception_test/TryExceptFinally.py
@@ -1,0 +1,10 @@
+def test_try_except(arg: int) -> int:
+    x = arg // 4
+    try:
+        x += arg
+    except:
+        x = -x
+    finally:
+        x *= 2
+
+    return x

--- a/boa3_test/test_sc/exception_test/TryExceptSpecificException.py
+++ b/boa3_test/test_sc/exception_test/TryExceptSpecificException.py
@@ -1,0 +1,7 @@
+def test_try_except(arg: int) -> int:
+    try:
+        x = arg
+    except ValueError:
+        x = 0
+
+    return x

--- a/boa3_test/test_sc/exception_test/TryExceptWithName.py
+++ b/boa3_test/test_sc/exception_test/TryExceptWithName.py
@@ -1,0 +1,7 @@
+def test_try_except(arg: int) -> int:
+    try:
+        x = arg
+    except BaseException as e:
+        x = 0
+
+    return x

--- a/boa3_test/test_sc/exception_test/TryExceptWithoutException.py
+++ b/boa3_test/test_sc/exception_test/TryExceptWithoutException.py
@@ -1,0 +1,7 @@
+def test_try_except(arg: int) -> int:
+    try:
+        x = arg
+    except:
+        x = 0
+
+    return x


### PR DESCRIPTION
- Implemented try-exception statements
```python
def foo(bar: int) -> int:
    try:
        x = may_raise_exception(bar)
    except Exception:
        x = bar
    return x
```
  - `finally` statements are not implemented yet
  - Currently, all exceptions are raised as `Exception`, so any specific exception in the `except` statement will be converted to `Exception`:
    ```python
    def foo(bar: int) -> int:
        try:
            x = may_raise_exception(bar)
        except AttributeError:
            x = bar
        return x
    ```
  - Multiple `except` statements to the same `try` body are not implemented yet:
    ```python
    def foo(bar: int) -> int:
        try:
            x = may_raise_exception(bar)
        except AttributeError:
            x = bar
        except BaseException:
            x = bar * 2
        return x
    ```