### PR TITLE
Boa-280 Fix error with comparison using list values

### DIFF
--- a/boa3/analyser/moduleanalyser.py
+++ b/boa3/analyser/moduleanalyser.py
@@ -844,7 +844,9 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
         :return: the value of the tuple
         """
         result = [self.get_type(value) for value in tup_node.elts]
-        if Type.none in result:
+        if Type.none in result and isinstance(tup_node.ctx, ast.Load):
+            # if can't define the type of any value, let it to be defined in the type checking
+            # only in load ctx because on store ctx means a tuple of variables to be assigned
             return None
         return tuple(result)
 
@@ -857,6 +859,7 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
         """
         result = [self.get_type(value) for value in list_node.elts]
         if Type.none in result:
+            # if can't define the type of any value, let it to be defined in the type checking
             return None
         return result
 
@@ -881,6 +884,7 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
         values = set(dictionary.values())
 
         if Type.none in keys or Type.none in values:
+            # if can't define the type of any key or value, let it to be defined in the type checking
             return None
         return dictionary
 

--- a/boa3/analyser/moduleanalyser.py
+++ b/boa3/analyser/moduleanalyser.py
@@ -836,25 +836,31 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
         """
         return str.s
 
-    def visit_Tuple(self, tup_node: ast.Tuple) -> Tuple[Any, ...]:
+    def visit_Tuple(self, tup_node: ast.Tuple) -> Optional[Tuple[Any, ...]]:
         """
         Visitor of literal tuple node
 
         :param tup_node: the python ast string node
         :return: the value of the tuple
         """
-        return tuple([self.get_type(value) for value in tup_node.elts])
+        result = [self.get_type(value) for value in tup_node.elts]
+        if Type.none in result:
+            return None
+        return tuple(result)
 
-    def visit_List(self, list_node: ast.List) -> List[Any]:
+    def visit_List(self, list_node: ast.List) -> Optional[List[Any]]:
         """
         Visitor of literal list node
 
         :param list_node: the python ast list node
         :return: the value of the list
         """
-        return [self.get_type(value) for value in list_node.elts]
+        result = [self.get_type(value) for value in list_node.elts]
+        if Type.none in result:
+            return None
+        return result
 
-    def visit_Dict(self, dict_node: ast.Dict) -> Dict[Any, Any]:
+    def visit_Dict(self, dict_node: ast.Dict) -> Optional[Dict[Any, Any]]:
         """
         Visitor of literal dict node
 
@@ -870,6 +876,12 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
                 dictionary[key] = Type.get_generic_type(dictionary[key], value)
             else:
                 dictionary[key] = value
+
+        keys = set(dictionary.keys())
+        values = set(dictionary.values())
+
+        if Type.none in keys or Type.none in values:
+            return None
         return dictionary
 
     # endregion

--- a/boa3_test/test_sc/dict_test/DictBoa2Test2.py
+++ b/boa3_test/test_sc/dict_test/DictBoa2Test2.py
@@ -1,0 +1,12 @@
+from boa3.builtin import public
+
+
+@public
+def Main() -> int:
+
+    d = { 'b': 3, 42: 10 + 7 }
+
+    d['a'] = 4
+    d[13] = 3
+
+    return d['a'] + d[13]

--- a/boa3_test/test_sc/list_test/ArrayBoa2Test1.py
+++ b/boa3_test/test_sc/list_test/ArrayBoa2Test1.py
@@ -1,0 +1,25 @@
+from boa3.builtin import public
+
+
+@public
+def Main() -> bool:
+
+    m = [2, 4, 1, 5 + 12]
+
+    # we cant do this.  once you create an array you cant extend it
+    # m[5] = 8
+
+    m[2] = 7 + 10
+
+    m2 = [9, 10, 11, 12]
+
+    # we can change items
+    m2[0] = 4
+
+    # we can access items in the array!
+    q = m[1]
+
+    # m3 = m + m2 // VM wont support concatenating arrays for now
+
+    # returns 1 aka true
+    return m2[0] == q

--- a/boa3_test/tests/test_dict.py
+++ b/boa3_test/tests/test_dict.py
@@ -387,3 +387,7 @@ class TestDict(BoaTest):
     def test_dict_boa2_test2(self):
         path = '%s/boa3_test/test_sc/dict_test/DictBoa2Test2.py' % self.dirname
         Boa3.compile_and_save(path)
+
+        engine = TestEngine(self.dirname)
+        result = self.run_smart_contract(engine, path, 'Main')
+        self.assertEqual(7, result)

--- a/boa3_test/tests/test_dict.py
+++ b/boa3_test/tests/test_dict.py
@@ -383,3 +383,7 @@ class TestDict(BoaTest):
     def test_dict_values_mismatched_type(self):
         path = '%s/boa3_test/test_sc/dict_test/MismatchedTypeValuesDict.py' % self.dirname
         self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_dict_boa2_test2(self):
+        path = '%s/boa3_test/test_sc/dict_test/DictBoa2Test2.py' % self.dirname
+        Boa3.compile_and_save(path)

--- a/boa3_test/tests/test_list.py
+++ b/boa3_test/tests/test_list.py
@@ -283,6 +283,10 @@ class TestList(BoaTest):
         path = '%s/boa3_test/test_sc/list_test/MismatchedTypeListIndex.py' % self.dirname
         self.assertCompilerLogs(MismatchedTypes, path)
 
+    def test_array_boa2_test1(self):
+        path = '%s/boa3_test/test_sc/list_test/ArrayBoa2Test1.py' % self.dirname
+        Boa3.compile(path)
+
     @unittest.skip("get values from inner arrays is not working as expected")
     def test_list_of_list(self):
         expected_output = (

--- a/boa3_test/tests/test_list.py
+++ b/boa3_test/tests/test_list.py
@@ -287,6 +287,11 @@ class TestList(BoaTest):
         path = '%s/boa3_test/test_sc/list_test/ArrayBoa2Test1.py' % self.dirname
         Boa3.compile(path)
 
+        engine = TestEngine(self.dirname)
+        result = self.run_smart_contract(engine, path, 'Main',
+                                         expected_result_type=bool)
+        self.assertEqual(True, result)
+
     @unittest.skip("get values from inner arrays is not working as expected")
     def test_list_of_list(self):
         expected_output = (


### PR DESCRIPTION
**Summary or solution description**
Evaluating value types of collection types (list, dict, tuple) was wrong when there are inner operations or function calls.

Solved this by checking in the ``typeanalyser.py`` the values again before setting to those variables

**How to Reproduce**
```python
m = [2, 4, 1, 5 + 12]  # instead of setting m as List[int] it was set to List[Any]
return m2[0] == q  # and this didn't work because == operation doesn't work with Any types yet
```

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/d51d74d3517065c5d8e152740c25c46890c4211b/boa3_test/tests/test_list.py#L286-L293
https://github.com/CityOfZion/neo3-boa/blob/d51d74d3517065c5d8e152740c25c46890c4211b/boa3_test/tests/test_dict.py#L387-L393

**Platform:**
 - OS: Windows 10 x64
 - Version: neo3-boa v0.6.0
 - Python version: Python 3.8.6