### PR TITLE
Boa-83 Implement Verify Interop

### DIFF
--- a/boa3/builtin/interop/crypto/__init__.py
+++ b/boa3/builtin/interop/crypto/__init__.py
@@ -23,3 +23,35 @@ def check_multisig_with_ecdsa_secp256r1(item: Any, pubkeys: List[bytes], signatu
 
 def check_multisig_with_ecdsa_secp256k1(item: Any, pubkeys: List[bytes], signatures: List[bytes]) -> bool:
     pass
+
+
+def verify_with_ecdsa_secp256r1(item: Any, pubkey: bytes, signature: bytes) -> bool:
+    """
+    Using the elliptic curve secp256r1, it checks if the signature of the any item was originally produced by the public key.
+
+    :param item: the encrypted message
+    :type item: Any
+    :param pubkey: the public key that might have created the item
+    :type pubkey: bytes
+    :param signature: the signature of the item
+    :type signature: bytes
+    :return:: a boolean value that represents whether the signature is valid
+    :rtype: bool
+    """
+    pass
+
+
+def verify_with_ecdsa_secp256k1(item: Any, pubkey: bytes, signature: bytes) -> bool:
+    """
+    Using the elliptic curve secp256k1, it checks if the signature of the any item was originally produced by the public key.
+
+    :param item: the encrypted message
+    :type item: Any
+    :param pubkey: the public key that might have created the item
+    :type pubkey: bytes
+    :param signature: the signature of the item
+    :type signature: bytes
+    :return:: a boolean value that represents whether the signature is valid
+    :rtype: bool
+    """
+    pass

--- a/boa3/model/builtin/interop/crypto/verifywithecdsasecp256k1.py
+++ b/boa3/model/builtin/interop/crypto/verifywithecdsasecp256k1.py
@@ -1,0 +1,18 @@
+from typing import Dict
+
+from boa3.model.builtin.interop.interopmethod import InteropMethod
+from boa3.model.variable import Variable
+
+
+class VerifyWithECDsaSecp256k1Method(InteropMethod):
+
+    def __init__(self):
+        from boa3.model.type.type import Type
+        identifier = 'verify_with_ecdsa_secp256k1'
+        syscall = 'Neo.Crypto.VerifyWithECDsaSecp256k1'
+        args: Dict[str, Variable] = {
+            'item': Variable(Type.any),
+            'pubkey': Variable(Type.bytes),
+            'signature': Variable(Type.bytes)
+        }
+        super().__init__(identifier, syscall, args, return_type=Type.bool)

--- a/boa3/model/builtin/interop/crypto/verifywithecdsasecp256r1.py
+++ b/boa3/model/builtin/interop/crypto/verifywithecdsasecp256r1.py
@@ -1,0 +1,18 @@
+from typing import Dict
+
+from boa3.model.builtin.interop.interopmethod import InteropMethod
+from boa3.model.variable import Variable
+
+
+class VerifyWithECDsaSecp256r1Method(InteropMethod):
+
+    def __init__(self):
+        from boa3.model.type.type import Type
+        identifier = 'verify_with_ecdsa_secp256r1'
+        syscall = 'Neo.Crypto.VerifyWithECDsaSecp256r1'
+        args: Dict[str, Variable] = {
+            'item': Variable(Type.any),
+            'pubkey': Variable(Type.bytes),
+            'signature': Variable(Type.bytes)
+        }
+        super().__init__(identifier, syscall, args, return_type=Type.bool)

--- a/boa3/model/builtin/interop/interop.py
+++ b/boa3/model/builtin/interop/interop.py
@@ -25,6 +25,8 @@ from boa3.model.builtin.interop.crypto.hash160method import Hash160Method
 from boa3.model.builtin.interop.crypto.hash256method import Hash256Method
 from boa3.model.builtin.interop.crypto.checkmultisigwithecdsasecp256r1method import CheckMultisigWithECDsaSecp256r1Method
 from boa3.model.builtin.interop.crypto.checkmultisigwithecdsasecp256k1method import CheckMultisigWithECDsaSecp256k1Method
+from boa3.model.builtin.interop.crypto.verifywithecdsasecp256r1 import VerifyWithECDsaSecp256r1Method
+from boa3.model.builtin.interop.crypto.verifywithecdsasecp256k1 import VerifyWithECDsaSecp256k1Method
 from boa3.model.identifiedsymbol import IdentifiedSymbol
 
 
@@ -84,6 +86,8 @@ class Interop:
     Hash256 = Hash256Method()
     CheckMultisigWithECDsaSecp256r1 = CheckMultisigWithECDsaSecp256r1Method()
     CheckMultisigWithECDsaSecp256k1 = CheckMultisigWithECDsaSecp256k1Method()
+    VerifyWithECDsaSecp256r1 = VerifyWithECDsaSecp256r1Method()
+    VerifyWithECDsaSecp256k1 = VerifyWithECDsaSecp256k1Method()
 
     _interop_symbols: Dict[InteropPackage, List[IdentifiedSymbol]] = {
         InteropPackage.Binary: [Base58Encode,
@@ -100,7 +104,9 @@ class Interop:
                                 Hash160,
                                 Hash256,
                                 CheckMultisigWithECDsaSecp256r1,
-                                CheckMultisigWithECDsaSecp256k1
+                                CheckMultisigWithECDsaSecp256k1,
+                                VerifyWithECDsaSecp256r1,
+                                VerifyWithECDsaSecp256k1
                                 ],
         InteropPackage.Runtime: [CheckWitness,
                                  Notify,

--- a/boa3_test/test_sc/interop_test/VerifyWithECDsaSecp256k1Bool.py
+++ b/boa3_test/test_sc/interop_test/VerifyWithECDsaSecp256k1Bool.py
@@ -1,0 +1,5 @@
+from boa3.builtin.interop.crypto import verify_with_ecdsa_secp256k1
+
+
+def Main():
+    verify_with_ecdsa_secp256k1(False, b'publickey', b'signature')

--- a/boa3_test/test_sc/interop_test/VerifyWithECDsaSecp256k1Bytes.py
+++ b/boa3_test/test_sc/interop_test/VerifyWithECDsaSecp256k1Bytes.py
@@ -1,0 +1,5 @@
+from boa3.builtin.interop.crypto import verify_with_ecdsa_secp256k1
+
+
+def Main():
+    verify_with_ecdsa_secp256k1(b'unit test', b'publickey', b'signature')

--- a/boa3_test/test_sc/interop_test/VerifyWithECDsaSecp256k1Int.py
+++ b/boa3_test/test_sc/interop_test/VerifyWithECDsaSecp256k1Int.py
@@ -1,0 +1,5 @@
+from boa3.builtin.interop.crypto import verify_with_ecdsa_secp256k1
+
+
+def Main():
+    verify_with_ecdsa_secp256k1(10, b'publickey', b'signature')

--- a/boa3_test/test_sc/interop_test/VerifyWithECDsaSecp256k1MismatchedType.py
+++ b/boa3_test/test_sc/interop_test/VerifyWithECDsaSecp256k1MismatchedType.py
@@ -1,0 +1,5 @@
+from boa3.builtin.interop.crypto import verify_with_ecdsa_secp256k1
+
+
+def Main():
+    verify_with_ecdsa_secp256k1('unit test', 10, b'signature')

--- a/boa3_test/test_sc/interop_test/VerifyWithECDsaSecp256k1Str.py
+++ b/boa3_test/test_sc/interop_test/VerifyWithECDsaSecp256k1Str.py
@@ -1,0 +1,5 @@
+from boa3.builtin.interop.crypto import verify_with_ecdsa_secp256k1
+
+
+def Main():
+    verify_with_ecdsa_secp256k1('unit test', b'publickey', b'signature')

--- a/boa3_test/test_sc/interop_test/VerifyWithECDsaSecp256r1Bool.py
+++ b/boa3_test/test_sc/interop_test/VerifyWithECDsaSecp256r1Bool.py
@@ -1,0 +1,5 @@
+from boa3.builtin.interop.crypto import verify_with_ecdsa_secp256r1
+
+
+def Main():
+    verify_with_ecdsa_secp256r1(False, b'publickey', b'signature')

--- a/boa3_test/test_sc/interop_test/VerifyWithECDsaSecp256r1Bytes.py
+++ b/boa3_test/test_sc/interop_test/VerifyWithECDsaSecp256r1Bytes.py
@@ -1,0 +1,5 @@
+from boa3.builtin.interop.crypto import verify_with_ecdsa_secp256r1
+
+
+def Main():
+    verify_with_ecdsa_secp256r1(b'unit test', b'publickey', b'signature')

--- a/boa3_test/test_sc/interop_test/VerifyWithECDsaSecp256r1Int.py
+++ b/boa3_test/test_sc/interop_test/VerifyWithECDsaSecp256r1Int.py
@@ -1,0 +1,5 @@
+from boa3.builtin.interop.crypto import verify_with_ecdsa_secp256r1
+
+
+def Main():
+    verify_with_ecdsa_secp256r1(10, b'publickey', b'signature')

--- a/boa3_test/test_sc/interop_test/VerifyWithECDsaSecp256r1MismatchedType.py
+++ b/boa3_test/test_sc/interop_test/VerifyWithECDsaSecp256r1MismatchedType.py
@@ -1,0 +1,5 @@
+from boa3.builtin.interop.crypto import verify_with_ecdsa_secp256r1
+
+
+def Main():
+    verify_with_ecdsa_secp256r1('unit test', 10, b'signature')

--- a/boa3_test/test_sc/interop_test/VerifyWithECDsaSecp256r1Str.py
+++ b/boa3_test/test_sc/interop_test/VerifyWithECDsaSecp256r1Str.py
@@ -1,0 +1,5 @@
+from boa3.builtin.interop.crypto import verify_with_ecdsa_secp256r1
+
+
+def Main():
+    verify_with_ecdsa_secp256r1('unit test', b'publickey', b'signature')

--- a/boa3_test/tests/test_interop.py
+++ b/boa3_test/tests/test_interop.py
@@ -1120,3 +1120,235 @@ class TestInterop(BoaTest):
         path = '%s/boa3_test/test_sc/interop_test/CheckMultisigWithECDsaSecp256k1Byte.py' % self.dirname
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
+
+    def test_verify_with_ecdsa_secp256r1_str(self):
+        byte_input1 = b'publickey'
+        byte_input2 = b'signature'
+        string = b'unit test'
+        expected_output = (
+            Opcode.PUSHDATA1
+            + Integer(len(byte_input2)).to_byte_array(min_length=1)
+            + byte_input2
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.PUSHDATA1
+            + Integer(len(byte_input1)).to_byte_array(min_length=1)
+            + byte_input1
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.PUSHDATA1
+            + Integer(len(string)).to_byte_array(min_length=1)
+            + string
+            + Opcode.SYSCALL
+            + Interop.VerifyWithECDsaSecp256r1.interop_method_hash
+            + Opcode.DROP
+            + Opcode.PUSHNULL
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/test_sc/interop_test/VerifyWithECDsaSecp256r1Str.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_verify_with_ecdsa_secp256r1_bool(self):
+        byte_input1 = b'publickey'
+        byte_input2 = b'signature'
+        expected_output = (
+            Opcode.PUSHDATA1
+            + Integer(len(byte_input2)).to_byte_array(min_length=1)
+            + byte_input2
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.PUSHDATA1
+            + Integer(len(byte_input1)).to_byte_array(min_length=1)
+            + byte_input1
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.PUSH0
+            + Opcode.SYSCALL
+            + Interop.VerifyWithECDsaSecp256r1.interop_method_hash
+            + Opcode.DROP
+            + Opcode.PUSHNULL
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/test_sc/interop_test/VerifyWithECDsaSecp256r1Bool.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_verify_with_ecdsa_secp256r1_int(self):
+        byte_input1 = b'publickey'
+        byte_input2 = b'signature'
+        expected_output = (
+            Opcode.PUSHDATA1
+            + Integer(len(byte_input2)).to_byte_array(min_length=1)
+            + byte_input2
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.PUSHDATA1
+            + Integer(len(byte_input1)).to_byte_array(min_length=1)
+            + byte_input1
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.PUSH10
+            + Opcode.SYSCALL
+            + Interop.VerifyWithECDsaSecp256r1.interop_method_hash
+            + Opcode.DROP
+            + Opcode.PUSHNULL
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/test_sc/interop_test/VerifyWithECDsaSecp256r1Int.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_verify_with_ecdsa_secp256r1_bytes(self):
+        byte_input1 = b'publickey'
+        byte_input2 = b'signature'
+        string = b'unit test'
+        expected_output = (
+            Opcode.PUSHDATA1
+            + Integer(len(byte_input2)).to_byte_array(min_length=1)
+            + byte_input2
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.PUSHDATA1
+            + Integer(len(byte_input1)).to_byte_array(min_length=1)
+            + byte_input1
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.PUSHDATA1
+            + Integer(len(string)).to_byte_array(min_length=1)
+            + string
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.SYSCALL
+            + Interop.VerifyWithECDsaSecp256r1.interop_method_hash
+            + Opcode.DROP
+            + Opcode.PUSHNULL
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/test_sc/interop_test/VerifyWithECDsaSecp256r1Bytes.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_verify_with_ecdsa_secp256r1_mismatched_type(self):
+        path = '%s/boa3_test/test_sc/interop_test/VerifyWithECDsaSecp256r1MismatchedType.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_verify_with_ecdsa_secp256k1_str(self):
+        byte_input1 = b'publickey'
+        byte_input2 = b'signature'
+        string = b'unit test'
+        expected_output = (
+            Opcode.PUSHDATA1
+            + Integer(len(byte_input2)).to_byte_array(min_length=1)
+            + byte_input2
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.PUSHDATA1
+            + Integer(len(byte_input1)).to_byte_array(min_length=1)
+            + byte_input1
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.PUSHDATA1
+            + Integer(len(string)).to_byte_array(min_length=1)
+            + string
+            + Opcode.SYSCALL
+            + Interop.VerifyWithECDsaSecp256k1.interop_method_hash
+            + Opcode.DROP
+            + Opcode.PUSHNULL
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/test_sc/interop_test/VerifyWithECDsaSecp256k1Str.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_verify_with_ecdsa_secp256k1_bool(self):
+        byte_input1 = b'publickey'
+        byte_input2 = b'signature'
+        expected_output = (
+            Opcode.PUSHDATA1
+            + Integer(len(byte_input2)).to_byte_array(min_length=1)
+            + byte_input2
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.PUSHDATA1
+            + Integer(len(byte_input1)).to_byte_array(min_length=1)
+            + byte_input1
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.PUSH0
+            + Opcode.SYSCALL
+            + Interop.VerifyWithECDsaSecp256k1.interop_method_hash
+            + Opcode.DROP
+            + Opcode.PUSHNULL
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/test_sc/interop_test/VerifyWithECDsaSecp256k1Bool.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_verify_with_ecdsa_secp256k1_int(self):
+        byte_input1 = b'publickey'
+        byte_input2 = b'signature'
+        expected_output = (
+            Opcode.PUSHDATA1
+            + Integer(len(byte_input2)).to_byte_array(min_length=1)
+            + byte_input2
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.PUSHDATA1
+            + Integer(len(byte_input1)).to_byte_array(min_length=1)
+            + byte_input1
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.PUSH10
+            + Opcode.SYSCALL
+            + Interop.VerifyWithECDsaSecp256k1.interop_method_hash
+            + Opcode.DROP
+            + Opcode.PUSHNULL
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/test_sc/interop_test/VerifyWithECDsaSecp256k1Int.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_verify_with_ecdsa_secp256k1_bytes(self):
+        byte_input1 = b'publickey'
+        byte_input2 = b'signature'
+        string = b'unit test'
+        expected_output = (
+            Opcode.PUSHDATA1
+            + Integer(len(byte_input2)).to_byte_array(min_length=1)
+            + byte_input2
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.PUSHDATA1
+            + Integer(len(byte_input1)).to_byte_array(min_length=1)
+            + byte_input1
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.PUSHDATA1
+            + Integer(len(string)).to_byte_array(min_length=1)
+            + string
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.SYSCALL
+            + Interop.VerifyWithECDsaSecp256k1.interop_method_hash
+            + Opcode.DROP
+            + Opcode.PUSHNULL
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/test_sc/interop_test/VerifyWithECDsaSecp256k1Bytes.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_verify_with_ecdsa_secp256k1_mismatched_type(self):
+        path = '%s/boa3_test/test_sc/interop_test/VerifyWithECDsaSecp256k1MismatchedType.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)


### PR DESCRIPTION
**Related issue**
#114 

**Summary or solution description**
 Implemented the Verify Interop 

**How to Reproduce**
Call verify_with_ecdsa_secp256r1 or verify_with_ecdsa_secp256k1

**Tests**
Unit tests are in located at boa3_test/tests/test_interop.py

**Platform:**
 - OS: Windows 10 x64
 - Version neo3-boa v0.5
 - Python version Python 3.7.9