### PR TITLE
Implement smart contract call Interop

### DIFF
--- a/boa3/analyser/optimizer/Operation.py
+++ b/boa3/analyser/optimizer/Operation.py
@@ -2,9 +2,8 @@ import ast
 from enum import Enum, auto
 from typing import Any, Union
 
-from boa3.model.operation.operator import Operator
-
 from boa3.model.operation.operation import IOperation
+from boa3.model.operation.operator import Operator
 
 
 class Operation(Enum):

--- a/boa3/builtin/interop/contract/__init__.py
+++ b/boa3/builtin/interop/contract/__init__.py
@@ -1,0 +1,22 @@
+from typing import Any, Sequence
+
+
+def call_contract(script_hash: bytes, method: str, args: Sequence = ()) -> Any:
+    """
+    Calls a smart contract given the method and the arguments
+
+    :param script_hash: the target smart contract's script hash
+    :param method: the name of the method to be executed
+    :param args: the specified method's arguments
+
+    :return: the result of the specified method.
+    :rtype: Any
+
+    :raise Exception: raised if the script hash is not a valid smart contract or the method was not found or the
+        arguments aren't valid to the specified method.
+    """
+    pass
+
+
+NEO: bytes = b'\xde\x5f\x57\xd4\x30\xd3\xde\xce\x51\x1c\xf9\x75\xa8\xd3\x78\x48\xcb\x9e\x05\x25'
+GAS: bytes = b'\x66\x8e\x0c\x1f\x9d\x7b\x70\xa9\x9d\xd9\xe0\x6e\xad\xd4\xc7\x84\xd6\x41\xaf\xbc'

--- a/boa3/model/builtin/interop/contract/callmethod.py
+++ b/boa3/model/builtin/interop/contract/callmethod.py
@@ -1,0 +1,21 @@
+import ast
+from typing import Dict
+
+from boa3.model.builtin.interop.interopmethod import InteropMethod
+from boa3.model.variable import Variable
+
+
+class CallMethod(InteropMethod):
+
+    def __init__(self):
+        from boa3.model.type.type import Type
+        identifier = 'call_contract'
+        syscall = 'System.Contract.Call'
+        args: Dict[str, Variable] = {
+            'script_hash': Variable(Type.bytes),
+            'method': Variable(Type.str),
+            'args': Variable(Type.sequence)  # TODO: change when *args is implemented
+        }
+        args_default = ast.parse("{0}".format(Type.sequence.default_value)
+                                 ).body[0].value
+        super().__init__(identifier, syscall, args, defaults=[args_default], return_type=Type.any)

--- a/boa3/model/builtin/interop/contract/getgasscripthashmethod.py
+++ b/boa3/model/builtin/interop/contract/getgasscripthashmethod.py
@@ -1,0 +1,40 @@
+from typing import Dict, List, Optional, Tuple
+
+from boa3.model.builtin.builtinproperty import IBuiltinProperty
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class GetGasScriptHashMethod(IBuiltinMethod):
+    def __init__(self):
+        from boa3.model.type.type import Type
+        identifier = '-get_gas'
+        args: Dict[str, Variable] = {}
+        super().__init__(identifier, args, return_type=Type.bytes)
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> Optional[str]:
+        return None
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        from boa3.model.type.type import Type
+        from boa3.neo.vm.type.Integer import Integer
+
+        value = b'\x66\x8e\x0c\x1f\x9d\x7b\x70\xa9\x9d\xd9\xe0\x6e\xad\xd4\xc7\x84\xd6\x41\xaf\xbc'
+        return [
+            (Opcode.PUSHDATA1, Integer(len(value)).to_byte_array() + value),
+            (Opcode.CONVERT, Type.bytes.stack_item)
+        ]
+
+
+class GasProperty(IBuiltinProperty):
+    def __init__(self):
+        identifier = 'GAS'
+        getter = GetGasScriptHashMethod()
+        super().__init__(identifier, getter)

--- a/boa3/model/builtin/interop/contract/getneoscripthashmethod.py
+++ b/boa3/model/builtin/interop/contract/getneoscripthashmethod.py
@@ -1,0 +1,40 @@
+from typing import Dict, List, Optional, Tuple
+
+from boa3.model.builtin.builtinproperty import IBuiltinProperty
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class GetNeoScriptHashMethod(IBuiltinMethod):
+    def __init__(self):
+        from boa3.model.type.type import Type
+        identifier = '-get_neo'
+        args: Dict[str, Variable] = {}
+        super().__init__(identifier, args, return_type=Type.bytes)
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> Optional[str]:
+        return None
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        from boa3.model.type.type import Type
+        from boa3.neo.vm.type.Integer import Integer
+
+        value = b'\xde\x5f\x57\xd4\x30\xd3\xde\xce\x51\x1c\xf9\x75\xa8\xd3\x78\x48\xcb\x9e\x05\x25'
+        return [
+            (Opcode.PUSHDATA1, Integer(len(value)).to_byte_array() + value),
+            (Opcode.CONVERT, Type.bytes.stack_item)
+        ]
+
+
+class NeoProperty(IBuiltinProperty):
+    def __init__(self):
+        identifier = 'NEO'
+        getter = GetNeoScriptHashMethod()
+        super().__init__(identifier, getter)

