### PR TITLE
Boa-206 Implement Json Interops

### DIFF
--- a/boa3/builtin/interop/json/__init__.py
+++ b/boa3/builtin/interop/json/__init__.py
@@ -5,13 +5,13 @@ def json_serialize(item: Any) -> bytes:
     """
     Serializes an item into a json
 
-    :param item: The item that will serialized
+    :param item: The item that will be serialized
     :type item: Any
     :return: The serialized item
     :rtype: bytes
 
-    :raise Exception: raised if item is an int value greater than MAX_SAFE_INTEGER or lower than MIN_SAFE_INTEGER, if
-        item is a dictionary that have a bytearray as key, if item isn't serializable or if item is too big.
+    :raise Exception: raised if the item is an integer value out of the Neo's accepted range, is a dictionary with a
+        bytearray key, or isn't serializable.
     """
     pass
 

--- a/boa3/builtin/interop/json/__init__.py
+++ b/boa3/builtin/interop/json/__init__.py
@@ -1,0 +1,30 @@
+from typing import Any
+
+
+def json_serialize(item: Any) -> bytes:
+    """
+    Serializes an item into a json
+
+    :param item: The item that will serialized
+    :type item: Any
+    :return: The serialized item
+    :rtype: bytes
+
+    :raise Exception: raised if item is an int value greater than MAX_SAFE_INTEGER or lower than MIN_SAFE_INTEGER, if
+        item is a dictionary that have a bytearray as key, if item isn't serializable or if item is too big.
+    """
+    pass
+
+
+def json_deserialize(json: bytes) -> Any:
+    """
+    Deserializes a json into some valid type
+
+    :param json: A json that will be deserialized
+    :type json: bytes
+    :return: The deserialized json
+    :rtype: Any
+
+    :raise Exception: raised if json's deserialization is not valid
+    """
+    pass

--- a/boa3/model/builtin/interop/interop.py
+++ b/boa3/model/builtin/interop/interop.py
@@ -6,6 +6,7 @@ from boa3.model.builtin.interop.blockchain import *
 from boa3.model.builtin.interop.contract import *
 from boa3.model.builtin.interop.crypto import *
 from boa3.model.builtin.interop.iterator import *
+from boa3.model.builtin.interop.json import *
 from boa3.model.builtin.interop.runtime import *
 from boa3.model.builtin.interop.storage import *
 from boa3.model.identifiedsymbol import IdentifiedSymbol
@@ -17,6 +18,7 @@ class InteropPackage(str, Enum):
     Contract = 'contract'
     Crypto = 'crypto'
     Iterator = 'iterator'
+    Json = 'json'
     Runtime = 'runtime'
     Storage = 'storage'
 
@@ -54,6 +56,10 @@ class Interop:
     # Iterator Interops
     Iterator = IteratorType.build()
     IteratorCreate = IteratorMethod(Iterator)
+
+    # Json Interops
+    JsonDeserialize = JsonDeserializeMethod()
+    JsonSerialize = JsonSerializeMethod()
 
     # Runtime Interops
     CheckWitness = CheckWitnessMethod()
@@ -112,6 +118,9 @@ class Interop:
                                 VerifyWithECDsaSecp256k1
                                 ],
         InteropPackage.Iterator: [Iterator],
