### PR TITLE
Boa-213 Implement Iterator Values Interop

### DIFF
--- a/boa3/builtin/interop/iterator/__init__.py
+++ b/boa3/builtin/interop/iterator/__init__.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any, Collection
 
+from boa3.builtin.interop.enumerator import Enumerator
+
 
 class Iterator:
     def __init__(self, entry: Collection):
@@ -19,4 +21,7 @@ class Iterator:
         pass
 
     def concat(self, other: Iterator) -> Iterator:
+        pass
+
+    def values(self) -> Enumerator:
         pass

--- a/boa3/model/builtin/interop/enumerator/enumeratortype.py
+++ b/boa3/model/builtin/interop/enumerator/enumeratortype.py
@@ -28,7 +28,6 @@ class EnumeratorType(ClassType):
         self._methods = None
         self._properties = None
 
-        self.key_type = self._origin_collection.valid_key
         self.item_type = self._origin_collection.item_type
 
     @property

--- a/boa3/model/builtin/interop/iterator/iteratortype.py
+++ b/boa3/model/builtin/interop/iterator/iteratortype.py
@@ -60,9 +60,11 @@ class IteratorType(ClassType, ICollectionType):
         if self._methods is None:
             from boa3.model.builtin.interop.iterator.iteratornextmethod import IteratorNextMethod
             from boa3.model.builtin.interop.iterator.iteratorconcatmethod import IteratorConcatMethod
+            from boa3.model.builtin.interop.iterator.iteratorvaluesmethod import IteratorValuesMethod
             self._methods = {
                 'next': IteratorNextMethod(),
-                'concat': IteratorConcatMethod(self)
+                'concat': IteratorConcatMethod(self),
+                'values': IteratorValuesMethod(self)
             }
         return self._methods.copy()
 

--- a/boa3/model/builtin/interop/iterator/iteratorvaluesmethod.py
+++ b/boa3/model/builtin/interop/iterator/iteratorvaluesmethod.py
@@ -1,0 +1,25 @@
+from typing import Dict
+
+from boa3.model.builtin.interop.interopmethod import InteropMethod
+from boa3.model.builtin.interop.iterator.iteratortype import IteratorType
+from boa3.model.variable import Variable
+
+
+class IteratorValuesMethod(InteropMethod):
+    def __init__(self, iterator: IteratorType):
+        syscall = 'System.Iterator.Values'
+        identifier = '-iterator_values'
+        args: Dict[str, Variable] = {'self': Variable(iterator)}
+
+        from boa3.model.builtin.interop.enumerator import EnumeratorType
+        return_type = EnumeratorType.build(iterator)
+        super().__init__(identifier, syscall, args, return_type=return_type)
+
+    @property
+    def identifier(self) -> str:
+        return '{0}_{1}'.format(self.raw_identifier,
+                                '_'.join([x.type.identifier for x in self.args.values()]))
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)

--- a/boa3_test/test_sc/interop_test/iterator/IteratorValues.py
+++ b/boa3_test/test_sc/interop_test/iterator/IteratorValues.py
@@ -1,0 +1,21 @@
+from typing import Any, Dict, List, Union
+
+from boa3.builtin import public
+from boa3.builtin.interop.enumerator import Enumerator
+from boa3.builtin.interop.iterator import Iterator
+
+
+@public
+def list_iterator(x: List[int]) -> Union[Enumerator, None]:
+    it = Iterator(x)
+    if it.next():
+        return it.values()
+    return None
+
+
+@public
+def dict_iterator(x: Dict[Any, int]) -> Union[Enumerator, None]:
+    it = Iterator(x)
+    if it.next():
+        return it.values()
+    return None

--- a/boa3_test/test_sc/interop_test/iterator/IteratorValuesMismatchedType.py
+++ b/boa3_test/test_sc/interop_test/iterator/IteratorValuesMismatchedType.py
@@ -1,0 +1,11 @@
+from typing import Any, Dict
+
+from boa3.builtin import public
+from boa3.builtin.interop.iterator import Iterator
+
+
+@public
+def dict_iterator(x: Dict[Any, int]) -> str:
+    it = Iterator(x)
+    it.next()
+    return it.values()

--- a/boa3_test/tests/test_interop/test_iterator.py
+++ b/boa3_test/tests/test_interop/test_iterator.py
@@ -152,3 +152,26 @@ class TestIteratorInterop(BoaTest):
     def test_iterator_concat_mismatched_type(self):
         path = '%s/boa3_test/test_sc/interop_test/iterator/IteratorConcatMismatchedType.py' % self.dirname
         self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_iterator_values(self):
+        path = '%s/boa3_test/test_sc/interop_test/iterator/IteratorValues.py' % self.dirname
+        self.compile_and_save(path)
+
+        engine = TestEngine(self.dirname)
+        result = self.run_smart_contract(engine, path, 'list_iterator', [1])
+        self.assertEqual(InteropInterface, result)
+        # TODO: validate actual result when Enumerator.next() and Enumerator.value() are implemented
+
+        result = self.run_smart_contract(engine, path, 'list_iterator', [])
+        self.assertIsNone(result)
+
+        result = self.run_smart_contract(engine, path, 'dict_iterator', {1: 5, 7: 9})
+        self.assertEqual(InteropInterface, result)
+        # TODO: validate actual result when Enumerator.next() and Enumerator.value() are implemented
+
+        result = self.run_smart_contract(engine, path, 'dict_iterator', {})
+        self.assertIsNone(result)
+
+    def test_iterator_values_mismatched_type(self):
+        path = '%s/boa3_test/test_sc/interop_test/iterator/IteratorValuesMismatchedType.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)


### PR DESCRIPTION
**Summary or solution description**
Implemented `values` method of `Iterator`s objects. It gets an enumerator of the iterator's values.

**How to Reproduce**
```python
iterator = Iterator([1, 2, 3])
x = iterator.values()
```

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/acbb815ee410049cede74baf894e95e52579ae8f/boa3_test/tests/test_interop/test_iterator.py#L156-L177

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8.6
