### PR TITLE
Boa-260 Include other smart contracts in the TestEngine (neo3-boa)

### DIFF
--- a/boa3_test/test_sc/interop_test/CallScriptHash.py
+++ b/boa3_test/test_sc/interop_test/CallScriptHash.py
@@ -1,5 +1,9 @@
+from typing import Any
+
+from boa3.builtin import public
 from boa3.builtin.interop.contract import call_contract
 
 
-def Main(scripthash: bytes, method: str, args: list):
-    call_contract(scripthash, method, args)
+@public
+def Main(scripthash: bytes, method: str, args: list) -> Any:
+    return call_contract(scripthash, method, args)

--- a/boa3_test/test_sc/interop_test/CallScriptHashWithoutArgs.py
+++ b/boa3_test/test_sc/interop_test/CallScriptHashWithoutArgs.py
@@ -1,5 +1,9 @@
+from typing import Any
+
+from boa3.builtin import public
 from boa3.builtin.interop.contract import call_contract
 
 
-def Main(scripthash: bytes, method: str):
-    call_contract(scripthash, method)
+@public
+def Main(scripthash: bytes, method: str) -> Any:
+    return call_contract(scripthash, method)

--- a/boa3_test/test_sc/list_test/IntList.py
+++ b/boa3_test/test_sc/list_test/IntList.py
@@ -1,2 +1,7 @@
-def Main():
+from boa3.builtin import public
+
+
+@public
+def Main() -> list:
     a = [1, 2, 3]
+    return a

--- a/boa3_test/tests/boa_test.py
+++ b/boa3_test/tests/boa_test.py
@@ -16,6 +16,7 @@ class BoaTest(TestCase):
     MAP_KEY_NOT_FOUND_ERROR_MSG = 'Key not found in Map'
     VALUE_IS_OUT_OF_RANGE_MSG = 'The value is out of range'
     STORAGE_VALUE_IS_OUT_OF_RANGE_MSG = 'Specified argument was out of the range of valid values.'
+    CALLED_CONTRACT_DOES_NOT_EXIST_MSG = 'Called Contract Does Not Exist'
 
     @classmethod
     def setUpClass(cls):
@@ -78,6 +79,28 @@ class BoaTest(TestCase):
             import json
             debug_info = json.loads(dbgnfo.read(os.path.basename(path.replace('.py', '.debug.json'))))
         return debug_info
+
+    def get_output(self, path: str) -> Tuple[bytes, Dict[str, Any]]:
+        nef_output = path.replace('.py', '.nef')
+        manifest_output = path.replace('.py', '.manifest.json')
+
+        from boa3.neo.contracts.neffile import NefFile
+
+        if not os.path.isfile(nef_output):
+            output = bytes()
+        else:
+            with open(nef_output, mode='rb') as nef:
+                file = nef.read()
+                output = NefFile.deserialize(file).script
+
+        if not os.path.isfile(manifest_output):
+            manifest = {}
+        else:
+            with open(manifest_output) as manifest_output:
+                import json
+                manifest = json.loads(manifest_output.read())
+
+        return output, manifest
 
     def run_smart_contract(self, test_engine: TestEngine, smart_contract_path: str, method: str,
                            *arguments: Any, reset_engine: bool = False,

--- a/boa3_test/tests/test_classes/testengine.py
+++ b/boa3_test/tests/test_classes/testengine.py
@@ -15,6 +15,7 @@ class TestEngine:
         self._result_stack: List[Any] = []
         self._storage: Dict[bytes, Any] = {}
         self._notifications: List[Notification] = []
+        self._contract_paths: List[str] = []
         self._error_message: Optional[str] = None
 
     @property
@@ -70,6 +71,14 @@ class TestEngine:
 
         if key in self._storage:
             self._storage.pop(key)
+
+    @property
+    def contracts(self) -> List[str]:
+        return self._contract_paths.copy()
+
+    def add_contract(self, contract_nef_path: str):
+        if contract_nef_path.endswith('.nef') and contract_nef_path not in self._contract_paths:
+            self._contract_paths.append(contract_nef_path)
 
     def run(self, nef_path: str, method: str, *arguments: Any, reset_engine: bool = False) -> Any:
         import json
@@ -165,5 +174,6 @@ class TestEngine:
             'arguments': [contract_parameter_to_json(x) for x in args],
             'storage': [{'key': contract_parameter_to_json(key),
                          'value': contract_parameter_to_json(value)
-                         } for key, value in self._storage.items()]
+                         } for key, value in self._storage.items()],
+            'contracts': [{'nef': contract_path} for contract_path in self._contract_paths]
         }

--- a/boa3_test/tests/test_file_generation.py
+++ b/boa3_test/tests/test_file_generation.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Dict, Tuple
+from typing import Dict
 
 from boa3 import constants
 from boa3.boa3 import Boa3
@@ -13,27 +13,6 @@ from boa3_test.tests.boa_test import BoaTest
 
 
 class TestFileGeneration(BoaTest):
-    def get_output(self, path: str) -> Tuple[bytes, Dict[str, Any]]:
-        nef_output = path.replace('.py', '.nef')
-        manifest_output = path.replace('.py', '.manifest.json')
-
-        from boa3.neo.contracts.neffile import NefFile
-
-        if not os.path.isfile(nef_output):
-            output = bytes()
-        else:
-            with open(nef_output, mode='rb') as nef:
-                file = nef.read()
-                output = NefFile.deserialize(file).script
-
-        if not os.path.isfile(manifest_output):
-            manifest = {}
-        else:
-            with open(manifest_output) as manifest_output:
-                import json
-                manifest = json.loads(manifest_output.read())
-
-        return output, manifest
 
     def test_generate_files(self):
         path = '%s/boa3_test/test_sc/generation_test/GenerationWithDecorator.py' % self.dirname

--- a/boa3_test/tests/test_list.py
+++ b/boa3_test/tests/test_list.py
@@ -24,8 +24,8 @@ class TestList(BoaTest):
             + Opcode.PUSH3      # array length
             + Opcode.PACK
             + Opcode.STLOC0
-            + Opcode.PUSHNULL
-            + Opcode.RET        # return
+            + Opcode.LDLOC0     # return a
+            + Opcode.RET
         )
 
         path = '%s/boa3_test/test_sc/list_test/IntList.py' % self.dirname


### PR DESCRIPTION
**Summary or solution description**
Implemented the option to include other smart contracts in the TestEngine to tests that require calling other contracts.

**How to Reproduce**
```
engine = TestEngine(self.dirname)
engine.add_contract(call_contract_path)

result = self.run_smart_contract(engine, path, 'Main', call_hash, 'method', args)
self.assertEqual(expected_output, result)
```

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/733e8a4495d0b439fcecf36bce02105ce4f2f1b4/boa3_test/tests/test_interop.py#L319-L337
https://github.com/CityOfZion/neo3-boa/blob/733e8a4495d0b439fcecf36bce02105ce4f2f1b4/boa3_test/tests/test_interop.py#L356-L370

