### PR TITLE
Boa-212 Implement Iterator Keys Interop

### DIFF
--- a/boa3/builtin/interop/iterator/__init__.py
+++ b/boa3/builtin/interop/iterator/__init__.py
@@ -23,5 +23,8 @@ class Iterator:
     def concat(self, other: Iterator) -> Iterator:
         pass
 
+    def keys(self) -> Enumerator:
+        pass
+
     def values(self) -> Enumerator:
         pass

--- a/boa3/model/builtin/interop/enumerator/enumeratortype.py
+++ b/boa3/model/builtin/interop/enumerator/enumeratortype.py
@@ -77,6 +77,9 @@ class EnumeratorType(ClassType):
     def build(cls, value: Any = None) -> EnumeratorType:
         if isinstance(value, ICollectionType):
             return EnumeratorType(value)
+        elif isinstance(value, IType):
+            from boa3.model.type.type import Type
+            return EnumeratorType(Type.list.build([value]))
         else:
             return _Enumerator
 

--- a/boa3/model/builtin/interop/iterator/iteratorkeysmethod.py
+++ b/boa3/model/builtin/interop/iterator/iteratorkeysmethod.py
@@ -5,14 +5,14 @@ from boa3.model.builtin.interop.iterator.iteratortype import IteratorType
 from boa3.model.variable import Variable
 
 
-class IteratorValuesMethod(InteropMethod):
+class IteratorKeysMethod(InteropMethod):
     def __init__(self, iterator: IteratorType):
-        syscall = 'System.Iterator.Values'
-        identifier = '-iterator_values'
+        syscall = 'System.Iterator.Keys'
+        identifier = '-iterator_keys'
         args: Dict[str, Variable] = {'self': Variable(iterator)}
 
         from boa3.model.builtin.interop.enumerator import EnumeratorType
-        return_type = EnumeratorType.build(iterator.value_type)
+        return_type = EnumeratorType.build(iterator.key_type)
         super().__init__(identifier, syscall, args, return_type=return_type)
 
     @property

--- a/boa3/model/builtin/interop/iterator/iteratortype.py
+++ b/boa3/model/builtin/interop/iterator/iteratortype.py
@@ -58,12 +58,15 @@ class IteratorType(ClassType, ICollectionType):
     @property
     def instance_methods(self) -> Dict[str, Method]:
         if self._methods is None:
-            from boa3.model.builtin.interop.iterator.iteratornextmethod import IteratorNextMethod
             from boa3.model.builtin.interop.iterator.iteratorconcatmethod import IteratorConcatMethod
+            from boa3.model.builtin.interop.iterator.iteratornextmethod import IteratorNextMethod
+            from boa3.model.builtin.interop.iterator.iteratorkeysmethod import IteratorKeysMethod
             from boa3.model.builtin.interop.iterator.iteratorvaluesmethod import IteratorValuesMethod
+
             self._methods = {
                 'next': IteratorNextMethod(),
                 'concat': IteratorConcatMethod(self),
+                'keys': IteratorKeysMethod(self),
                 'values': IteratorValuesMethod(self)
             }
         return self._methods.copy()
@@ -73,6 +76,7 @@ class IteratorType(ClassType, ICollectionType):
         if self._constructor is None:
             from boa3.model.builtin.interop.iterator.iteratorinitmethod import IteratorMethod
             self._constructor: Method = IteratorMethod(self)
+
         return self._constructor
 
     @property

--- a/boa3_test/examples/HTLC.py
+++ b/boa3_test/examples/HTLC.py
@@ -1,11 +1,11 @@
 from typing import Any
 
-from boa3.builtin.interop.contract import call_contract
-from boa3.builtin.interop.runtime import executing_script_hash, get_time, calling_script_hash, check_witness
 from boa3.builtin import NeoMetadata, metadata, public
-from boa3.builtin.interop.crypto import hash160
-from boa3.builtin.interop.storage import get, put
 from boa3.builtin.contract import abort
+from boa3.builtin.interop.contract import call_contract
+from boa3.builtin.interop.crypto import hash160
+from boa3.builtin.interop.runtime import calling_script_hash, check_witness, executing_script_hash, get_time
+from boa3.builtin.interop.storage import get, put
 from boa3.builtin.type import UInt160
 
 

