### PR TITLE
Boa-288 Fix Type checking bug with for variable

### DIFF
--- a/boa3/analyser/moduleanalyser.py
+++ b/boa3/analyser/moduleanalyser.py
@@ -779,14 +779,14 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
         """
         iter_type = self.get_type(for_node.iter)
         targets = self.visit(for_node.target)
+        iterator_type = iter_type.value_type if hasattr(iter_type, 'value_type') else iter_type
 
-        if isinstance(iter_type, SequenceType):
-            if isinstance(targets, str):
-                self.__include_variable(targets, iter_type.value_type, source_node=for_node.target)
-            else:
-                for target in targets:
-                    if isinstance(target, str):
-                        self.__include_variable(target, iter_type.value_type, source_node=for_node.target)
+        if isinstance(targets, str):
+            self.__include_variable(targets, iterator_type, source_node=for_node.target)
+        elif isinstance(iter_type, SequenceType):
+            for target in targets:
+                if isinstance(target, str):
+                    self.__include_variable(target, iterator_type, source_node=for_node.target)
 
         # continue to walk through the tree
         self.generic_visit(for_node)

--- a/boa3_test/test_sc/for_test/ForIterateDict.py
+++ b/boa3_test/test_sc/for_test/ForIterateDict.py
@@ -1,0 +1,15 @@
+def main() -> str:
+    j = 20
+    d = {
+        'a': 1,
+        'b': 4,
+        4: 'blah',
+        'm': j,
+        'z': [1, 3, 4, 5, 'abcd', j]
+    }
+
+    output = ''
+    for item in d.keys():
+        output += item
+
+    return output

--- a/boa3_test/tests/test_for.py
+++ b/boa3_test/tests/test_for.py
@@ -504,3 +504,7 @@ class TestFor(BoaTest):
         engine = TestEngine(self.dirname)
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(6, result)
+
+    def test_for_iterate_dict(self):
+        path = '%s/boa3_test/test_sc/for_test/ForIterateDict.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)


### PR DESCRIPTION
**Summary or solution description**
Fixed a bug related to the type checking of for statement's variable

**How to Reproduce**
```python
j = 20
d = {
    'a': 1,
    'b': 4,
    4: 'blah',
    'm': j,
    'z': [1, 3, 4, 5, 'abcd', j]
}

output = ''
for item in d.keys():
    output += item
```
In this code, ``d`` is evaluated as ``Dict[Any, Any]`` and consequently ``d.keys()`` is ``Sequence[Any]``. 
neo3-boa doesn't allow the + operator between ``str`` and ``Any``, so the instruction ``output += item`` should raise an error, but the smart contract with this piece of code was being successfully compiled

**Tests**
Created a unit test expecting a ``MismatchedTypes`` to be raised. Before the changes, this unit test would fail
https://github.com/CityOfZion/neo3-boa/blob/6fdda74eb51549b30e5d9d8a85719e9011f23269/boa3_test/tests/test_for.py#L508-L510
