### PR TITLE
Boa-179 Convert builtin min

### DIFF
--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -27,6 +27,7 @@ from boa3.model.builtin.method.exitmethod import ExitMethod
 from boa3.model.builtin.method.isinstancemethod import IsInstanceMethod
 from boa3.model.builtin.method.lenmethod import LenMethod
 from boa3.model.builtin.method.maxmethod import MaxMethod
+from boa3.model.builtin.method.minmethod import MinMethod
 from boa3.model.builtin.method.printmethod import PrintMethod
 from boa3.model.builtin.method.rangemethod import RangeMethod
 from boa3.model.builtin.method.toscripthashmethod import ScriptHashMethod
@@ -72,6 +73,7 @@ class Builtin:
     NewEvent = CreateEventMethod()
     Exit = ExitMethod()
     Max = MaxMethod()
+    Min = MinMethod()
 
     # python builtin class constructor
     ByteArray = ByteArrayMethod()
@@ -104,6 +106,7 @@ class Builtin:
                                                 IsInstance,
                                                 Len,
                                                 Max,
+                                                Min,
                                                 Print,
                                                 ScriptHash,
                                                 SequenceAppend,

--- a/boa3/model/builtin/method/minmethod.py
+++ b/boa3/model/builtin/method/minmethod.py
@@ -1,0 +1,29 @@
+from typing import Dict, List, Optional, Tuple
+
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class MinMethod(IBuiltinMethod):
+
+    def __init__(self):     # TODO: make it so that it can accept the same parameters as Python
+        from boa3.model.type.type import Type
+        identifier = 'min'
+        args: Dict[str, Variable] = {
+            'val1': Variable(Type.int),
+            'val2': Variable(Type.int),
+        }
+        super().__init__(identifier, args, return_type=Type.int)
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        return [(Opcode.MIN, b'')]
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> Optional[str]:
+        return None

--- a/boa3_test/test_sc/built_in_methods_test/MinInt.py
+++ b/boa3_test/test_sc/built_in_methods_test/MinInt.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main(val1: int, val2: int) -> int:
+    return min(val1, val2)

--- a/boa3_test/test_sc/built_in_methods_test/MinMismatchedTypes.py
+++ b/boa3_test/test_sc/built_in_methods_test/MinMismatchedTypes.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main() -> int:
+    return min(10, 'test')

--- a/boa3_test/test_sc/built_in_methods_test/MinTooFewParameters.py
+++ b/boa3_test/test_sc/built_in_methods_test/MinTooFewParameters.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main() -> int:
+    return min()

--- a/boa3_test/tests/test_builtin_method.py
+++ b/boa3_test/tests/test_builtin_method.py
@@ -990,6 +990,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_max_mismatched_types(self):
         path = '%s/boa3_test/test_sc/built_in_methods_test/MaxMismatchedTypes.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)
 
     # end region
 

--- a/boa3_test/tests/test_builtin_method.py
+++ b/boa3_test/tests/test_builtin_method.py
@@ -990,6 +990,27 @@ class TestBuiltinMethod(BoaTest):
 
     def test_max_mismatched_types(self):
         path = '%s/boa3_test/test_sc/built_in_methods_test/MaxMismatchedTypes.py' % self.dirname
+
+    # end region
+
+    # region min test
+
+    def test_min_int(self):
+        path = '%s/boa3_test/test_sc/built_in_methods_test/MinInt.py' % self.dirname
+        engine = TestEngine(self.dirname)
+
+        val1 = 50
+        val2 = 1
+        expected_result = min(val1, val2)
+        result = self.run_smart_contract(engine, path, 'main', val1, val2)
+        self.assertEqual(expected_result, result)
+
+    def test_min_too_few_parameters(self):
+        path = '%s/boa3_test/test_sc/built_in_methods_test/MinTooFewParameters.py' % self.dirname
+        self.assertCompilerLogs(UnfilledArgument, path)
+
+    def test_min_mismatched_types(self):
+        path = '%s/boa3_test/test_sc/built_in_methods_test/MinMismatchedTypes.py' % self.dirname
         self.assertCompilerLogs(MismatchedTypes, path)
 
     # end region


### PR DESCRIPTION
**Summary or solution description**
 Implemented min() to neo3-boa, the method currently only compares 2 ints.

**How to Reproduce**
Call the method with 2 ints as parameters
`min(int_1, int_2)`

**Tests**
 Tested it using the test engine
https://github.com/CityOfZion/neo3-boa/blob/4e0685e30aa272f4dccae6437eb4cb25a5ddf9ff/boa3_test/tests/test_builtin_method.py#L998-L1014

**Platform:**
 - OS: Windows 10 x64
 - Version: neo3-boa v0.6
 - Python version: Python 3.8

**(Optional) Additional context**
 The original Python min() doesn't compare only 2 ints, so, in the future, this will be tweaked to correspond with the original one.
