### PR TITLE
Implement Runtime GasLeft Interop

### DIFF
--- a/boa3/builtin/interop/runtime/__init__.py
+++ b/boa3/builtin/interop/runtime/__init__.py
@@ -66,3 +66,4 @@ def is_verification_trigger() -> bool:
 
 calling_script_hash: bytes = b''
 get_time: int = 0
+gas_left: int = 0

--- a/boa3/model/builtin/interop/interop.py
+++ b/boa3/model/builtin/interop/interop.py
@@ -8,6 +8,7 @@ from boa3.model.builtin.interop.contract.getneoscripthashmethod import NeoProper
 from boa3.model.builtin.interop.runtime.checkwitnessmethod import CheckWitnessMethod
 from boa3.model.builtin.interop.runtime.getblocktimemethod import BlockTimeProperty
 from boa3.model.builtin.interop.runtime.getcallingscripthashmethod import CallingScriptHashProperty
+from boa3.model.builtin.interop.runtime.getgasleftmethod import GasLeftProperty
 from boa3.model.builtin.interop.runtime.logmethod import LogMethod
 from boa3.model.builtin.interop.runtime.notifymethod import NotifyMethod
 from boa3.model.builtin.interop.runtime.triggermethod import TriggerMethod
@@ -53,6 +54,7 @@ class Interop:
     GetTrigger = TriggerMethod(TriggerType)
     CallingScriptHash = CallingScriptHashProperty()
     BlockTime = BlockTimeProperty()
+    GasLeft = GasLeftProperty()
 
     # Storage Interops
     StorageGet = StorageGetMethod()
@@ -72,7 +74,8 @@ class Interop:
                                  TriggerType,
                                  GetTrigger,
                                  CallingScriptHash,
-                                 BlockTime
+                                 BlockTime,
+                                 GasLeft
                                  ],
         InteropPackage.Storage: [StorageGet,
                                  StoragePut,

--- a/boa3/model/builtin/interop/runtime/getgasleftmethod.py
+++ b/boa3/model/builtin/interop/runtime/getgasleftmethod.py
@@ -1,0 +1,21 @@
+from typing import Dict
+
+from boa3.model.builtin.builtinproperty import IBuiltinProperty
+from boa3.model.builtin.interop.interopmethod import InteropMethod
+from boa3.model.variable import Variable
+
+
+class GetGasLeftMethod(InteropMethod):
+    def __init__(self):
+        from boa3.model.type.type import Type
+        identifier = '-get_gas_left'
+        syscall = 'System.Runtime.GasLeft'
+        args: Dict[str, Variable] = {}
+        super().__init__(identifier, syscall, args, return_type=Type.int)
+
+
+class GasLeftProperty(IBuiltinProperty):
+    def __init__(self):
+        identifier = 'gas_left'
+        getter = GetGasLeftMethod()
+        super().__init__(identifier, getter)

--- a/boa3_test/test_sc/interop_test/GasLeft.py
+++ b/boa3_test/test_sc/interop_test/GasLeft.py
@@ -1,0 +1,5 @@
+from boa3.builtin.interop.runtime import gas_left
+
+
+def Main() -> int:
+    return gas_left

--- a/boa3_test/test_sc/interop_test/GasLeftCantAssign.py
+++ b/boa3_test/test_sc/interop_test/GasLeftCantAssign.py
@@ -1,0 +1,6 @@
+from boa3.builtin.interop.runtime import gas_left
+
+
+def Main(example: int) -> int:
+    gas_left = example
+    return gas_left

--- a/boa3_test/tests/test_interop.py
+++ b/boa3_test/tests/test_interop.py
@@ -334,6 +334,20 @@ class TestInterop(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
+    def test_gas_native_script_hash_cant_assign(self):
+        expected_output = (
+                Opcode.INITSLOT
+                + b'\x01\x01'
+                + Opcode.LDARG0
+                + Opcode.STLOC0
+                + Opcode.LDLOC0
+                + Opcode.RET
+        )
+
+        path = '%s/boa3_test/test_sc/interop_test/GasScriptHashCantAssign.py' % self.dirname
+        output = self.assertCompilerLogs(NameShadowing, path)
+        self.assertEqual(expected_output, output)
+
     def test_get_block_time(self):
         expected_output = (
             Opcode.SYSCALL
@@ -356,20 +370,6 @@ class TestInterop(BoaTest):
         )
 
         path = '%s/boa3_test/test_sc/interop_test/BlockTimeCantAssign.py' % self.dirname
-        output = self.assertCompilerLogs(NameShadowing, path)
-        self.assertEqual(expected_output, output)
-
-    def test_gas_native_script_hash_cant_assign(self):
-        expected_output = (
-            Opcode.INITSLOT
-            + b'\x01\x01'
-            + Opcode.LDARG0
-            + Opcode.STLOC0
-            + Opcode.LDLOC0
-            + Opcode.RET
-        )
-
-        path = '%s/boa3_test/test_sc/interop_test/GasScriptHashCantAssign.py' % self.dirname
         output = self.assertCompilerLogs(NameShadowing, path)
         self.assertEqual(expected_output, output)
 
@@ -396,4 +396,29 @@ class TestInterop(BoaTest):
 
         path = '%s/boa3_test/test_sc/interop_test/CurrentHeightCantAssign.py' % self.dirname
         output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_get_gas_left(self):
+        expected_output = (
+            Opcode.SYSCALL
+            + Interop.GasLeft.getter.interop_method_hash
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/test_sc/interop_test/GasLeft.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_gas_left_cant_assign(self):
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x01\x01'
+            + Opcode.LDARG0
+            + Opcode.STLOC0
+            + Opcode.LDLOC0
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/test_sc/interop_test/GasLeftCantAssign.py' % self.dirname
+        output = self.assertCompilerLogs(NameShadowing, path)
         self.assertEqual(expected_output, output)


### PR DESCRIPTION
Implemented `Runtime.GasLeft` interop to get smart contracts' invoker remaining gas.
```python
from boa3.builtin.interop.runtime import gas_left


def has_gas() -> bool:
    return gas_left > 0

```