### PR TITLE
Boa-128 Implement bytes toScriptHash() with Neo opcodes

### DIFF
--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -111,7 +111,8 @@ class Builtin:
                                              NewEvent,
                                              Event,
                                              Metadata,
-                                             NeoMetadataType
+                                             NeoMetadataType,
+                                             ScriptHash
                                              ]
 
     metadata_fields: Dict[str, Union[type, Tuple[type]]] = \

--- a/boa3/model/builtin/method/toscripthashmethod.py
+++ b/boa3/model/builtin/method/toscripthashmethod.py
@@ -1,19 +1,24 @@
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Sized, Tuple
 
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.expression import IExpression
 from boa3.model.type.primitive.primitivetype import PrimitiveType
+from boa3.model.type.type import IType, Type
 from boa3.model.variable import Variable
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
 class ScriptHashMethod(IBuiltinMethod):
 
-    def __init__(self):
-        from boa3.model.type.type import Type
+    def __init__(self, data_type: IType = None):
+        if (not Type.int.is_type_of(data_type)
+                and not Type.str.is_type_of(data_type)
+                and not Type.bytes.is_type_of(data_type)):
+            data_type = Type.any
+
         identifier = 'to_script_hash'
-        args: Dict[str, Variable] = {'data_bytes': Variable(Type.any)}
-        super().__init__(identifier, args, Type.bytes)
+        args: Dict[str, Variable] = {'self': Variable(data_type)}
+        super().__init__(identifier, args, return_type=Type.bytes)
 
     def validate_parameters(self, *params: IExpression) -> bool:
         if len(params) != 1:
@@ -24,12 +29,44 @@ class ScriptHashMethod(IBuiltinMethod):
 
     @property
     def is_supported(self) -> bool:
-        # TODO: change when implement variable values conversion to script hash
-        return False
+        return self.args['self'].type is not Type.any
 
     @property
     def opcode(self) -> List[Tuple[Opcode, bytes]]:
-        return []
+        from boa3.constants import SIZE_OF_INT160
+        from boa3.model.builtin.interop.binary.base58decodemethod import Base58DecodeMethod
+        from boa3.model.type.type import Type
+        from boa3.neo.vm.type.Integer import Integer
+
+        opcodes = [
+            (Opcode.DUP, b''),      # convert value to string
+            (Opcode.SIZE, b''),
+            (Opcode.JMPIFNOT, Integer(36).to_byte_array(signed=True, min_length=1)),
+            (Opcode.DUP, b''),      # convert value to string
+            (Opcode.ISTYPE, Type.str.stack_item),
+            (Opcode.JMPIF, Integer(4).to_byte_array(min_length=1)),
+            (Opcode.CONVERT, Type.str.stack_item)
+        ]
+        opcodes.extend(Base58DecodeMethod().opcode)
+        script_len = Integer(SIZE_OF_INT160).to_byte_array(min_length=1)
+        opcodes.extend([
+            (Opcode.DUP, b''),      # if len(result) > SIZE_OF_INT160, truncates the result
+            (Opcode.SIZE, b''),
+            (Opcode.PUSHDATA1, Integer(len(script_len)).to_byte_array(min_length=1) + script_len),
+            (Opcode.CONVERT, Type.int.stack_item),
+            (Opcode.JMPGT, Integer(8).to_byte_array(min_length=1, signed=True)),
+            (Opcode.DUP, b''),
+            (Opcode.SIZE, b''),     # first byte identifies address version
+            (Opcode.DEC, b''),
+            (Opcode.RIGHT, b''),
+            (Opcode.JMP, Integer(9).to_byte_array(min_length=1, signed=True)),
+            (Opcode.PUSH1, b''),
+            (Opcode.PUSHDATA1, Integer(len(script_len)).to_byte_array(min_length=1) + script_len),
+            (Opcode.CONVERT, Type.int.stack_item),
+            (Opcode.SUBSTR, b''),
+            (Opcode.CONVERT, Type.bytes.stack_item)
+        ])
+        return opcodes
 
     @property
     def _args_on_stack(self) -> int:
