### PR TITLE
Boa-281 Fix if else jumps when inside an if body

### DIFF
--- a/boa3/compiler/codegenerator.py
+++ b/boa3/compiler/codegenerator.py
@@ -370,15 +370,16 @@ class CodeGenerator:
         self._insert_jump(OpcodeInfo.JMPIFNOT)
         return VMCodeMapping.instance().get_start_address(self.last_code)
 
-    def convert_begin_else(self, start_address: int) -> int:
+    def convert_begin_else(self, start_address: int, insert_jump: bool = False) -> int:
         """
         Converts the beginning of the if else statement
 
         :param start_address: the address of the if first opcode
+        :param insert_jump: whether should be included a jump to the end before the else branch
         :return: the address of the if else first opcode
         """
         # it will be updated when the if ends
-        self._insert_jump(OpcodeInfo.JMP)
+        self._insert_jump(OpcodeInfo.JMP, insert_jump=insert_jump)
 
         # updates the begin jmp with the target address
         self._update_jump(start_address, VMCodeMapping.instance().bytecode_size)
@@ -1193,17 +1194,18 @@ class CodeGenerator:
             if len(vmcodes) == 0:
                 self._missing_target.pop(target)
 
-    def _insert_jump(self, op_info: OpcodeInformation, jump_to: Union[int, VMCode] = 0):
+    def _insert_jump(self, op_info: OpcodeInformation, jump_to: Union[int, VMCode] = 0, insert_jump: bool = False):
         """
         Inserts a jump opcode into the bytecode
 
         :param op_info: info of the opcode  that will be inserted
         :param jump_to: data of the opcode
+        :param insert_jump: whether should be included a jump to the end before the else branch
         """
         if isinstance(jump_to, VMCode):
             jump_to = VMCodeMapping.instance().get_start_address(jump_to) - VMCodeMapping.instance().bytecode_size
 
-        if self.last_code.opcode is not Opcode.RET:
+        if self.last_code.opcode is not Opcode.RET or insert_jump:
             data: bytes = self._get_jump_data(op_info, jump_to)
             self.__insert1(op_info, data)
         for x in range(op_info.stack_items):

--- a/boa3/compiler/codegeneratorvisitor.py
+++ b/boa3/compiler/codegeneratorvisitor.py
@@ -481,8 +481,10 @@ class VisitorCodeGenerator(ast.NodeVisitor):
         for stmt in if_node.body:
             self.visit_to_map(stmt, generate=True)
 
+        ends_with_if = len(if_node.body) > 0 and isinstance(if_node.body[-1], ast.If)
+
         if len(if_node.orelse) > 0:
-            start_addr = self.generator.convert_begin_else(start_addr)
+            start_addr = self.generator.convert_begin_else(start_addr, ends_with_if)
             for stmt in if_node.orelse:
                 self.visit_to_map(stmt, generate=True)
 

--- a/boa3/model/builtin/interop/interop.py
+++ b/boa3/model/builtin/interop/interop.py
@@ -149,4 +149,3 @@ class Interop:
                                  StoragePut
                                  ]
     }
-

--- a/boa3_test/test_sc/if_test/InnerIfElse.py
+++ b/boa3_test/test_sc/if_test/InnerIfElse.py
@@ -1,0 +1,40 @@
+from boa3.builtin import public
+
+
+@public
+def main(a: int, b: int, c: int, d: int) -> int:
+    m = 0
+
+    if a > b:
+
+        if c > d:
+
+            m = 3
+
+        else:
+
+            if b > c:
+
+                return 8
+
+            else:
+
+                return 10
+
+    else:
+
+        if c > d:
+
+            m = 1
+
+        else:
+
+            if b < c:
+
+                return 11
+
+            else:
+
+                m = 22
+
+    return m

--- a/boa3_test/tests/test_function.py
+++ b/boa3_test/tests/test_function.py
@@ -488,57 +488,7 @@ class TestFunction(BoaTest):
         self.assertCompilerLogs(MissingReturnStatement, path)
 
     def test_return_inside_multiple_inner_if(self):
