### PR TITLE
Boa-208 Implement Iterator Concat Interop

### DIFF
--- a/boa3/analyser/moduleanalyser.py
+++ b/boa3/analyser/moduleanalyser.py
@@ -748,6 +748,8 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
         value_id = attribute.value.id if isinstance(attribute.value, ast.Name) else None
         value: ISymbol = self.get_symbol(value_id) if value_id is not None else self.visit(attribute.value)
 
+        if isinstance(value, Variable):
+            value = value.type
         if hasattr(value, 'symbols') and attribute.attr in value.symbols:
             return value.symbols[attribute.attr]
         elif Builtin.get_symbol(attribute.attr) is not None:

--- a/boa3/builtin/interop/iterator/__init__.py
+++ b/boa3/builtin/interop/iterator/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Collection
 
 
@@ -14,4 +16,7 @@ class Iterator:
         return None
 
     def next(self) -> bool:
+        pass
+
+    def concat(self, other: Iterator) -> Iterator:
         pass

--- a/boa3/compiler/vmcodemapping.py
+++ b/boa3/compiler/vmcodemapping.py
@@ -178,6 +178,16 @@ class VMCodeMapping:
             self.insert_code(code)
         self._update_targets()
 
+    def remove_opcodes(self, first_code_address: int, last_code_address: int):
+        if last_code_address < first_code_address:
+            first_code_address, last_code_address = last_code_address, first_code_address
+
+        for index in sorted(self._codes).copy():
+            if first_code_address <= index <= last_code_address:
+                self._codes.pop(index)
+
+        self._update_addresses()
+
     def _update_targets(self):
         from boa3.neo.vm.type.Integer import Integer
         for address, code in self.code_map.items():

--- a/boa3/model/builtin/interop/interop.py
+++ b/boa3/model/builtin/interop/interop.py
@@ -81,6 +81,7 @@ class Interop:
 
     # Iterator Interops
     IteratorCreate = IteratorMethod(Iterator)
+    IteratorConcat = IteratorConcatMethod(Iterator)
 
     # Json Interops
     JsonDeserialize = JsonDeserializeMethod()
@@ -135,7 +136,8 @@ class Interop:
                                 VerifyWithECDsaSecp256r1
                                 ],
         InteropPackage.Enumerator: [Enumerator],
-        InteropPackage.Iterator: [Iterator],
+        InteropPackage.Iterator: [Iterator,
+                                  IteratorConcat],
         InteropPackage.Json: [JsonDeserialize,
                               JsonSerialize
                               ],

