### PR TITLE
Boa-308 Fix operation validation for non-primitive types

### DIFF
--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -13,9 +13,9 @@ from boa3.model.builtin.classmethod.toboolmethod import ToBool as ToBoolMethod
 from boa3.model.builtin.classmethod.tobytesmethod import ToBytes as ToBytesMethod
 from boa3.model.builtin.classmethod.tointmethod import ToInt as ToIntMethod
 from boa3.model.builtin.classmethod.tostrmethod import ToStr as ToStrMethod
-from boa3.model.builtin.contract.nep5transferevent import Nep5TransferEvent
-from boa3.model.builtin.contract.nep17transferevent import Nep17TransferEvent
 from boa3.model.builtin.contract.abortmethod import AbortMethod
+from boa3.model.builtin.contract.nep17transferevent import Nep17TransferEvent
+from boa3.model.builtin.contract.nep5transferevent import Nep5TransferEvent
 from boa3.model.builtin.decorator.metadatadecorator import MetadataDecorator
 from boa3.model.builtin.decorator.publicdecorator import PublicDecorator
 from boa3.model.builtin.interop.interop import Interop

--- a/boa3/model/operation/binary/arithmetic/concat.py
+++ b/boa3/model/operation/binary/arithmetic/concat.py
@@ -27,7 +27,15 @@ class Concat(BinaryOperation):
         left: IType = types[0]
         right: IType = types[1]
 
-        return left == right and left in self._valid_types
+        if left == right and left in self._valid_types:
+            return True
+
+        left_valid_type = next((valid_type for valid_type in self._valid_types
+                                if valid_type.is_type_of(left)), None)
+        right_valid_type = next((valid_type for valid_type in self._valid_types
+                                 if valid_type.is_type_of(right)), None)
+
+        return left_valid_type == right_valid_type
 
     def _get_result(self, left: IType, right: IType) -> IType:
         if self.validate_type(left, right):

--- a/boa3/model/operation/binary/arithmetic/concat.py
+++ b/boa3/model/operation/binary/arithmetic/concat.py
@@ -32,10 +32,13 @@ class Concat(BinaryOperation):
 
         left_valid_type = next((valid_type for valid_type in self._valid_types
                                 if valid_type.is_type_of(left)), None)
+        if left_valid_type is None:
+            return False
+
         right_valid_type = next((valid_type for valid_type in self._valid_types
                                  if valid_type.is_type_of(right)), None)
 
-        return left_valid_type == right_valid_type
+        return right_valid_type is not None and left_valid_type == right_valid_type
 
     def _get_result(self, left: IType, right: IType) -> IType:
         if self.validate_type(left, right):

--- a/boa3_test/examples/NEP17.py
+++ b/boa3_test/examples/NEP17.py
@@ -1,12 +1,12 @@
 from typing import Any
 
-from boa3.builtin.type import UInt160
 from boa3.builtin import NeoMetadata, metadata, public
 from boa3.builtin.contract import Nep17TransferEvent, abort
 from boa3.builtin.interop.blockchain import get_contract
-from boa3.builtin.interop.contract import call_contract, NEO, GAS
+from boa3.builtin.interop.contract import GAS, NEO, call_contract
 from boa3.builtin.interop.runtime import calling_script_hash, check_witness
 from boa3.builtin.interop.storage import delete, get, put
+from boa3.builtin.type import UInt160
 
 
 # -------------------------------------------

--- a/boa3_test/examples/nep5.py
+++ b/boa3_test/examples/nep5.py
@@ -1,3 +1,9 @@
+# -------------------------------------------
+# This standard is deprecated
+# Please check the NEP17 example
+# -------------------------------------------
+
+
 from boa3.builtin import NeoMetadata, metadata, public
 from boa3.builtin.contract import Nep5TransferEvent
 from boa3.builtin.interop.runtime import calling_script_hash, check_witness

--- a/boa3_test/examples/test_native/methods.py
+++ b/boa3_test/examples/test_native/methods.py
@@ -1,10 +1,9 @@
 from typing import Any
 
-from boa3.builtin.type import UInt160
 from boa3.builtin import NeoMetadata, metadata, public
-from boa3.builtin.interop.contract import call_contract, NEO, GAS
+from boa3.builtin.interop.contract import GAS, NEO, call_contract
 from boa3.builtin.interop.runtime import check_witness
-
+from boa3.builtin.type import UInt160
 
 # -------------------------------------------
 # TOKEN SETTINGS

--- a/boa3_test/test_sc/neo_type_test/UInt160ConcatWithBytes.py
+++ b/boa3_test/test_sc/neo_type_test/UInt160ConcatWithBytes.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+from boa3.builtin.type import UInt160
+
+@public
+def uint160_method(arg: UInt160) -> bytes:
+    return arg + b'123'

--- a/boa3_test/tests/examples/test_examples.py
+++ b/boa3_test/tests/examples/test_examples.py
@@ -215,7 +215,6 @@ class TestTemplate(BoaTest):
 
     # endregion
 
-
     # region ico
 
     KYC_WHITELIST_PREFIX = b'KYCWhitelistApproved'

--- a/boa3_test/tests/test_classes/nativeaccountstate.py
+++ b/boa3_test/tests/test_classes/nativeaccountstate.py
@@ -17,5 +17,3 @@ class NativeAccountState:
                 + StackItem.serialize(self.balance)
                 + b'!\x00\x00'
                 )
-
-

--- a/boa3_test/tests/test_neo_types.py
+++ b/boa3_test/tests/test_neo_types.py
@@ -79,3 +79,18 @@ class TestNeoTypes(BoaTest):
         with self.assertRaises(TestExecutionException, msg=self.ASSERT_RESULTED_FALSE_MSG):
             self.run_smart_contract(engine, path, 'uint160', bytes(30),
                                     expected_result_type=bytes)
+
+    def test_uint160_concat_with_bytes(self):
+        path = '%s/boa3_test/test_sc/neo_type_test/UInt160ConcatWithBytes.py' % self.dirname
+        self.compile_and_save(path)
+
+        engine = TestEngine(self.dirname)
+        value = bytes(20)
+        result = self.run_smart_contract(engine, path, 'uint160_method', value,
+                                         expected_result_type=bytes)
+        self.assertEqual(value + b'123', result)
+
+        value = bytes(range(20))
+        result = self.run_smart_contract(engine, path, 'uint160_method', value,
+                                         expected_result_type=bytes)
+        self.assertEqual(value + b'123', result)


### PR DESCRIPTION
**Summary or solution description**
Fixed concat operation validation when using non-primitive types (for example: `UInt160` instead of `bytes`)

**How to Reproduce**
```python
x = UInt160() + b'12345'  # UInt160 implements bytes, so this operation should be accepted
```

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/907d4be02fef7971cae74f46976c34cb7416aedb/boa3_test/tests/test_neo_types.py#L83-L96


**Platform:**
 - OS: Windows 10 x64
 - Version: neo3-boa v0.6.1
 - Python version: Python 3.8.6
