### PR TITLE
Boa-199 Implement Runtime Platform Interop

### DIFF
--- a/boa3/builtin/interop/runtime/__init__.py
+++ b/boa3/builtin/interop/runtime/__init__.py
@@ -69,6 +69,7 @@ executing_script_hash: bytes = b''
 calling_script_hash: bytes = b''
 get_time: int = 0
 gas_left: int = 0
+get_platform: str = ''
 invocation_counter: int = 0
 
 

--- a/boa3/model/builtin/interop/interop.py
+++ b/boa3/model/builtin/interop/interop.py
@@ -62,6 +62,7 @@ class Interop:
     GetTrigger = TriggerMethod(TriggerType)
     CallingScriptHash = CallingScriptHashProperty()
     ExecutingScriptHash = ExecutingScriptHashProperty()
+    Platform = PlatformProperty()
     BlockTime = BlockTimeProperty()
     GasLeft = GasLeftProperty()
     InvocationCounter = InvocationCounterProperty()
@@ -112,6 +113,7 @@ class Interop:
                                  CallingScriptHash,
                                  CheckWitness,
                                  ExecutingScriptHash,
+                                 Platform,
                                  GasLeft,
                                  GetNotifications,
                                  GetTrigger,

--- a/boa3/model/builtin/interop/runtime/__init__.py
+++ b/boa3/model/builtin/interop/runtime/__init__.py
@@ -2,6 +2,7 @@ __all__ = ['CheckWitnessMethod',
            'BlockTimeProperty',
            'CallingScriptHashProperty',
            'ExecutingScriptHashProperty',
+           'PlatformProperty',
            'GasLeftProperty',
            'InvocationCounterProperty',
            'GetNotificationsMethod',
@@ -19,6 +20,7 @@ from boa3.model.builtin.interop.runtime.getexecutingscripthashmethod import Exec
 from boa3.model.builtin.interop.runtime.getgasleftmethod import GasLeftProperty
 from boa3.model.builtin.interop.runtime.getinvocationcountermethod import InvocationCounterProperty
 from boa3.model.builtin.interop.runtime.getnotificationsmethod import GetNotificationsMethod
+from boa3.model.builtin.interop.runtime.getplatformmethod import PlatformProperty
 from boa3.model.builtin.interop.runtime.logmethod import LogMethod
 from boa3.model.builtin.interop.runtime.notificationtype import NotificationType
 from boa3.model.builtin.interop.runtime.notifymethod import NotifyMethod

--- a/boa3/model/builtin/interop/runtime/getplatformmethod.py
+++ b/boa3/model/builtin/interop/runtime/getplatformmethod.py
@@ -1,0 +1,21 @@
+from typing import Dict
+
+from boa3.model.builtin.builtinproperty import IBuiltinProperty
+from boa3.model.builtin.interop.interopmethod import InteropMethod
+from boa3.model.variable import Variable
+
+
+class GetPlatformMethod(InteropMethod):
+    def __init__(self):
+        from boa3.model.type.type import Type
+        identifier = '-get_platform'
+        syscall = 'System.Runtime.Platform'
+        args: Dict[str, Variable] = {}
+        super().__init__(identifier, syscall, args, return_type=Type.str)
+
+
+class PlatformProperty(IBuiltinProperty):
+    def __init__(self):
+        identifier = 'get_platform'
+        getter = GetPlatformMethod()
+        super().__init__(identifier, getter)

--- a/boa3_test/test_sc/interop_test/GetPlatform.py
+++ b/boa3_test/test_sc/interop_test/GetPlatform.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.interop.runtime import get_platform
+
+
+@public
+def main() -> str:
+    return get_platform

--- a/boa3_test/test_sc/interop_test/GetPlatformCantAssign.py
+++ b/boa3_test/test_sc/interop_test/GetPlatformCantAssign.py
@@ -1,0 +1,7 @@
+from boa3.builtin.interop.runtime import get_platform
+
+
+def main(example: str) -> str:
+    global get_platform
+    get_platform = example
+    return get_platform

--- a/boa3_test/tests/test_interop.py
+++ b/boa3_test/tests/test_interop.py
@@ -580,6 +580,35 @@ class TestInterop(BoaTest):
         output = self.assertCompilerLogs(NameShadowing, path)
         self.assertEqual(expected_output, output)
 
+    def test_get_platform(self):
+        expected_output = (
+            Opcode.SYSCALL
+            + Interop.Platform.getter.interop_method_hash
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/test_sc/interop_test/GetPlatform.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+        engine = TestEngine(self.dirname)
+        result = self.run_smart_contract(engine, path, 'main')
+        self.assertEqual('NEO', result)
+
+    def test_get_platform_cant_assign(self):
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x01\x01'
+            + Opcode.LDARG0
+            + Opcode.STLOC0
+            + Opcode.LDLOC0
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/test_sc/interop_test/GetPlatformCantAssign.py' % self.dirname
+        output = self.assertCompilerLogs(NameShadowing, path)
+        self.assertEqual(expected_output, output)
+
     def test_get_current_height(self):
         expected_output = (
             Opcode.SYSCALL


### PR DESCRIPTION
**Related issue**
#114 

**Summary or solution description**
Implemented Platform interop.

**How to Reproduce**
Use get_platform.

**Tests**
Used Opcode and Test engine.

**Platform:**
 - OS: Windows 10 x64
 - Version neo3-boa v0.5
 - Python version Python 3.8