### PR TITLE
Boa-279 Fix get type from slices

### DIFF
--- a/boa3/analyser/moduleanalyser.py
+++ b/boa3/analyser/moduleanalyser.py
@@ -617,10 +617,14 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
 
         if isinstance(subscript.ctx, ast.Load):
             if isinstance(symbol, Collection):
-                values_type: Iterable[IType] = self.get_values_type(subscript.slice.value)
+                value = subscript.slice.value if isinstance(subscript.slice, ast.Index) else subscript.slice
+                values_type: Iterable[IType] = self.get_values_type(value)
                 return symbol.build_collection(*values_type)
 
             symbol_type = self.get_type(symbol)
+            if isinstance(subscript.slice, ast.Slice):
+                return symbol_type
+
             if isinstance(symbol_type, SequenceType):
                 return symbol_type.value_type
 

--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -310,13 +310,12 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
         :param subscript: the python ast subscript node
         :return: the type of the accessed value if it is valid. Type.none otherwise.
         """
-        if isinstance(subscript.slice, ast.Index):
-            return self.validate_get_or_set(subscript, subscript.slice)
-        elif isinstance(subscript.slice, ast.Slice):
+        if isinstance(subscript.slice, ast.Slice):
             return self.validate_slice(subscript, subscript.slice)
-        return Type.none
 
-    def validate_get_or_set(self, subscript: ast.Subscript, index_node: ast.Index) -> IType:
+        return self.validate_get_or_set(subscript, subscript.slice)
+
+    def validate_get_or_set(self, subscript: ast.Subscript, index_node: ast.AST) -> IType:
         """
         Verifies if the subscribed value is a sequence and if the index is valid to this sequence
 

--- a/boa3/compiler/codegeneratorvisitor.py
+++ b/boa3/compiler/codegeneratorvisitor.py
@@ -293,10 +293,10 @@ class VisitorCodeGenerator(ast.NodeVisitor):
 
         :param subscript: the python ast subscript node
         """
-        if isinstance(subscript.slice, ast.Index):
-            return self.visit_Subscript_Index(subscript)
-        elif isinstance(subscript.slice, ast.Slice):
+        if isinstance(subscript.slice, ast.Slice):
             return self.visit_Subscript_Slice(subscript)
+
+        return self.visit_Subscript_Index(subscript)
 
     def visit_Subscript_Index(self, subscript: ast.Subscript):
         """
@@ -307,7 +307,8 @@ class VisitorCodeGenerator(ast.NodeVisitor):
         if isinstance(subscript.ctx, ast.Load):
             # get item
             self.visit_to_generate(subscript.value)
-            self.visit_to_generate(subscript.slice.value)
+            value = subscript.slice.value if isinstance(subscript.slice, ast.Index) else subscript.slice
+            self.visit_to_generate(value)
             self.generator.convert_get_item()
         else:
             # set item

--- a/boa3_test/test_sc/bytes_test/AssignSlice.py
+++ b/boa3_test/test_sc/bytes_test/AssignSlice.py
@@ -1,0 +1,9 @@
+from boa3.builtin import public
+
+
+@public
+def main(a: bytearray) -> bytearray:
+
+    m = a[1:2]
+
+    return m

--- a/boa3_test/test_sc/relational_test/ListEqualityWithSlice.py
+++ b/boa3_test/test_sc/relational_test/ListEqualityWithSlice.py
@@ -1,0 +1,8 @@
+from typing import List
+
+from boa3.builtin import public
+
+
+@public
+def main(a: List[str], b: str) -> bool:
+    return a[0] == b

--- a/boa3_test/test_sc/string_test/GetValueToVariable.py
+++ b/boa3_test/test_sc/string_test/GetValueToVariable.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+
+
+@public
+def Main(a: str) -> str:
+    b = a[0]
+    return b

--- a/boa3_test/tests/boa_test.py
+++ b/boa3_test/tests/boa_test.py
@@ -137,4 +137,8 @@ class BoaTest(TestCase):
                     result = Integer.from_bytes(result, signed=True)
                 if isinstance(result, int) and result in (False, True):
                     result = bool(result)
+
+            if expected_result_type is bytearray and isinstance(result, bytes):
+                result = bytearray(result)
+
         return result

--- a/boa3_test/tests/test_bytes.py
+++ b/boa3_test/tests/test_bytes.py
@@ -6,6 +6,7 @@ from boa3.model.type.type import Type
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3_test.tests.boa_test import BoaTest
+from boa3_test.tests.test_classes.TestExecutionException import TestExecutionException
 from boa3_test.tests.test_classes.testengine import TestEngine
 
 