--- a/boa3/model/builtin/interop/interop.py
+++ b/boa3/model/builtin/interop/interop.py
@@ -1,6 +1,9 @@
 from enum import Enum
 from typing import Dict, List
 
+from boa3.model.builtin.interop.contract.callmethod import CallMethod
+from boa3.model.builtin.interop.contract.getgasscripthashmethod import GasProperty
+from boa3.model.builtin.interop.contract.getneoscripthashmethod import NeoProperty
 from boa3.model.builtin.interop.runtime.checkwitnessmethod import CheckWitnessMethod
 from boa3.model.builtin.interop.runtime.getcallingscripthashmethod import CallingScriptHashProperty
 from boa3.model.builtin.interop.runtime.logmethod import LogMethod
@@ -14,6 +17,7 @@ from boa3.model.identifiedsymbol import IdentifiedSymbol
 
 
 class InteropPackage(str, Enum):
+    Contract = 'contract'
     Runtime = 'runtime'
     Storage = 'storage'
 
@@ -30,6 +34,11 @@ class Interop:
             lst.extend(symbols)
         return lst
 
+    # Contract Interops
+    CallContract = CallMethod()
+    NeoScriptHash = NeoProperty()
+    GasScriptHash = GasProperty()
+
     # Runtime Interops
     CheckWitness = CheckWitnessMethod()
     Notify = NotifyMethod()
@@ -44,6 +53,10 @@ class Interop:
     StorageDelete = StorageDeleteMethod()
 
     _interop_symbols: Dict[InteropPackage, List[IdentifiedSymbol]] = {
+        InteropPackage.Contract: [CallContract,
+                                  NeoScriptHash,
+                                  GasScriptHash
+                                  ],
         InteropPackage.Runtime: [CheckWitness,
                                  Notify,
                                  Log,

--- a/boa3/model/builtin/method/rangemethod.py
+++ b/boa3/model/builtin/method/rangemethod.py
@@ -29,8 +29,7 @@ class RangeMethod(IBuiltinMethod):
         }
         start_default = ast.parse("{0}".format(Type.int.default_value)
                                   ).body[0].value
-        step_default = ast.parse("1".format(Type.int.default_value)
-                                 ).body[0].value
+        step_default = ast.parse("1").body[0].value
         super().__init__(identifier, args, defaults=[start_default, step_default], return_type=Type.range)
 
     @property

--- a/boa3_test/test_sc/interop_test/CallScriptHash.py
+++ b/boa3_test/test_sc/interop_test/CallScriptHash.py
@@ -1,0 +1,5 @@
+from boa3.builtin.interop.contract import call_contract
+
+
+def Main(scripthash: bytes, method: str, args: list):
+    call_contract(scripthash, method, args)

--- a/boa3_test/test_sc/interop_test/CallScriptHashTooFewArguments.py
+++ b/boa3_test/test_sc/interop_test/CallScriptHashTooFewArguments.py
@@ -1,0 +1,5 @@
+from boa3.builtin.interop.contract import call_contract
+
+
+def Main(scripthash: bytes):
+    call_contract(scripthash)

--- a/boa3_test/test_sc/interop_test/CallScriptHashTooManyArguments.py
+++ b/boa3_test/test_sc/interop_test/CallScriptHashTooManyArguments.py
@@ -1,0 +1,8 @@
+from typing import Any
+
+from boa3.builtin.interop.contract import call_contract
+
+
+def Main(scripthash: bytes, method: str, arg0: Any, arg1: Any):
+    call_contract(scripthash, method, arg0, arg1)
+

--- a/boa3_test/test_sc/interop_test/CallScriptHashWithoutArgs.py
+++ b/boa3_test/test_sc/interop_test/CallScriptHashWithoutArgs.py
@@ -1,0 +1,5 @@
+from boa3.builtin.interop.contract import call_contract
+
+
+def Main(scripthash: bytes, method: str):
+    call_contract(scripthash, method)

--- a/boa3_test/test_sc/interop_test/GasScriptHash.py
+++ b/boa3_test/test_sc/interop_test/GasScriptHash.py
@@ -1,0 +1,5 @@
+from boa3.builtin.interop.contract import GAS
+
+
+def Main() -> bytes:
+    return GAS

--- a/boa3_test/test_sc/interop_test/NeoScriptHash.py
+++ b/boa3_test/test_sc/interop_test/NeoScriptHash.py
@@ -1,0 +1,5 @@
+from boa3.builtin.interop.contract import NEO
+
+
+def Main() -> bytes:
+    return NEO

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from os import path
 from pkg_resources import parse_version
 # Always prefer setuptools over distutils
 # To use a consistent encoding
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 from boa3 import __version__ as version
 


### PR DESCRIPTION
Implemented the `Contrac.Call` interop. Now it's possible to call other smart contracts from the ones compiled with neo3-boa
```python
from typing import Any

from boa3.builtin.interop.contract import NEO, call_contract


sample_script_hash = b'0123456789abcdefghij'


def example() -> Any:
    result = call_contract(sample_script_hash, 'example', [1, 2])
    if result is None:
        return b''
    else:
        return result


def neo_balance(address: bytes) -> Any:
    if len(address) != 20:
        return None
    balance = call_contract(NEO, 'balanceOf', [address])
    if isinstance(balance, int):
        return balance
    else:
        return 0
```