-        expected_output = (
-            Opcode.INITSLOT     # Main
-            + b'\x00'
-            + b'\x01'
-            + Opcode.LDARG0     # if condition
-            + Opcode.JMPIFNOT
-            + Integer(29).to_byte_array(min_length=1, signed=True)
-            + Opcode.LDARG0     # if condition
-            + Opcode.JMPIFNOT
-            + Integer(14).to_byte_array(min_length=1, signed=True)
-            + Opcode.LDARG0     # if condition
-            + Opcode.JMPIFNOT
-            + Integer(4).to_byte_array(min_length=1, signed=True)
-            + Opcode.PUSH1          # return 1
-            + Opcode.RET
-            + Opcode.LDARG0     # if condition
-            + Opcode.JMPIFNOT
-            + Integer(4).to_byte_array(min_length=1, signed=True)
-            + Opcode.PUSH2          # return 2
-            + Opcode.RET
-            + Opcode.PUSH3      # else
-            + Opcode.RET            # return 3
-            + Opcode.LDARG0     # elif condition
-            + Opcode.JMPIFNOT
-            + Integer(9).to_byte_array(min_length=1, signed=True)
-            + Opcode.LDARG0     # if condition
-            + Opcode.JMPIFNOT
-            + Integer(4).to_byte_array(min_length=1, signed=True)
-            + Opcode.PUSH4          # return 4
-            + Opcode.RET
-            + Opcode.PUSH5      # else
-            + Opcode.RET            # return 5
-            + Opcode.PUSH6      # else
-            + Opcode.RET            # return 6
-            + Opcode.LDARG0     # else
-            + Opcode.JMPIFNOT       # if condition
-            + Integer(4).to_byte_array(min_length=1, signed=True)
-            + Opcode.PUSH7          # return 7
-            + Opcode.RET
-            + Opcode.LDARG0         # if condition
-            + Opcode.JMPIFNOT
-            + Integer(4).to_byte_array(min_length=1, signed=True)
-            + Opcode.PUSH8          # return 8
-            + Opcode.RET
-            + Opcode.PUSH9          # else
-            + Opcode.RET                # return 9
-        )
-
         path = '%s/boa3_test/test_sc/function_test/ReturnMultipleInnerIf.py' % self.dirname
-        output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
 
         engine = TestEngine(self.dirname)
         result = self.run_smart_contract(engine, path, 'Main', True)

--- a/boa3_test/tests/test_if.py
+++ b/boa3_test/tests/test_if.py
@@ -331,3 +331,26 @@ class TestIf(BoaTest):
     def test_if_expression_mismatched_types(self):
         path = '%s/boa3_test/test_sc/if_test/MismatchedIfExp.py' % self.dirname
         self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_inner_if_else(self):
+        path = '%s/boa3_test/test_sc/if_test/InnerIfElse.py' % self.dirname
+        self.compile_and_save(path)
+
+        engine = TestEngine(self.dirname)
+        result = self.run_smart_contract(engine, path, 'main', 4, 3, 2, 1)
+        self.assertEqual(3, result)
+
+        result = self.run_smart_contract(engine, path, 'main', 4, 3, 1, 2)
+        self.assertEqual(8, result)
+
+        result = self.run_smart_contract(engine, path, 'main', 4, 1, 2, 3)
+        self.assertEqual(10, result)
+
+        result = self.run_smart_contract(engine, path, 'main', 1, 2, 4, 3)
+        self.assertEqual(1, result)
+
+        result = self.run_smart_contract(engine, path, 'main', 1, 2, 3, 4)
+        self.assertEqual(11, result)
+
+        result = self.run_smart_contract(engine, path, 'main', 1, 3, 2, 4)
+        self.assertEqual(22, result)


### PR DESCRIPTION
**Summary or solution description**
Fixed the bug with multiple if-else branches inside of each other. The compiled smart contract wasn't following the same execution flow as expected.

**How to Reproduce**
```python
if a > b:

    if c > d:

        m = 3

    else:

        if b > c:

            m =8

        else:

            m =10

else:

    if c > d:

        m = 1

    else:

        if b < c:

            m = 11

        else:

            m = 22
```

**Tests**
Included a new unit test for testing the execution of issue
https://github.com/CityOfZion/neo3-boa/blob/b43d17bee348a3c4741351886ec61cd632b2c185/boa3_test/tests/test_if.py#L335-L356