### PR TITLE
Update Storage Get interop to return an empty bytearray when the key doesn't exist

### DIFF
--- a/boa3/analyser/builtinfunctioncallanalyser.py
+++ b/boa3/analyser/builtinfunctioncallanalyser.py
@@ -1,14 +1,12 @@
 import ast
-from typing import List, Callable, Dict, Type, Any, Optional
-
-from boa3.model.symbol import ISymbol
-
-from boa3.exception import CompilerError
-from boa3.model.builtin.method.isinstancemethod import IsInstanceMethod
-from boa3.model.type.itype import IType
+from typing import Any, Callable, Dict, List, Optional, Type
 
 from boa3.analyser.astanalyser import IAstAnalyser
+from boa3.exception import CompilerError
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.builtin.method.isinstancemethod import IsInstanceMethod
+from boa3.model.symbol import ISymbol
+from boa3.model.type.itype import IType
 
 
 class BuiltinFunctionCallAnalyser(IAstAnalyser):
@@ -21,10 +19,9 @@ class BuiltinFunctionCallAnalyser(IAstAnalyser):
 
         # all methods validators must be (IBuiltinMethod, List[IType]) -> None
         self._methods_validators: Dict[Type[IBuiltinMethod],
-                                       Callable[[IBuiltinMethod, List[IType]], None]] = \
-            {
-                IsInstanceMethod: self._validate_IsInstanceMethod
-            }
+                                       Callable[[IBuiltinMethod, List[IType]], None]] = {
+            IsInstanceMethod: self._validate_IsInstanceMethod
+        }
 
     @property
     def method(self) -> IBuiltinMethod:

--- a/boa3/model/builtin/interop/storage/storagegetmethod.py
+++ b/boa3/model/builtin/interop/storage/storagegetmethod.py
@@ -39,8 +39,19 @@ class StorageGetMethod(InteropMethod):
 
     @property
     def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        from boa3.model.type.type import Type
+        from boa3.neo.vm.type.Integer import Integer
+
         opcodes = [(Opcode.SYSCALL, self.storage_context_hash)]
         opcodes.extend(super().opcode)
+        opcodes.extend([
+            (Opcode.DUP, b''),
+            (Opcode.ISNULL, b''),
+            (Opcode.JMPIFNOT, Integer(7).to_byte_array(signed=True, min_length=1)),
+            (Opcode.DROP, b''),
+            (Opcode.PUSHDATA1, b'\x00'),
+            (Opcode.CONVERT, Type.bytes.stack_item),
+        ])
         return opcodes
 
     @property

--- a/boa3/model/builtin/method/isinstancemethod.py
+++ b/boa3/model/builtin/method/isinstancemethod.py
@@ -35,7 +35,7 @@ class IsInstanceMethod(IBuiltinMethod):
         from boa3.model.type.type import Type
         if (len(self._instances_type) == 0
                 or (len(self._instances_type) == 1 and self._instances_type[0] in (None, Type.none))
-        ):
+            ):
             return self._identifier
 
         types = list({tpe.raw_identifier for tpe in self._instances_type})

--- a/boa3_test/tests/test_storage.py
+++ b/boa3_test/tests/test_storage.py
@@ -20,6 +20,15 @@ class TestStorage(BoaTest):
             + Interop.StorageGet.storage_context_hash
             + Opcode.SYSCALL
             + Interop.StorageGet.interop_method_hash
+            + Opcode.DUP
+            + Opcode.ISNULL
+            + Opcode.JMPIFNOT
+            + Integer(7).to_byte_array(signed=True, min_length=1)
+            + Opcode.DROP
+            + Opcode.PUSHDATA1
+            + Integer(0).to_byte_array(signed=False, min_length=1)
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
             + Opcode.RET
         )
 
@@ -41,6 +50,15 @@ class TestStorage(BoaTest):
             + Interop.StorageGet.storage_context_hash
             + Opcode.SYSCALL
             + Interop.StorageGet.interop_method_hash
+            + Opcode.DUP
+            + Opcode.ISNULL
+            + Opcode.JMPIFNOT
+            + Integer(7).to_byte_array(signed=True, min_length=1)
+            + Opcode.DROP
+            + Opcode.PUSHDATA1
+            + Integer(0).to_byte_array(signed=False, min_length=1)
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
             + Opcode.RET
         )
 


### PR DESCRIPTION
The method was returning `None` when the key doesn't exist in the storage. Changed to return an empty `bytes`
```python
def main() -> bytes:
    key = 'unknown_key'
    return get(key)  # expected b''
```