### PR TITLE
Boa-214 Implement Enumerator Create Interop

### DIFF
--- a/boa3/builtin/interop/enumerator/__init__.py
+++ b/boa3/builtin/interop/enumerator/__init__.py
@@ -1,0 +1,6 @@
+from typing import Sequence, Union
+
+
+class Enumerator:
+    def __init__(self, entry: Union[Sequence, int]):
+        pass

--- a/boa3/model/builtin/interop/contract/contracttype.py
+++ b/boa3/model/builtin/interop/contract/contracttype.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Dict, List, Optional, Tuple
 
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
@@ -5,7 +7,6 @@ from boa3.model.expression import IExpression
 from boa3.model.method import Method
 from boa3.model.property import Property
 from boa3.model.type.classtype import ClassType
-from boa3.model.type.itype import IType
 from boa3.model.variable import Variable
 from boa3.neo.vm.opcode.Opcode import Opcode
 
@@ -52,7 +53,7 @@ class ContractType(ClassType):
         return self._constructor
 
     @classmethod
-    def build(cls, value: Any = None) -> IType:
+    def build(cls, value: Any = None) -> ContractType:
         if value is None or cls._is_type_of(value):
             return _Contract
 

--- a/boa3/model/builtin/interop/enumerator/__init__.py
+++ b/boa3/model/builtin/interop/enumerator/__init__.py
@@ -1,0 +1,5 @@
+__all__ = ['EnumeratorMethod',
+           'EnumeratorType']
+
+from boa3.model.builtin.interop.enumerator.enumeratorinitmethod import EnumeratorMethod
+from boa3.model.builtin.interop.enumerator.enumeratortype import EnumeratorType

--- a/boa3/model/builtin/interop/enumerator/enumeratorinitmethod.py
+++ b/boa3/model/builtin/interop/enumerator/enumeratorinitmethod.py
@@ -1,0 +1,48 @@
+from typing import Any, Dict, Optional, Sequence
+
+from boa3.model.builtin.interop.enumerator.enumeratortype import EnumeratorType
+from boa3.model.builtin.interop.interopmethod import InteropMethod
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.expression import IExpression
+from boa3.model.variable import Variable
+
+
+class EnumeratorMethod(InteropMethod):
+
+    def __init__(self, return_type: EnumeratorType):
+        identifier = '-Enumerator__init__'
+        syscall = 'System.Enumerator.Create'
+
+        # neo enumerator accepts array or primitive type, except None
+        # since the primitives types here are str, bytes, int, bool and none and both str and bytes are sequences and
+        # bool is int, only needed to include int in the union
+        from boa3.model.type.type import Type
+        args: Dict[str, Variable] = {'entry': Variable(Type.union.build([Type.sequence,
+                                                                         Type.int]))}
+        super().__init__(identifier, syscall, args, return_type=return_type)
+
+    def validate_parameters(self, *params: IExpression) -> bool:
+        return len(params) == 0
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> Optional[str]:
+        return
+
+    def _entry_arg(self) -> Variable:
+        return self.args['entry']
+
+    def build(self, value: Any) -> IBuiltinMethod:
+        if isinstance(value, Sequence) and len(value) == 1:
+            argument = value[0]
+        else:
+            argument = value
+
+        if self._entry_arg().type.is_type_of(argument):
+            enumerator = EnumeratorType.build(argument)
+            if enumerator is not self.return_type:
+                return EnumeratorMethod(enumerator)
+        return super().build(value)

--- a/boa3/model/builtin/interop/enumerator/enumeratortype.py
+++ b/boa3/model/builtin/interop/enumerator/enumeratortype.py
@@ -10,13 +10,13 @@ from boa3.model.type.itype import IType
 from boa3.model.variable import Variable
 
 
-class IteratorType(ClassType, ICollectionType):
+class EnumeratorType(ClassType):
     """
     A class used to represent Neo Iterator class
     """
 
     def __init__(self, collection: ICollectionType = None):
-        super().__init__('Iterator')
+        super().__init__('Enumerator')
 
         if collection is None:
             from boa3.model.type.type import Type
@@ -33,7 +33,7 @@ class IteratorType(ClassType, ICollectionType):
 
     @property
     def identifier(self) -> str:
-        return '{0}[{1}, {2}]'.format(self._identifier, self.valid_key.identifier, self.item_type.identifier)
+        return '{0}[{1}]'.format(self._identifier, self.item_type.identifier)
 
     @property
     def variables(self) -> Dict[str, Variable]:
@@ -42,12 +42,7 @@ class IteratorType(ClassType, ICollectionType):
     @property
     def properties(self) -> Dict[str, Property]:
         if self._properties is None:
