### PR TITLE
Boa-283 Include CheckWitness in neo-boa's TestEngine

### DIFF
--- a/boa3/compiler/filegenerator.py
+++ b/boa3/compiler/filegenerator.py
@@ -62,7 +62,7 @@ class FileGenerator:
 
         :return: the hex string representation of the hash
         """
-        return '0x' + to_hex_str(self._nef.script_hash)
+        return to_hex_str(self._nef.script_hash)
 
     def generate_nef_file(self) -> bytes:
         """

--- a/boa3/neo/__init__.py
+++ b/boa3/neo/__init__.py
@@ -34,4 +34,4 @@ def to_hex_str(data_bytes: bytes) -> str:
     if isinstance(data_bytes, bytes):
         data_bytes = bytearray(data_bytes)
     data_bytes.reverse()
-    return data_bytes.hex()
+    return '0x' + data_bytes.hex()

--- a/boa3_test/test_sc/interop_test/CheckWitness.py
+++ b/boa3_test/test_sc/interop_test/CheckWitness.py
@@ -1,5 +1,7 @@
+from boa3.builtin import public
 from boa3.builtin.interop.runtime import check_witness
 
 
+@public
 def Main(script_hash: bytes) -> bool:
     return check_witness(script_hash)

--- a/boa3_test/test_sc/interop_test/CheckWitnessImportedAs.py
+++ b/boa3_test/test_sc/interop_test/CheckWitnessImportedAs.py
@@ -1,5 +1,7 @@
+from boa3.builtin import public
 from boa3.builtin.interop.runtime import check_witness as CheckWitness
 
 
+@public
 def Main(script_hash: bytes) -> bool:
     return CheckWitness(script_hash)

--- a/boa3_test/test_sc/interop_test/DestroyContractTooManyArguments.py
+++ b/boa3_test/test_sc/interop_test/DestroyContractTooManyArguments.py
@@ -5,4 +5,3 @@ from boa3.builtin.interop.contract import destroy_contract
 
 def Main(arg0: Any):
     destroy_contract(arg0)
-

--- a/boa3_test/test_sc/interop_test/UpdateContractTooManyArguments.py
+++ b/boa3_test/test_sc/interop_test/UpdateContractTooManyArguments.py
@@ -5,4 +5,3 @@ from boa3.builtin.interop.contract import update_contract
 
 def Main(script: bytes, manifest: str, arg0: Any):
     update_contract(script, manifest, arg0)
-

--- a/boa3_test/tests/test_classes/testengine.py
+++ b/boa3_test/tests/test_classes/testengine.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, List, Optional, Union
 
+from boa3.neo import to_hex_str
 from boa3.neo.smart_contract.notification import Notification
 from boa3.neo.utils import bytes_from_json, contract_parameter_to_json, stack_item_from_json
 from boa3.neo.vm.type.String import String
@@ -13,9 +14,13 @@ class TestEngine:
         self._vm_state: VMState = VMState.NONE
         self._gas_consumed: int = 0
         self._result_stack: List[Any] = []
+
         self._storage: Dict[bytes, Any] = {}
         self._notifications: List[Notification] = []
+
+        self._accounts: List[bytes] = []
         self._contract_paths: List[str] = []
+
         self._error_message: Optional[str] = None
 
     @property
@@ -36,7 +41,7 @@ class TestEngine:
 
     @property
     def notifications(self) -> List[Notification]:
-        return self._notifications
+        return self._notifications.copy()
 
     def get_events(self, event_name: str) -> List[Notification]:
         return [n for n in self._notifications if n.name == event_name]
@@ -71,6 +76,10 @@ class TestEngine:
 
         if key in self._storage:
             self._storage.pop(key)
+
+    def add_signer_account(self, account: bytes):
+        if account not in self._accounts:
+            self._accounts.append(account)
 
     @property
     def contracts(self) -> List[str]:
@@ -175,5 +184,6 @@ class TestEngine:
             'storage': [{'key': contract_parameter_to_json(key),
                          'value': contract_parameter_to_json(value)
                          } for key, value in self._storage.items()],
-            'contracts': [{'nef': contract_path} for contract_path in self._contract_paths]
+            'contracts': [{'nef': contract_path} for contract_path in self._contract_paths],
+            "signerAccounts": [to_hex_str(address) for address in self._accounts]
         }

--- a/boa3_test/tests/test_interop.py
+++ b/boa3_test/tests/test_interop.py
@@ -5,6 +5,7 @@ from boa3.exception.CompilerError import MismatchedTypes, UnexpectedArgument, Un
 from boa3.exception.CompilerWarning import NameShadowing
 from boa3.model.builtin.interop.interop import Interop
 from boa3.model.type.type import Type
+from boa3.neo import to_script_hash
 from boa3.neo.core.types.InteropInterface import InteropInterface
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
@@ -17,34 +18,28 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 class TestInterop(BoaTest):
 
     def test_check_witness(self):
-        expected_output = (
-            Opcode.INITSLOT
-            + b'\x00'
-            + b'\x01'
-            + Opcode.LDARG0
-            + Opcode.SYSCALL
-            + Interop.CheckWitness.interop_method_hash
-            + Opcode.RET
-        )
-
         path = '%s/boa3_test/test_sc/interop_test/CheckWitness.py' % self.dirname
-        output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
+        account = to_script_hash(b'NiNmXL8FjEUEs1nfX9uHFBNaenxDHJtmuB')
+
+        engine = TestEngine(self.dirname)
+        result = self.run_smart_contract(engine, path, 'Main', account)
+        self.assertEqual(False, result)
+
+        engine.add_signer_account(account)
+        result = self.run_smart_contract(engine, path, 'Main', account)
+        self.assertEqual(True, result)
 
     def test_check_witness_imported_as(self):
-        expected_output = (
-            Opcode.INITSLOT
-            + b'\x00'
-            + b'\x01'
-            + Opcode.LDARG0
-            + Opcode.SYSCALL
-            + Interop.CheckWitness.interop_method_hash
-            + Opcode.RET
-        )
-
         path = '%s/boa3_test/test_sc/interop_test/CheckWitnessImportedAs.py' % self.dirname
-        output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
+        account = to_script_hash(b'NiNmXL8FjEUEs1nfX9uHFBNaenxDHJtmuB')
+
+        engine = TestEngine(self.dirname)
+        result = self.run_smart_contract(engine, path, 'Main', account)
+        self.assertEqual(False, result)
+
+        engine.add_signer_account(account)
+        result = self.run_smart_contract(engine, path, 'Main', account)
+        self.assertEqual(True, result)
 
     def test_check_witness_mismatched_type(self):
         path = '%s/boa3_test/test_sc/interop_test/CheckWitnessMismatchedType.py' % self.dirname


### PR DESCRIPTION
**Summary or solution description**
Included in the TestEngine the signing tests for testing ``check_witness``

**How to Reproduce**
```python
engine = TestEngine(self.dirname)
engine.add_signer_account(account)
result = self.run_smart_contract(engine, path, 'check_witness', account)
self.assertEqual(True, result)
```

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/c9e596a7d2b62cff50acbf57700a98fd2663fd43/boa3_test/tests/test_interop.py#L20-L46
