### PR TITLE
Boa-223 Implement Base64 Interop

### DIFF
--- a/boa3/builtin/interop/binary/__init__.py
+++ b/boa3/builtin/interop/binary/__init__.py
@@ -20,3 +20,27 @@ def base58_decode(key: bytes) -> str:
     :rtype: str
     """
     pass
+
+
+def base64_encode(key: bytes) -> str:
+    """
+    Encodes a string value using base64
+
+    :param key: bytes value to be encoded
+    :type key: bytes
+    :return: the encoded bytes as string.
+    :rtype: str
+    """
+    pass
+
+
+def base64_decode(key: str) -> bytes:
+    """
+    Decodes a bytes value encoded with base64
+
+    :param key: string value to be decoded
+    :type key: string
+    :return: the decoded string as bytes.
+    :rtype: bytes
+    """
+    pass

--- a/boa3/model/builtin/interop/binary/base64decodemethod.py
+++ b/boa3/model/builtin/interop/binary/base64decodemethod.py
@@ -1,0 +1,14 @@
+from typing import Dict
+
+from boa3.model.builtin.interop.interopmethod import InteropMethod
+from boa3.model.variable import Variable
+
+
+class Base64DecodeMethod(InteropMethod):
+
+    def __init__(self):
+        from boa3.model.type.type import Type
+        identifier = 'base64_decode'
+        syscall = 'System.Binary.Base64Decode'
+        args: Dict[str, Variable] = {'key': Variable(Type.str)}
+        super().__init__(identifier, syscall, args, return_type=Type.bytes)

--- a/boa3/model/builtin/interop/binary/base64encodemethod.py
+++ b/boa3/model/builtin/interop/binary/base64encodemethod.py
@@ -1,0 +1,14 @@
+from typing import Dict
+
+from boa3.model.builtin.interop.interopmethod import InteropMethod
+from boa3.model.variable import Variable
+
+
+class Base64EncodeMethod(InteropMethod):
+
+    def __init__(self):
+        from boa3.model.type.type import Type
+        identifier = 'base64_encode'
+        syscall = 'System.Binary.Base64Encode'
+        args: Dict[str, Variable] = {'key': Variable(Type.bytes)}
+        super().__init__(identifier, syscall, args, return_type=Type.str)

--- a/boa3/model/builtin/interop/interop.py
+++ b/boa3/model/builtin/interop/interop.py
@@ -3,6 +3,8 @@ from typing import Dict, List
 
 from boa3.model.builtin.interop.binary.base58decodemethod import Base58DecodeMethod
 from boa3.model.builtin.interop.binary.base58encodemethod import Base58EncodeMethod
+from boa3.model.builtin.interop.binary.base64decodemethod import Base64DecodeMethod
+from boa3.model.builtin.interop.binary.base64encodemethod import Base64EncodeMethod
 from boa3.model.builtin.interop.blockchain.getcurrentheightmethod import CurrentHeightProperty
 from boa3.model.builtin.interop.contract.callmethod import CallMethod
 from boa3.model.builtin.interop.contract.getgasscripthashmethod import GasProperty
@@ -54,6 +56,8 @@ class Interop:
     # Binary Interops
     Base58Encode = Base58EncodeMethod()
     Base58Decode = Base58DecodeMethod()
+    Base64Encode = Base64EncodeMethod()
+    Base64Decode = Base64DecodeMethod()
 
     # Blockchain Interops
     CurrentHeight = CurrentHeightProperty()
@@ -91,7 +95,9 @@ class Interop:
 
     _interop_symbols: Dict[InteropPackage, List[IdentifiedSymbol]] = {
         InteropPackage.Binary: [Base58Encode,
-                                Base58Decode
+                                Base58Decode,
+                                Base64Encode,
+                                Base64Decode
                                 ],
         InteropPackage.Blockchain: [CurrentHeight
                                     ],

--- a/boa3_test/test_sc/interop_test/Base64Decode.py
+++ b/boa3_test/test_sc/interop_test/Base64Decode.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.interop.binary import base64_decode
+
+
+@public
+def Main(key: str) -> bytes:
+    return base64_decode(key)

--- a/boa3_test/test_sc/interop_test/Base64DecodeMismatchedType.py
+++ b/boa3_test/test_sc/interop_test/Base64DecodeMismatchedType.py
@@ -1,0 +1,5 @@
+from boa3.builtin.interop.binary import base64_decode
+
+
+def Main(key: int) -> str:
+    return base64_decode(key)

--- a/boa3_test/test_sc/interop_test/Base64Encode.py
+++ b/boa3_test/test_sc/interop_test/Base64Encode.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.interop.binary import base64_encode
+
+
+@public
+def Main(key: bytes) -> str:
+    return base64_encode(key)

--- a/boa3_test/test_sc/interop_test/Base64EncodeMismatchedType.py
+++ b/boa3_test/test_sc/interop_test/Base64EncodeMismatchedType.py
@@ -1,0 +1,5 @@
+from boa3.builtin.interop.binary import base64_encode
+
+
+def Main(key: int) -> bytes:
+    return base64_encode(key)

--- a/boa3_test/tests/test_interop.py
+++ b/boa3_test/tests/test_interop.py
@@ -636,15 +636,15 @@ class TestInterop(BoaTest):
         import base64
         engine = TestEngine(self.dirname)
         expected_result = base64.b64encode(b'unit test')
-        if isinstance(expected_result, bytes):
-            expected_result = String.from_bytes(expected_result)
         result = self.run_smart_contract(engine, path, 'Main', b'unit test')
+        if isinstance(result, str):
+            result = String(result).to_bytes()
         self.assertEqual(expected_result, result)
 
         expected_result = base64.b64encode(b'')
-        if isinstance(expected_result, bytes):
-            expected_result = String.from_bytes(expected_result)
         result = self.run_smart_contract(engine, path, 'Main', b'')
+        if isinstance(result, str):
+            result = String(result).to_bytes()
         self.assertEqual(expected_result, result)
         
         long_byte_string = (b'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam accumsan magna eu massa '
@@ -656,9 +656,9 @@ class TestInterop(BoaTest):
                        b'dolor sit amet, consectetur adipiscing elit. Ut tincidunt, nisi in ullamcorper ornare, '
                        b'est enim dictum massa, id aliquet justo magna in purus.')
         expected_result = base64.b64encode(long_byte_string)
-        if isinstance(expected_result, bytes):
-            expected_result = String.from_bytes(expected_result)
         result = self.run_smart_contract(engine, path, 'Main', long_byte_string)
+        if isinstance(result, str):
+            result = String(result).to_bytes()
         self.assertEqual(expected_result, result)
 
     def test_base64_encode_mismatched_type(self):
@@ -681,16 +681,16 @@ class TestInterop(BoaTest):
 
         import base64
         engine = TestEngine(self.dirname)
-        arg = base64.b64encode(b'unit test')
-        if isinstance(arg, bytes):
-            arg = String.from_bytes(arg)
+        arg = String.from_bytes(base64.b64encode(b'unit test'))
         result = self.run_smart_contract(engine, path, 'Main', arg)
+        if isinstance(result, bytes):
+            result = String.from_bytes(result)
         self.assertEqual('unit test', result)
 
-        arg = base64.b64encode(b'')
-        if isinstance(arg, bytes):
-            arg = String.from_bytes(arg)
+        arg = String.from_bytes(base64.b64encode(b''))
         result = self.run_smart_contract(engine, path, 'Main', arg)
+        if isinstance(result, bytes):
+            result = String.from_bytes(result)
         self.assertEqual('', result)
 
         long_string = ('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam accumsan magna eu massa '
@@ -701,10 +701,10 @@ class TestInterop(BoaTest):
                        'Maecenas aliquam velit sit amet nisi ultricies, ac sollicitudin nisi mollis. Lorem ipsum '
                        'dolor sit amet, consectetur adipiscing elit. Ut tincidunt, nisi in ullamcorper ornare, '
                        'est enim dictum massa, id aliquet justo magna in purus.')
-        arg = base64.b64encode(String(long_string).to_bytes())
-        if isinstance(arg, bytes):
-            arg = String.from_bytes(arg)
+        arg = String.from_bytes(base64.b64encode(String(long_string).to_bytes()))
         result = self.run_smart_contract(engine, path, 'Main', arg)
+        if isinstance(result, bytes):
+            result = String.from_bytes(result)
         self.assertEqual(long_string, result)
 
     def test_base64_decode_mismatched_type(self):

--- a/boa3_test/tests/test_interop.py
+++ b/boa3_test/tests/test_interop.py
@@ -683,15 +683,15 @@ class TestInterop(BoaTest):
         engine = TestEngine(self.dirname)
         arg = String.from_bytes(base64.b64encode(b'unit test'))
         result = self.run_smart_contract(engine, path, 'Main', arg)
-        if isinstance(result, bytes):
-            result = String.from_bytes(result)
-        self.assertEqual('unit test', result)
+        if isinstance(result, str):
+            result = String(result).to_bytes()
+        self.assertEqual(b'unit test', result)
 
         arg = String.from_bytes(base64.b64encode(b''))
         result = self.run_smart_contract(engine, path, 'Main', arg)
-        if isinstance(result, bytes):
-            result = String.from_bytes(result)
-        self.assertEqual('', result)
+        if isinstance(result, str):
+            result = String(result).to_bytes()
+        self.assertEqual(b'', result)
 
         long_string = ('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam accumsan magna eu massa '
                        'vulputate bibendum. Aliquam commodo euismod tristique. Sed purus erat, pretium ut interdum '
@@ -703,9 +703,9 @@ class TestInterop(BoaTest):
                        'est enim dictum massa, id aliquet justo magna in purus.')
         arg = String.from_bytes(base64.b64encode(String(long_string).to_bytes()))
         result = self.run_smart_contract(engine, path, 'Main', arg)
-        if isinstance(result, bytes):
-            result = String.from_bytes(result)
-        self.assertEqual(long_string, result)
+        if isinstance(result, str):
+            result = String(result).to_bytes()
+        self.assertEqual(String(long_string).to_bytes(), result)
 
     def test_base64_decode_mismatched_type(self):
         path = '%s/boa3_test/test_sc/interop_test/Base64DecodeMismatchedType.py' % self.dirname

--- a/boa3_test/tests/test_interop.py
+++ b/boa3_test/tests/test_interop.py
@@ -619,6 +619,98 @@ class TestInterop(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
+    def test_base64_encode(self):
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x00\x01'
+            + Opcode.LDARG0
+            + Opcode.SYSCALL
+            + Interop.Base64Encode.interop_method_hash
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/test_sc/interop_test/Base64Encode.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+        import base64
+        engine = TestEngine(self.dirname)
+        expected_result = base64.b64encode(b'unit test')
+        if isinstance(expected_result, bytes):
+            expected_result = String.from_bytes(expected_result)
+        result = self.run_smart_contract(engine, path, 'Main', b'unit test')
+        self.assertEqual(expected_result, result)
+
+        expected_result = base64.b64encode(b'')
+        if isinstance(expected_result, bytes):
+            expected_result = String.from_bytes(expected_result)
+        result = self.run_smart_contract(engine, path, 'Main', b'')
+        self.assertEqual(expected_result, result)
+        
+        long_byte_string = (b'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam accumsan magna eu massa '
+                       b'vulputate bibendum. Aliquam commodo euismod tristique. Sed purus erat, pretium ut interdum '
+                       b'et, aliquet sed mauris. Curabitur vitae turpis euismod, hendrerit mi a, rhoncus justo. Mauris '
+                       b'sollicitudin, nisl sit amet feugiat pharetra, odio ligula congue tellus, vel pellentesque '
+                       b'libero leo id dui. Morbi vel risus vehicula, consectetur mauris eget, gravida ligula. '
+                       b'Maecenas aliquam velit sit amet nisi ultricies, ac sollicitudin nisi mollis. Lorem ipsum '
+                       b'dolor sit amet, consectetur adipiscing elit. Ut tincidunt, nisi in ullamcorper ornare, '
+                       b'est enim dictum massa, id aliquet justo magna in purus.')
+        expected_result = base64.b64encode(long_byte_string)
+        if isinstance(expected_result, bytes):
+            expected_result = String.from_bytes(expected_result)
+        result = self.run_smart_contract(engine, path, 'Main', long_byte_string)
+        self.assertEqual(expected_result, result)
+
+    def test_base64_encode_mismatched_type(self):
+        path = '%s/boa3_test/test_sc/interop_test/Base64EncodeMismatchedType.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_base64_decode(self):
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x00\x01'
+            + Opcode.LDARG0
+            + Opcode.SYSCALL
+            + Interop.Base64Decode.interop_method_hash
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/test_sc/interop_test/Base64Decode.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+        import base64
+        engine = TestEngine(self.dirname)
+        arg = base64.b64encode(b'unit test')
+        if isinstance(arg, bytes):
+            arg = String.from_bytes(arg)
+        result = self.run_smart_contract(engine, path, 'Main', arg)
+        self.assertEqual('unit test', result)
+
+        arg = base64.b64encode(b'')
+        if isinstance(arg, bytes):
+            arg = String.from_bytes(arg)
+        result = self.run_smart_contract(engine, path, 'Main', arg)
+        self.assertEqual('', result)
+
+        long_string = ('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam accumsan magna eu massa '
+                       'vulputate bibendum. Aliquam commodo euismod tristique. Sed purus erat, pretium ut interdum '
+                       'et, aliquet sed mauris. Curabitur vitae turpis euismod, hendrerit mi a, rhoncus justo. Mauris '
+                       'sollicitudin, nisl sit amet feugiat pharetra, odio ligula congue tellus, vel pellentesque '
+                       'libero leo id dui. Morbi vel risus vehicula, consectetur mauris eget, gravida ligula. '
+                       'Maecenas aliquam velit sit amet nisi ultricies, ac sollicitudin nisi mollis. Lorem ipsum '
+                       'dolor sit amet, consectetur adipiscing elit. Ut tincidunt, nisi in ullamcorper ornare, '
+                       'est enim dictum massa, id aliquet justo magna in purus.')
+        arg = base64.b64encode(String(long_string).to_bytes())
+        if isinstance(arg, bytes):
+            arg = String.from_bytes(arg)
+        result = self.run_smart_contract(engine, path, 'Main', arg)
+        self.assertEqual(long_string, result)
+
+    def test_base64_decode_mismatched_type(self):
+        path = '%s/boa3_test/test_sc/interop_test/Base64DecodeMismatchedType.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)
+
     def test_base58_encode(self):
         expected_output = (
             Opcode.INITSLOT


### PR DESCRIPTION
**Related issue**
#114

**Summary or solution description**
Implemented Base64 Interop

**How to Reproduce**
Step to reproduce the behaviour:
Call either base64_encode() or base64_decode()

**Tests**
It was tested using the test engine

**Platform:**
 - OS: Windows 10 x64
 - Version: neo3-boa v0.5
 - Python version: Python 3.7.9