+        InteropPackage.Json: [JsonDeserialize,
+                              JsonSerialize
+                              ],
         InteropPackage.Runtime: [BlockTime,
                                  CallingScriptHash,
                                  CheckWitness,

--- a/boa3/model/builtin/interop/json/__init__.py
+++ b/boa3/model/builtin/interop/json/__init__.py
@@ -1,0 +1,6 @@
+__all__ = ['JsonDeserializeMethod',
+           'JsonSerializeMethod'
+           ]
+
+from boa3.model.builtin.interop.json.jsonserializemethod import JsonSerializeMethod
+from boa3.model.builtin.interop.json.jsondeserializemethod import JsonDeserializeMethod

--- a/boa3/model/builtin/interop/json/jsondeserializemethod.py
+++ b/boa3/model/builtin/interop/json/jsondeserializemethod.py
@@ -1,0 +1,13 @@
+from typing import Dict
+
+from boa3.model.builtin.interop.interopmethod import InteropMethod
+from boa3.model.variable import Variable
+
+
+class JsonDeserializeMethod(InteropMethod):
+    def __init__(self):
+        from boa3.model.type.type import Type
+        identifier = 'json_deserialize'
+        syscall = 'System.Json.Deserialize'
+        args: Dict[str, Variable] = {'json': Variable(Type.bytes)}
+        super().__init__(identifier, syscall, args, return_type=Type.any)

--- a/boa3/model/builtin/interop/json/jsonserializemethod.py
+++ b/boa3/model/builtin/interop/json/jsonserializemethod.py
@@ -1,0 +1,13 @@
+from typing import Dict
+
+from boa3.model.builtin.interop.interopmethod import InteropMethod
+from boa3.model.variable import Variable
+
+
+class JsonSerializeMethod(InteropMethod):
+    def __init__(self):
+        from boa3.model.type.type import Type
+        identifier = 'json_serialize'
+        syscall = 'System.Json.Serialize'
+        args: Dict[str, Variable] = {'item': Variable(Type.any)}
+        super().__init__(identifier, syscall, args, return_type=Type.bytes)

--- a/boa3_test/test_sc/interop_test/JsonDeserialize.py
+++ b/boa3_test/test_sc/interop_test/JsonDeserialize.py
@@ -1,0 +1,9 @@
+from typing import Any
+
+from boa3.builtin import public
+from boa3.builtin.interop.json import json_deserialize
+
+
+@public
+def main(json: bytes) -> Any:
+    return json_deserialize(json)

--- a/boa3_test/test_sc/interop_test/JsonSerialize.py
+++ b/boa3_test/test_sc/interop_test/JsonSerialize.py
@@ -1,0 +1,9 @@
+from typing import Any
+
+from boa3.builtin import public
+from boa3.builtin.interop.json import json_serialize
+
+
+@public
+def main(item: Any) -> bytes:
+    return json_serialize(item)

--- a/boa3_test/test_sc/interop_test/JsonSerializeBool.py
+++ b/boa3_test/test_sc/interop_test/JsonSerializeBool.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.interop.json import json_serialize
+
+
+@public
+def main() -> bytes:
+    return json_serialize(True)

--- a/boa3_test/test_sc/interop_test/JsonSerializeBytes.py
+++ b/boa3_test/test_sc/interop_test/JsonSerializeBytes.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.interop.json import json_serialize
+
+
+@public
+def main() -> bytes:
+    return json_serialize(b'unit test')

--- a/boa3_test/test_sc/interop_test/JsonSerializeInt.py
+++ b/boa3_test/test_sc/interop_test/JsonSerializeInt.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.interop.json import json_serialize
+
+
+@public
+def main() -> bytes:
+    return json_serialize(10)

--- a/boa3_test/test_sc/interop_test/JsonSerializeStr.py
+++ b/boa3_test/test_sc/interop_test/JsonSerializeStr.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.interop.json import json_serialize
+
+
+@public
+def main() -> bytes:
+    return json_serialize('unit test')

--- a/boa3_test/tests/test_interop.py
+++ b/boa3_test/tests/test_interop.py
@@ -1777,3 +1777,79 @@ class TestInterop(BoaTest):
     def test_verify_with_ecdsa_secp256k1_mismatched_type(self):
         path = '%s/boa3_test/test_sc/interop_test/IteratorCreateMismatchedTypes.py' % self.dirname
         self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_json_serialize(self):
+        path = '%s/boa3_test/test_sc/interop_test/JsonSerialize.py' % self.dirname
+
+        import json
+        engine = TestEngine(self.dirname)
+        test_input = {"one": 'um', "two": 'dois', "three": 'tres'}
+        # test_input = [1, 2, 3, 4]
+        expected_result = String(json.dumps(test_input, separators=(',', ':'))).to_bytes()
+        result = self.run_smart_contract(engine, path, 'main', test_input)
+        if isinstance(result, str):
+            result = String(result).to_bytes()
+        self.assertEqual(expected_result, result)
+
+    def test_json_serialize_int(self):
+        path = '%s/boa3_test/test_sc/interop_test/JsonSerializeInt.py' % self.dirname
+
+        import json
+        engine = TestEngine(self.dirname)
+        expected_result = String(json.dumps(10)).to_bytes()
+        result = self.run_smart_contract(engine, path, 'main')
+        if isinstance(result, str):
+            result = String(result).to_bytes()
+        self.assertEqual(expected_result, result)
+
+    def test_json_serialize_bool(self):
+        path = '%s/boa3_test/test_sc/interop_test/JsonSerializeBool.py' % self.dirname
+
+        import json
+        engine = TestEngine(self.dirname)
+        expected_result = String(json.dumps(1)).to_bytes()
+        result = self.run_smart_contract(engine, path, 'main')
+        if isinstance(result, str):
+            result = String(result).to_bytes()
+        self.assertEqual(expected_result, result)
+
+    def test_json_serialize_str(self):
+        path = '%s/boa3_test/test_sc/interop_test/JsonSerializeStr.py' % self.dirname
+
+        import json
+        engine = TestEngine(self.dirname)
+        expected_result = String(json.dumps('unit test')).to_bytes()
+        result = self.run_smart_contract(engine, path, 'main')
+        if isinstance(result, str):
+            result = String(result).to_bytes()
+        self.assertEqual(expected_result, result)
+
+    def test_json_serialize_bytes(self):
+        path = '%s/boa3_test/test_sc/interop_test/JsonSerializeBytes.py' % self.dirname
+
+        engine = TestEngine(self.dirname)
+        expected_result = b'"unit test"'
+        result = self.run_smart_contract(engine, path, 'main')
+        if isinstance(result, str):
+            result = String(result).to_bytes()
+        self.assertEqual(expected_result, result)
+
+    def test_json_deserialize(self):
+        path = '%s/boa3_test/test_sc/interop_test/JsonDeserialize.py' % self.dirname
+
+        import json
+        engine = TestEngine(self.dirname)
+        test_input = String(json.dumps(12345)).to_bytes()
+        expected_result = json.loads(test_input)
+        result = self.run_smart_contract(engine, path, 'main', test_input)
+        self.assertEqual(expected_result, result)
+
+        test_input = String(json.dumps('unit test')).to_bytes()
+        expected_result = json.loads(test_input)
+        result = self.run_smart_contract(engine, path, 'main', test_input)
+        self.assertEqual(expected_result, result)
+
+        test_input = String(json.dumps(True)).to_bytes()
+        expected_result = json.loads(test_input)
+        result = self.run_smart_contract(engine, path, 'main', test_input)
+        self.assertEqual(expected_result, result)

--- a/boa3_test/tests/test_interop.py
+++ b/boa3_test/tests/test_interop.py
@@ -13,6 +13,7 @@ from boa3.neo.vm.type.String import String
 from boa3_test.tests.boa_test import BoaTest
 from boa3_test.tests.test_classes.TestExecutionException import TestExecutionException
 from boa3_test.tests.test_classes.testengine import TestEngine
+import json
 
 
 class TestInterop(BoaTest):
@@ -365,7 +366,6 @@ class TestInterop(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        import json
         call_contract_path = '%s/boa3_test/test_sc/arithmetic_test/Addition.py' % self.dirname
         Boa3.compile_and_save(call_contract_path)
 
@@ -1781,7 +1781,6 @@ class TestInterop(BoaTest):
     def test_json_serialize(self):
         path = '%s/boa3_test/test_sc/interop_test/JsonSerialize.py' % self.dirname
 
-        import json
         engine = TestEngine(self.dirname)
         test_input = {"one": 'um', "two": 'dois', "three": 'tres'}
         # test_input = [1, 2, 3, 4]
@@ -1794,7 +1793,6 @@ class TestInterop(BoaTest):
     def test_json_serialize_int(self):
         path = '%s/boa3_test/test_sc/interop_test/JsonSerializeInt.py' % self.dirname
 
-        import json
         engine = TestEngine(self.dirname)
         expected_result = String(json.dumps(10)).to_bytes()
         result = self.run_smart_contract(engine, path, 'main')
@@ -1805,7 +1803,6 @@ class TestInterop(BoaTest):
     def test_json_serialize_bool(self):
         path = '%s/boa3_test/test_sc/interop_test/JsonSerializeBool.py' % self.dirname
 
-        import json
         engine = TestEngine(self.dirname)
         expected_result = String(json.dumps(1)).to_bytes()
         result = self.run_smart_contract(engine, path, 'main')
@@ -1816,7 +1813,6 @@ class TestInterop(BoaTest):
     def test_json_serialize_str(self):
         path = '%s/boa3_test/test_sc/interop_test/JsonSerializeStr.py' % self.dirname
 
-        import json
         engine = TestEngine(self.dirname)
         expected_result = String(json.dumps('unit test')).to_bytes()
         result = self.run_smart_contract(engine, path, 'main')
@@ -1837,7 +1833,6 @@ class TestInterop(BoaTest):
     def test_json_deserialize(self):
         path = '%s/boa3_test/test_sc/interop_test/JsonDeserialize.py' % self.dirname
 
-        import json
         engine = TestEngine(self.dirname)
         test_input = String(json.dumps(12345)).to_bytes()
         expected_result = json.loads(test_input)

--- a/boa3_test/tests/test_interop.py
+++ b/boa3_test/tests/test_interop.py
@@ -1782,8 +1782,7 @@ class TestInterop(BoaTest):
         path = '%s/boa3_test/test_sc/interop_test/JsonSerialize.py' % self.dirname
 
         engine = TestEngine(self.dirname)
-        test_input = {"one": 'um', "two": 'dois', "three": 'tres'}
-        # test_input = [1, 2, 3, 4]
+        test_input = {"one": 1, "two": 2, "three": 3}
         expected_result = String(json.dumps(test_input, separators=(',', ':'))).to_bytes()
         result = self.run_smart_contract(engine, path, 'main', test_input)
         if isinstance(result, str):


### PR DESCRIPTION
**Related issue**
#114 

**Summary or solution description**
Implemented JsonSerialize and JsonDeserialize interops

**How to Reproduce**
Call json_serialize or json_deserialize.

**Tests**
Tested json_serialize and json_deserialize with the TestEngine

**Platform:**
 - OS: Windows 10 x64
 - Version neo3-boa v0.5
 - Python version Python 3.8