@@ -38,3 +75,20 @@ class ScriptHashMethod(IBuiltinMethod):
     @property
     def _body(self) -> Optional[str]:
         return None
+
+    def build(self, value: Any):
+        if 'self' in self.args and self.args['self'].type is not Type.any:
+            return self
+
+        from boa3.model.type.primitive.inttype import IntType
+        from boa3.model.type.primitive.strtype import StrType
+        from boa3.model.type.primitive.bytestype import BytesType
+
+        if isinstance(value, Sized) and len(value) == 1:
+            value = value[0]
+
+        if isinstance(value, (IntType, StrType, BytesType)):
+            return ScriptHashMethod(value)
+        elif isinstance(value, IType):
+            return ScriptHashMethod(Type.bytes)
+        return super().build(value)

--- a/boa3_test/test_sc/built_in_methods_test/ScriptHashVariable.py
+++ b/boa3_test/test_sc/built_in_methods_test/ScriptHashVariable.py
@@ -1,3 +1,3 @@
 def Main() -> bytes:
     a = 123
-    return a.to_script_hash()  # only works with literals
+    return a.to_script_hash()

--- a/boa3_test/test_sc/built_in_methods_test/ScriptHashVariableBuiltinCall.py
+++ b/boa3_test/test_sc/built_in_methods_test/ScriptHashVariableBuiltinCall.py
@@ -1,3 +1,3 @@
 def Main() -> bytes:
     a = '123'
-    return str.to_script_hash(a)  # only works with literals
+    return str.to_script_hash(a)

--- a/boa3_test/tests/test_builtin_method.py
+++ b/boa3_test/tests/test_builtin_method.py
@@ -585,12 +585,123 @@ class TestBuiltinMethod(BoaTest):
         self.assertEqual(script_hash, result)
 
     def test_script_hash_variable(self):
+        script_hash = Integer(123).to_byte_array()
+        twenty = Integer(20).to_byte_array()
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x01\x00'
+            + Opcode.PUSHDATA1      # a = 123
+            + Integer(len(script_hash)).to_byte_array(min_length=1)
+            + script_hash
+            + Opcode.CONVERT
+            + Type.int.stack_item
+            + Opcode.STLOC0
+            + Opcode.PUSHDATA1      # a.to_script_hash()
+            + Integer(len(script_hash)).to_byte_array(min_length=1)
+            + script_hash
+            + Opcode.CONVERT
+            + Type.int.stack_item
+            + Opcode.DUP
+            + Opcode.SIZE
+            + Opcode.JMPIFNOT
+            + Integer(36).to_byte_array(min_length=1)
+            + Opcode.DUP
+            + Opcode.ISTYPE
+            + Type.str.stack_item
+            + Opcode.JMPIF
+            + Integer(4).to_byte_array(min_length=1)
+            + Opcode.CONVERT
+            + Type.str.stack_item
+            + Opcode.SYSCALL
+            + Interop.Base58Decode.interop_method_hash
+            + Opcode.DUP
+            + Opcode.SIZE
+            + Opcode.PUSHDATA1
+            + Integer(len(twenty)).to_byte_array(min_length=1)
+            + twenty
+            + Opcode.CONVERT
+            + Type.int.stack_item
+            + Opcode.JMPGT
+            + Integer(8).to_byte_array(min_length=1)
+            + Opcode.DUP
+            + Opcode.SIZE
+            + Opcode.DEC
+            + Opcode.RIGHT
+            + Opcode.JMP
+            + Integer(9).to_byte_array(min_length=1)
+            + Opcode.PUSH1
+            + Opcode.PUSHDATA1
+            + Integer(len(twenty)).to_byte_array(min_length=1)
+            + twenty
+            + Opcode.CONVERT
+            + Type.int.stack_item
+            + Opcode.SUBSTR
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.RET
+        )
+
         path = '%s/boa3_test/test_sc/built_in_methods_test/ScriptHashVariable.py' % self.dirname