--- a/boa3/model/builtin/interop/iterator/__init__.py
+++ b/boa3/model/builtin/interop/iterator/__init__.py
@@ -1,5 +1,7 @@
-__all__ = ['IteratorMethod',
+__all__ = ['IteratorConcatMethod',
+           'IteratorMethod',
            'IteratorType']
 
+from boa3.model.builtin.interop.iterator.iteratorconcatmethod import IteratorConcatMethod
 from boa3.model.builtin.interop.iterator.iteratorinitmethod import IteratorMethod
 from boa3.model.builtin.interop.iterator.iteratortype import IteratorType

--- a/boa3/model/builtin/interop/iterator/iteratorconcatmethod.py
+++ b/boa3/model/builtin/interop/iterator/iteratorconcatmethod.py
@@ -1,0 +1,58 @@
+from typing import Any, Dict, Optional, Sized
+
+from boa3.model.builtin.interop.interopmethod import InteropMethod
+from boa3.model.builtin.interop.iterator.iteratortype import IteratorType
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.type.itype import IType
+from boa3.model.variable import Variable
+
+
+class IteratorConcatMethod(InteropMethod):
+    def __init__(self, iterator: IteratorType, other_type: Optional[IteratorType] = None):
+        syscall = 'System.Iterator.Concat'
+        identifier = '-iterator_concat'
+
+        iterator_type = IteratorType.build()
+        if other_type is None:
+            other_type = iterator_type
+        args: Dict[str, Variable] = {'self': Variable(iterator),
+                                     'other': Variable(other_type)}
+
+        return_type = self._build_result(iterator, other_type)
+        super().__init__(identifier, syscall, args, return_type=return_type)
+
+    @property
+    def identifier(self) -> str:
+        return '{0}_{1}'.format(self.raw_identifier,
+                                '_'.join([x.type.identifier for x in self.args.values()]))
+
+    def _build_result(self, iterator: IteratorType, other_type: IteratorType) -> IType:
+        if iterator == other_type:
+            return iterator
+
+        from boa3.model.type.type import Type
+        key_type = Type.union.build([iterator.valid_key, other_type.valid_key])
+        value_type = Type.union.build([iterator.value_type, other_type.value_type])
+
+        new_collection = Type.dict.build([key_type, value_type])
+        if new_collection.valid_key == iterator.valid_key and new_collection.value_type == iterator.value_type:
+            return iterator
+
+        elif new_collection.valid_key == other_type.valid_key and new_collection.value_type == other_type.value_type:
+            return other_type
+
+        return IteratorType.build(new_collection)
+
+    def push_self_first(self) -> bool:
+        return True
+
+    def build(self, value: Any) -> IBuiltinMethod:
+        if not isinstance(value, Sized) or len(value) != 2:
+            return self
+
+        iterator_type = IteratorType.build()
+        self_type, other_type = value
+        if not iterator_type.is_type_of(self_type) or not iterator_type.is_type_of(other_type):
+            return self
+
+        return IteratorConcatMethod(self_type, other_type)

--- a/boa3/model/builtin/interop/iterator/iteratortype.py
+++ b/boa3/model/builtin/interop/iterator/iteratortype.py
@@ -59,8 +59,10 @@ class IteratorType(ClassType, ICollectionType):
     def instance_methods(self) -> Dict[str, Method]:
         if self._methods is None:
             from boa3.model.builtin.interop.iterator.iteratornextmethod import IteratorNextMethod
+            from boa3.model.builtin.interop.iterator.iteratorconcatmethod import IteratorConcatMethod
             self._methods = {
-                'next': IteratorNextMethod()
+                'next': IteratorNextMethod(),
+                'concat': IteratorConcatMethod(self)
             }
         return self._methods.copy()
 
@@ -92,6 +94,14 @@ class IteratorType(ClassType, ICollectionType):
     @classmethod
     def _is_type_of(cls, value: Any):
         return isinstance(value, IteratorType)
+
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, IteratorType):
+            return False
+        return self.valid_key == other.valid_key and self.value_type == other.value_type
+
+    def __hash__(self) -> int:
+        return self._origin_collection.__hash__()
 
 
 _Iterator = IteratorType()

--- a/boa3/model/type/annotation/uniontype.py
+++ b/boa3/model/type/annotation/uniontype.py
@@ -36,6 +36,10 @@ class UnionType(IType):
         else:
             types = {value}
 
+        from boa3.model.type.type import Type
+        if any(t is Type.any for t in types):
+            return Type.any
+
         if all(isinstance(t, IType) for t in types):
             if len(types) == 1:
                 return list(types)[0]

--- a/boa3/model/type/collection/mapping/mappingtype.py
+++ b/boa3/model/type/collection/mapping/mappingtype.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import Any, Iterable, Set
+from typing import Any, Iterable, Set, Sized
 
 from boa3.model.type.collection.icollection import ICollectionType
 from boa3.model.type.itype import IType
@@ -83,6 +83,7 @@ class MappingType(ICollectionType, ABC):
     @classmethod
     def build(cls, value: Any) -> IType:
         if cls._is_type_of(value):
+            # value is an instance of mapping
             if isinstance(value, dict):
                 keys = list(value.keys())
                 values = list(value.values())
@@ -93,3 +94,22 @@ class MappingType(ICollectionType, ABC):
             keys_types: Set[IType] = cls.get_types(keys)
             values_types: Set[IType] = cls.get_types(values)
             return cls(keys_types, values_types)
+
+        elif isinstance(value, Sized) and len(value) == 2:
+            # value is a tuple with two lists of types for contructing the map
+            keys_type, values_type = value
+
+            if not isinstance(keys_type, Iterable):
+                keys_type = {keys_type}
+            else:
+                keys_type = set(keys_type)
+
+            if not isinstance(values_type, Iterable):
+                values_types = {values_type}
+            else:
+                values_types = set(values_type)
+
+            if all(isinstance(k, IType) for k in keys_type) and all(isinstance(v, IType) for v in values_types):
+                return cls(keys_type, values_type)
+
+        return super(MappingType, cls).build(value)

