### PR TITLE
Implement global keyword

### DIFF
--- a/boa3/analyser/moduleanalyser.py
+++ b/boa3/analyser/moduleanalyser.py
@@ -574,7 +574,10 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
 
         :param global_node:
         """
-        raise NotImplementedError
+        for var_id in global_node.names:
+            symbol = self.get_symbol(var_id)
+            if isinstance(symbol, Variable) and self._current_method is not None:
+                self._current_method.include_variable(var_id, symbol, is_global=True)
 
     def visit_Expr(self, expr: ast.Expr):
         """

--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -625,6 +625,9 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
         l_type: IType = self.get_type(left)
         r_type: IType = self.get_type(right)
 
+        if l_type is None or r_type is None:
+            return BinaryOp.get_operation_by_operator(operator, l_type if l_type is not None else r_type)
+
         actual_types = (l_type.identifier, r_type.identifier)
         operation: IOperation = BinaryOp.validate_type(operator, l_type, r_type)
 

--- a/boa3/compiler/codegenerator.py
+++ b/boa3/compiler/codegenerator.py
@@ -880,19 +880,23 @@ class CodeGenerator:
         Gets the necessary information about the variable to get the correct opcode
 
         :param var_id: the name id of the
-        :return: returns the index of the variable in its scope and two boolean variables for representing the variable
-        scope: `local` is True if it is a local variable and `is_arg` is True only if the variable is a parameter of
-        the function. If the variable is not found, returns (-1, False, False)
+        :return: returns the index of the variable in its scope and two boolean variables for representing the
+        variable scope:
+            `local` is True if it is a local variable and
+            `is_arg` is True only if the variable is a parameter of the function.
+        If the variable is not found, returns (-1, False, False)
         """
-        is_arg: bool = False
-        local: bool = isinstance(self._current_method, Method) and var_id in self._current_method.symbols
-        if local:
-            is_arg = var_id in self._args
-            if is_arg:
-                scope = self._args
-            else:
-                scope = self._locals
+        if var_id in self._args:
+            is_arg: bool = True
+            local: bool = True
+            scope = self._args
+        elif var_id in self._locals:
+            is_arg = False
+            local: bool = True
+            scope = self._locals
         else:
+            is_arg: bool = False
+            local: bool = False
             scope = self._globals
 
         index: int = scope.index(var_id) if var_id in scope else -1

--- a/boa3/model/method.py
+++ b/boa3/model/method.py
@@ -25,6 +25,7 @@ class Method(Callable):
 
         self.imported_symbols = {}
         self._requires_storage: bool = False
+        self._symbols = {}
         self.locals: Dict[str, Variable] = {}
 
         self._debug_map: List[DebugInstruction] = []
@@ -33,15 +34,19 @@ class Method(Callable):
     def shadowing_name(self) -> str:
         return 'method'
 
-    def include_variable(self, var_id: str, var: Variable):
+    def include_variable(self, var_id: str, var: Variable, is_global: bool = False):
         """
         Includes a variable into the list of locals
 
         :param var_id: variable identifier
         :param var: variable to be included
+        :param is_global: whether the variable is declared outside the method
         """
         if var_id not in self.symbols:
-            self.locals[var_id] = var
+            if is_global:
+                self._symbols[var_id] = var
+            else:
+                self.locals[var_id] = var
 
     def __str__(self) -> str:
         args_types: List[str] = [str(arg.type) for arg in self.args.values()]
@@ -59,22 +64,23 @@ class Method(Callable):
 
         :return: a dictionary that maps each symbol in the module with its name
         """
-        symbols = {}
+        symbols = self._symbols.copy()
         symbols.update(self.imported_symbols)
         symbols.update(self.args)
         symbols.update(self.locals)
         return symbols
 
-    def include_symbol(self, symbol_id: str, symbol: ISymbol):
+    def include_symbol(self, symbol_id: str, symbol: ISymbol, is_global: bool = False):
         """
         Includes a method into the scope of the module
 
         :param symbol_id: method identifier
         :param symbol: method to be included
+        :param is_global: whether the variable is declared outside the method
         """
         if symbol_id not in self.symbols:
             if isinstance(symbol, Variable):
-                self.include_variable(symbol_id, symbol)
+                self.include_variable(symbol_id, symbol, is_global)
             else:
                 self.imported_symbols[symbol_id] = symbol
 

--- a/boa3_test/test_sc/variable_test/GlobalAssignmentInFunctionWithArgument.py
+++ b/boa3_test/test_sc/variable_test/GlobalAssignmentInFunctionWithArgument.py
@@ -1,7 +1,7 @@
-b: int = 0
-
-
 def Main(a: int) -> int:
-    global b  # not implemented yet
+    global b
     b = a
     return b
+
+
+b: int = 0

--- a/boa3_test/tests/test_variable.py
+++ b/boa3_test/tests/test_variable.py
@@ -387,8 +387,21 @@ class TestVariable(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-    def test_assign_global_in_function(self):
+    def test_assign_global_in_function_with_global_keyword(self):
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x00'
+            + b'\x01'
+            + Opcode.LDARG0     # b = a
+            + Opcode.STSFLD0
+            + Opcode.LDSFLD0    # return b
+            + Opcode.RET
+            + Opcode.INITSSLOT  # global variables
+            + b'\x01'           # number of globals
+            + Opcode.PUSH0      # b = 0
+            + Opcode.STSFLD0
+            + Opcode.RET
+        )
         path = '%s/boa3_test/test_sc/variable_test/GlobalAssignmentInFunctionWithArgument.py' % self.dirname
-
-        with self.assertRaises(NotImplementedError):
-            output = Boa3.compile(path)
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)


### PR DESCRIPTION
- Implemented `global` keyword, to update external variables inside functions
```python
x = 10

def increase1():
    global x  # it's using the external x instead of creating a local x
    x += 1
```