### PR TITLE
Implement isinstance function

### DIFF
--- a/boa3/analyser/builtinfunctioncallanalyser.py
+++ b/boa3/analyser/builtinfunctioncallanalyser.py
@@ -19,7 +19,7 @@ class BuiltinFunctionCallAnalyser(IAstAnalyser):
 
         self._origin: IAstAnalyser = origin
 
-        # all methods validators must be (IBuiltinMethod, List[IType]) -> bool
+        # all methods validators must be (IBuiltinMethod, List[IType]) -> None
         self._methods_validators: Dict[Type[IBuiltinMethod],
                                        Callable[[IBuiltinMethod, List[IType]], None]] = \
             {

--- a/boa3/analyser/builtinfunctioncallanalyser.py
+++ b/boa3/analyser/builtinfunctioncallanalyser.py
@@ -1,0 +1,86 @@
+import ast
+from typing import List, Callable, Dict, Type, Any, Optional
+
+from boa3.model.symbol import ISymbol
+
+from boa3.exception import CompilerError
+from boa3.model.builtin.method.isinstancemethod import IsInstanceMethod
+from boa3.model.type.itype import IType
+
+from boa3.analyser.astanalyser import IAstAnalyser
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+
+
+class BuiltinFunctionCallAnalyser(IAstAnalyser):
+    def __init__(self, origin: IAstAnalyser, call: ast.Call, method_id: str, builtin_method: IBuiltinMethod):
+        self._method: IBuiltinMethod = builtin_method
+        self.method_id: str = method_id
+        super().__init__(call)
+
+        self._origin: IAstAnalyser = origin
+
+        # all methods validators must be (IBuiltinMethod, List[IType]) -> bool
+        self._methods_validators: Dict[Type[IBuiltinMethod],
+                                       Callable[[IBuiltinMethod, List[IType]], None]] = \
+            {
+                IsInstanceMethod: self._validate_IsInstanceMethod
+            }
+
+    @property
+    def method(self) -> IBuiltinMethod:
+        return self._method
+
+    @property
+    def call(self) -> ast.Call:
+        return self._tree
+
+    def get_symbol(self, symbol_id: str) -> Optional[ISymbol]:
+        return self._origin.get_symbol(symbol_id)
+
+    def get_type(self, value: Any) -> IType:
+        return self._origin.get_type(value)
+
+    def validate(self) -> bool:
+        """
+        Validates the method arguments.
+
+        :return: whether the method have specific validation
+        """
+        if type(self.method) in self._methods_validators:
+            if self.method_id == self.method.raw_identifier:
+                # if the identifiers are diffrente, this method was validated already
+                validator = self._methods_validators[type(self.method)]
+                args = [self.get_type(param) for param in self.call.args]
+                validator(self.method, args)
+            return True
+        return False
+
+    def _validate_IsInstanceMethod(self, method: IsInstanceMethod, args_types: List[IType]):
+        """
+        Validates the arguments for `isinstance` method
+
+        :param method: instance of the builtin method
+        :param args_types: types of the arguments
+        """
+        last_arg = self.call.args[-1]
+        if isinstance(last_arg, ast.Tuple) and all(isinstance(tpe, ast.Name) for tpe in last_arg.elts):
+            if len(last_arg.elts) == 1:
+                # if the types tuple has only one type, remove it from inside the tuple
+                last_arg = self.call.args[-1] = last_arg.elts[-1]
+                args_types[-1] = args_types[-1].value_type
+            elif len(last_arg.elts) > 1:
+                # if there are more than one type, updates information in the instance of the method
+                types: List[IType] = [self.get_symbol(name.id) for name in last_arg.elts]
+                method.set_instance_type(types)
+                self.call.args[-1] = last_arg.elts[-1]
+                return
+
+        if not isinstance(last_arg, ast.Name) or (last_arg.id != args_types[-1].identifier
+                                                  and last_arg.id != args_types[-1].raw_identifier):
+            # if the value is not the identifier of a type
+            self._log_error(
+                CompilerError.MismatchedTypes(
+                    last_arg.lineno, last_arg.col_offset,
+                    expected_type_id=type.__name__,
+                    actual_type_id=args_types[-1].identifier
+                ))

--- a/boa3/compiler/codegeneratorvisitor.py
+++ b/boa3/compiler/codegeneratorvisitor.py
@@ -519,7 +519,11 @@ class VisitorCodeGenerator(ast.NodeVisitor):
                 VMCodeMapping.instance().bytecode_size
             )
             self.visit_to_generate(arg)