@@ -218,6 +219,21 @@ class TestBytes(BoaTest):
         path = '%s/boa3_test/test_sc/bytes_test/BytesFromBytearray.py' % self.dirname
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
+
+    def test_assign_with_slice(self):
+        path = '%s/boa3_test/test_sc/bytes_test/AssignSlice.py' % self.dirname
+
+        engine = TestEngine(self.dirname)
+        result = self.run_smart_contract(engine, path, 'main', b'unittest',
+                                         expected_result_type=bytearray)
+        self.assertEqual(b'unittest'[1:2], result)
+
+        result = self.run_smart_contract(engine, path, 'main', b'123',
+                                         expected_result_type=bytearray)
+        self.assertEqual(b'123'[1:2], result)
+
+        with self.assertRaises(TestExecutionException):
+            self.run_smart_contract(engine, path, 'main', bytearray())
 
     def test_byte_array_get_value(self):
         expected_output = (

--- a/boa3_test/tests/test_relational.py
+++ b/boa3_test/tests/test_relational.py
@@ -3,6 +3,7 @@ from boa3.exception.CompilerError import MismatchedTypes, NotSupportedOperation
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3_test.tests.boa_test import BoaTest
+from boa3_test.tests.test_classes.TestExecutionException import TestExecutionException
 from boa3_test.tests.test_classes.testengine import TestEngine
 
 
@@ -418,3 +419,18 @@ class TestRelational(BoaTest):
     def test_mixed_greater_or_equal_than_operation(self):
         path = '%s/boa3_test/test_sc/relational_test/MixedGreaterOrEqual.py' % self.dirname
         self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_list_equality_with_slice(self):
+        path = '%s/boa3_test/test_sc/relational_test/ListEqualityWithSlice.py' % self.dirname
+
+        engine = TestEngine(self.dirname)
+        result = self.run_smart_contract(engine, path, 'main', ['unittest', '123'], 'unittest',
+                                         expected_result_type=bool)
+        self.assertEqual(True, result)
+
+        result = self.run_smart_contract(engine, path, 'main', ['unittest', '123'], '123',
+                                         expected_result_type=bool)
+        self.assertEqual(False, result)
+
+        with self.assertRaises(TestExecutionException):
+            self.run_smart_contract(engine, path, 'main', [], '')

--- a/boa3_test/tests/test_string.py
+++ b/boa3_test/tests/test_string.py
@@ -48,6 +48,43 @@ class TestString(BoaTest):
         with self.assertRaises(TestExecutionException):
             self.run_smart_contract(engine, path, 'Main', '')
 
+    def test_string_get_value_to_variable(self):
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x01'
+            + b'\x01'
+            + Opcode.LDARG0     # b = arg[0]
+            + Opcode.PUSH0
+            + Opcode.DUP
+            + Opcode.SIGN
+            + Opcode.PUSHM1
+            + Opcode.JMPNE
+            + Integer(5).to_byte_array(min_length=1, signed=True)
+            + Opcode.OVER
+            + Opcode.SIZE
+            + Opcode.ADD
+            + Opcode.PUSH1
+            + Opcode.SUBSTR
+            + Opcode.CONVERT
+            + Type.str.stack_item
+            + Opcode.STLOC0
+            + Opcode.LDLOC0     # return b
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/test_sc/string_test/GetValueToVariable.py' % self.dirname
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+        engine = TestEngine(self.dirname)
+        result = self.run_smart_contract(engine, path, 'Main', 'unit')
+        self.assertEqual('u', result)
+        result = self.run_smart_contract(engine, path, 'Main', '123')
+        self.assertEqual('1', result)
+
+        with self.assertRaises(TestExecutionException):
+            self.run_smart_contract(engine, path, 'Main', '')
+
     def test_string_set_value(self):
         path = '%s/boa3_test/test_sc/string_test/SetValue.py' % self.dirname
         self.assertCompilerLogs(UnresolvedOperation, path)


### PR DESCRIPTION

**Summary or solution description**
Fixed the type checking when using slices

**How to Reproduce**
```python 
@public
def main(a: bytearray) -> bytearray:

    m = a[1:2]

    return m
```
Instead of associating ``m`` with a ``bytearray`` variable, it was associating with ``int``

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/bf5372e23129409cebc727287a05a372b50a5b8e/boa3_test/tests/test_bytes.py#L223-L236