### PR TITLE
Boa-178 Convert builtin max

### DIFF
--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -26,6 +26,7 @@ from boa3.model.builtin.method.exceptionmethod import ExceptionMethod
 from boa3.model.builtin.method.exitmethod import ExitMethod
 from boa3.model.builtin.method.isinstancemethod import IsInstanceMethod
 from boa3.model.builtin.method.lenmethod import LenMethod
+from boa3.model.builtin.method.maxmethod import MaxMethod
 from boa3.model.builtin.method.printmethod import PrintMethod
 from boa3.model.builtin.method.rangemethod import RangeMethod
 from boa3.model.builtin.method.toscripthashmethod import ScriptHashMethod
@@ -70,6 +71,7 @@ class Builtin:
     ScriptHash = ScriptHashMethod()
     NewEvent = CreateEventMethod()
     Exit = ExitMethod()
+    Max = MaxMethod()
 
     # python builtin class constructor
     ByteArray = ByteArrayMethod()
@@ -101,6 +103,7 @@ class Builtin:
                                                 Exit,
                                                 IsInstance,
                                                 Len,
+                                                Max,
                                                 Print,
                                                 ScriptHash,
                                                 SequenceAppend,

--- a/boa3/model/builtin/method/maxmethod.py
+++ b/boa3/model/builtin/method/maxmethod.py
@@ -1,0 +1,29 @@
+from typing import Dict, List, Optional, Tuple
+
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class MaxMethod(IBuiltinMethod):
+
+    def __init__(self):     # TODO: make it so that it can accept the same parameters as Python
+        from boa3.model.type.type import Type
+        identifier = 'max'
+        args: Dict[str, Variable] = {
+            'val1': Variable(Type.int),
+            'val2': Variable(Type.int),
+        }
+        super().__init__(identifier, args, return_type=Type.int)
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        return [(Opcode.MAX, b'')]
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> Optional[str]:
+        return

--- a/boa3_test/test_sc/built_in_methods_test/MaxInt.py
+++ b/boa3_test/test_sc/built_in_methods_test/MaxInt.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main(val1: int, val2: int) -> int:
+    return max(val1, val2)

--- a/boa3_test/test_sc/built_in_methods_test/MaxMismatchedTypes.py
+++ b/boa3_test/test_sc/built_in_methods_test/MaxMismatchedTypes.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main() -> int:
+    return max(123, '123')

--- a/boa3_test/test_sc/built_in_methods_test/MaxTooFewParameters.py
+++ b/boa3_test/test_sc/built_in_methods_test/MaxTooFewParameters.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main() -> int:
+    return max()

--- a/boa3_test/tests/test_builtin_method.py
+++ b/boa3_test/tests/test_builtin_method.py
@@ -988,7 +988,7 @@ class TestBuiltinMethod(BoaTest):
         path = '%s/boa3_test/test_sc/built_in_methods_test/MaxTooFewParameters.py' % self.dirname
         self.assertCompilerLogs(UnfilledArgument, path)
 
-    def test_max_too_few_parameters(self):
+    def test_max_mismatched_types(self):
         path = '%s/boa3_test/test_sc/built_in_methods_test/MaxMismatchedTypes.py' % self.dirname
         self.assertCompilerLogs(MismatchedTypes, path)
 

--- a/boa3_test/tests/test_builtin_method.py
+++ b/boa3_test/tests/test_builtin_method.py
@@ -971,3 +971,17 @@ class TestBuiltinMethod(BoaTest):
             self.run_smart_contract(engine, path, 'main', True)
 
     # end region
+
+    # region max test
+
+    def test_max_int(self):
+        path = '%s/boa3_test/test_sc/built_in_methods_test/MaxInt.py' % self.dirname
+        engine = TestEngine(self.dirname)
+
+        value1 = 10
+        value2 = 999
+        expected_result = max(value1, value2)
+        result = self.run_smart_contract(engine, path, 'main', value1, value2)
+        self.assertEqual(expected_result, result)
+
+    # end region

--- a/boa3_test/tests/test_builtin_method.py
+++ b/boa3_test/tests/test_builtin_method.py
@@ -984,4 +984,12 @@ class TestBuiltinMethod(BoaTest):
         result = self.run_smart_contract(engine, path, 'main', value1, value2)
         self.assertEqual(expected_result, result)
 
+    def test_max_too_few_parameters(self):
+        path = '%s/boa3_test/test_sc/built_in_methods_test/MaxTooFewParameters.py' % self.dirname
+        self.assertCompilerLogs(UnfilledArgument, path)
+
+    def test_max_too_few_parameters(self):
+        path = '%s/boa3_test/test_sc/built_in_methods_test/MaxMismatchedTypes.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)
+
     # end region


### PR DESCRIPTION
**Summary or solution description**
Implemented max() to neo3-boa, the method currently only compares 2 ints.

**How to Reproduce**
Call the method with 2 ints as parameters
`max(int_1, int_2)`

**Tests**
Tested it using the test engine
https://github.com/CityOfZion/neo3-boa/blob/2f1938139d905550dc432e4e6a55548705c2d4c6/boa3_test/tests/test_builtin_method.py#L970-L980

**Platform:**
 - OS: Windows 10 x64
 - Version: neo3-boa v0.6
 - Python version: Python 3.8

**(Optional) Additional context**
The original Python max() doesn't compare only 2 ints, so, in the future, this will be tweaked to correspond with the original one
.