### PR TITLE
update neo debugger JSON of the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,10 +146,10 @@ Boa3.compile_and_save('path/to/your/file.py')
 ### Debugger ready
 Neo3-boa is compatible with the [Neo Debugger](https://github.com/neo-project/neo-debugger).
 Debugger launch configuration example:
-```json
+```
 {
     //Launch configuration example for Neo3-boa.
-    //Make sure you compiled you smart-contract before you try to debug it.
+    //Make sure you compile your smart-contract before you try to debug it.
     "version": "0.2.0",
     "configurations": [
         {


### PR DESCRIPTION
- fix typo's in comment
- remove `json` code block identifier as it shows as red errors. Given that it previously only highlighted the `true` word, we don't really lose any highlighting

Old view
![image](https://user-images.githubusercontent.com/6625537/92696777-a6cfff00-f34a-11ea-8fb8-f8803c666046.png)