-            from boa3.model.builtin.interop.iterator.getiteratorvalue import IteratorValueProperty
-            from boa3.model.builtin.interop.iterator.getiteratorkey import IteratorKeyProperty
-            self._properties = {
-                'value': IteratorValueProperty(self),
-                'key': IteratorKeyProperty(self)
-            }
+            self._properties = {}
 
         return self._properties.copy()
 
@@ -58,17 +53,14 @@ class IteratorType(ClassType, ICollectionType):
     @property
     def instance_methods(self) -> Dict[str, Method]:
         if self._methods is None:
-            from boa3.model.builtin.interop.iterator.iteratornextmethod import IteratorNextMethod
-            self._methods = {
-                'next': IteratorNextMethod()
-            }
+            self._methods = {}
         return self._methods.copy()
 
     def constructor_method(self) -> Method:
         # was having a problem with recursive import
         if self._constructor is None:
-            from boa3.model.builtin.interop.iterator.iteratorinitmethod import IteratorMethod
-            self._constructor: Method = IteratorMethod(self)
+            from boa3.model.builtin.interop.enumerator.enumeratorinitmethod import EnumeratorMethod
+            self._constructor: Method = EnumeratorMethod(self)
         return self._constructor
 
     @property
@@ -83,15 +75,15 @@ class IteratorType(ClassType, ICollectionType):
         return self._origin_collection.is_valid_key(key_type)
 
     @classmethod
-    def build(cls, value: Any = None) -> IteratorType:
+    def build(cls, value: Any = None) -> EnumeratorType:
         if isinstance(value, ICollectionType):
-            return IteratorType(value)
+            return EnumeratorType(value)
         else:
-            return _Iterator
+            return _Enumerator
 
     @classmethod
     def _is_type_of(cls, value: Any):
-        return isinstance(value, IteratorType)
+        return isinstance(value, EnumeratorType)
 
 
-_Iterator = IteratorType()
+_Enumerator = EnumeratorType()

--- a/boa3/model/builtin/interop/interop.py
+++ b/boa3/model/builtin/interop/interop.py
@@ -5,6 +5,7 @@ from boa3.model.builtin.interop.binary import *
 from boa3.model.builtin.interop.blockchain import *
 from boa3.model.builtin.interop.contract import *
 from boa3.model.builtin.interop.crypto import *
+from boa3.model.builtin.interop.enumerator import *
 from boa3.model.builtin.interop.iterator import *
 from boa3.model.builtin.interop.json import *
 from boa3.model.builtin.interop.runtime import *
@@ -17,6 +18,7 @@ class InteropPackage(str, Enum):
     Blockchain = 'blockchain'
     Contract = 'contract'
     Crypto = 'crypto'
+    Enumerator = 'enumerator'
     Iterator = 'iterator'
     Json = 'json'
     Runtime = 'runtime'
@@ -37,6 +39,7 @@ class Interop:
 
     # Interop Types
     ContractType = ContractType.build()
+    Enumerator = EnumeratorType.build()
     Iterator = IteratorType.build()
     NotificationType = NotificationType.build()
     StorageContextType = StorageContextType.build()
@@ -72,6 +75,9 @@ class Interop:
     Sha256 = Sha256Method()
     VerifyWithECDsaSecp256k1 = VerifyWithECDsaSecp256k1Method()
     VerifyWithECDsaSecp256r1 = VerifyWithECDsaSecp256r1Method()
+
+    # Enumerator Interops
+    EnumeratorCreate = EnumeratorMethod(Enumerator)
 
     # Iterator Interops
     IteratorCreate = IteratorMethod(Iterator)
@@ -128,6 +134,7 @@ class Interop:
                                 VerifyWithECDsaSecp256k1,
                                 VerifyWithECDsaSecp256r1
                                 ],
