### PR TITLE
Boa-302 Verify the issue with empty return

### DIFF
--- a/boa3/compiler/codegenerator.py
+++ b/boa3/compiler/codegenerator.py
@@ -1050,6 +1050,7 @@ class CodeGenerator:
             self.convert_builtin_method_call(method)
         else:
             self.convert_method_call(method, 0)
+        return symbol_id
 
     def convert_class_variable(self, class_type: ClassType, symbol_id: str, load: bool = True):
         """

--- a/boa3/neo/smart_contract/VoidType.py
+++ b/boa3/neo/smart_contract/VoidType.py
@@ -2,7 +2,8 @@ __all__ = ['VoidType']
 
 
 class _Void:
-    pass
+    def __repr__(self) -> str:
+        return 'Void'
 
 
 VoidType = _Void()

--- a/boa3_test/test_sc/function_test/ConditionEmptyReturnFunction.py
+++ b/boa3_test/test_sc/function_test/ConditionEmptyReturnFunction.py
@@ -1,0 +1,9 @@
+from boa3.builtin import public
+
+
+@public
+def Main(a: int):
+    if a > 10:
+        return
+
+    b = a % 10

--- a/boa3_test/test_sc/function_test/EmptyReturnWithOptionalReturnType.py
+++ b/boa3_test/test_sc/function_test/EmptyReturnWithOptionalReturnType.py
@@ -1,0 +1,11 @@
+from typing import Union
+
+from boa3.builtin import public
+
+
+@public
+def Main(a: int) -> Union[int, None]:
+    if a % 2 == 1:
+        return  # in this case returns None because the method is not void
+    return a // 2
+

--- a/boa3_test/test_sc/function_test/ReturnVoidFunction.py
+++ b/boa3_test/test_sc/function_test/ReturnVoidFunction.py
@@ -1,0 +1,12 @@
+from typing import Any
+
+from boa3.builtin import public
+
+
+@public
+def Main() -> Any:
+    return TestFunction()
+
+
+def TestFunction():
+    a = 1

--- a/boa3_test/test_sc/function_test/ReturnVoidFunctionMismatchedType.py
+++ b/boa3_test/test_sc/function_test/ReturnVoidFunctionMismatchedType.py
@@ -1,0 +1,12 @@
+from typing import Any
+
+from boa3.builtin import public
+
+
+@public
+def Main() -> int:
+    return TestFunction()
+
+
+def TestFunction():
+    a = 1

--- a/boa3_test/tests/boa_test.py
+++ b/boa3_test/tests/boa_test.py
@@ -54,8 +54,9 @@ class BoaTest(TestCase):
             raise AssertionError('{0} not logged'.format(expected_logged_exception.__name__))
         return output
 
-    def assertIsVoid(self, obj: Any, msg=None):
-        self.assertEqual(VoidType, obj, msg)
+    def assertIsVoid(self, obj: Any):
+        if obj is not VoidType:
+            self.fail('{0} is not Void'.format(obj))
 
     def compile_and_save(self, path: str, log: bool = True) -> Tuple[bytes, Dict[str, Any]]:
         nef_output = path.replace('.py', '.nef')
@@ -117,7 +118,9 @@ class BoaTest(TestCase):
                            rollback_on_fault: bool = True) -> Any:
 
         if smart_contract_path.endswith('.py'):
-            if not os.path.isfile(smart_contract_path.replace('.py', '.nef')):
+            if not (os.path.isfile(smart_contract_path.replace('.py', '.nef'))
+                    and os.path.isfile(smart_contract_path.replace('.py', '.manifest.json'))):
+                # both .nef and .manifest.json are required to execute the smart contract
                 self.compile_and_save(smart_contract_path, log=False)
             smart_contract_path = smart_contract_path.replace('.py', '.nef')
 


### PR DESCRIPTION
**Summary or solution description**
When using empty `return` statements in the middle of logic, the statement was being ignored in the execution.

**How to Reproduce**
```python
def foo(condition: bool, x: int):
   if condition:
       return  # this was being ignored and the execution flow was converted wrongly
   
   do_something(x)
```

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/17fc914ad7f5eaa2419b1f38bdc07a17d810e012/boa3_test/tests/test_function.py#L88-L146

**Platform:**
 - OS: Windows 10 x64
 - Version: neo3-boa v0.6.1
 - Python version: Python 3.8.6