-        self.generator.convert_load_symbol(function_id, args_addresses)
+
+        if self.is_exception_name(function_id):
+            self.generator.convert_new_exception(len(call.args))
+        else:
+            self.generator.convert_load_symbol(function_id, args_addresses)
 
     def visit_Raise(self, raise_node: ast.Raise):
         """

--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -20,6 +20,7 @@ from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.builtin.method.bytearraymethod import ByteArrayMethod
 from boa3.model.builtin.method.createeventmethod import CreateEventMethod, EventType
 from boa3.model.builtin.method.exceptionmethod import ExceptionMethod
+from boa3.model.builtin.method.isinstancemethod import IsInstanceMethod
 from boa3.model.builtin.method.lenmethod import LenMethod
 from boa3.model.builtin.method.rangemethod import RangeMethod
 from boa3.model.builtin.method.toscripthashmethod import ScriptHashMethod
@@ -50,6 +51,7 @@ class Builtin:
 
     # builtin method
     Len = LenMethod()
+    IsInstance = IsInstanceMethod()
     ScriptHash = ScriptHashMethod()
     NewEvent = CreateEventMethod()
 
@@ -73,6 +75,7 @@ class Builtin:
     ConvertToStr = ToStrMethod
 
     _python_builtins: List[IdentifiedSymbol] = [Len,
+                                                IsInstance,
                                                 ScriptHash,
                                                 ByteArray,
                                                 SequenceAppend,

--- a/boa3/model/builtin/method/isinstancemethod.py
+++ b/boa3/model/builtin/method/isinstancemethod.py
@@ -1,0 +1,98 @@
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.expression import IExpression
+from boa3.model.type.itype import IType
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class IsInstanceMethod(IBuiltinMethod):
+
+    def __init__(self, target_type: IType = None):
+        from boa3.model.type.type import Type
+        identifier = 'isinstance'
+
+        args: Dict[str, Variable] = {
+            'x': Variable(Type.any),
+            'A_tuple': None
+        }
+
+        super().__init__(identifier, args, return_type=Type.bool)
+        self._instances_type: List[IType] = [target_type if isinstance(target_type, IType) else Type.none]
+
+    def set_instance_type(self, value: List[IType]):
+        new_list = []
+        for tpe in value:
+            if isinstance(tpe, IType):
+                if not any(tpe.raw_identifier == other.raw_identifier for other in new_list):
+                    new_list.append(tpe)
+
+        self._instances_type = new_list
+
+    @property
+    def identifier(self) -> str:
+        from boa3.model.type.type import Type
+        if (len(self._instances_type) == 0
+                or (len(self._instances_type) == 1 and self._instances_type[0] in (None, Type.none))
+        ):
+            return self._identifier
+
+        types = list({tpe.raw_identifier for tpe in self._instances_type})
+        types.sort()
+        return '-{0}_of_{1}'.format(self._identifier, '_or_'.join(types))
+
+    def validate_parameters(self, *params: Union[IExpression, IType]) -> bool:
+        if len(params) != 2:
+            return False
+
+        return not any(not isinstance(param, (IExpression, IType)) for param in params)
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        if len(self._instances_type) == 0:
+            return [
+                (Opcode.ISNULL, b'')
+            ]
+        else:
+            opcodes = []
+            from boa3.model.type.type import Type
+            types = self._instances_type.copy()
+
+            code, data = self._type_opcode(types[-1])
+            size = len(code + data)
+            opcodes.append((code, data))
+            for instance_type in reversed(types[:-1]):
+                from boa3.neo.vm.type.Integer import Integer
+                jmp_if_true_body = [
+                    self._type_opcode(instance_type),
+                    (Opcode.DUP, b''),
+                    (Opcode.JMPIF, Integer(size + 2).to_byte_array(min_length=1, signed=True))
+                ]
+
+                for opcode, code_data in jmp_if_true_body:
+                    size += len(opcode + code_data)
+
+                opcodes = jmp_if_true_body + opcodes
+
+            return opcodes
+
+    def _type_opcode(self, instance_type: Optional[IType]) -> Tuple[Opcode, bytes]:
+        from boa3.model.type.type import Type
+        if instance_type in (None, Type.none):
+            return Opcode.ISNULL, b''
+        else:
+            return Opcode.ISTYPE, instance_type.stack_item
+
+    @property
+    def _args_on_stack(self) -> int:
+        return 1
+
+    @property
+    def _body(self) -> Optional[str]:
+        return
+
+    def build(self, value: Any):
+        if isinstance(value, list) and self.validate_parameters(*value):
+            return IsInstanceMethod(value[-1])
+        return super().build(value)

--- a/boa3/model/identifiedsymbol.py
+++ b/boa3/model/identifiedsymbol.py
@@ -21,3 +21,12 @@ class IdentifiedSymbol(ISymbol, ABC):
         :return: the resulting type when the expression is evaluated
         """
         return self._identifier
