### PR TITLE
Boa-282 Include blocks and transactions in neo-boa's TestEngine

### DIFF
--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -6,7 +6,6 @@ from boa3.analyser.builtinfunctioncallanalyser import BuiltinFunctionCallAnalyse
 from boa3.exception import CompilerError, CompilerWarning
 from boa3.model.attribute import Attribute
 from boa3.model.builtin.builtin import Builtin
-from boa3.model.builtin.builtincallable import IBuiltinCallable
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.callable import Callable
 from boa3.model.expression import IExpression

--- a/boa3/model/builtin/interop/runtime/getnotificationsmethod.py
+++ b/boa3/model/builtin/interop/runtime/getnotificationsmethod.py
@@ -20,7 +20,7 @@ class GetNotificationsMethod(InteropMethod):
         args: Dict[str, Variable] = {'script_hash': Variable(uint160)}
         args_default = ast.parse("{0}()".format(uint160.raw_identifier)
                                  ).body[0].value
-        
+
         super().__init__(identifier, syscall, args, [args_default],
                          return_type=Type.list.build([notification_type]))
 

--- a/boa3/model/builtin/interop/storage/storagegetcontextmethod.py
+++ b/boa3/model/builtin/interop/storage/storagegetcontextmethod.py
@@ -1,7 +1,7 @@
 from typing import Dict
 
-from boa3.model.builtin.interop.storage.storagecontexttype import StorageContextType
 from boa3.model.builtin.interop.interopmethod import InteropMethod
+from boa3.model.builtin.interop.storage.storagecontexttype import StorageContextType
 from boa3.model.variable import Variable
 
 

--- a/boa3/neo/core/types/UInt.py
+++ b/boa3/neo/core/types/UInt.py
@@ -1,0 +1,39 @@
+__all__ = ['UInt160', 'UInt256']
+
+from boa3.neo import to_hex_str
+
+
+class _UIntBase(bytes):
+    def __init__(self, num_bytes: int, data: bytes = None):
+        super(_UIntBase, self).__init__()
+
+        if data is None:
+            self._data = bytearray(num_bytes)
+        else:
+            if isinstance(data, bytes):
+                # make sure it's mutable for string representation
+                self._data = bytearray(data)
+            elif isinstance(data, bytearray):
+                self._data = data
+            else:
+                raise TypeError(f"Invalid data type {type(data)}. Expecting bytes or bytearray")
+
+            if len(self._data) != num_bytes:
+                raise ValueError(f"Invalid UInt: data length {len(self._data)} != specified num_bytes {num_bytes}")
+
+    def __str__(self) -> str:
+        return to_hex_str(self._data)
+
+
+class UInt160(_UIntBase):
+    _BYTE_LEN = 20
+
+    def __init__(self, data: bytes = None):
+        super().__init__(num_bytes=self._BYTE_LEN, data=data)
+
+
+class UInt256(_UIntBase):
+    _BYTE_LEN = 32
+
+    def __init__(self, data: bytes = None):
+        super().__init__(num_bytes=self._BYTE_LEN, data=data)

--- a/boa3/neo3/contracts/nef.py
+++ b/boa3/neo3/contracts/nef.py
@@ -163,7 +163,7 @@ class NEF(serialization.ISerializable):
         with BinaryWriter() as bw:
             bw.write_var_bytes(self.script)
             return bw._stream.getvalue()