+        InteropPackage.Enumerator: [Enumerator],
         InteropPackage.Iterator: [Iterator],
         InteropPackage.Json: [JsonDeserialize,
                               JsonSerialize

--- a/boa3/model/builtin/interop/runtime/notificationtype.py
+++ b/boa3/model/builtin/interop/runtime/notificationtype.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Dict, List, Optional, Tuple
 
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
@@ -6,7 +8,6 @@ from boa3.model.method import Method
 from boa3.model.property import Property
 from boa3.model.type.classtype import ClassType
 from boa3.model.type.collection.sequence.uint160type import UInt160Type
-from boa3.model.type.itype import IType
 from boa3.model.variable import Variable
 from boa3.neo.vm.opcode.Opcode import Opcode
 
@@ -50,7 +51,7 @@ class NotificationType(ClassType):
         return self._constructor
 
     @classmethod
-    def build(cls, value: Any = None) -> IType:
+    def build(cls, value: Any = None) -> NotificationType:
         if value is None or cls._is_type_of(value):
             return _Notification
 

--- a/boa3/model/builtin/interop/storage/storagecontexttype.py
+++ b/boa3/model/builtin/interop/storage/storagecontexttype.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Dict, List, Optional, Tuple
 
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
@@ -5,7 +7,6 @@ from boa3.model.expression import IExpression
 from boa3.model.method import Method
 from boa3.model.property import Property
 from boa3.model.type.classtype import ClassType
-from boa3.model.type.itype import IType
 from boa3.model.variable import Variable
 from boa3.neo.vm.opcode.Opcode import Opcode
 
@@ -44,7 +45,7 @@ class StorageContextType(ClassType):
         return self._constructor
 
     @classmethod
-    def build(cls, value: Any = None) -> IType:
+    def build(cls, value: Any = None) -> StorageContextType:
         if value is None or cls._is_type_of(value):
             return _StorageContext
 

--- a/boa3/model/type/annotation/uniontype.py
+++ b/boa3/model/type/annotation/uniontype.py
@@ -41,7 +41,7 @@ class UnionType(IType):
                 return list(types)[0]
             return cls(types)
 
-    def except_type(self, other_type) -> IType:
+    def except_type(self, other_type: IType) -> IType:
         """
         Gets a type that is type of `self` but is not type of `other_type`.
         If `other_type` is an implementation of `self`, returns `self`
@@ -64,6 +64,24 @@ class UnionType(IType):
             return Type.none if len(new_union) == 0 else new_union[0]
         else:
             return UnionType(set(new_union))
+
+    def intersect_type(self, other_type: IType) -> IType:
+        if self.is_type_of(other_type):
+            return other_type
+        if other_type.is_type_of(self):
+            return self
+
+        if isinstance(other_type, type(self)):
+            other_types = [x for x in other_type.union_types if self.is_type_of(x)]
+            self_types = [x for x in self.union_types if other_type.is_type_of(x)]
+
+            common_types = other_types + self_types
+            if len(common_types) == 1:
+                return common_types[0]
+            elif len(common_types) > 1:
+                return self.build(common_types)
+
+        return super().intersect_type(other_type)
 
     def __hash__(self):
         return hash(self.identifier)

--- a/boa3/model/type/itype.py
+++ b/boa3/model/type/itype.py
@@ -104,7 +104,7 @@ class IType(IdentifiedSymbol):
         """
         return {}
 
-    def union_type(self, other_type) -> IType:
+    def union_type(self, other_type: IType) -> IType:
         """
         Gets a type that is an union of `self` and `other_type`
 
@@ -116,7 +116,7 @@ class IType(IdentifiedSymbol):
         from boa3.model.type.annotation.uniontype import UnionType
         return UnionType.build((self, other_type))
 
-    def except_type(self, other_type) -> IType:
+    def except_type(self, other_type: IType) -> IType:
         """
         Gets a type that is type of `self` but is not type of `other_type`.
         If `other_type` is an implementation of `self`, returns `self`
@@ -128,7 +128,7 @@ class IType(IdentifiedSymbol):
         """
         return self
 
-    def intersect_type(self, other_type) -> IType:
+    def intersect_type(self, other_type: IType) -> IType:
         """
         Gets a type that is the intersection of `self` but is not type of `other_type`.
         If `other_type` is an implementation of `self`, returns `other_type`

--- a/boa3_test/test_sc/import_test/FromImportTypingNotImplementedType.py
+++ b/boa3_test/test_sc/import_test/FromImportTypingNotImplementedType.py
@@ -1,5 +1,5 @@
-from typing import Iterable
+from typing import Reversible
 
 
 def Main():
-    a: Iterable = []
+    a: Reversible = []

--- a/boa3_test/test_sc/interop_test/enumerator/EnumeratorCreateInt.py
+++ b/boa3_test/test_sc/interop_test/enumerator/EnumeratorCreateInt.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.interop.enumerator import Enumerator
+
+
+@public
+def int_enumerator(x: int) -> Enumerator:
+    return Enumerator(x)

--- a/boa3_test/test_sc/interop_test/enumerator/EnumeratorCreateList.py
+++ b/boa3_test/test_sc/interop_test/enumerator/EnumeratorCreateList.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.interop.enumerator import Enumerator
+
+
+@public
+def list_enumerator(x: list) -> Enumerator:
+    return Enumerator(x)

--- a/boa3_test/test_sc/interop_test/enumerator/EnumeratorCreateMismatchedTypes.py
+++ b/boa3_test/test_sc/interop_test/enumerator/EnumeratorCreateMismatchedTypes.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.interop.enumerator import Enumerator
+
+
+@public
+def dict_enumerator(x: dict) -> Enumerator:
+    return Enumerator(x)

--- a/boa3_test/test_sc/interop_test/enumerator/EnumeratorCreateTuple.py
+++ b/boa3_test/test_sc/interop_test/enumerator/EnumeratorCreateTuple.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.interop.enumerator import Enumerator
+
+
+@public
+def tuple_enumerator(x: tuple) -> Enumerator:
+    return Enumerator(x)

--- a/boa3_test/tests/test_interop/test_enumerator.py
+++ b/boa3_test/tests/test_interop/test_enumerator.py
@@ -1,0 +1,76 @@
+from boa3.exception.CompilerError import MismatchedTypes
+from boa3.model.builtin.interop.interop import Interop
+from boa3.neo.core.types.InteropInterface import InteropInterface
+from boa3.neo.vm.opcode.Opcode import Opcode
+from boa3_test.tests.boa_test import BoaTest
+from boa3_test.tests.test_classes.testengine import TestEngine
+
+
+class TestEnumeratorInterop(BoaTest):
+
+    def test_create_enumerator_list(self):
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\00'
+            + b'\01'
+            + Opcode.LDARG0
+            + Opcode.SYSCALL
+            + Interop.EnumeratorCreate.interop_method_hash
+            + Opcode.RET
+        )
+        path = '%s/boa3_test/test_sc/interop_test/enumerator/EnumeratorCreateList.py' % self.dirname
+        output, manifest = self.compile_and_save(path)
+        self.assertEqual(expected_output, output)
+
+        engine = TestEngine(self.dirname)
+        result = self.run_smart_contract(engine, path, 'list_enumerator', [])
+        self.assertEqual(InteropInterface, result)  # returns an interop interface
+
+        result = self.run_smart_contract(engine, path, 'list_enumerator', [1, 2, 3])
+        self.assertEqual(InteropInterface, result)  # returns an interop interface
+
+    def test_create_enumerator_tuple(self):
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\00'
+            + b'\01'
+            + Opcode.LDARG0
+            + Opcode.SYSCALL
+            + Interop.EnumeratorCreate.interop_method_hash
+            + Opcode.RET
+        )
+        path = '%s/boa3_test/test_sc/interop_test/enumerator/EnumeratorCreateTuple.py' % self.dirname
+        output, manifest = self.compile_and_save(path)
+        self.assertEqual(expected_output, output)
+
+        engine = TestEngine(self.dirname)
+        result = self.run_smart_contract(engine, path, 'tuple_enumerator', ())
+        self.assertEqual(InteropInterface, result)  # returns an interop interface
+
+        result = self.run_smart_contract(engine, path, 'tuple_enumerator', (1, 2, 3))
+        self.assertEqual(InteropInterface, result)  # returns an interop interface
+
+    def test_create_enumerator_int(self):
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\00'
+            + b'\01'
+            + Opcode.LDARG0
+            + Opcode.SYSCALL
+            + Interop.EnumeratorCreate.interop_method_hash
+            + Opcode.RET
+        )
+        path = '%s/boa3_test/test_sc/interop_test/enumerator/EnumeratorCreateInt.py' % self.dirname
+        output, manifest = self.compile_and_save(path)
+        self.assertEqual(expected_output, output)
+
+        engine = TestEngine(self.dirname)
+        result = self.run_smart_contract(engine, path, 'int_enumerator', 42)
+        self.assertEqual(InteropInterface, result)  # returns an interop interface
+
+        result = self.run_smart_contract(engine, path, 'int_enumerator', 123456)
+        self.assertEqual(InteropInterface, result)  # returns an interop interface
+
+    def test_create_enumerator_mismatched_type(self):
+        path = '%s/boa3_test/test_sc/interop_test/enumerator/EnumeratorCreateMismatchedTypes.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)


### PR DESCRIPTION
**Summary or solution description**
Implemented the class `Enumerator` with its constructor being the Neo interop `Enumerator.Create`

**How to Reproduce**
```python
from boa3.builtin.interop.enumerator import Enumerator


def list_enumerator(x: list) -> Enumerator:
    return Enumerator(x)
```

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/4d589e01bbe786aca7805cc219ebbeb72f0a5d73/boa3_test/tests/test_interop/test_enumerator.py#L11-L76

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8
