### PR TITLE
Boa-290 Create an abort method that uses Opcode.ABORT

### DIFF
--- a/boa3/builtin/contract/__init__.py
+++ b/boa3/builtin/contract/__init__.py
@@ -8,3 +8,10 @@ Nep5TransferEvent = CreateNewEvent(
     ],
     'transfer'
 )
+
+
+def abort():
+    """
+    Abort the execution of a smart contract
+    """
+    pass

--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -13,6 +13,7 @@ from boa3.model.builtin.classmethod.tobytesmethod import ToBytes as ToBytesMetho
 from boa3.model.builtin.classmethod.tointmethod import ToInt as ToIntMethod
 from boa3.model.builtin.classmethod.tostrmethod import ToStr as ToStrMethod
 from boa3.model.builtin.contract.nep5transferevent import Nep5TransferEvent
+from boa3.model.builtin.contract.abortmethod import AbortMethod
 from boa3.model.builtin.decorator.metadatadecorator import MetadataDecorator
 from boa3.model.builtin.decorator.publicdecorator import PublicDecorator
 from boa3.model.builtin.interop.interop import Interop
@@ -108,6 +109,9 @@ class Builtin:
     # boa events
     Nep5Transfer = Nep5TransferEvent()
 
+    # boa smart contract methods
+    Abort = AbortMethod()
+
     _boa_builtins: List[IdentifiedSymbol] = [Public,
                                              NewEvent,
                                              Event,
@@ -137,6 +141,7 @@ class Builtin:
         return cls.boa_symbols()
 
     _boa_symbols: Dict[BoaPackage, List[IdentifiedSymbol]] = {
-        BoaPackage.Contract: [Nep5Transfer
+        BoaPackage.Contract: [Nep5Transfer,
+                              Abort
                               ]
     }

--- a/boa3/model/builtin/contract/abortmethod.py
+++ b/boa3/model/builtin/contract/abortmethod.py
@@ -1,0 +1,26 @@
+from typing import Any, Dict, List, Optional, Tuple
+
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class AbortMethod(IBuiltinMethod):
+
+    def __init__(self):
+        from boa3.model.type.type import Type
+        identifier = 'abort'
+        args: Dict[str, Variable] = {}
+        super().__init__(identifier, args, return_type=Type.none)
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        return [(Opcode.ABORT, b'')]
+
+    @property
+    def _args_on_stack(self) -> int:
+        return 0
+
+    @property
+    def _body(self) -> Optional[str]:
+        return None

--- a/boa3_test/test_sc/boa_built_in_methods_test/Abort.py
+++ b/boa3_test/test_sc/boa_built_in_methods_test/Abort.py
@@ -1,0 +1,9 @@
+from boa3.builtin import public
+from boa3.builtin.contract import abort
+
+
+@public
+def main(check: bool) -> int:
+    if check:
+        abort()
+    return 123

--- a/boa3_test/tests/boa_test.py
+++ b/boa3_test/tests/boa_test.py
@@ -19,6 +19,7 @@ class BoaTest(TestCase):
     VALUE_IS_OUT_OF_RANGE_MSG = 'The value is out of range'
     STORAGE_VALUE_IS_OUT_OF_RANGE_MSG = 'Specified argument was out of the range of valid values.'
     CALLED_CONTRACT_DOES_NOT_EXIST_MSG = 'Called Contract Does Not Exist'
+    ABORTED_CONTRACT_MSG = 'ABORT is executed'
 
     @classmethod
     def setUpClass(cls):

--- a/boa3_test/tests/test_boa_builtin_method.py
+++ b/boa3_test/tests/test_boa_builtin_method.py
@@ -1,0 +1,16 @@
+from boa3_test.tests.boa_test import BoaTest
+from boa3_test.tests.test_classes.testengine import TestEngine
+from boa3_test.tests.test_classes.TestExecutionException import TestExecutionException
+
+
+class TestBuiltinMethod(BoaTest):
+
+    def test_abort(self):
+        path = '%s/boa3_test/test_sc/boa_built_in_methods_test/Abort.py' % self.dirname
+
+        engine = TestEngine(self.dirname)
+        result = self.run_smart_contract(engine, path, 'main', False)
+        self.assertEqual(123, result)
+
+        with self.assertRaises(TestExecutionException, msg=self.ABORTED_CONTRACT_MSG):
+            self.run_smart_contract(engine, path, 'main', True)


### PR DESCRIPTION
**Related issue**
#114 

**Summary or solution description**
Created abort(), a smart contract method, that uses Opcode.ABORT

**How to Reproduce**
Call abort()

**Tests**
Tested it using the test engine

**Platform:**
 - OS: Windows 10 x64
 - Version neo3-boa v0.5
 - Python version Python 3.8