-        self.assertCompilerLogs(NotSupportedOperation, path)
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
 
     def test_script_hash_variable_with_builtin(self):
+        script_hash = String('123').to_bytes()
+        twenty = Integer(20).to_byte_array()
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x01\x00'
+            + Opcode.PUSHDATA1      # a = 123
+            + Integer(len(script_hash)).to_byte_array(min_length=1)
+            + script_hash
+            + Opcode.STLOC0
+            + Opcode.PUSHDATA1      # a.to_script_hash()
+            + Integer(len(script_hash)).to_byte_array(min_length=1)
+            + script_hash
+            + Opcode.DUP
+            + Opcode.SIZE
+            + Opcode.JMPIFNOT
+            + Integer(36).to_byte_array(min_length=1)
+            + Opcode.DUP
+            + Opcode.ISTYPE
+            + Type.str.stack_item
+            + Opcode.JMPIF
+            + Integer(4).to_byte_array(min_length=1)
+            + Opcode.CONVERT
+            + Type.str.stack_item
+            + Opcode.SYSCALL
+            + Interop.Base58Decode.interop_method_hash
+            + Opcode.DUP
+            + Opcode.SIZE
+            + Opcode.PUSHDATA1
+            + Integer(len(twenty)).to_byte_array(min_length=1)
+            + twenty
+            + Opcode.CONVERT
+            + Type.int.stack_item
+            + Opcode.JMPGT
+            + Integer(8).to_byte_array(min_length=1)
+            + Opcode.DUP
+            + Opcode.SIZE
+            + Opcode.DEC
+            + Opcode.RIGHT
+            + Opcode.JMP
+            + Integer(9).to_byte_array(min_length=1)
+            + Opcode.PUSH1
+            + Opcode.PUSHDATA1
+            + Integer(len(twenty)).to_byte_array(min_length=1)
+            + twenty
+            + Opcode.CONVERT
+            + Type.int.stack_item
+            + Opcode.SUBSTR
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.RET
+        )
+
         path = '%s/boa3_test/test_sc/built_in_methods_test/ScriptHashVariableBuiltinCall.py' % self.dirname
-        self.assertCompilerLogs(NotSupportedOperation, path)
+        output = Boa3.compile(path)
+        from boa3.compiler.vmcodemapping import VMCodeMapping
+        self.assertEqual(expected_output, output)
 
     def test_script_hahs_too_many_parameters(self):
         path = '%s/boa3_test/test_sc/built_in_methods_test/ScriptHashTooManyParameters.py' % self.dirname
@@ -602,13 +713,11 @@ class TestBuiltinMethod(BoaTest):
 
     def test_script_hash_mismatched_types(self):
         path = '%s/boa3_test/test_sc/built_in_methods_test/ScriptHashMismatchedType.py' % self.dirname
-        # TODO: change to MismatchedTypes when 'to_script_hash' with variables is implemented
-        self.assertCompilerLogs(NotSupportedOperation, path)
+        self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_script_hash_builtin_mismatched_types(self):
         path = '%s/boa3_test/test_sc/built_in_methods_test/ScriptHashBuiltinMismatchedType.py' % self.dirname
-        # TODO: change to MismatchedTypes when 'to_script_hash' with variables is implemented
-        self.assertCompilerLogs(NotSupportedOperation, path)
+        self.assertCompilerLogs(MismatchedTypes, path)
 
     # endregion
 


### PR DESCRIPTION
**Summary or solution description**
Change the to_script_hash implementation to allow it to be used inside functions and with variables

**How to Reproduce**
```
from boa3.builtin import to_script_hash


def foo():
    address1: bytes = 'NPHivMjKsez5Z8opCkTUr5r8Uqk9uW6sif'.to_scrip_hash()
    address2: bytes = str.to_script_hash('Nd7eAuHsKvvzHzSPyuJQALcYCcUrcwvm5W')
```

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/4a73b056f1879cac6834c4743220899c457d874c/boa3_test/tests/test_builtin_method.py#L587-L704
