### PR TITLE
Boa-293 Make manifest and nef compatible with preview 4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
               sudo apt-get update && \
               sudo apt-get install -y dotnet-sdk-3.1
             git clone https://github.com/simplitech/neo-devpack-dotnet.git -b test-engine-executable --single-branch
-            dotnet build ./neo-devpack-dotnet/src/Neo.TestEngine/Neo.TestEngine.csproj -o ./TestEngine
+            dotnet build ./neo-devpack-dotnet/src/Neo.TestEngine/Neo.TestEngine.csproj -o ./Neo.TestEngine
             python -m unittest discover boa3_test
 
   build_deploy: &build_deploy

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,5 @@ build
 _build
 neo3_boa.egg-info
 /neo-devpack-dotnet/
-/TestEngine/
+/Neo.TestEngine/
 autopep8

--- a/boa3/builtin/interop/contract/contract.py
+++ b/boa3/builtin/interop/contract/contract.py
@@ -1,7 +1,12 @@
 from typing import Any, Dict
 
+from boa3.builtin.type import UInt160
+
 
 class Contract:
     def __init__(self):
+        self.id: int = 0
+        self.update_counter: int = 0
+        self.hash: UInt160 = UInt160()
         self.script: bytes = bytes()
         self.manifest: Dict[str, Any] = {}

--- a/boa3/compiler/compiler.py
+++ b/boa3/compiler/compiler.py
@@ -17,6 +17,7 @@ class Compiler:
     def __init__(self):
         self.bytecode: bytearray = bytearray()
         self._analyser: Analyser = None
+        self._entry_smart_contract: str = ''
 
     def compile(self, path: str, log: bool = True) -> bytes:
         """
@@ -30,6 +31,7 @@ class Compiler:
         filepath, filename = os.path.split(fullpath)
 
         logging.info('Started compiling\t{0}'.format(filename))
+        self._entry_smart_contract = os.path.splitext(filename)[0]
         self._analyse(fullpath, log)
         return self._compile()
 
@@ -76,7 +78,7 @@ class Compiler:
                 or len(self.bytecode) == 0):
             raise NotLoadedException
 
-        generator = FileGenerator(self.bytecode, self._analyser)
+        generator = FileGenerator(self.bytecode, self._analyser, self._entry_smart_contract)
         with open(output_path, 'wb+') as nef_file:
             nef_bytes = generator.generate_nef_file()
             nef_file.write(nef_bytes)

--- a/boa3/compiler/filegenerator.py
+++ b/boa3/compiler/filegenerator.py
@@ -17,12 +17,13 @@ class FileGenerator:
     This class is responsible for generating the files.
     """
 
-    def __init__(self, bytecode: bytes, analyser: Analyser):
+    def __init__(self, bytecode: bytes, analyser: Analyser, entry_file: str):
         self._metadata = analyser.metadata
         self._symbols: Dict[str, ISymbol] = analyser.symbol_table
         import os
         self._files: List[str] = [analyser.path.replace(os.sep, '/')]
         self._nef: NefFile = NefFile(bytecode)
+        self._entry_file = entry_file
 
     @property
     def _public_methods(self) -> Dict[str, Method]:
@@ -94,6 +95,7 @@ class FileGenerator:
         """
         # TODO: fill the information of the manifest
         return {
+            "name": self._entry_file,
             "groups": [],
             "features": {
                 "storage": self._metadata.has_storage,
@@ -119,7 +121,6 @@ class FileGenerator:
         :return: a dictionary with the abi information
         """
         return {
-            "hash": self._nef_hash,
             "methods": self._get_abi_methods(),
             "events": self._get_abi_events()
         }

--- a/boa3/model/builtin/interop/contract/contracttype.py
+++ b/boa3/model/builtin/interop/contract/contracttype.py
@@ -16,9 +16,13 @@ class ContractType(ClassType):
 
     def __init__(self):
         super().__init__('Contract')
-
         from boa3.model.type.type import Type
+        from boa3.model.type.collection.sequence.uint160type import UInt160Type
+
         self._variables: Dict[str, Variable] = {
+            'id': Variable(Type.int),
+            'update_counter': Variable(Type.int),
+            'hash': Variable(UInt160Type.build()),
             'script': Variable(Type.bytes),
             'manifest': Variable(Type.dict)
         }
@@ -75,7 +79,10 @@ class ContractMethod(IBuiltinMethod):
         return [
             (Opcode.NEWMAP, b''),
             (Opcode.PUSHDATA1, Integer(0).to_byte_array()),
-            (Opcode.PUSH2, b''),
+            (Opcode.PUSHDATA1, Integer(20).to_byte_array() + bytes(20)),
+            (Opcode.PUSH0, b''),
+            (Opcode.PUSH0, b''),
+            (Opcode.PUSH5, b''),
             (Opcode.PACK, b'')
         ]
 

--- a/boa3/neo/contracts/neffile.py
+++ b/boa3/neo/contracts/neffile.py
@@ -24,7 +24,8 @@ class NefFile:
 
     @property
     def script_hash(self) -> bytes:
-        return self._nef.script_hash.to_array()
+        from boa3.neo.cryptography import hash160
+        return hash160(self.script)
 
     def _set_version(self, version: str):
         """
@@ -61,6 +62,6 @@ class NefFile:
             nef = NEF()
             nef.deserialize(reader)
 
-            nef_file = cls(b'')
+            nef_file = cls(nef.script)
             nef_file._nef = nef
         return nef_file

--- a/boa3_test/test_sc/class_test/ContractConstructor.py
+++ b/boa3_test/test_sc/class_test/ContractConstructor.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.interop.contract import Contract
+
+
+@public
+def new_contract() -> Contract:
+    return Contract()

--- a/boa3_test/tests/test_class.py
+++ b/boa3_test/tests/test_class.py
@@ -1,3 +1,5 @@
+from boa3.neo.vm.type.String import String
+
 from boa3.neo.cryptography import hash160
 from boa3_test.tests.boa_test import BoaTest
 from boa3_test.tests.test_classes.testengine import TestEngine
@@ -45,11 +47,7 @@ class TestClass(BoaTest):
         path = '%s/boa3_test/test_sc/class_test/NotificationSetVariables.py' % self.dirname
         output, manifest = self.compile_and_save(path)
 
-        abi_hash = manifest['abi']['hash']
-        script = bytearray()
-        for x in range(2, len(abi_hash), 2):
-            script.append(int(abi_hash[x:x + 2], 16))
-        script.reverse()
+        script = hash160(output)
 
         engine = TestEngine(self.dirname)
         result = self.run_smart_contract(engine, path, 'script_hash', script,
@@ -61,3 +59,24 @@ class TestClass(BoaTest):
 
         result = self.run_smart_contract(engine, path, 'state', (1, 2, 3))
         self.assertEqual([1, 2, 3], result)
+
+    def test_contract_constructor(self):
+        path = '%s/boa3_test/test_sc/class_test/ContractConstructor.py' % self.dirname
+        output, manifest = self.compile_and_save(path)
+
+        import json
+        engine = TestEngine(self.dirname)
+        result = self.run_smart_contract(engine, path, 'new_contract')
+        self.assertEqual(5, len(result))
+
+        if isinstance(result[2], str):
+            result[2] = String(result[2]).to_bytes()
+        if isinstance(result[3], str):
+            result[3] = String(result[3]).to_bytes()
+
+        self.assertEqual(0, result[0])
+        self.assertEqual(0, result[1])
+        self.assertEqual(bytes(20), result[2])
+        self.assertEqual(bytes(), result[3])
+        self.assertEqual({}, result[4])
+

--- a/boa3_test/tests/test_classes/testengine.py
+++ b/boa3_test/tests/test_classes/testengine.py
@@ -9,7 +9,7 @@ from boa3.neo3.vm import VMState
 
 class TestEngine:
     def __init__(self, root_path: str):
-        self._test_engine_path = '{0}/TestEngine/TestEngine.dll'.format(root_path)
+        self._test_engine_path = '{0}/Neo.TestEngine/Neo.TestEngine.dll'.format(root_path)
 
         self._vm_state: VMState = VMState.NONE
         self._gas_consumed: int = 0

--- a/boa3_test/tests/test_file_generation.py
+++ b/boa3_test/tests/test_file_generation.py
@@ -34,17 +34,15 @@ class TestFileGeneration(BoaTest):
         with open(expected_nef_output, 'rb') as nef_output:
             magic = nef_output.read(constants.SIZE_OF_INT32)
             compiler = nef_output.read(32)
-            version = nef_output.read(16)
-            hash = nef_output.read(constants.SIZE_OF_INT160)
-            check_sum = nef_output.read(constants.SIZE_OF_INT32)
+            version = nef_output.read(32)
             script_size = nef_output.read(1)
-            script = nef_output.read()
+            script = nef_output.read(int.from_bytes(script_size, BYTEORDER))
+            check_sum = nef_output.read(constants.SIZE_OF_INT32)
 
         self.assertEqual(int.from_bytes(script_size, BYTEORDER), len(script))
 
         nef = NefFile(script)._nef
         self.assertEqual(compiler.decode(ENCODING), nef.compiler)
-        self.assertEqual(hash, nef.script_hash.to_array())
         self.assertEqual(check_sum, nef.checksum)
         self.assertEqual(version, nef.version.to_array())
 

--- a/boa3_test/tests/test_neo_types.py
+++ b/boa3_test/tests/test_neo_types.py
@@ -6,7 +6,7 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 class TestNeoTypes(BoaTest):
 
-    def test_hash160_call_bytes(self):
+    def test_uint160_call_bytes(self):
         path = '%s/boa3_test/test_sc/neo_type_test/UInt160CallBytes.py' % self.dirname
 
         engine = TestEngine(self.dirname)
@@ -28,7 +28,7 @@ class TestNeoTypes(BoaTest):
             self.run_smart_contract(engine, path, 'uint160', bytes(30),
                                     expected_result_type=bytes)
 
-    def test_hash160_call_int(self):
+    def test_uint160_call_int(self):
         path = '%s/boa3_test/test_sc/neo_type_test/UInt160CallInt.py' % self.dirname
         self.compile_and_save(path)
 
@@ -50,7 +50,7 @@ class TestNeoTypes(BoaTest):
             self.run_smart_contract(engine, path, 'uint160', bytes(30),
                                     expected_result_type=bytes)
 
-    def test_hash160_call_without_args(self):
+    def test_uint160_call_without_args(self):
         path = '%s/boa3_test/test_sc/neo_type_test/UInt160CallWithoutArgs.py' % self.dirname
 
         engine = TestEngine(self.dirname)
@@ -58,7 +58,7 @@ class TestNeoTypes(BoaTest):
                                          expected_result_type=bytes)
         self.assertEqual(bytes(20), result)
 
-    def test_hash160_return_bytes(self):
+    def test_uint160_return_bytes(self):
         path = '%s/boa3_test/test_sc/neo_type_test/UInt160ReturnBytes.py' % self.dirname
 
         engine = TestEngine(self.dirname)


### PR DESCRIPTION
**Summary or solution description**
Changed manifest and nef implementation to be compatible with the upcoming neo preview 4

**Tests**:
Tested all the unit tests using the most recent version of TestEngine, which uses a Neo version updated with manifest and nef changes