+
+    @property
+    def raw_identifier(self) -> str:
+        """
+        Gets the type's simple id of the evaluated expression
+
+        :return: the simple id of the resulting type when the expression is evaluated
+        """
+        return self._identifier

--- a/boa3_test/test_sc/built_in_methods_test/IsInstanceBoolLiteral.py
+++ b/boa3_test/test_sc/built_in_methods_test/IsInstanceBoolLiteral.py
@@ -1,0 +1,2 @@
+def Main() -> bool:
+    return isinstance(123, bool)

--- a/boa3_test/test_sc/built_in_methods_test/IsInstanceBoolVariable.py
+++ b/boa3_test/test_sc/built_in_methods_test/IsInstanceBoolVariable.py
@@ -1,0 +1,5 @@
+from typing import Any
+
+
+def Main(a: Any) -> bool:
+    return isinstance(a, bool)

--- a/boa3_test/test_sc/built_in_methods_test/IsInstanceIntLiteral.py
+++ b/boa3_test/test_sc/built_in_methods_test/IsInstanceIntLiteral.py
@@ -1,0 +1,2 @@
+def Main() -> bool:
+    return isinstance(123, int)

--- a/boa3_test/test_sc/built_in_methods_test/IsInstanceIntVariable.py
+++ b/boa3_test/test_sc/built_in_methods_test/IsInstanceIntVariable.py
@@ -1,0 +1,5 @@
+from typing import Any
+
+
+def Main(a: Any) -> bool:
+    return isinstance(a, int)

--- a/boa3_test/test_sc/built_in_methods_test/IsInstanceListLiteral.py
+++ b/boa3_test/test_sc/built_in_methods_test/IsInstanceListLiteral.py
@@ -1,0 +1,2 @@
+def Main() -> bool:
+    return isinstance([], list)

--- a/boa3_test/test_sc/built_in_methods_test/IsInstanceManyTypes.py
+++ b/boa3_test/test_sc/built_in_methods_test/IsInstanceManyTypes.py
@@ -1,0 +1,5 @@
+from typing import Any
+
+
+def Main(a: Any) -> bool:
+    return isinstance(a, (list, int, bool, dict))

--- a/boa3_test/test_sc/built_in_methods_test/IsInstanceStrLiteral.py
+++ b/boa3_test/test_sc/built_in_methods_test/IsInstanceStrLiteral.py
@@ -1,0 +1,2 @@
+def Main() -> bool:
+    return isinstance('123', str)

--- a/boa3_test/test_sc/built_in_methods_test/IsInstanceStrVariable.py
+++ b/boa3_test/test_sc/built_in_methods_test/IsInstanceStrVariable.py
@@ -1,0 +1,5 @@
+from typing import Any
+
+
+def Main(a: Any) -> bool:
+    return isinstance(a, str)

--- a/boa3_test/test_sc/built_in_methods_test/IsInstanceTupleLiteral.py
+++ b/boa3_test/test_sc/built_in_methods_test/IsInstanceTupleLiteral.py
@@ -1,0 +1,2 @@
+def Main() -> bool:
+    return isinstance([], tuple)

