### PR TITLE
Boa-211 Implement Iterator Value Interop

### DIFF
--- a/boa3/analyser/moduleanalyser.py
+++ b/boa3/analyser/moduleanalyser.py
@@ -520,6 +520,21 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
                     symbol_id=str(target_type)
                 )
             )
+
+        if isinstance(target_type, ClassType):
+            args = []
+            for arg in target.args:
+                result = self.visit(arg)
+                if (isinstance(result, str) and not isinstance(arg, (ast.Str, ast.Constant))
+                        and result in self._current_scope.symbols):
+                    result = self.get_type(self._current_scope.symbols[result])
+                args.append(result)
+
+            init = target_type.constructor_method()
+            if hasattr(init, 'build'):
+                init = init.build(args)
+            target_type = init.return_type
+
         return self.get_type(target_type)
 
     def get_enumerate_type(self, var_type: IType) -> IType:

--- a/boa3/builtin/interop/iterator/__init__.py
+++ b/boa3/builtin/interop/iterator/__init__.py
@@ -1,9 +1,13 @@
-from typing import Collection
+from typing import Any, Collection
 
 
 class Iterator:
     def __init__(self, entry: Collection):
         pass
+
+    @property
+    def value(self) -> Any:
+        return None
 
     def next(self) -> bool:
         pass

--- a/boa3/model/builtin/interop/iterator/getiteratorvalue.py
+++ b/boa3/model/builtin/interop/iterator/getiteratorvalue.py
@@ -1,0 +1,25 @@
+from typing import Dict
+
+from boa3.model.builtin.builtinproperty import IBuiltinProperty
+from boa3.model.builtin.interop.interopmethod import InteropMethod
+from boa3.model.builtin.interop.iterator.iteratortype import IteratorType
+from boa3.model.variable import Variable
+
+
+class GetIteratorValue(InteropMethod):
+    def __init__(self, iterator: IteratorType):
+        syscall = 'System.Enumerator.Value'
+        identifier = '-get_iterator_value'
+        args: Dict[str, Variable] = {'self': Variable(iterator)}
+        super().__init__(identifier, syscall, args, return_type=iterator.item_type)
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+
+class IteratorValueProperty(IBuiltinProperty):
+    def __init__(self, iterator: IteratorType):
+        identifier = 'iterator_value'
+        getter = GetIteratorValue(iterator)
+        super().__init__(identifier, getter)

--- a/boa3/model/builtin/interop/iterator/iteratorinitmethod.py
+++ b/boa3/model/builtin/interop/iterator/iteratorinitmethod.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Any, Dict, Optional, Sequence
 
 from boa3.model.builtin.interop.interopmethod import InteropMethod
 from boa3.model.builtin.interop.iterator.iteratortype import IteratorType
@@ -25,3 +25,18 @@ class IteratorMethod(InteropMethod):
     @property
     def _body(self) -> Optional[str]:
         return
+
+    def _entry_arg(self) -> Variable:
+        return self.args['entry']
+
+    def build(self, value: Any):
+        if isinstance(value, Sequence) and len(value) == 1:
+            argument = value[0]
+        else:
+            argument = value
+
+        if self._entry_arg().type.is_type_of(argument):
+            iterator = IteratorType.build(argument)
+            if iterator is not self.return_type:
+                return IteratorMethod(iterator)
+        return super().build(value)

--- a/boa3/model/builtin/interop/iterator/iteratornextmethod.py
+++ b/boa3/model/builtin/interop/iterator/iteratornextmethod.py
@@ -1,10 +1,8 @@
-from typing import Dict, List, Tuple
+from typing import Dict
 
-from boa3.model.builtin.builtinproperty import IBuiltinProperty
 from boa3.model.builtin.interop.interopmethod import InteropMethod
 from boa3.model.builtin.interop.iterator.iteratortype import IteratorType
 from boa3.model.variable import Variable
-from boa3.neo.vm.opcode.Opcode import Opcode
 
 
 class IteratorNextMethod(InteropMethod):

--- a/boa3_test/test_sc/interop_test/IteratorDictValueMismatchedType.py
+++ b/boa3_test/test_sc/interop_test/IteratorDictValueMismatchedType.py
@@ -1,0 +1,11 @@
+from typing import Any, Dict
+
+from boa3.builtin import public
+from boa3.builtin.interop.iterator import Iterator
+
+
+@public
+def dict_iterator(x: Dict[Any, int]) -> str:
+    it = Iterator(x)
+    it.next()
+    return it.value

--- a/boa3_test/test_sc/interop_test/IteratorListValueMismatchedType.py
+++ b/boa3_test/test_sc/interop_test/IteratorListValueMismatchedType.py
@@ -1,0 +1,11 @@
+from typing import List
+
+from boa3.builtin import public
+from boa3.builtin.interop.iterator import Iterator
+
+
+@public
+def list_iterator(x: List[int]) -> str:
+    it = Iterator(x)
+    it.next()
+    return it.value

--- a/boa3_test/test_sc/interop_test/IteratorValue.py
+++ b/boa3_test/test_sc/interop_test/IteratorValue.py
@@ -1,0 +1,20 @@
+from typing import Any, Dict, List, Union
+
+from boa3.builtin import public
+from boa3.builtin.interop.iterator import Iterator
+
+
+@public
+def list_iterator(x: List[int]) -> Union[int, None]:
+    it = Iterator(x)
+    if it.next():
+        return it.value
+    return None
+
+
+@public
+def dict_iterator(x: Dict[Any, int]) -> Union[int, None]:
+    it = Iterator(x)
+    if it.next():
+        return it.value
+    return None

--- a/boa3_test/tests/test_interop.py
+++ b/boa3_test/tests/test_interop.py
@@ -1394,6 +1394,31 @@ class TestInterop(BoaTest):
         result = self.run_smart_contract(engine, path, 'has_next', {})
         self.assertEqual(False, result)
 
+    def test_iterator_value(self):
+        path = '%s/boa3_test/test_sc/interop_test/IteratorValue.py' % self.dirname
+        self.compile_and_save(path)
+
+        engine = TestEngine(self.dirname)
+        result = self.run_smart_contract(engine, path, 'list_iterator', [1])
+        self.assertEqual(1, result)
+
+        result = self.run_smart_contract(engine, path, 'list_iterator', [])
+        self.assertEqual(None, result)
+
+        result = self.run_smart_contract(engine, path, 'dict_iterator', {1: 5, 7: 9})
+        self.assertEqual(5, result)
+
+        result = self.run_smart_contract(engine, path, 'dict_iterator', {})
+        self.assertEqual(None, result)
+
+    def test_iterator_value_dict_mismatched_type(self):
+        path = '%s/boa3_test/test_sc/interop_test/IteratorDictValueMismatchedType.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_iterator_value_list_mismatched_type(self):
+        path = '%s/boa3_test/test_sc/interop_test/IteratorListValueMismatchedType.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)
+
     # endregion
 
     # region Json


### PR DESCRIPTION
**Summary or solution description**
Implemented `value` property of `Iterator`s objects. It gets the value for the current position.

**How to Reproduce**
```python
iterator = Iterator([1, 2, 3])
iterator.next()
x: int = iterator.value
```

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/f902123ebcf2ec22617aaffe35f524549f5d82a6/boa3_test/tests/test_interop.py#L1397-L1412

**Platform:**
 - OS: Windows 10 x64
 - Version: neo3-boa v0.6.1
 - Python version: Python 3.8.6
