### PR TITLE
Boa-277 Change Create Contract interop implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ _build
 neo3_boa.egg-info
 /neo-devpack-dotnet/
 /TestEngine/
+autopep8

--- a/boa3/builtin/interop/contract/__init__.py
+++ b/boa3/builtin/interop/contract/__init__.py
@@ -1,7 +1,8 @@
 from typing import Any, Sequence
+from boa3.builtin.interop.contract.contract import Contract
 
 
-def create_contract(script: bytes, manifest: bytes) -> Any:
+def create_contract(script: bytes, manifest: bytes) -> Contract:
     """
     Creates a smart contract given the script and the manifest
 
@@ -9,7 +10,7 @@ def create_contract(script: bytes, manifest: bytes) -> Any:
     :type script: bytes
     :param manifest: the manifest.json that describes how the script should behave
     type manifest: bytes
-    :return: the result of the specified method.
+    :return: the contract that was created.
     :rtype: Any
 
     :raise Exception: raised if the script or the manifest are not a valid smart contract.

--- a/boa3/builtin/interop/contract/contract.py
+++ b/boa3/builtin/interop/contract/contract.py
@@ -1,0 +1,7 @@
+from typing import Any, Dict
+
+
+class Contract:
+    def __init__(self):
+        self.script: bytes = bytes()
+        self.manifest: Dict[str, Any] = {}

--- a/boa3/model/builtin/interop/contract/__init__.py
+++ b/boa3/model/builtin/interop/contract/__init__.py
@@ -3,10 +3,12 @@ __all__ = ['CallMethod',
            'DestroyMethod',
            'GasProperty',
            'NeoProperty',
-           'UpdateMethod'
+           'UpdateMethod',
+           'ContractType'
            ]
 
 from boa3.model.builtin.interop.contract.callmethod import CallMethod
+from boa3.model.builtin.interop.contract.contracttype import ContractType
 from boa3.model.builtin.interop.contract.createmethod import CreateMethod
 from boa3.model.builtin.interop.contract.destroymethod import DestroyMethod
 from boa3.model.builtin.interop.contract.getgasscripthashmethod import GasProperty

--- a/boa3/model/builtin/interop/contract/__init__.py
+++ b/boa3/model/builtin/interop/contract/__init__.py
@@ -1,10 +1,10 @@
 __all__ = ['CallMethod',
+           'ContractType',
            'CreateMethod',
            'DestroyMethod',
            'GasProperty',
            'NeoProperty',
-           'UpdateMethod',
-           'ContractType'
+           'UpdateMethod'
            ]
 
 from boa3.model.builtin.interop.contract.callmethod import CallMethod

--- a/boa3/model/builtin/interop/contract/contracttype.py
+++ b/boa3/model/builtin/interop/contract/contracttype.py
@@ -1,0 +1,88 @@
+from typing import Any, Dict, List, Optional, Tuple
+
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.expression import IExpression
+from boa3.model.method import Method
+from boa3.model.property import Property
+from boa3.model.type.classtype import ClassType
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class ContractType(ClassType):
+    """
+    A class used to represent Neo Contract class
+    """
+
+    def __init__(self):
+        super().__init__('Contract')
+
+        from boa3.model.type.type import Type
+        self._variables: Dict[str, Variable] = {
+            'script': Variable(Type.bytes),
+            'manifest': Variable(Type.dict)
+        }
+        self._constructor: Method = None
+
+    @property
+    def variables(self) -> Dict[str, Variable]:
+        return self._variables.copy()
+
+    @property
+    def properties(self) -> Dict[str, Property]:
+        return {}
+
+    @property
+    def class_methods(self) -> Dict[str, Method]:
+        return {}
+
+    @property
+    def instance_methods(self) -> Dict[str, Method]:
+        return {}
+
+    def constructor_method(self) -> Method:
+        # was having a problem with recursive import
+        if self._constructor is None:
+            self._constructor: Method = ContractMethod(self)
+        return self._constructor
+
+    @classmethod
+    def build(cls, value: Any = None):
+        if value is None or cls._is_type_of(value):
+            return _Contract
+
+    @classmethod
+    def _is_type_of(cls, value: Any):
+        return isinstance(value, ContractType)
+
+
+_Contract = ContractType()
+
+
+class ContractMethod(IBuiltinMethod):
+
+    def __init__(self, return_type: ContractType):
+        identifier = '-Contract__init__'
+        args: Dict[str, Variable] = {}
+        super().__init__(identifier, args, return_type=return_type)
+
+    def validate_parameters(self, *params: IExpression) -> bool:
+        return len(params) == 0
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        from boa3.neo.vm.type.Integer import Integer
+        return [
+            Opcode.NEWMAP,
+            (Opcode.PUSHDATA1, Integer(0).to_byte_array()),
+            (Opcode.PUSH2, b''),
+            (Opcode.PACK, b'')
+        ]
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> Optional[str]:
+        return

--- a/boa3/model/builtin/interop/contract/contracttype.py
+++ b/boa3/model/builtin/interop/contract/contracttype.py
@@ -73,7 +73,7 @@ class ContractMethod(IBuiltinMethod):
     def opcode(self) -> List[Tuple[Opcode, bytes]]:
         from boa3.neo.vm.type.Integer import Integer
         return [
-            Opcode.NEWMAP,
+            (Opcode.NEWMAP, b''),
             (Opcode.PUSHDATA1, Integer(0).to_byte_array()),
             (Opcode.PUSH2, b''),
             (Opcode.PACK, b'')

--- a/boa3/model/builtin/interop/contract/createmethod.py
+++ b/boa3/model/builtin/interop/contract/createmethod.py
@@ -1,12 +1,13 @@
 from typing import Dict
 
 from boa3.model.builtin.interop.interopmethod import InteropMethod
+from boa3.model.builtin.interop.contract.contracttype import ContractType
 from boa3.model.variable import Variable
 
 
 class CreateMethod(InteropMethod):
 
-    def __init__(self):
+    def __init__(self, contract_type: ContractType):
         from boa3.model.type.type import Type
         identifier = 'create_contract'
         syscall = 'System.Contract.Create'
@@ -15,4 +16,4 @@ class CreateMethod(InteropMethod):
             'manifest': Variable(Type.bytes)
         }
 
-        super().__init__(identifier, syscall, args, return_type=Type.any)
+        super().__init__(identifier, syscall, args, return_type=contract_type)

--- a/boa3/model/builtin/interop/interop.py
+++ b/boa3/model/builtin/interop/interop.py
@@ -43,7 +43,8 @@ class Interop:
     CurrentHeight = CurrentHeightProperty()
 
     # Contract Interops
-    CreateContract = CreateMethod()
+    ContractType = ContractType.build()
+    CreateContract = CreateMethod(ContractType)
     CallContract = CallMethod()
     UpdateContract = UpdateMethod()
     DestroyContract = DestroyMethod()
@@ -98,7 +99,8 @@ class Interop:
                                   UpdateContract,
                                   DestroyContract,
                                   NeoScriptHash,
-                                  GasScriptHash
+                                  GasScriptHash,
+                                  ContractType
                                   ],
         InteropPackage.Crypto: [Sha256,
                                 Ripemd160,

--- a/boa3_test/test_sc/interop_test/CreateContract.py
+++ b/boa3_test/test_sc/interop_test/CreateContract.py
@@ -1,9 +1,7 @@
-from typing import Any
-
 from boa3.builtin import public
-from boa3.builtin.interop.contract import create_contract
+from boa3.builtin.interop.contract import create_contract, Contract
 
 
 @public
-def Main(script: bytes, manifest: bytes) -> Any:
+def Main(script: bytes, manifest: bytes) -> Contract:
     return create_contract(script, manifest)

--- a/boa3_test/tests/test_interop.py
+++ b/boa3_test/tests/test_interop.py
@@ -380,11 +380,13 @@ class TestInterop(BoaTest):
         engine = TestEngine(self.dirname)
         result = self.run_smart_contract(engine, path, 'Main', script, arg_manifest)
 
-        self.assertEqual(4, len(result))
+        del manifest['features']    # TODO: Remove when metadata is altered
+
+        self.assertEqual(2, len(result))
         self.assertEqual(script, result[0])
         self.assertEqual(manifest, json.loads(result[1]))
-        self.assertEqual(manifest['features']['storage'], result[2])
-        self.assertEqual(manifest['features']['payable'], result[3])
+
+
 
     def test_create_contract_too_many_parameters(self):
         path = '%s/boa3_test/test_sc/interop_test/CreateContractTooManyArguments.py' % self.dirname

--- a/boa3_test/tests/test_interop.py
+++ b/boa3_test/tests/test_interop.py
@@ -386,8 +386,6 @@ class TestInterop(BoaTest):
         self.assertEqual(script, result[0])
         self.assertEqual(manifest, json.loads(result[1]))
 
-
-
     def test_create_contract_too_many_parameters(self):
         path = '%s/boa3_test/test_sc/interop_test/CreateContractTooManyArguments.py' % self.dirname
         self.assertCompilerLogs(UnexpectedArgument, path)


### PR DESCRIPTION
**Related issue**
#114 

**Summary or solution description**
Changed Create Contract interop implementation, now it's returning a Contract class and it's attributes are a script and a manifest.

**How to Reproduce**
Call create_contract().

**Tests**
Using Opcode and Test engine.

**Platform:**
 - OS: Windows 10 x64
 - Version neo3-boa v0.5
 - Python version Python 3.8