--- a/boa3_test/test_sc/interop_test/iterator/IteratorConcat.py
+++ b/boa3_test/test_sc/interop_test/iterator/IteratorConcat.py
@@ -1,0 +1,23 @@
+from boa3.builtin import public
+from boa3.builtin.interop.iterator import Iterator
+
+
+@public
+def concat_iterators(x: list, y: dict) -> Iterator:
+    it1 = Iterator(x)
+    it2 = Iterator(y)
+
+    return it1.concat(it2)
+
+
+@public
+def concat_and_get_result(x: list, y: dict) -> dict:
+    new_map = {}
+    it = concat_iterators(x, y)
+
+    while it.next():
+        k = it.key
+        v = it.value
+        new_map[k] = v
+
+    return new_map

--- a/boa3_test/test_sc/interop_test/iterator/IteratorConcatMismatchedType.py
+++ b/boa3_test/test_sc/interop_test/iterator/IteratorConcatMismatchedType.py
@@ -1,0 +1,9 @@
+from boa3.builtin import public
+from boa3.builtin.interop.iterator import Iterator
+
+
+@public
+def concat_iterators(x: list) -> Iterator:
+    it1 = Iterator(x)
+
+    return it1.concat(42)

--- a/boa3_test/test_sc/interop_test/iterator/IteratorConcatWithDefinedTypes.py
+++ b/boa3_test/test_sc/interop_test/iterator/IteratorConcatWithDefinedTypes.py
@@ -1,0 +1,25 @@
+from typing import Dict, List
+
+from boa3.builtin import public
+from boa3.builtin.interop.iterator import Iterator
+
+
+@public
+def concat_iterators(x: List[str], y: Dict[int, bool]) -> Iterator:
+    it1 = Iterator(x)
+    it2 = Iterator(y)
+
+    return it1.concat(it2)
+
+
+@public
+def concat_and_get_result(x: List[str], y: Dict[int, bool]) -> dict:
+    new_map: dict = {}
+    it = concat_iterators(x, y)
+
+    while it.next():
+        k = it.key
+        v = it.value
+        new_map[k] = v
+
+    return new_map

--- a/boa3_test/tests/test_interop/test_iterator.py
+++ b/boa3_test/tests/test_interop/test_iterator.py
@@ -120,3 +120,35 @@ class TestIteratorInterop(BoaTest):
     def test_iterator_key_list_mismatched_type(self):
         path = '%s/boa3_test/test_sc/interop_test/iterator/IteratorListKeyMismatchedType.py' % self.dirname
         self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_iterator_concat(self):
+        path = '%s/boa3_test/test_sc/interop_test/iterator/IteratorConcat.py' % self.dirname
+        self.compile_and_save(path)
+
+        engine = TestEngine(self.dirname)
+        result = self.run_smart_contract(engine, path, 'concat_iterators', [1], {'1': 5, '7': 9})
+        self.assertEqual(InteropInterface, result)  # returns an interop interface
+
+        result = self.run_smart_contract(engine, path, 'concat_and_get_result', [1], {'1': 5, '7': 9})
+        self.assertEqual({0: 1, '1': 5, '7': 9}, result)
+
+    def test_iterator_concat_with_defined_types(self):
+        path = '%s/boa3_test/test_sc/interop_test/iterator/IteratorConcatWithDefinedTypes.py' % self.dirname
+        self.compile_and_save(path)
+
+        engine = TestEngine(self.dirname)
+        result = self.run_smart_contract(engine, path, 'concat_iterators',
+                                         ['1', '2', '3'], {1: False, 10: True})
+        self.assertEqual(InteropInterface, result)  # returns an interop interface
+
+        result = self.run_smart_contract(engine, path, 'concat_and_get_result',
+                                         ['1', '2', '3'], {1: False, 10: True})
+        self.assertEqual({0: '1', 1: '2', 2: '3', 10: True}, result)
+
+        result = self.run_smart_contract(engine, path, 'concat_and_get_result',
+                                         ['1', '2', '3'], {5: False, 10: True})
+        self.assertEqual({0: '1', 1: '2', 2: '3', 5: False, 10: True}, result)
+
+    def test_iterator_concat_mismatched_type(self):
+        path = '%s/boa3_test/test_sc/interop_test/iterator/IteratorConcatMismatchedType.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)


### PR DESCRIPTION
**Summary or solution description**
Implemented the ``concat`` method for concatenating two ``Iterator``s objects

**How to Reproduce**
```python
iterator1 = Iterator([1, 2, 3])
iterator2 = Iterator({'1': 1, '2': 2, '3': 3})
iterator3 = iterator1.concat(iterator2)
```

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/317aa1bacd0fd68cb902e249e4102d9b1759cba3/boa3_test/tests/test_interop/test_iterator.py#L124-L154 

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8.6
