### PR TITLE
Boa-219 Implement Runtime ExecutingScriptHash Interop

### DIFF
--- a/boa3/builtin/interop/runtime/__init__.py
+++ b/boa3/builtin/interop/runtime/__init__.py
@@ -64,6 +64,7 @@ def is_verification_trigger() -> bool:
     pass
 
 
+executing_script_hash: bytes = b''
 calling_script_hash: bytes = b''
 get_time: int = 0
 gas_left: int = 0

--- a/boa3/model/builtin/interop/interop.py
+++ b/boa3/model/builtin/interop/interop.py
@@ -10,6 +10,7 @@ from boa3.model.builtin.interop.contract.getneoscripthashmethod import NeoProper
 from boa3.model.builtin.interop.runtime.checkwitnessmethod import CheckWitnessMethod
 from boa3.model.builtin.interop.runtime.getblocktimemethod import BlockTimeProperty
 from boa3.model.builtin.interop.runtime.getcallingscripthashmethod import CallingScriptHashProperty
+from boa3.model.builtin.interop.runtime.getexecutingscripthashmethod import ExecutingScriptHashProperty
 from boa3.model.builtin.interop.runtime.getgasleftmethod import GasLeftProperty
 from boa3.model.builtin.interop.runtime.getinvocationcountermethod import InvocationCounterProperty
 from boa3.model.builtin.interop.runtime.logmethod import LogMethod
@@ -70,6 +71,7 @@ class Interop:
     TriggerType = TriggerTyping()
     GetTrigger = TriggerMethod(TriggerType)
     CallingScriptHash = CallingScriptHashProperty()
+    ExecutingScriptHash = ExecutingScriptHashProperty()
     BlockTime = BlockTimeProperty()
     GasLeft = GasLeftProperty()
     InvocationCounter = InvocationCounterProperty()
@@ -114,6 +116,7 @@ class Interop:
                                  TriggerType,
                                  GetTrigger,
                                  CallingScriptHash,
+                                 ExecutingScriptHash,
                                  BlockTime,
                                  GasLeft,
                                  InvocationCounter

--- a/boa3/model/builtin/interop/runtime/getexecutingscripthashmethod.py
+++ b/boa3/model/builtin/interop/runtime/getexecutingscripthashmethod.py
@@ -1,0 +1,32 @@
+from typing import Dict, List, Tuple
+
+from boa3.model.builtin.builtinproperty import IBuiltinProperty
+from boa3.model.builtin.interop.interopmethod import InteropMethod
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class GetExecutingScriptHashMethod(InteropMethod):
+    def __init__(self):
+        from boa3.model.type.type import Type
+        identifier = '-get_executing_script_hash'
+        syscall = 'System.Runtime.GetExecutingScriptHash'
+        args: Dict[str, Variable] = {}
+        super().__init__(identifier, syscall, args, return_type=Type.bytes)
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        from boa3.model.type.type import Type
+
+        opcodes = super().opcode
+        opcodes.extend([
+            (Opcode.CONVERT, Type.bytes.stack_item)
+        ])
+        return opcodes
+
+
+class ExecutingScriptHashProperty(IBuiltinProperty):
+    def __init__(self):
+        identifier = 'executing_script_hash'
+        getter = GetExecutingScriptHashMethod()
+        super().__init__(identifier, getter)

--- a/boa3_test/test_sc/interop_test/ExecutingScriptHash.py
+++ b/boa3_test/test_sc/interop_test/ExecutingScriptHash.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.interop.runtime import executing_script_hash
+
+
+@public
+def Main() -> bytes:
+    return executing_script_hash

--- a/boa3_test/test_sc/interop_test/ExecutingScriptHashCantAssign.py
+++ b/boa3_test/test_sc/interop_test/ExecutingScriptHashCantAssign.py
@@ -1,0 +1,9 @@
+from boa3.builtin import public
+from boa3.builtin.interop.runtime import executing_script_hash
+
+
+@public
+def Main(example: bytes) -> bytes:
+    global executing_script_hash
+    executing_script_hash = example
+    return executing_script_hash

--- a/boa3_test/tests/test_interop.py
+++ b/boa3_test/tests/test_interop.py
@@ -299,6 +299,33 @@ class TestInterop(BoaTest):
         output = self.assertCompilerLogs(NameShadowing, path)
         self.assertEqual(expected_output, output)
 
+    def test_get_executing_script_hash(self):
+        expected_output = (
+            Opcode.SYSCALL
+            + Interop.ExecutingScriptHash.getter.interop_method_hash
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/test_sc/interop_test/ExecutingScriptHash.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_executing_script_hash_cant_assign(self):
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x01\x01'
+            + Opcode.LDARG0
+            + Opcode.STLOC0
+            + Opcode.LDLOC0
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/test_sc/interop_test/ExecutingScriptHashCantAssign.py' % self.dirname
+        output = self.assertCompilerLogs(NameShadowing, path)
+        self.assertEqual(expected_output, output)
+
     def test_call_contract(self):
         expected_output = (
             Opcode.INITSLOT


### PR DESCRIPTION
**Related issue**
#114 

**Summary or solution description**
Implemented ExecutingScriptHash Interop.

**How to Reproduce**
Assign executing_script_hash to a variable

**Tests**
Unit tests located at boa3/model/builtin/interop/interop.py

**Platform:**
 - OS: Windows 10 x64
 - Version neo3-boa v0.5
 - Python version Python 3.7.9