### PR TITLE
Implement Runtime Time Interop

### DIFF
--- a/boa3/builtin/interop/runtime/__init__.py
+++ b/boa3/builtin/interop/runtime/__init__.py
@@ -65,3 +65,4 @@ def is_verification_trigger() -> bool:
 
 
 calling_script_hash: bytes = b''
+get_time: int = 0

--- a/boa3/model/builtin/interop/interop.py
+++ b/boa3/model/builtin/interop/interop.py
@@ -5,6 +5,7 @@ from boa3.model.builtin.interop.contract.callmethod import CallMethod
 from boa3.model.builtin.interop.contract.getgasscripthashmethod import GasProperty
 from boa3.model.builtin.interop.contract.getneoscripthashmethod import NeoProperty
 from boa3.model.builtin.interop.runtime.checkwitnessmethod import CheckWitnessMethod
+from boa3.model.builtin.interop.runtime.getblocktimemethod import BlockTimeProperty
 from boa3.model.builtin.interop.runtime.getcallingscripthashmethod import CallingScriptHashProperty
 from boa3.model.builtin.interop.runtime.logmethod import LogMethod
 from boa3.model.builtin.interop.runtime.notifymethod import NotifyMethod
@@ -46,6 +47,7 @@ class Interop:
     TriggerType = TriggerTyping()
     GetTrigger = TriggerMethod(TriggerType)
     CallingScriptHash = CallingScriptHashProperty()
+    BlockTime = BlockTimeProperty()
 
     # Storage Interops
     StorageGet = StorageGetMethod()
@@ -62,7 +64,8 @@ class Interop:
                                  Log,
                                  TriggerType,
                                  GetTrigger,
-                                 CallingScriptHash
+                                 CallingScriptHash,
+                                 BlockTime
                                  ],
         InteropPackage.Storage: [StorageGet,
                                  StoragePut,

--- a/boa3/model/builtin/interop/runtime/getblocktimemethod.py
+++ b/boa3/model/builtin/interop/runtime/getblocktimemethod.py
@@ -1,0 +1,22 @@
+from typing import Dict, List, Tuple
+
+from boa3.model.builtin.builtinproperty import IBuiltinProperty
+from boa3.model.builtin.interop.interopmethod import InteropMethod
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class GetBlockTimeMethod(InteropMethod):
+    def __init__(self):
+        from boa3.model.type.type import Type
+        identifier = '-get_time'
+        syscall = 'System.Runtime.GetTime'
+        args: Dict[str, Variable] = {}
+        super().__init__(identifier, syscall, args, return_type=Type.int)
+
+
+class BlockTimeProperty(IBuiltinProperty):
+    def __init__(self):
+        identifier = 'get_time'
+        getter = GetBlockTimeMethod()
+        super().__init__(identifier, getter)

--- a/boa3_test/test_sc/interop_test/BlockTime.py
+++ b/boa3_test/test_sc/interop_test/BlockTime.py
@@ -1,0 +1,5 @@
+from boa3.builtin.interop.runtime import get_time
+
+
+def Main() -> int:
+    return get_time

--- a/boa3_test/test_sc/interop_test/BlockTimeCantAssign.py
+++ b/boa3_test/test_sc/interop_test/BlockTimeCantAssign.py
@@ -1,0 +1,7 @@
+from boa3.builtin.interop.runtime import get_time
+
+
+def Main(example: int) -> int:
+    global get_time
+    get_time = example
+    return get_time

--- a/boa3_test/tests/test_interop.py
+++ b/boa3_test/tests/test_interop.py
@@ -2,6 +2,7 @@ from boa3.boa3 import Boa3
 from boa3.builtin.interop.contract import GAS, NEO
 from boa3.builtin.interop.runtime import TriggerType
 from boa3.exception.CompilerError import MismatchedTypes, UnexpectedArgument, UnfilledArgument
+from boa3.exception.CompilerWarning import NameShadowing
 from boa3.model.builtin.interop.interop import Interop
 from boa3.model.type.type import Type
 from boa3.neo.vm.opcode.Opcode import Opcode
@@ -303,4 +304,29 @@ class TestInterop(BoaTest):
 
         path = '%s/boa3_test/test_sc/interop_test/GasScriptHash.py' % self.dirname
         output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_get_block_time(self):
+        expected_output = (
+            Opcode.SYSCALL
+            + Interop.BlockTime.getter.interop_method_hash
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/test_sc/interop_test/BlockTime.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_block_time_cant_assign(self):
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x01\x01'
+            + Opcode.LDARG0
+            + Opcode.STLOC0
+            + Opcode.LDLOC0
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/test_sc/interop_test/BlockTimeCantAssign.py' % self.dirname
+        output = self.assertCompilerLogs(NameShadowing, path)
         self.assertEqual(expected_output, output)


### PR DESCRIPTION
Implemented `Runtime.GetTime` interop to get blockchain's last block timestamp.
```python
from boa3.builtin.interop.runtime import get_time


def example() -> int:
    return get_time

```