-    
+
     def compute_checksum(self) -> bytes:
         data = (self.magic.to_bytes(4, 'little')
                 + self.compiler.encode('utf-8')

--- a/boa3_test/tests/neo/smart_contract/test_neffile.py
+++ b/boa3_test/tests/neo/smart_contract/test_neffile.py
@@ -3,7 +3,6 @@ from unittest import TestCase
 from boa3.constants import ENCODING
 from boa3.neo import to_script_hash
 from boa3.neo.contracts.neffile import NefFile
-from boa3.neo.vm.type.Integer import Integer
 
 
 class TestNefFile(TestCase):

--- a/boa3_test/tests/test_class.py
+++ b/boa3_test/tests/test_class.py
@@ -1,6 +1,5 @@
-from boa3.neo.vm.type.String import String
-
 from boa3.neo.cryptography import hash160
+from boa3.neo.vm.type.String import String
 from boa3_test.tests.boa_test import BoaTest
 from boa3_test.tests.test_classes.testengine import TestEngine
 
@@ -64,7 +63,6 @@ class TestClass(BoaTest):
         path = '%s/boa3_test/test_sc/class_test/ContractConstructor.py' % self.dirname
         output, manifest = self.compile_and_save(path)
 
-        import json
         engine = TestEngine(self.dirname)
         result = self.run_smart_contract(engine, path, 'new_contract')
         self.assertEqual(5, len(result))
@@ -79,4 +77,3 @@ class TestClass(BoaTest):
         self.assertEqual(bytes(20), result[2])
         self.assertEqual(bytes(), result[3])
         self.assertEqual({}, result[4])
-

--- a/boa3_test/tests/test_classes/block.py
+++ b/boa3_test/tests/test_classes/block.py
@@ -1,0 +1,30 @@
+from typing import Any, Dict, List
+
+from boa3_test.tests.test_classes.transaction import Transaction
+
+
+class Block:
+    def __init__(self, index: int):
+        import time
+        self._index: int = index
+        # time() returns timestamp in seconds and Neo uses timestamp in milliseconds
+        self._timestamp: int = int(time.time() * 1000)
+        self._transactions: List[Transaction] = []
+
+    @property
+    def index(self) -> int:
+        return self._index
+
+    @property
+    def timestamp(self) -> int:
+        return self._timestamp
+
+    def add_transaction(self, tx: Transaction):
+        self._transactions.append(tx)
+
+    def to_json(self) -> Dict[str, Any]:
+        return {
+            'index': self._index,
+            'timestamp': self._timestamp,
+            'transactions': [tx.to_json() for tx in self._transactions]
+        }

--- a/boa3_test/tests/test_classes/signer.py
+++ b/boa3_test/tests/test_classes/signer.py
@@ -1,0 +1,20 @@
+from typing import Any, Dict
+
+from boa3.neo.core.types.UInt import UInt160
+
+
+class Signer:
+    def __init__(self, account: UInt160):
+        self._account: UInt160 = account
+
+    @property
+    def account(self) -> UInt160:
+        return self._account
+
+    def to_json(self) -> Dict[str, Any]:
+        return {
+            'account': str(self._account)
+        }
+
+    def __str__(self) -> str:
+        return self._account.__str__()

--- a/boa3_test/tests/test_classes/transaction.py
+++ b/boa3_test/tests/test_classes/transaction.py
@@ -1,0 +1,19 @@
+from typing import Any, Dict, List
+
+from boa3.neo.core.types.UInt import UInt160
+from boa3_test.tests.test_classes.signer import Signer
+from boa3_test.tests.test_classes.witness import Witness
+
+
+class Transaction:
+    def __init__(self, script: UInt160, signers: List[Signer] = None, witnesses: List[Witness] = None):
+        self._signers: List[Signer] = signers if signers is not None else []
+        self._witnesses: List[Witness] = witnesses if witnesses is not None else []
+        self._script: UInt160 = script
+
+    def to_json(self) -> Dict[str, Any]:
+        return {
+            'signers': [signer.to_json() for signer in self._signers],
+            'witnesses': [witness.to_json() for witness in self._witnesses],
+            'script': str(self._script)
+        }

--- a/boa3_test/tests/test_classes/witness.py
+++ b/boa3_test/tests/test_classes/witness.py
@@ -1,0 +1,22 @@
+from typing import Any, Dict
+
+
+class Witness:
+    def __init__(self, invocation_script: bytes, verification_script: bytes):
+        self._invocation_script = invocation_script
+        self._verification_script = verification_script
+
+    @property
+    def invocation_script(self) -> bytes:
+        return self._invocation_script
+
+    @property
+    def verification_script(self) -> bytes:
+        return self._verification_script
+
+    def to_json(self) -> Dict[str, Any]:
+        import base64
+        return {
+            'invocation': base64.b64encode(self._invocation_script).decode(),
+            'verification': base64.b64encode(self._verification_script).decode()
+        }

--- a/boa3_test/tests/test_interop.py
+++ b/boa3_test/tests/test_interop.py
@@ -1,5 +1,4 @@
 import json
-import unittest
 
 from boa3.boa3 import Boa3
 from boa3.builtin.interop.contract import GAS, NEO
@@ -438,14 +437,14 @@ class TestInterop(BoaTest):
 
     def test_create_contract(self):
         expected_output = (
-                Opcode.INITSLOT
-                + b'\x00'
-                + b'\x02'
-                + Opcode.LDARG1
-                + Opcode.LDARG0
-                + Opcode.SYSCALL
-                + Interop.CreateContract.interop_method_hash
-                + Opcode.RET
+            Opcode.INITSLOT
+            + b'\x00'
+            + b'\x02'
+            + Opcode.LDARG1
+            + Opcode.LDARG0
+            + Opcode.SYSCALL
+            + Interop.CreateContract.interop_method_hash
+            + Opcode.RET
         )
 
         path = '%s/boa3_test/test_sc/interop_test/CreateContract.py' % self.dirname
@@ -1820,7 +1819,6 @@ class TestInterop(BoaTest):
         output = self.assertCompilerLogs(NameShadowing, path)
         self.assertEqual(expected_output, output)
 
-    @unittest.skip("Block time doesn't return zero")
     def test_get_block_time(self):
         expected_output = (
             Opcode.SYSCALL
@@ -1833,8 +1831,9 @@ class TestInterop(BoaTest):
         self.assertEqual(expected_output, output)
 
         engine = TestEngine(self.dirname)
+        new_block = engine.increase_block()
         result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(0, result)
+        self.assertEqual(new_block.timestamp, result)
 
     def test_block_time_cant_assign(self):
         expected_output = (


### PR DESCRIPTION
**Summary or solution description**
Included blocks and transactions in the TestEngine and fixed ``test_get_block_time`` unit test.

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/6ca727eaf539601e916a8055fd412a9e31559df8/boa3_test/tests/test_interop.py#L1822-L1836