### PR TITLE
Rollback TestEngine Changes on FAULT result

### DIFF
--- a/boa3_test/tests/boa_test.py
+++ b/boa3_test/tests/boa_test.py
@@ -109,7 +109,8 @@ class BoaTest(TestCase):
                            *arguments: Any, reset_engine: bool = False,
                            fake_storage: Dict[str, Any] = None,
                            signer_accounts: Iterable[bytes] = (),
-                           expected_result_type: Type = None) -> Any:
+                           expected_result_type: Type = None,
+                           rollback_on_fault: bool = True) -> Any:
 
         if smart_contract_path.endswith('.py'):
             if not os.path.isfile(smart_contract_path.replace('.py', '.nef')):
@@ -123,7 +124,7 @@ class BoaTest(TestCase):
             test_engine.add_signer_account(account)
 
         result = test_engine.run(smart_contract_path, method, *arguments,
-                                 reset_engine=reset_engine)
+                                 reset_engine=reset_engine, rollback_on_fault=rollback_on_fault)
 
         if test_engine.vm_state is not VMState.HALT and test_engine.error is not None:
             raise TestExecutionException(test_engine.error)


### PR DESCRIPTION
**Summary or solution description**
The executions resulting FAULT was propagating its results to the following tests, as if the execution was successful.
Changed the TestEngine to only update its properties (storage, events, etc) if the execution result is HALT or when it's explicitly asked to update.

**How to Reproduce**
```
self.run_smart_contract(engine, path, 'Main')  # rollback on fault is True by default
self.run_smart_contract(engine, path, 'Main', rollback_on_fault=False)  # but it can save the changes if needed
```

**Platform:**
 - OS: Windows 10 x64
 - Version; neo3-boa v.0.6.0
 - Python version: Python 3.8.6
