### PR TITLE
Boa-228 Create atomic swap example for neo3-boa

### DIFF
--- a/boa3/model/type/collection/icollection.py
+++ b/boa3/model/type/collection/icollection.py
@@ -99,7 +99,7 @@ class ICollectionType(IType, ABC):
             if all(isinstance(x, collection_type) for x in values_type):
                 # if all the types are the same sequence type, build this sequence with any as parameters
                 types = set(value.item_type for value in values_type)
-                values_type = {collection_type(values_type=types)}
+                values_type = {collection_type.build(types)}
             else:
                 generic_type: IType = Type.get_generic_type(*values_type)
                 if (isinstance(generic_type, ICollectionType)

--- a/boa3_test/examples/HTLC.py
+++ b/boa3_test/examples/HTLC.py
@@ -1,0 +1,234 @@
+from typing import Any
+
+from boa3.builtin.interop.contract import call_contract
+from boa3.builtin.interop.runtime import executing_script_hash, get_time, calling_script_hash, check_witness
+from boa3.builtin import NeoMetadata, metadata, public
+from boa3.builtin.interop.crypto import hash160
+from boa3.builtin.interop.storage import get, put
+from boa3.builtin.contract import abort
+from boa3.builtin.type import UInt160
+
+
+# -------------------------------------------
+# METADATA
+# -------------------------------------------
+
+
+@metadata
+def manifest_metadata() -> NeoMetadata:
+    """
+    Defines this smart contract's metadata information
+    """
+    meta = NeoMetadata()
+    return meta
+
+
+# -------------------------------------------
+# VARIABLES SETTINGS
+# -------------------------------------------
+
+OWNER = UInt160(b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
+OTHER_PERSON: bytes = b'person b'
+ADDRESS_PREFIX: bytes = b'address'
+AMOUNT_PREFIX: bytes = b'amount'
+TOKEN_PREFIX: bytes = b'token'
+FUNDED_PREFIX: bytes = b'funded'
+
+# Number of seconds that need to pass before refunding the contract
+LOCK_TIME = 15 * 1
+
+NOT_INITIALIZED: bytes = b'not initialized'
+START_TIME: bytes = b'start time'
+SECRET_HASH: bytes = b'secret hash'
+DEPLOYED: bytes = b'deployed'
+
+
+# -------------------------------------------
+# Methods
+# -------------------------------------------
+
+
+@public
+def verify() -> bool:
+    """
+    When this contract address is included in the transaction signature,
+    this method will be triggered as a VerificationTrigger to verify that the signature is correct.
+    For example, this method needs to be called when withdrawing token from the contract.
+
+    :return: whether the transaction signature is correct
+    """
+    return check_witness(OWNER)
+
+
+@public
+def deploy() -> bool:
+    """
+    Initializes OWNER and change values of NOT_INITIALIZED and DEPLOYED when the smart contract is deployed.
+
+    :return: whether the deploy was successful. This method must return True only during the smart contract's deploy.
+    """
+    if not check_witness(OWNER):
+        return False
+    if get(DEPLOYED).to_bool() == True:
+        return False
+
+    put(OWNER, OWNER)
+    put(NOT_INITIALIZED, True)
+    put(DEPLOYED, True)
+    return True
+
+
+@public
+def atomic_swap(owner_address: UInt160, owner_token: bytes, owner_amount: int, other_person_address: UInt160,
+                other_person_token: bytes, other_person_amount: int, secret_hash: bytes) -> bool:
+    """
+    Initializes the storage when the atomic swap starts.
+
+    :param owner_address: address of owner
+    :type owner_address: UInt160
+    :param owner_token: other_person's desired token
+    :type owner_token: bytes
+    :param owner_amount: other_person's desired amount of tokens
+    :type owner_amount: int
+    :param other_person_address: address of other_person
+    :type other_person_address: bytes
+    :param other_person_token: owner's desired token
+    :type other_person_token: bytes
+    :param other_person_amount: owner's desired amount of tokens
+    :type other_person_amount: int
+    :param secret_hash: the secret hash created by the contract deployer
+    :type secret_hash: bytes
+
+    :return: whether the deploy was successful or not
+    :rtype: bool
+
+    :raise AssertionError: raised if `owner_address` or `other_person_address` length is not 20 or if `amount` is not
+    greater than zero.
+    """
+    # the parameters from and to should be 20-byte addresses. If not, this method should throw an exception.
+    assert len(owner_address) == 20 and len(other_person_address) == 20
+    # the parameter amount must be greater than 0. If not, this method should throw an exception.
+    assert owner_amount > 0 and other_person_amount > 0
+
+    if get(NOT_INITIALIZED).to_bool() == True and verify():
+        put(ADDRESS_PREFIX + OWNER, owner_address)
+        put(TOKEN_PREFIX + OWNER, owner_token)
+        put(AMOUNT_PREFIX + OWNER, owner_amount)
+        put(ADDRESS_PREFIX + OTHER_PERSON, other_person_address)
+        put(TOKEN_PREFIX + OTHER_PERSON, other_person_token)
+        put(AMOUNT_PREFIX + OTHER_PERSON, other_person_amount)
+        put(SECRET_HASH, secret_hash)
+        put(NOT_INITIALIZED, False)
+        put(START_TIME, get_time)
+        return True
+    return False
+
+
+@public
+def onPayment(from_address: UInt160, amount: int, data: Any):
+    """
+    Since this is a deployed contract, transfer will be calling this onPayment method with the data parameter from
+    transfer. If someone is doing a not required transfer, then ABORT will be called.
+
+    :param from_address: the address of the one who is trying to transfer cryptocurrency to this smart contract
+    :type from_address: UInt160
+    :param amount: the amount of cryptocurrency that is being sent to this smart contract
+    :type amount: int
+    :param data: any pertinent data that may validate the transaction
+    :type data: Any
+
+    :raise AssertionError: raised if `from_address` length is not 20
+    """
+    # the parameters from and to should be 20-byte addresses. If not, this method should throw an exception.
+    assert len(from_address) == 20
+
+    if get(NOT_INITIALIZED).to_bool() == False:
+        # Used to check if the one who's transferring to this contract is the OWNER
+        address = get(ADDRESS_PREFIX + OWNER)
+        # Used to check if OWNER already transfer to this smart contract
+        funded_crypto = get(FUNDED_PREFIX + OWNER).to_int()
+        # Used to check if OWNER is transferring the correct amount
+        amount_crypto = get(AMOUNT_PREFIX + OWNER).to_int()
+        # Used to check if OWNER is transferring the correct token
+        token_crypto = get(TOKEN_PREFIX + OWNER)
+        if (from_address == address and
+                funded_crypto == 0 and
+                amount == amount_crypto and
+                calling_script_hash == token_crypto):
+            put(FUNDED_PREFIX + OWNER, amount)
+            return
+        else:
+            # Used to check if the one who's transferring to this contract is the OTHER_PERSON
+            address = get(ADDRESS_PREFIX + OTHER_PERSON)
+            # Used to check if OTHER_PERSON already transfer to this smart contract
+            funded_crypto = get(FUNDED_PREFIX + OTHER_PERSON).to_int()
+            # Used to check if OTHER_PERSON is transferring the correct amount
+            amount_crypto = get(AMOUNT_PREFIX + OTHER_PERSON).to_int()
+            # Used to check if OTHER_PERSON is transferring the correct token
+            token_crypto = get(TOKEN_PREFIX + OTHER_PERSON)
+            if (from_address == address and
+                    funded_crypto == 0 and
+                    amount == amount_crypto and
+                    calling_script_hash == token_crypto):
+                put(FUNDED_PREFIX + OTHER_PERSON, amount)
+                return
+    abort()
+
+
+@public
+def withdraw(secret: str) -> bool:
+    """
+    Deposits the contract's cryptocurrency into the owner and other_person addresses as long as they both transferred
+    to this contract and there is some time remaining
+
+    :param secret: the private key that unlocks the transaction
+    :type secret: str
+
+    :return: whether the transfers were successful
+    :rtype: bool
+    """
+    # Checking if OWNER and OTHER_PERSON transferred to this smart contract
+    funded_owner = get(FUNDED_PREFIX + OWNER).to_int()
+    funded_other_person = get(FUNDED_PREFIX + OTHER_PERSON).to_int()
+    if verify() and not refund() and hash160(secret) == get(SECRET_HASH) and funded_owner != 0 and funded_other_person != 0:
+        put(FUNDED_PREFIX + OWNER, 0)
+        put(FUNDED_PREFIX + OTHER_PERSON, 0)
+        put(NOT_INITIALIZED, True)
+        put(START_TIME, 0)
+        call_contract(UInt160(get(TOKEN_PREFIX + OTHER_PERSON)), 'transfer',
+                      [executing_script_hash, get(ADDRESS_PREFIX + OWNER), get(AMOUNT_PREFIX + OTHER_PERSON), ''])
+        call_contract(UInt160(get(TOKEN_PREFIX + OWNER)), 'transfer',
+                      [executing_script_hash, get(ADDRESS_PREFIX + OTHER_PERSON), get(AMOUNT_PREFIX + OWNER), ''])
+        return True
+
+    return False
+
+
+@public
+def refund() -> bool:
+    """
+    If the atomic swap didn't occur in time, refunds the cryptocurrency that was deposited in this smart contract
+
+    :return: whether enough time has passed and the cryptocurrencies were refunded
+    :rtype: bool
+    """
+    if get_time > get(START_TIME).to_int() + LOCK_TIME:
+
+        # Checking if OWNER transferred to this smart contract
+        funded_crypto = get(FUNDED_PREFIX + OWNER).to_int()
+        if funded_crypto != 0:
+            call_contract(UInt160(get(TOKEN_PREFIX + OWNER)), 'transfer',
+                          [executing_script_hash, get(ADDRESS_PREFIX + OWNER), get(AMOUNT_PREFIX + OWNER)])
+
+        # Checking if OTHER_PERSON transferred to this smart contract
+        funded_crypto = get(FUNDED_PREFIX + OTHER_PERSON).to_int()
+        if funded_crypto != 0:
+            call_contract(UInt160(get(TOKEN_PREFIX + OTHER_PERSON)), 'transfer',
+                          [executing_script_hash, get(ADDRESS_PREFIX + OTHER_PERSON), get(AMOUNT_PREFIX + OTHER_PERSON)])
+
+        put(FUNDED_PREFIX + OWNER, 0)
+        put(FUNDED_PREFIX + OTHER_PERSON, 0)
+        put(NOT_INITIALIZED, True)
+        put(START_TIME, 0)
+        return True
+    return False

--- a/boa3_test/examples/HTLC.py
+++ b/boa3_test/examples/HTLC.py
@@ -27,7 +27,7 @@ def manifest_metadata() -> NeoMetadata:
 # VARIABLES SETTINGS
 # -------------------------------------------
 
-OWNER = UInt160(b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
+OWNER = UInt160()
 OTHER_PERSON: bytes = b'person b'
 ADDRESS_PREFIX: bytes = b'address'
 AMOUNT_PREFIX: bytes = b'amount'
@@ -69,7 +69,7 @@ def deploy() -> bool:
     """
     if not check_witness(OWNER):
         return False
-    if get(DEPLOYED).to_bool() == True:
+    if get(DEPLOYED).to_bool():
         return False
 
     put(OWNER, OWNER)
@@ -110,7 +110,7 @@ def atomic_swap(owner_address: UInt160, owner_token: bytes, owner_amount: int, o
     # the parameter amount must be greater than 0. If not, this method should throw an exception.
     assert owner_amount > 0 and other_person_amount > 0
 
-    if get(NOT_INITIALIZED).to_bool() == True and verify():
+    if get(NOT_INITIALIZED).to_bool() and verify():
         put(ADDRESS_PREFIX + OWNER, owner_address)
         put(TOKEN_PREFIX + OWNER, owner_token)
         put(AMOUNT_PREFIX + OWNER, owner_amount)
@@ -142,7 +142,7 @@ def onPayment(from_address: UInt160, amount: int, data: Any):
     # the parameters from and to should be 20-byte addresses. If not, this method should throw an exception.
     assert len(from_address) == 20
 
-    if get(NOT_INITIALIZED).to_bool() == False:
+    if not get(NOT_INITIALIZED).to_bool():
         # Used to check if the one who's transferring to this contract is the OWNER
         address = get(ADDRESS_PREFIX + OWNER)
         # Used to check if OWNER already transfer to this smart contract

--- a/boa3_test/examples/test_native/example_contract_for_htlc.py
+++ b/boa3_test/examples/test_native/example_contract_for_htlc.py
@@ -5,6 +5,9 @@ from boa3.builtin.interop.contract import GAS, NEO, call_contract
 from boa3.builtin.interop.runtime import check_witness
 from boa3.builtin.type import UInt160
 
+# This smart contract is being used to call Neo's native tokens (NEO and GAS).
+# Though, in the future, the TestEngine will have a method that allows to call NEO and GAS, rendering this smart contract useless
+# TODO: delete this smart contract and change HTLC tests when the TestEngine gets updated
 
 # -------------------------------------------
 # TOKEN SETTINGS

--- a/boa3_test/examples/test_native/methods.py
+++ b/boa3_test/examples/test_native/methods.py
@@ -5,6 +5,9 @@ from boa3.builtin.interop.contract import GAS, NEO, call_contract
 from boa3.builtin.interop.runtime import check_witness
 from boa3.builtin.type import UInt160
 
+# This smart contract is being used to call Neo's native tokens (NEO and GAS).
+# Though, in the future, the TestEngine will have a method that allows to call NEO and GAS, rendering this smart contract useless
+# TODO: delete this smart contract and change HTLC tests when the TestEngine gets updated
 
 # -------------------------------------------
 # TOKEN SETTINGS

--- a/boa3_test/examples/test_native/methods_copy.py
+++ b/boa3_test/examples/test_native/methods_copy.py
@@ -12,7 +12,7 @@ from boa3.builtin.type import UInt160
 
 
 # Script hash of the contract owner
-OWNER = UInt160(b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
+OWNER = UInt160(b'\xf6dCI\x8d8x\xd3+\x99NN\x12\x83\xc6\x93D!\xda\xfe')
 
 
 # -------------------------------------------

--- a/boa3_test/tests/examples/HTLCTests.py
+++ b/boa3_test/tests/examples/HTLCTests.py
@@ -62,7 +62,7 @@ class TestTemplate(BoaTest):
         path = '%s/boa3_test/examples/HTLC.py' % self.dirname
         engine = TestEngine(self.dirname)
         path_contract1 = '%s/boa3_test/examples/test_native/methods.py' % self.dirname
-        path_contract2 = '%s/boa3_test/examples/test_native/methods_copy.py' % self.dirname
+        path_contract2 = '%s/boa3_test/examples/test_native/example_contract_for_htlc.py' % self.dirname
         transferred_amount_neo = 10 * 10**8
         transferred_amount_gas = 10000 * 10**8
 
@@ -98,7 +98,7 @@ class TestTemplate(BoaTest):
         path = '%s/boa3_test/examples/HTLC.py' % self.dirname
         engine = TestEngine(self.dirname)
         path_contract1 = '%s/boa3_test/examples/test_native/methods.py' % self.dirname
-        path_contract2 = '%s/boa3_test/examples/test_native/methods_copy.py' % self.dirname
+        path_contract2 = '%s/boa3_test/examples/test_native/example_contract_for_htlc.py' % self.dirname
         transferred_amount_neo = 10 * 10**8
         transferred_amount_gas = 10000 * 10**8
 
@@ -140,7 +140,7 @@ class TestTemplate(BoaTest):
         path = '%s/boa3_test/examples/HTLC.py' % self.dirname
         engine = TestEngine(self.dirname)
         path_contract1 = '%s/boa3_test/examples/test_native/methods.py' % self.dirname
-        path_contract2 = '%s/boa3_test/examples/test_native/methods_copy.py' % self.dirname
+        path_contract2 = '%s/boa3_test/examples/test_native/example_contract_for_htlc.py' % self.dirname
         transferred_amount_neo = 10 * 10**8
         transferred_amount_gas = 10000 * 10**8
 

--- a/boa3_test/tests/examples/HTLCTests.py
+++ b/boa3_test/tests/examples/HTLCTests.py
@@ -1,0 +1,190 @@
+from boa3.boa3 import Boa3
+from boa3.builtin.interop.contract import NEO, GAS
+from boa3.neo import to_script_hash
+from boa3.neo.vm.type.String import String
+from boa3_test.tests.boa_test import BoaTest
+from boa3_test.tests.test_classes.TestExecutionException import TestExecutionException
+from boa3_test.tests.test_classes.testengine import TestEngine
+from boa3.neo.cryptography import hash160
+
+
+class TestTemplate(BoaTest):
+
+    OWNER_SCRIPT_HASH = bytes(20)
+    OTHER_ACCOUNT_1 = to_script_hash(b'NiNmXL8FjEUEs1nfX9uHFBNaenxDHJtmuB')
+    OTHER_ACCOUNT_2 = bytes(range(20))
+
+    def test_HTLC_compile(self):
+        path = '%s/boa3_test/examples/HTLC.py' % self.dirname
+        Boa3.compile(path)
+
+    def test_HTLC_deploy(self):
+        path = '%s/boa3_test/examples/HTLC.py' % self.dirname
+        engine = TestEngine(self.dirname)
+
+        # deploying the smart contract
+        result = self.run_smart_contract(engine, path, 'deploy',
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
+                                         expected_result_type=bool)
+        self.assertEqual(True, result)
+
+        # deploy can not occur more than once
+        result = self.run_smart_contract(engine, path, 'deploy',
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
+                                         expected_result_type=bool)
+        self.assertEqual(False, result)
+
+    def test_HTLC_atomic_swap(self):
+        path = '%s/boa3_test/examples/HTLC.py' % self.dirname
+        engine = TestEngine(self.dirname)
+
+        # can not atomic_swap() without deploying first
+        result = self.run_smart_contract(engine, path, 'atomic_swap', self.OWNER_SCRIPT_HASH, NEO, 10 * 10**8,
+                                         self.OTHER_ACCOUNT_1, GAS, 10000 * 10**8, hash160(String('unit test').to_bytes()),
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
+                                         expected_result_type=bool)
+        self.assertEqual(False, result)
+
+        # deploying contract
+        result = self.run_smart_contract(engine, path, 'deploy',
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
+                                         expected_result_type=bool)
+        self.assertEqual(True, result)
+
+        # starting atomic swap by using the atomic_swap method
+        result = self.run_smart_contract(engine, path, 'atomic_swap', self.OWNER_SCRIPT_HASH, NEO, 10 * 10 ** 8,
+                                         self.OTHER_ACCOUNT_1, GAS, 10000 * 10 ** 8, hash160(String('unit test').to_bytes()),
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
+                                         expected_result_type=bool)
+        self.assertEqual(True, result)
+
+    def test_HTLC_onPayment(self):
+        path = '%s/boa3_test/examples/HTLC.py' % self.dirname
+        engine = TestEngine(self.dirname)
+        path_contract1 = '%s/boa3_test/examples/test_native/methods.py' % self.dirname
+        path_contract2 = '%s/boa3_test/examples/test_native/methods_copy.py' % self.dirname
+        transferred_amount_neo = 10 * 10**8
+        transferred_amount_gas = 10000 * 10**8
+
+        output, manifest = self.compile_and_save(path_contract1)
+        contract_address1 = hash160(output)
+
+        output, manifest = self.compile_and_save(path_contract2)
+        contract_address2 = hash160(output)
+
+        output, manifest = self.compile_and_save(path)
+        htlc_address = hash160(output)
+
+        engine.add_neo(contract_address1, transferred_amount_neo)
+        engine.add_gas(contract_address2, transferred_amount_gas)
+
+        # deploying contract
+        result = self.run_smart_contract(engine, path, 'deploy',
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
+                                         expected_result_type=bool)
+        self.assertEqual(True, result)
+
+        # starting atomic swap
+        result = self.run_smart_contract(engine, path, 'atomic_swap', contract_address1, NEO, transferred_amount_neo,
+                                         contract_address2, GAS, transferred_amount_gas,
+                                         hash160(String('unit test').to_bytes()),
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
+                                         expected_result_type=bool)
+        self.assertEqual(True, result)
+
+        # TODO: Test if onPayment is successful when update the TestEngine to make Neo/Gas transfers
+
+    def test_HTLC_withdraw(self):
+        path = '%s/boa3_test/examples/HTLC.py' % self.dirname
+        engine = TestEngine(self.dirname)
+        path_contract1 = '%s/boa3_test/examples/test_native/methods.py' % self.dirname
+        path_contract2 = '%s/boa3_test/examples/test_native/methods_copy.py' % self.dirname
+        transferred_amount_neo = 10 * 10**8
+        transferred_amount_gas = 10000 * 10**8
+
+        output, manifest = self.compile_and_save(path_contract1)
+        contract_address1 = hash160(output)
+
+        output, manifest = self.compile_and_save(path_contract2)
+        contract_address2 = hash160(output)
+
+        output, manifest = self.compile_and_save(path)
+        htlc_address = hash160(output)
+
+        engine.add_neo(contract_address1, transferred_amount_neo)
+        engine.add_gas(contract_address2, transferred_amount_gas)
+
+        # deploying smart contract
+        result = self.run_smart_contract(engine, path, 'deploy',
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
+                                         expected_result_type=bool)
+        self.assertEqual(True, result)
+
+        # starting atomic swap by using the atomic_swap method
+        result = self.run_smart_contract(engine, path, 'atomic_swap', contract_address1, NEO, transferred_amount_neo,
+                                         contract_address2, GAS,transferred_amount_gas,
+                                         hash160(String('unit test').to_bytes()),
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
+                                         expected_result_type=bool)
+        self.assertEqual(True, result)
+
+        # won't be able to withdraw, because no one transferred cryptocurrency to the smart contract
+        result = self.run_smart_contract(engine, path, 'withdraw', 'unit test',
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
+                                         expected_result_type=bool)
+        self.assertEqual(False, result)
+
+        # TODO: Test if the withdraw is successful when update the TestEngine to make Neo/Gas transfers
+
+    def test_HTLC_refund(self):
+        path = '%s/boa3_test/examples/HTLC.py' % self.dirname
+        engine = TestEngine(self.dirname)
+        path_contract1 = '%s/boa3_test/examples/test_native/methods.py' % self.dirname
+        path_contract2 = '%s/boa3_test/examples/test_native/methods_copy.py' % self.dirname
+        transferred_amount_neo = 10 * 10**8
+        transferred_amount_gas = 10000 * 10**8
+
+        output, manifest = self.compile_and_save(path_contract1)
+        contract_address1 = hash160(output)
+
+        output, manifest = self.compile_and_save(path_contract2)
+        contract_address2 = hash160(output)
+
+        output, manifest = self.compile_and_save(path)
+        htlc_address = hash160(output)
+
+        engine.add_neo(contract_address1, transferred_amount_neo)
+        engine.add_gas(contract_address2, transferred_amount_gas)
+
+        result = self.run_smart_contract(engine, path, 'deploy',
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
+                                         expected_result_type=bool)
+        self.assertEqual(True, result)
+
+        result = self.run_smart_contract(engine, path, 'atomic_swap', contract_address1, NEO, transferred_amount_neo,
+                                         contract_address2, GAS, transferred_amount_gas,
+                                         hash160(String('unit test').to_bytes()),
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
+                                         expected_result_type=bool)
+        self.assertEqual(True, result)
+
+        # won't be able to refund, because not enough time has passed
+        result = self.run_smart_contract(engine, path, 'refund', 'unit test',
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
+                                         expected_result_type=bool)
+        self.assertEqual(False, result)
+
+        # this simulates a new block in the blockchain
+        # get_time only changes value when a new block enters the blockchain
+        engine.increase_block()
+        # will be able to refund, because enough time has passed
+        result = self.run_smart_contract(engine, path, 'refund', 'unit test',
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
+                                         expected_result_type=bool)
+        self.assertEqual(True, result)
+
+        # no one transferred cryptocurrency to the contract, so no one was refunded and no Transfer occurred
+        transfer_events = engine.get_events('Transfer')
+        self.assertEqual(0, len(transfer_events))
+
+        # TODO: Test if the refund is successful when update the TestEngine to make Neo/Gas transfers

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -4,11 +4,13 @@ Examples
 For an extensive collection of examples:
 
 - `HelloWorld.py`_
+- `HTLC.py`_
 - `ico.py`_
 - `nep5.py`_
 - `Features tests folder`_
 
 .. _HelloWorld.py: https://github.com/CityOfZion/neo3-boa/blob/development/boa3_test/examples/HelloWorld.py
+.. _HTLC.py: https://github.com/CityOfZion/neo3-boa/blob/development/boa3_test/examples/HTLC.py
 .. _ico.py: https://github.com/CityOfZion/neo3-boa/blob/development/boa3_test/examples/ico.py
 .. _nep5.py: https://github.com/CityOfZion/neo3-boa/blob/development/boa3_test/examples/nep5.py
 .. _Features tests folder: https://github.com/CityOfZion/neo3-boa/tree/development/boa3_test/test_sc


### PR DESCRIPTION
**Summary or solution description**
Added a template for an atomic swap transaction and some tests.

**How to Reproduce**
Deploy the HTLC smart contract, call atomic_swap(), transfer NEO or GAS to the smart contract, then withdraw with the right password.

**Tests**
Tested it using the TestEngine

**Platform:**
 - OS: Windows 10 x64
 - Version: neo3-boa v0.6
 - Python version: Python 3.8

**(Optional) Additional context**
Currently, it's not possible to call the NEO or GAS contracts, therefore some tests were omitted, when call_contract() starts working properly again the tests will receive an update.