### PR TITLE
Boa-310 Include transaction result in the TestEngine

### DIFF
--- a/boa3/neo/__init__.py
+++ b/boa3/neo/__init__.py
@@ -35,3 +35,21 @@ def to_hex_str(data_bytes: bytes) -> str:
         data_bytes = bytearray(data_bytes)
     data_bytes.reverse()
     return '0x' + data_bytes.hex()
+
+
+def from_hex_str(hex_string: str) -> bytes:
+    """
+    Converts a string hex representation to the equivalent bytes.
+
+    :param hex_string: data hex representation.
+    :type hex_string: str
+
+    :return: the represented bytes
+    :rtype: bytes
+    """
+    if hex_string.startswith('0x'):
+        hex_string = hex_string[2:]
+
+    data_bytes = bytearray.fromhex(hex_string)
+    data_bytes.reverse()
+    return bytes(data_bytes)

--- a/boa3_test/tests/test_classes/block.py
+++ b/boa3_test/tests/test_classes/block.py
@@ -1,5 +1,7 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
+from boa3.neo import from_hex_str
+from boa3.neo.core.types.UInt import UInt256
 from boa3_test.tests.test_classes.transaction import Transaction
 
 
@@ -7,8 +9,9 @@ class Block:
     def __init__(self, index: int):
         import time
         self._index: int = index
-        # time() returns timestamp in seconds and Neo uses timestamp in milliseconds
-        self._timestamp: int = int(time.time() * 1000)
+        # time() returns timestamp in nanoseconds and Neo uses timestamp in milliseconds
+        self._timestamp: int = int(time.time_ns() / 1_000_000)
+        self._hash: Optional[UInt256] = None
         self._transactions: List[Transaction] = []
 
     @property
@@ -19,6 +22,15 @@ class Block:
     def timestamp(self) -> int:
         return self._timestamp
 
+    def get_transactions(self) -> List[Transaction]:
+        """
+        Gets a list of the block transactions. Changes in those transactions don't affect the ones inside the block.
+
+        :return: the block transactions
+        :rtype: List[Transaction]
+        """
+        return [tx.copy() for tx in self._transactions]
+
     def add_transaction(self, tx: Transaction):
         self._transactions.append(tx)
 
@@ -28,3 +40,20 @@ class Block:
             'timestamp': self._timestamp,
             'transactions': [tx.to_json() for tx in self._transactions]
         }
+
+    @classmethod
+    def from_json(cls, json: Dict[str, Any]):
+        # 'index' and 'timestamp' fields are required
+        block = cls(int(json['index']))
+        block._timestamp = int(json['timestamp'])
+
+        if 'transactions' in json:
+            tx_json = json['transactions']
+            if not isinstance(tx_json, list):
+                tx_json = [tx_json]
+            block._transactions = [Transaction.from_json(js) for js in tx_json]
+
+        if 'hash' in json and isinstance(json['hash'], str):
+            block._hash = UInt256(from_hex_str(json['hash']))
+
+        return block

--- a/boa3_test/tests/test_classes/signer.py
+++ b/boa3_test/tests/test_classes/signer.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict
 
+from boa3.neo import from_hex_str
 from boa3.neo.core.types.UInt import UInt160
 
 
@@ -15,6 +16,12 @@ class Signer:
         return {
             'account': str(self._account)
         }
+
+    @classmethod
+    def from_json(cls, json: Dict[str, Any]):
+        account_hex = json['account']
+        account = UInt160(from_hex_str(account_hex))
+        return cls(account)
 
     def __str__(self) -> str:
         return self._account.__str__()

--- a/boa3_test/tests/test_classes/transaction.py
+++ b/boa3_test/tests/test_classes/transaction.py
@@ -1,19 +1,47 @@
-from typing import Any, Dict, List
+import base64
+from typing import Any, Dict, List, Optional
 
-from boa3.neo.core.types.UInt import UInt160
+from boa3.neo import from_hex_str, to_hex_str
+from boa3.neo.core.types.UInt import UInt256
 from boa3_test.tests.test_classes.signer import Signer
 from boa3_test.tests.test_classes.witness import Witness
 
 
 class Transaction:
-    def __init__(self, script: UInt160, signers: List[Signer] = None, witnesses: List[Witness] = None):
+    def __init__(self, script: bytes, signers: List[Signer] = None, witnesses: List[Witness] = None):
         self._signers: List[Signer] = signers if signers is not None else []
         self._witnesses: List[Witness] = witnesses if witnesses is not None else []
-        self._script: UInt160 = script
+        self._script: bytes = script
+        self._hash: Optional[UInt256] = None
 
     def to_json(self) -> Dict[str, Any]:
         return {
             'signers': [signer.to_json() for signer in self._signers],
             'witnesses': [witness.to_json() for witness in self._witnesses],
-            'script': str(self._script)
+            'script': to_hex_str(self._script)
         }
+
+    @classmethod
+    def from_json(cls, json: Dict[str, Any]):
+        script = base64.b64decode(json['script'])
+        tx = cls(script)
+        if 'signers' in json:
+            signers_json = json['signers']
+            if not isinstance(signers_json, list):
+                signers_json = [signers_json]
+            tx._signers = [Signer.from_json(js) for js in signers_json]
+
+        if 'witnesses' in json:
+            witnesses_json = json['witnesses']
+            if not isinstance(witnesses_json, list):
+                witnesses_json = [witnesses_json]
+            tx._witnesses = [Witness.from_json(js) for js in witnesses_json]
+
+        if 'hash' in json and isinstance(json['hash'], str):
+            tx._hash = UInt256(from_hex_str(json['hash']))
+        return tx
+
+    def copy(self):
+        copied = Transaction(self._script, self._signers, self._witnesses)
+        copied._hash = self._hash
+        return copied

--- a/boa3_test/tests/test_classes/witness.py
+++ b/boa3_test/tests/test_classes/witness.py
@@ -1,3 +1,4 @@
+import base64
 from typing import Any, Dict
 
 
@@ -20,3 +21,9 @@ class Witness:
             'invocation': base64.b64encode(self._invocation_script).decode(),
             'verification': base64.b64encode(self._verification_script).decode()
         }
+
+    @classmethod
+    def from_json(cls, json: Dict[str, Any]):
+        invocation = base64.b64decode(json['invocation'])
+        verification = base64.b64decode(json['verification'])
+        return cls(invocation, verification)


### PR DESCRIPTION
**Summary or solution description**
When an execution using the TestEngine returns HALT state, the executed transaction has to be included in the current block to better simulate the actual blockchain execution

**Platform:**
 - OS: Windows 10 x64
 - Version: neo3-boa v0.6.1
 - Python version: Python 3.8.6
