### PR TITLE
Boa-130 Convert bytearray extend method

### DIFF
--- a/boa3/model/builtin/classmethod/extendmethod.py
+++ b/boa3/model/builtin/classmethod/extendmethod.py
@@ -42,15 +42,19 @@ class ExtendMethod(IBuiltinMethod):
         return sequence_type.value_type.is_type_of(iterator_type.value_type)
 
     @property
-    def is_supported(self) -> bool:
-        # TODO: remove when bytearray.extend() is implemented
-        from boa3.model.type.type import Type
-        return self._arg_self.type is not Type.bytearray
+    def stores_on_slot(self) -> bool:
+        return True
 
     @property
     def opcode(self) -> List[Tuple[Opcode, bytes]]:
         from boa3.neo.vm.type.Integer import Integer
+        from boa3.neo.vm.type.StackItem import StackItemType
         return [
+            (Opcode.OVER, b''),
+            (Opcode.ISTYPE, StackItemType.Array),
+            (Opcode.JMPIF, Integer(5).to_byte_array(signed=True, min_length=1)),
+            (Opcode.CAT, b''),
+            (Opcode.JMP, Integer(18).to_byte_array(signed=True, min_length=1)),
             (Opcode.UNPACK, b''),       # get the values, top of stack will be the array size
             (Opcode.JMP, Integer(9).to_byte_array(signed=True, min_length=1)),  # begin while
             (Opcode.DUP, b''),

--- a/boa3_test/test_sc/bytes_test/BytearrayExtendWithBuiltin.py
+++ b/boa3_test/test_sc/bytes_test/BytearrayExtendWithBuiltin.py
@@ -4,5 +4,5 @@ from boa3.builtin import public
 @public
 def Main() -> bytearray:
     a = bytearray(b'\x01\x02\x03')
-    a.extend(b'\x04\x05\x06')
+    bytearray.extend(a, b'\x04\x05\x06')
     return a

--- a/boa3_test/test_sc/list_test/ExtendAnyValue.py
+++ b/boa3_test/test_sc/list_test/ExtendAnyValue.py
@@ -1,7 +1,10 @@
 from typing import Any, List
 
+from boa3.builtin import public
 
-def Main(op: str, args: list) -> List[Any]:
+
+@public
+def Main() -> List[Any]:
     a: List[Any] = [1, 2, 3]
     a.extend(('4', 5, True))
     return a  # expected [1, 2, 3, '4', 5, True]

--- a/boa3_test/test_sc/list_test/ExtendTupleValue.py
+++ b/boa3_test/test_sc/list_test/ExtendTupleValue.py
@@ -1,7 +1,10 @@
 from typing import List
 
+from boa3.builtin import public
 
-def Main(op: str, args: list) -> List[int]:
+
+@public
+def Main() -> List[int]:
     a = [1, 2, 3]
     a.extend((4, 5, 6))
     return a  # expected [1, 2, 3, 4, 5, 6]

--- a/boa3_test/test_sc/list_test/ExtendWithBuiltin.py
+++ b/boa3_test/test_sc/list_test/ExtendWithBuiltin.py
@@ -1,7 +1,10 @@
 from typing import List
 
+from boa3.builtin import public
 
-def Main(op: str, args: list) -> List[int]:
+
+@public
+def Main() -> List[int]:
     a = [1, 2, 3]
     list.extend(a, [4, 5, 6])
     return a  # expected [1, 2, 3, 4, 5, 6]

--- a/boa3_test/tests/test_builtin_method.py
+++ b/boa3_test/tests/test_builtin_method.py
@@ -368,88 +368,16 @@ class TestBuiltinMethod(BoaTest):
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_extend_mutable_sequence(self):
-        expected_output = (
-            Opcode.INITSLOT     # function signature
-            + b'\x01'
-            + b'\x00'
-            + Opcode.PUSH3      # a = [1, 2, 3]
-            + Opcode.PUSH2
-            + Opcode.PUSH1
-            + Opcode.PUSH3
-            + Opcode.PACK
-            + Opcode.STLOC0
-            + Opcode.LDLOC0     # a.extend((4, 5, 6))
-            + Opcode.PUSH6      # (4, 5, 6)
-            + Opcode.PUSH5
-            + Opcode.PUSH4
-            + Opcode.PUSH3
-            + Opcode.PACK
-            + Opcode.UNPACK     # a.extend
-            + Opcode.JMP
-            + Integer(9).to_byte_array(signed=True, min_length=1)
-            + Opcode.DUP
-            + Opcode.INC
-            + Opcode.PICK
-            + Opcode.PUSH2
-            + Opcode.ROLL
-            + Opcode.APPEND
-            + Opcode.DEC
-            + Opcode.DUP
-            + Opcode.JMPIF
-            + Integer(-8).to_byte_array(signed=True, min_length=1)
-            + Opcode.DROP
-            + Opcode.DROP
-            + Opcode.LDLOC0     # return a
-            + Opcode.RET
-        )
         path = '%s/boa3_test/test_sc/built_in_methods_test/ExtendMutableSequence.py' % self.dirname
-
         output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
 
         engine = TestEngine(self.dirname)
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([1, 2, 3, 4, 5, 6], result)
 
     def test_extend_mutable_sequence_with_builtin(self):
-        expected_output = (
-            Opcode.INITSLOT     # function signature
-            + b'\x01'
-            + b'\x00'
-            + Opcode.PUSH3      # a = [1, 2, 3]
-            + Opcode.PUSH2
-            + Opcode.PUSH1
-            + Opcode.PUSH3
-            + Opcode.PACK
-            + Opcode.STLOC0
-            + Opcode.LDLOC0     # MutableSequence.extend(a, [4, 5, 6])
-            + Opcode.PUSH6      # [4, 5, 6]
-            + Opcode.PUSH5
-            + Opcode.PUSH4
-            + Opcode.PUSH3
-            + Opcode.PACK
-            + Opcode.UNPACK     # a.extend
-            + Opcode.JMP
-            + Integer(9).to_byte_array(signed=True, min_length=1)
-            + Opcode.DUP
-            + Opcode.INC
-            + Opcode.PICK
-            + Opcode.PUSH2
-            + Opcode.ROLL
-            + Opcode.APPEND
-            + Opcode.DEC
-            + Opcode.DUP
-            + Opcode.JMPIF
-            + Integer(-8).to_byte_array(signed=True, min_length=1)
-            + Opcode.DROP
-            + Opcode.DROP
-            + Opcode.LDLOC0     # return a
-            + Opcode.RET
-        )
         path = '%s/boa3_test/test_sc/built_in_methods_test/ExtendMutableSequenceBuiltinCall.py' % self.dirname
-
         output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
 
         engine = TestEngine(self.dirname)
         result = self.run_smart_contract(engine, path, 'Main')

--- a/boa3_test/tests/test_bytes.py
+++ b/boa3_test/tests/test_bytes.py
@@ -437,7 +437,7 @@ class TestBytes(BoaTest):
     @unittest.skip("reverse items doesn't work with bytestring")
     def test_byte_array_reverse(self):
         path = '%s/boa3_test/test_sc/bytes_test/BytearrayReverse.py' % self.dirname
-        output = Boa3.compile(path)
+        Boa3.compile(path)
 
         engine = TestEngine(self.dirname)
         result = self.run_smart_contract(engine, path, 'Main',
@@ -446,7 +446,21 @@ class TestBytes(BoaTest):
 
     def test_byte_array_extend(self):
         path = '%s/boa3_test/test_sc/bytes_test/BytearrayExtend.py' % self.dirname
-        self.assertCompilerLogs(NotSupportedOperation, path)
+        Boa3.compile(path)
+
+        engine = TestEngine(self.dirname)
+        result = self.run_smart_contract(engine, path, 'Main',
+                                         expected_result_type=bytes)
+        self.assertEqual(b'\x01\x02\x03\x04\x05\x06', result)
+
+    def test_byte_array_extend_with_builtin(self):
+        path = '%s/boa3_test/test_sc/bytes_test/BytearrayExtendWithBuiltin.py' % self.dirname
+        Boa3.compile(path)
+
+        engine = TestEngine(self.dirname)
+        result = self.run_smart_contract(engine, path, 'Main',
+                                         expected_result_type=bytes)
+        self.assertEqual(b'\x01\x02\x03\x04\x05\x06', result)
 
     def test_byte_array_to_int(self):
         path = '%s/boa3_test/test_sc/bytes_test/BytearrayToInt.py' % self.dirname

--- a/boa3_test/tests/test_list.py
+++ b/boa3_test/tests/test_list.py
@@ -1108,86 +1108,19 @@ class TestList(BoaTest):
 
     def test_list_extend_tuple_value(self):
         path = '%s/boa3_test/test_sc/list_test/ExtendTupleValue.py' % self.dirname
-
-        expected_output = (
-            Opcode.INITSLOT     # function signature
-            + b'\x01'
-            + b'\x02'
-            + Opcode.PUSH3      # a = [1, 2, 3]
-            + Opcode.PUSH2
-            + Opcode.PUSH1
-            + Opcode.PUSH3
-            + Opcode.PACK
-            + Opcode.STLOC0
-            + Opcode.LDLOC0     # a.extend((4, 5, 6))
-            + Opcode.PUSH6      # (4, 5, 6)
-            + Opcode.PUSH5
-            + Opcode.PUSH4
-            + Opcode.PUSH3
-            + Opcode.PACK
-            + Opcode.UNPACK     # a.extend
-            + Opcode.JMP
-            + Integer(9).to_byte_array(signed=True, min_length=1)
-            + Opcode.DUP
-            + Opcode.INC
-            + Opcode.PICK
-            + Opcode.PUSH2
-            + Opcode.ROLL
-            + Opcode.APPEND
-            + Opcode.DEC
-            + Opcode.DUP
-            + Opcode.JMPIF
-            + Integer(-8).to_byte_array(signed=True, min_length=1)
-            + Opcode.DROP
-            + Opcode.DROP
-            + Opcode.LDLOC0     # return a
-            + Opcode.RET
-        )
         output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
+
+        engine = TestEngine(self.dirname)
+        result = self.run_smart_contract(engine, path, 'Main')
+        self.assertEqual([1, 2, 3, 4, 5, 6], result)
 
     def test_list_extend_any_value(self):
-        four = String('4').to_bytes(min_length=1)
         path = '%s/boa3_test/test_sc/list_test/ExtendAnyValue.py' % self.dirname
-
-        expected_output = (
-            Opcode.INITSLOT     # function signature
-            + b'\x01'
-            + b'\x02'
-            + Opcode.PUSH3      # a = [1, 2, 3]
-            + Opcode.PUSH2
-            + Opcode.PUSH1
-            + Opcode.PUSH3
-            + Opcode.PACK
-            + Opcode.STLOC0
-            + Opcode.LDLOC0     # a.extend(4)
-            + Opcode.PUSH1      # ('4', 5, True)
-            + Opcode.PUSH5
-            + Opcode.PUSHDATA1
-            + Integer(len(four)).to_byte_array()
-            + four
-            + Opcode.PUSH3
-            + Opcode.PACK
-            + Opcode.UNPACK     # a.extend
-            + Opcode.JMP
-            + Integer(9).to_byte_array(signed=True, min_length=1)
-            + Opcode.DUP
-            + Opcode.INC
-            + Opcode.PICK
-            + Opcode.PUSH2
-            + Opcode.ROLL
-            + Opcode.APPEND
-            + Opcode.DEC
-            + Opcode.DUP
-            + Opcode.JMPIF
-            + Integer(-8).to_byte_array(signed=True, min_length=1)
-            + Opcode.DROP
-            + Opcode.DROP
-            + Opcode.LDLOC0     # return a
-            + Opcode.RET
-        )
         output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
+
+        engine = TestEngine(self.dirname)
+        result = self.run_smart_contract(engine, path, 'Main')
+        self.assertEqual([1, 2, 3, '4', 5, 1], result)
 
     def test_list_extend_mismatched_type(self):
         path = '%s/boa3_test/test_sc/list_test/MismatchedTypeExtendValue.py' % self.dirname
@@ -1199,43 +1132,11 @@ class TestList(BoaTest):
 
     def test_list_extend_with_builtin(self):
         path = '%s/boa3_test/test_sc/list_test/ExtendWithBuiltin.py' % self.dirname
-
-        expected_output = (
-            Opcode.INITSLOT     # function signature
-            + b'\x01'
-            + b'\x02'
-            + Opcode.PUSH3      # a = [1, 2, 3]
-            + Opcode.PUSH2
-            + Opcode.PUSH1
-            + Opcode.PUSH3
-            + Opcode.PACK
-            + Opcode.STLOC0
-            + Opcode.LDLOC0     # list.extend(a, [4, 5, 6])
-            + Opcode.PUSH6      # [4, 5, 6]
-            + Opcode.PUSH5
-            + Opcode.PUSH4
-            + Opcode.PUSH3
-            + Opcode.PACK
-            + Opcode.UNPACK     # a.extend
-            + Opcode.JMP
-            + Integer(9).to_byte_array(signed=True, min_length=1)
-            + Opcode.DUP
-            + Opcode.INC
-            + Opcode.PICK
-            + Opcode.PUSH2
-            + Opcode.ROLL
-            + Opcode.APPEND
-            + Opcode.DEC
-            + Opcode.DUP
-            + Opcode.JMPIF
-            + Integer(-8).to_byte_array(signed=True, min_length=1)
-            + Opcode.DROP
-            + Opcode.DROP
-            + Opcode.LDLOC0     # return a
-            + Opcode.RET
-        )
         output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
+
+        engine = TestEngine(self.dirname)
+        result = self.run_smart_contract(engine, path, 'Main')
+        self.assertEqual([1, 2, 3, 4, 5, 6], result)
 
     def test_list_extend_with_builtin_mismatched_type(self):
         path = '%s/boa3_test/test_sc/list_test/MismatchedTypeExtendWithBuiltin.py' % self.dirname


### PR DESCRIPTION
**Summary or solution description**
Implemented the ``extend`` method for ``bytearray`` values. This method just worked for ``list`` values before

**How to Reproduce**
```python
def Main() -> bytearray:
    a = bytearray(b'\x01\x02\x03')
    a.extend(b'\x04\x05\x06')
    return a
```

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/d820c8e78a535c54c7a37c1a90f2d439afcc2e6d/boa3_test/tests/test_bytes.py#L447-L463

**Platform:**
 - OS: Windows 10 x64
 - Version: neo3-boa v0.6.0
 - Python version: Python 3.8.6