--- a/boa3_test/test_sc/interop_test/iterator/IteratorKeys.py
+++ b/boa3_test/test_sc/interop_test/iterator/IteratorKeys.py
@@ -1,0 +1,21 @@
+from typing import Any, Dict, List, Union
+
+from boa3.builtin import public
+from boa3.builtin.interop.enumerator import Enumerator
+from boa3.builtin.interop.iterator import Iterator
+
+
+@public
+def list_iterator(x: List[int]) -> Union[Enumerator, None]:
+    it = Iterator(x)
+    if it.next():
+        return it.keys()
+    return None
+
+
+@public
+def dict_iterator(x: Dict[Any, int]) -> Union[Enumerator, None]:
+    it = Iterator(x)
+    if it.next():
+        return it.keys()
+    return None

--- a/boa3_test/test_sc/interop_test/iterator/IteratorKeysMismatchedType.py
+++ b/boa3_test/test_sc/interop_test/iterator/IteratorKeysMismatchedType.py
@@ -1,0 +1,11 @@
+from typing import Any, Dict
+
+from boa3.builtin import public
+from boa3.builtin.interop.iterator import Iterator
+
+
+@public
+def dict_iterator(x: Dict[Any, int]) -> str:
+    it = Iterator(x)
+    it.next()
+    return it.keys()

--- a/boa3_test/tests/examples/HTLCTests.py
+++ b/boa3_test/tests/examples/HTLCTests.py
@@ -1,11 +1,10 @@
 from boa3.boa3 import Boa3
-from boa3.builtin.interop.contract import NEO, GAS
+from boa3.builtin.interop.contract import GAS, NEO
 from boa3.neo import to_script_hash
+from boa3.neo.cryptography import hash160
 from boa3.neo.vm.type.String import String
 from boa3_test.tests.boa_test import BoaTest
-from boa3_test.tests.test_classes.TestExecutionException import TestExecutionException
 from boa3_test.tests.test_classes.testengine import TestEngine
-from boa3.neo.cryptography import hash160
 
 
 class TestTemplate(BoaTest):
@@ -122,7 +121,7 @@ class TestTemplate(BoaTest):
 
         # starting atomic swap by using the atomic_swap method
         result = self.run_smart_contract(engine, path, 'atomic_swap', contract_address1, NEO, transferred_amount_neo,
-                                         contract_address2, GAS,transferred_amount_gas,
+                                         contract_address2, GAS, transferred_amount_gas,
                                          hash160(String('unit test').to_bytes()),
                                          signer_accounts=[self.OWNER_SCRIPT_HASH],
                                          expected_result_type=bool)

--- a/boa3_test/tests/test_interop/test_iterator.py
+++ b/boa3_test/tests/test_interop/test_iterator.py
@@ -175,3 +175,26 @@ class TestIteratorInterop(BoaTest):
     def test_iterator_values_mismatched_type(self):
         path = '%s/boa3_test/test_sc/interop_test/iterator/IteratorValuesMismatchedType.py' % self.dirname
         self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_iterator_keys(self):
+        path = '%s/boa3_test/test_sc/interop_test/iterator/IteratorKeys.py' % self.dirname
+        self.compile_and_save(path)
+
+        engine = TestEngine(self.dirname)
+        result = self.run_smart_contract(engine, path, 'list_iterator', [1])
+        self.assertEqual(InteropInterface, result)
+        # TODO: validate actual result when Enumerator.next() and Enumerator.value() are implemented
+
+        result = self.run_smart_contract(engine, path, 'list_iterator', [])
+        self.assertIsNone(result)
+
+        result = self.run_smart_contract(engine, path, 'dict_iterator', {1: 5, 7: 9})
+        self.assertEqual(InteropInterface, result)
+        # TODO: validate actual result when Enumerator.next() and Enumerator.value() are implemented
+
+        result = self.run_smart_contract(engine, path, 'dict_iterator', {})
+        self.assertIsNone(result)
+
+    def test_iterator_keys_mismatched_type(self):
+        path = '%s/boa3_test/test_sc/interop_test/iterator/IteratorKeysMismatchedType.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [pycodestyle]
-ignore = E721,E402,W291,E501,E704
+ignore = W291,E501,E702,E704,E721
+exclude = */ico.py, *Python2.py, *TryExcept*


### PR DESCRIPTION
**Summary or solution description**
Implemented `keys` method of `Iterator`s objects. It gets an enumerator of the iterator's keys.

**How to Reproduce**
```python
iterator = Iterator([1, 2, 3])
enumerator = iterator.keys()
```

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/fb6704ae115f028649bcbbae548ec3b03ed4ad8b/boa3_test/tests/test_interop/test_iterator.py#L179-L200

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8.6