### PR TITLE
Boa-297 Use isinstance condition in the semantics

### DIFF
--- a/boa3/analyser/optimizer/__init__.py
+++ b/boa3/analyser/optimizer/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Dict, Optional, Set
 
 
@@ -12,7 +14,7 @@ class ScopeValue:
         scope._values = self._values.copy()
         scope._assigned_variables = self._assigned_variables.copy()
         scope._parent_scope = self
-        return
+        return scope
 
     def previous_scope(self) -> Optional[ScopeValue]:
         return self._parent_scope

--- a/boa3/analyser/symbolscope.py
+++ b/boa3/analyser/symbolscope.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from typing import Dict
 
 from boa3.model.symbol import ISymbol

--- a/boa3/model/builtin/interop/contract/contracttype.py
+++ b/boa3/model/builtin/interop/contract/contracttype.py
@@ -5,6 +5,7 @@ from boa3.model.expression import IExpression
 from boa3.model.method import Method
 from boa3.model.property import Property
 from boa3.model.type.classtype import ClassType
+from boa3.model.type.itype import IType
 from boa3.model.variable import Variable
 from boa3.neo.vm.opcode.Opcode import Opcode
 

--- a/boa3/neo3/contracts/__init__.py
+++ b/boa3/neo3/contracts/__init__.py
@@ -1,0 +1,3 @@
+from boa3.neo3.contracts.contracttypes import TriggerType
+
+__all__ = ['TriggerType']

--- a/boa3/neo3/contracts/contracttypes.py
+++ b/boa3/neo3/contracts/contracttypes.py
@@ -1,0 +1,8 @@
+from enum import IntFlag
+
+
+class TriggerType(IntFlag):
+    SYSTEM = 0x01
+    VERIFICATION = 0x20
+    APPLICATION = 0x40
+    ALL = SYSTEM | VERIFICATION | APPLICATION

--- a/boa3_test/tests/test_types.py
+++ b/boa3_test/tests/test_types.py
@@ -85,7 +85,7 @@ class TestTypes(BoaTest):
         input = (1, '2', False)
         node = ast.parse(str(input)).body[0].value
         expected_output = TupleType(UnionType.build([Type.str,
-                                                    Type.int]))
+                                                     Type.int]))
 
         typeanalyser = TypeAnalyser(Analyser(node), {})
         output = typeanalyser.get_type(input)

--- a/boa3_test/tests/test_union.py
+++ b/boa3_test/tests/test_union.py
@@ -1,5 +1,4 @@
 from boa3.boa3 import Boa3
-from boa3.exception.CompilerError import MismatchedTypes
 from boa3.model.type.type import Type
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer


### PR DESCRIPTION
**Related issue**
#207 

**Summary or solution description**
Fixed the execution errors caused by missing imports in #207

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8.6