--- a/boa3_test/test_sc/built_in_methods_test/IsInstanceTupleVariable.py
+++ b/boa3_test/test_sc/built_in_methods_test/IsInstanceTupleVariable.py
@@ -1,0 +1,5 @@
+from typing import Any
+
+
+def Main(a: Any) -> bool:
+    return isinstance(a, list)

--- a/boa3_test/test_sc/built_in_methods_test/IsInstanceVariableType.py
+++ b/boa3_test/test_sc/built_in_methods_test/IsInstanceVariableType.py
@@ -1,0 +1,5 @@
+from typing import Any
+
+
+def Main(a: Any, b: Any) -> bool:
+    return isinstance(a, b)

--- a/boa3_test/tests/test_builtin_method.py
+++ b/boa3_test/tests/test_builtin_method.py
@@ -8,9 +8,9 @@ from boa3.neo.vm.type.String import String
 from boa3_test.tests.boa_test import BoaTest
 
 
-class TestVariable(BoaTest):
+class TestBuiltinMethod(BoaTest):
 
-    # region TestLen
+    # region len test
 
     def test_len_of_tuple(self):
         expected_output = (
@@ -113,7 +113,7 @@ class TestVariable(BoaTest):
 
     # endregion
 
-    # region TestAppend
+    # region append test
 
     def test_append_tuple(self):
         path = '%s/boa3_test/test_sc/built_in_methods_test/AppendTuple.py' % self.dirname
@@ -199,7 +199,7 @@ class TestVariable(BoaTest):
 
     # endregion
 
-    # region TestClear
+    # region clear test
 
     def test_clear_tuple(self):
         path = '%s/boa3_test/test_sc/built_in_methods_test/ClearTuple.py' % self.dirname
@@ -287,7 +287,7 @@ class TestVariable(BoaTest):
 
     # endregion
 
-    # region TestReverse
+    # region reverse test
 
     def test_reverse_tuple(self):
         path = '%s/boa3_test/test_sc/built_in_methods_test/ReverseTuple.py' % self.dirname
@@ -346,7 +346,7 @@ class TestVariable(BoaTest):
 
     # endregion
 
-    # region TestExtend
+    # region extend test
 
     def test_extend_tuple(self):
         path = '%s/boa3_test/test_sc/built_in_methods_test/ExtendTuple.py' % self.dirname
@@ -446,7 +446,7 @@ class TestVariable(BoaTest):
 
     # endregion
 
-    # region TestToScriptHash
+    # region to_script_hash test
 
     def test_script_hash_int(self):
         from boa3.neo import to_script_hash
@@ -540,7 +540,7 @@ class TestVariable(BoaTest):
 
     # endregion
 
-    # region TestToBytes
+    # region to_bytes test
 
     def test_int_to_bytes(self):
         value = Integer(123).to_byte_array()
@@ -612,10 +612,177 @@ class TestVariable(BoaTest):
 
     # endregion
 
-    # region TestPrint
+    # region print test
 
     def test_print_missing_outer_function_return(self):
         path = '%s/boa3_test/test_sc/built_in_methods_test/PrintIntMissingFunctionReturn.py' % self.dirname
         self.assertCompilerLogs(MissingReturnStatement, path)
+
+    # endregion
+
+    # region isinstance test
+
+    def test_isinstance_int_literal(self):
+        value = Integer(123).to_byte_array()
+        expected_output = (
+            Opcode.PUSHDATA1        # isinstance(123, int)
+            + Integer(len(value)).to_byte_array(min_length=1)
+            + value
+            + Opcode.CONVERT
+            + Type.int.stack_item
+            + Opcode.ISTYPE
+            + Type.int.stack_item
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/test_sc/built_in_methods_test/IsInstanceIntLiteral.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_isinstance_int_variable(self):
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x00'
+            + b'\x01'
+            + Opcode.LDARG0         # isinstance(a, int)
+            + Opcode.ISTYPE
+            + Type.int.stack_item
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/test_sc/built_in_methods_test/IsInstanceIntVariable.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_isinstance_bool_literal(self):
+        value = Integer(123).to_byte_array()
+        expected_output = (
+            Opcode.PUSHDATA1        # isinstance(123, bool)
+            + Integer(len(value)).to_byte_array(min_length=1)
+            + value
+            + Opcode.CONVERT
+            + Type.int.stack_item
+            + Opcode.ISTYPE
+            + Type.bool.stack_item
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/test_sc/built_in_methods_test/IsInstanceBoolLiteral.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_isinstance_bool_variable(self):
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x00'
+            + b'\x01'
+            + Opcode.LDARG0         # isinstance(a, bool)
+            + Opcode.ISTYPE
+            + Type.bool.stack_item
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/test_sc/built_in_methods_test/IsInstanceBoolVariable.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_isinstance_str_literal(self):
+        value = String('123').to_bytes()
+        expected_output = (
+            Opcode.PUSHDATA1        # isinstance('123', str)
+            + Integer(len(value)).to_byte_array(min_length=1)
+            + value
+            + Opcode.ISTYPE
+            + Type.str.stack_item
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/test_sc/built_in_methods_test/IsInstanceStrLiteral.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_isinstance_str_variable(self):
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x00'
+            + b'\x01'
+            + Opcode.LDARG0         # isinstance(a, str)
+            + Opcode.ISTYPE
+            + Type.str.stack_item
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/test_sc/built_in_methods_test/IsInstanceStrVariable.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_isinstance_list_literal(self):
+        expected_output = (
+            Opcode.NEWARRAY0        # isinstance([], list)
+            + Opcode.ISTYPE
+            + Type.list.stack_item
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/test_sc/built_in_methods_test/IsInstanceListLiteral.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_isinstance_tuple_literal(self):
+        expected_output = (
+            Opcode.NEWARRAY0        # isinstance([], tuple)
+            + Opcode.ISTYPE
+            + Type.tuple.stack_item
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/test_sc/built_in_methods_test/IsInstanceTupleLiteral.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_isinstance_tuple_variable(self):
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x00'
+            + b'\x01'
+            + Opcode.LDARG0         # isinstance(a, tuple)
+            + Opcode.ISTYPE
+            + Type.tuple.stack_item
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/test_sc/built_in_methods_test/IsInstanceTupleVariable.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_isinstance_many_types(self):
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x00'
+            + b'\x01'
+            + Opcode.LDARG0         # isinstance(a, tuple)
+            + Opcode.ISTYPE
+            + Type.list.stack_item
+            + Opcode.DUP
+            + Opcode.JMPIF
+            + Integer(14).to_byte_array(min_length=1, signed=True)
+            + Opcode.ISTYPE
+            + Type.int.stack_item
+            + Opcode.DUP
+            + Opcode.JMPIF
+            + Integer(9).to_byte_array(min_length=1, signed=True)
+            + Opcode.ISTYPE
+            + Type.bool.stack_item
+            + Opcode.DUP
+            + Opcode.JMPIF
+            + Integer(4).to_byte_array(min_length=1, signed=True)
+            + Opcode.ISTYPE
+            + Type.dict.stack_item
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/test_sc/built_in_methods_test/IsInstanceManyTypes.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
 
     # endregion

--- a/boa3_test/tests/test_none.py
+++ b/boa3_test/tests/test_none.py
@@ -4,7 +4,7 @@ from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3_test.tests.boa_test import BoaTest
 
 
-class TestAny(BoaTest):
+class TestNone(BoaTest):
 
     def test_variable_none(self):
         path = '%s/boa3_test/test_sc/none_test/VariableNone.py' % self.dirname


### PR DESCRIPTION
Implemented `isinstance` builtin method:
```python
def foo(bar: Any) -> bool:
    return isinstance(bar, (int, str))
```
- Didn't implement type validation with `isinstance` method. So methods like:
   ```python
   def foo(bar: Any) -> int:
       if isinstance(bar, int):
           return bar
       else:
           return 0
   ```
  won't compile because the variable `bar` is not interpreted as an `int` value even after `isinstance` returns True. That'll be implemented when reassigning types to existing variables is implemented.