### PR TITLE
Implement Runtime InvocationCounter Interop

### DIFF
--- a/boa3/builtin/interop/runtime/__init__.py
+++ b/boa3/builtin/interop/runtime/__init__.py
@@ -67,3 +67,4 @@ def is_verification_trigger() -> bool:
 calling_script_hash: bytes = b''
 get_time: int = 0
 gas_left: int = 0
+invocation_counter: int = 0

--- a/boa3/model/builtin/interop/interop.py
+++ b/boa3/model/builtin/interop/interop.py
@@ -9,6 +9,7 @@ from boa3.model.builtin.interop.runtime.checkwitnessmethod import CheckWitnessMe
 from boa3.model.builtin.interop.runtime.getblocktimemethod import BlockTimeProperty
 from boa3.model.builtin.interop.runtime.getcallingscripthashmethod import CallingScriptHashProperty
 from boa3.model.builtin.interop.runtime.getgasleftmethod import GasLeftProperty
+from boa3.model.builtin.interop.runtime.getinvocationcountermethod import InvocationCounterProperty
 from boa3.model.builtin.interop.runtime.logmethod import LogMethod
 from boa3.model.builtin.interop.runtime.notifymethod import NotifyMethod
 from boa3.model.builtin.interop.runtime.triggermethod import TriggerMethod
@@ -55,6 +56,7 @@ class Interop:
     CallingScriptHash = CallingScriptHashProperty()
     BlockTime = BlockTimeProperty()
     GasLeft = GasLeftProperty()
+    InvocationCounter = InvocationCounterProperty()
 
     # Storage Interops
     StorageGet = StorageGetMethod()
@@ -75,7 +77,8 @@ class Interop:
                                  GetTrigger,
                                  CallingScriptHash,
                                  BlockTime,
-                                 GasLeft
+                                 GasLeft,
+                                 InvocationCounter
                                  ],
         InteropPackage.Storage: [StorageGet,
                                  StoragePut,

--- a/boa3/model/builtin/interop/runtime/getinvocationcountermethod.py
+++ b/boa3/model/builtin/interop/runtime/getinvocationcountermethod.py
@@ -1,0 +1,21 @@
+from typing import Dict
+
+from boa3.model.builtin.builtinproperty import IBuiltinProperty
+from boa3.model.builtin.interop.interopmethod import InteropMethod
+from boa3.model.variable import Variable
+
+
+class GetInvocationCounterMethod(InteropMethod):
+    def __init__(self):
+        from boa3.model.type.type import Type
+        identifier = '-get_invocation_counter'
+        syscall = 'System.Runtime.GetInvocationCounter'
+        args: Dict[str, Variable] = {}
+        super().__init__(identifier, syscall, args, return_type=Type.int)
+
+
+class InvocationCounterProperty(IBuiltinProperty):
+    def __init__(self):
+        identifier = 'invocation_counter'
+        getter = GetInvocationCounterMethod()
+        super().__init__(identifier, getter)

--- a/boa3_test/test_sc/interop_test/InvocationCounter.py
+++ b/boa3_test/test_sc/interop_test/InvocationCounter.py
@@ -1,0 +1,5 @@
+from boa3.builtin.interop.runtime import invocation_counter
+
+
+def Main() -> int:
+    return invocation_counter

--- a/boa3_test/test_sc/interop_test/InvocationCounterCantAssign.py
+++ b/boa3_test/test_sc/interop_test/InvocationCounterCantAssign.py
@@ -1,0 +1,6 @@
+from boa3.builtin.interop.runtime import invocation_counter
+
+
+def Main(example: int) -> int:
+    invocation_counter = example
+    return invocation_counter

--- a/boa3_test/tests/test_interop.py
+++ b/boa3_test/tests/test_interop.py
@@ -422,3 +422,28 @@ class TestInterop(BoaTest):
         path = '%s/boa3_test/test_sc/interop_test/GasLeftCantAssign.py' % self.dirname
         output = self.assertCompilerLogs(NameShadowing, path)
         self.assertEqual(expected_output, output)
+
+    def test_get_invocation_counter(self):
+        expected_output = (
+            Opcode.SYSCALL
+            + Interop.InvocationCounter.getter.interop_method_hash
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/test_sc/interop_test/InvocationCounter.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_gas_left_cant_assign(self):
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x01\x01'
+            + Opcode.LDARG0
+            + Opcode.STLOC0
+            + Opcode.LDLOC0
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/test_sc/interop_test/InvocationCounterCantAssign.py' % self.dirname
+        output = self.assertCompilerLogs(NameShadowing, path)
+        self.assertEqual(expected_output, output)


### PR DESCRIPTION
Implemented `Runtime.GetInvocationCounter` interop.
```python
from boa3.builtin.interop.runtime import invocation_counter


def example():
    invocations: int = invocation_counter

```