### PR TITLE
Boa-221 Implement Runtime EntryScriptHash Interop

### DIFF
--- a/boa3/builtin/interop/runtime/__init__.py
+++ b/boa3/builtin/interop/runtime/__init__.py
@@ -70,6 +70,7 @@ calling_script_hash: bytes = b''
 get_time: int = 0
 gas_left: int = 0
 invocation_counter: int = 0
+entry_script_hash: bytes = b''
 
 
 def get_notifications(script_hash: bytes = bytes(20)) -> List[Notification]:

--- a/boa3/model/builtin/interop/interop.py
+++ b/boa3/model/builtin/interop/interop.py
@@ -67,6 +67,7 @@ class Interop:
     InvocationCounter = InvocationCounterProperty()
     NotificationType = NotificationType.build()
     GetNotifications = GetNotificationsMethod(NotificationType)
+    EntryScriptHash = EntryScriptHashProperty()
 
     # Storage Interops
     StorageGet = StorageGetMethod()
@@ -119,7 +120,8 @@ class Interop:
                                  Log,
                                  NotificationType,
                                  Notify,
-                                 TriggerType
+                                 TriggerType,
+                                 EntryScriptHash
                                  ],
         InteropPackage.Storage: [StorageGet,
                                  StoragePut,

--- a/boa3/model/builtin/interop/runtime/__init__.py
+++ b/boa3/model/builtin/interop/runtime/__init__.py
@@ -9,12 +9,14 @@ __all__ = ['CheckWitnessMethod',
            'NotificationType',
            'NotifyMethod',
            'TriggerMethod',
-           'TriggerType'
+           'TriggerType',
+           'EntryScriptHashProperty'
            ]
 
 from boa3.model.builtin.interop.runtime.checkwitnessmethod import CheckWitnessMethod
 from boa3.model.builtin.interop.runtime.getblocktimemethod import BlockTimeProperty
 from boa3.model.builtin.interop.runtime.getcallingscripthashmethod import CallingScriptHashProperty
+from boa3.model.builtin.interop.runtime.getentryscripthashmethod import EntryScriptHashProperty
 from boa3.model.builtin.interop.runtime.getexecutingscripthashmethod import ExecutingScriptHashProperty
 from boa3.model.builtin.interop.runtime.getgasleftmethod import GasLeftProperty
 from boa3.model.builtin.interop.runtime.getinvocationcountermethod import InvocationCounterProperty

--- a/boa3/model/builtin/interop/runtime/getentryscripthashmethod.py
+++ b/boa3/model/builtin/interop/runtime/getentryscripthashmethod.py
@@ -1,0 +1,32 @@
+from typing import Dict, List, Tuple
+
+from boa3.model.builtin.builtinproperty import IBuiltinProperty
+from boa3.model.builtin.interop.interopmethod import InteropMethod
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class GetEntryScriptHashMethod(InteropMethod):
+    def __init__(self):
+        from boa3.model.type.type import Type
+        identifier = '-get_entry_script_hash'
+        syscall = 'System.Runtime.GetEntryScriptHash'
+        args: Dict[str, Variable] = {}
+        super().__init__(identifier, syscall, args, return_type=Type.bytes)
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        from boa3.model.type.type import Type
+
+        opcodes = super().opcode
+        opcodes.extend([
+            (Opcode.CONVERT, Type.bytes.stack_item)
+        ])
+        return opcodes
+
+
+class EntryScriptHashProperty(IBuiltinProperty):
+    def __init__(self):
+        identifier = 'entry_script_hash'
+        getter = GetEntryScriptHashMethod()
+        super().__init__(identifier, getter)

--- a/boa3_test/test_sc/interop_test/EntryScriptHash.py
+++ b/boa3_test/test_sc/interop_test/EntryScriptHash.py
@@ -1,0 +1,5 @@
+from boa3.builtin.interop.runtime import entry_script_hash
+
+
+def main() -> bytes:
+    return entry_script_hash

--- a/boa3_test/test_sc/interop_test/EntryScriptHashCantAssign.py
+++ b/boa3_test/test_sc/interop_test/EntryScriptHashCantAssign.py
@@ -1,0 +1,7 @@
+from boa3.builtin.interop.runtime import entry_script_hash
+
+
+def main(example: bytes) -> bytes:
+    global entry_script_hash
+    entry_script_hash = example
+    return entry_script_hash

--- a/boa3_test/tests/test_interop.py
+++ b/boa3_test/tests/test_interop.py
@@ -327,6 +327,33 @@ class TestInterop(BoaTest):
         output = self.assertCompilerLogs(NameShadowing, path)
         self.assertEqual(expected_output, output)
 
+    def test_get_entry_script_hash(self):
+        expected_output = (
+            Opcode.SYSCALL
+            + Interop.EntryScriptHash.getter.interop_method_hash
+            + Opcode.CONVERT
+            + Type.bytes.stack_item
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/test_sc/interop_test/EntryScriptHash.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_entry_script_hash_cant_assign(self):
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x01\x01'
+            + Opcode.LDARG0
+            + Opcode.STLOC0
+            + Opcode.LDLOC0
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/test_sc/interop_test/EntryScriptHashCantAssign.py' % self.dirname
+        output = self.assertCompilerLogs(NameShadowing, path)
+        self.assertEqual(expected_output, output)
+
     def test_create_contract(self):
         expected_output = (
             Opcode.INITSLOT


### PR DESCRIPTION
**Related issue**
#114 

**Summary or solution description**
Implemented EntryScriptHash Interop

**How to Reproduce**
Call entry_script_hash.

**Tests**
Tested it using Opcode

**Platform:**
 - OS: Windows 10 x64
 - Version neo3-boa v0.5
 - Python version e.g. Python 3.8