### PR TITLE
Boa-209 Implement Iterator Next Interop

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,7 +503,7 @@ For an extensive collection of examples:
     </td>
   </tbody>
   <tbody>
-    <td>?</td>
+    <td>✅</td>
     <td>v0.6.1</td>
     <td>Union type</td>
     <td>

--- a/boa3/builtin/interop/iterator/__init__.py
+++ b/boa3/builtin/interop/iterator/__init__.py
@@ -4,3 +4,6 @@ from typing import Collection
 class Iterator:
     def __init__(self, entry: Collection):
         pass
+
+    def next(self) -> bool:
+        pass

--- a/boa3/compiler/codegenerator.py
+++ b/boa3/compiler/codegenerator.py
@@ -1020,16 +1020,22 @@ class CodeGenerator:
         :param symbol_id:
         :param load:
         """
+        method: Method
+
         if symbol_id in class_type.variables:
             return self.convert_class_variable(class_type, symbol_id, load)
         elif symbol_id in class_type.properties:
             symbol = class_type.properties[symbol_id]
             method = symbol.getter if load else symbol.setter
+        elif symbol_id in class_type.instance_methods:
+            method = class_type.instance_methods[symbol_id]
+        else:
+            return
 
-            if isinstance(method, IBuiltinMethod):
-                self.convert_builtin_method_call(method)
-            else:
-                self.convert_method_call(method, 0)
+        if isinstance(method, IBuiltinMethod):
+            self.convert_builtin_method_call(method)
+        else:
+            self.convert_method_call(method, 0)
 
     def convert_class_variable(self, class_type: ClassType, symbol_id: str, load: bool = True):
         """

--- a/boa3/compiler/codegeneratorvisitor.py
+++ b/boa3/compiler/codegeneratorvisitor.py
@@ -543,6 +543,9 @@ class VisitorCodeGenerator(ast.NodeVisitor):
         """
         # the parameters are included into the stack in the reversed order
         function_id = self.visit(call.func)
+        if not isinstance(function_id, str):
+            return Type.none
+
         symbol = self.generator.get_symbol(function_id)
         if isinstance(symbol, ClassType):
             symbol = symbol.constructor_method()

--- a/boa3/model/builtin/interop/iterator/iteratornextmethod.py
+++ b/boa3/model/builtin/interop/iterator/iteratornextmethod.py
@@ -1,0 +1,16 @@
+from typing import Dict, List, Tuple
+
+from boa3.model.builtin.builtinproperty import IBuiltinProperty
+from boa3.model.builtin.interop.interopmethod import InteropMethod
+from boa3.model.builtin.interop.iterator.iteratortype import IteratorType
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class IteratorNextMethod(InteropMethod):
+    def __init__(self):
+        from boa3.model.type.type import Type
+        syscall = 'System.Enumerator.Next'
+        identifier = '-iterator_next'
+        args: Dict[str, Variable] = {'self': Variable(IteratorType.build())}
+        super().__init__(identifier, syscall, args, return_type=Type.bool)

--- a/boa3/model/builtin/interop/iterator/iteratortype.py
+++ b/boa3/model/builtin/interop/iterator/iteratortype.py
@@ -23,6 +23,8 @@ class IteratorType(ClassType, ICollectionType):
         self._constructor: Method = None
         self._origin_collection: ICollectionType = collection
 
+        self._methods = None
+
     @property
     def identifier(self) -> str:
         return '{0}[{1}, {2}]'.format(self._identifier, self.key_type.identifier, self.item_type.identifier)
@@ -41,7 +43,12 @@ class IteratorType(ClassType, ICollectionType):
 
     @property
     def instance_methods(self) -> Dict[str, Method]:
-        return {}
+        if self._methods is None:
+            from boa3.model.builtin.interop.iterator.iteratornextmethod import IteratorNextMethod
+            self._methods = {
+                'next': IteratorNextMethod()
+            }
+        return self._methods.copy()
 
     def constructor_method(self) -> Method:
         # was having a problem with recursive import

--- a/boa3_test/test_sc/interop_test/IteratorNext.py
+++ b/boa3_test/test_sc/interop_test/IteratorNext.py
@@ -1,0 +1,9 @@
+from typing import Collection
+
+from boa3.builtin import public
+from boa3.builtin.interop.iterator import Iterator
+
+
+@public
+def has_next(x: Collection) -> bool:
+    return Iterator(x).next()

--- a/boa3_test/tests/test_interop.py
+++ b/boa3_test/tests/test_interop.py
@@ -1377,6 +1377,23 @@ class TestInterop(BoaTest):
         path = '%s/boa3_test/test_sc/interop_test/IteratorCreateMismatchedTypes.py' % self.dirname
         self.assertCompilerLogs(MismatchedTypes, path)
 
+    def test_iterator_next(self):
+        path = '%s/boa3_test/test_sc/interop_test/IteratorNext.py' % self.dirname
+        self.compile_and_save(path)
+
+        engine = TestEngine(self.dirname)
+        result = self.run_smart_contract(engine, path, 'has_next', [1])
+        self.assertEqual(True, result)
+
+        result = self.run_smart_contract(engine, path, 'has_next', [])
+        self.assertEqual(False, result)
+
+        result = self.run_smart_contract(engine, path, 'has_next', {1: 2, 2: 4})
+        self.assertEqual(True, result)
+
+        result = self.run_smart_contract(engine, path, 'has_next', {})
+        self.assertEqual(False, result)
+
     # endregion
 
     # region Json


### PR DESCRIPTION
**Summary or solution description**
Implemented the ``next`` method for iterating a ``Iterator`` object

**How to Reproduce**
```python
iterator = Iterator([1, 2, 3])
iterator.next()
```

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/9de9ab0dd261a0bf4c18d2974f16ac0435e44689/boa3_test/test_sc/interop_test/IteratorNext.py#L7-L9

**Platform:**
 - OS: Windows 10 x64
 - Version: neo3-boa v0.6.1
 - Python version: Python 3.8.6
