### PR TITLE
Boa-215 Implement Enumerator Concat Interop

### DIFF
--- a/boa3/builtin/interop/enumerator/__init__.py
+++ b/boa3/builtin/interop/enumerator/__init__.py
@@ -1,6 +1,11 @@
+from __future__ import annotations
+
 from typing import Sequence, Union
 
 
 class Enumerator:
     def __init__(self, entry: Union[Sequence, int]):
+        pass
+
+    def concat(self, other: Enumerator) -> Enumerator:
         pass

--- a/boa3/model/builtin/interop/enumerator/enumeratorconcatmethod.py
+++ b/boa3/model/builtin/interop/enumerator/enumeratorconcatmethod.py
@@ -1,0 +1,56 @@
+from typing import Any, Dict, Optional, Sized
+
+from boa3.model.builtin.interop.enumerator.enumeratortype import EnumeratorType
+from boa3.model.builtin.interop.interopmethod import InteropMethod
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.type.itype import IType
+from boa3.model.variable import Variable
+
+
+class EnumeratorConcatMethod(InteropMethod):
+    def __init__(self, enumerator: EnumeratorType, other_type: Optional[EnumeratorType] = None):
+        syscall = 'System.Enumerator.Concat'
+        identifier = '-enumerator_concat'
+
+        if other_type is None:
+            other_type = EnumeratorType.build()
+        args: Dict[str, Variable] = {'self': Variable(enumerator),
+                                     'other': Variable(other_type)}
+
+        return_type = self._build_result(enumerator, other_type)
+        super().__init__(identifier, syscall, args, return_type=return_type)
+
+    @property
+    def identifier(self) -> str:
+        return '{0}_{1}'.format(self.raw_identifier,
+                                '_'.join([x.type.identifier for x in self.args.values()]))
+
+    def _build_result(self, enumerator: EnumeratorType, other_type: EnumeratorType) -> IType:
+        if enumerator == other_type:
+            return enumerator
+
+        from boa3.model.type.type import Type
+        value_type = Type.union.build([enumerator.value_type, other_type.value_type])
+
+        new_sequence = Type.list.build([value_type])
+        if new_sequence.value_type == enumerator.value_type:
+            return enumerator
+
+        elif new_sequence.value_type == other_type.value_type:
+            return other_type
+
+        return EnumeratorType.build(new_sequence)
+
+    def push_self_first(self) -> bool:
+        return True
+
+    def build(self, value: Any) -> IBuiltinMethod:
+        if not isinstance(value, Sized) or len(value) != 2:
+            return self
+
+        enumerator_type = EnumeratorType.build()
+        self_type, other_type = value
+        if not enumerator_type.is_type_of(self_type) or not enumerator_type.is_type_of(other_type):
+            return self
+
+        return EnumeratorConcatMethod(self_type, other_type)

--- a/boa3/model/builtin/interop/enumerator/enumeratortype.py
+++ b/boa3/model/builtin/interop/enumerator/enumeratortype.py
@@ -52,7 +52,10 @@ class EnumeratorType(ClassType):
     @property
     def instance_methods(self) -> Dict[str, Method]:
         if self._methods is None:
-            self._methods = {}
+            from boa3.model.builtin.interop.enumerator.enumeratorconcatmethod import EnumeratorConcatMethod
+            self._methods = {
+                'concat': EnumeratorConcatMethod(self)
+            }
         return self._methods.copy()
 
     def constructor_method(self) -> Method:

--- a/boa3/model/builtin/interop/iterator/iteratorconcatmethod.py
+++ b/boa3/model/builtin/interop/iterator/iteratorconcatmethod.py
@@ -12,9 +12,8 @@ class IteratorConcatMethod(InteropMethod):
         syscall = 'System.Iterator.Concat'
         identifier = '-iterator_concat'
 
-        iterator_type = IteratorType.build()
         if other_type is None:
-            other_type = iterator_type
+            other_type = IteratorType.build()
         args: Dict[str, Variable] = {'self': Variable(iterator),
                                      'other': Variable(other_type)}
 

--- a/boa3_test/test_sc/interop_test/enumerator/EnumeratorConcat.py
+++ b/boa3_test/test_sc/interop_test/enumerator/EnumeratorConcat.py
@@ -1,0 +1,10 @@
+from boa3.builtin import public
+from boa3.builtin.interop.enumerator import Enumerator
+
+
+@public
+def concat_enumerators(x: list, y: list) -> Enumerator:
+    it1 = Enumerator(x)
+    it2 = Enumerator(y)
+
+    return it1.concat(it2)

--- a/boa3_test/test_sc/interop_test/enumerator/EnumeratorConcatMismatchedType.py
+++ b/boa3_test/test_sc/interop_test/enumerator/EnumeratorConcatMismatchedType.py
@@ -1,0 +1,9 @@
+from boa3.builtin import public
+from boa3.builtin.interop.enumerator import Enumerator
+
+
+@public
+def concat_enumerators(x: list) -> Enumerator:
+    it1 = Enumerator(x)
+
+    return it1.concat(42)

--- a/boa3_test/test_sc/interop_test/enumerator/EnumeratorConcatWithDefinedTypes.py
+++ b/boa3_test/test_sc/interop_test/enumerator/EnumeratorConcatWithDefinedTypes.py
@@ -1,0 +1,12 @@
+from typing import List
+
+from boa3.builtin import public
+from boa3.builtin.interop.enumerator import Enumerator
+
+
+@public
+def concat_enumerators(x: List[str], y: List[int]) -> Enumerator:
+    it1 = Enumerator(x)
+    it2 = Enumerator(y)
+
+    return it1.concat(it2)

--- a/boa3_test/tests/test_interop/test_enumerator.py
+++ b/boa3_test/tests/test_interop/test_enumerator.py
@@ -74,3 +74,26 @@ class TestEnumeratorInterop(BoaTest):
     def test_create_enumerator_mismatched_type(self):
         path = '%s/boa3_test/test_sc/interop_test/enumerator/EnumeratorCreateMismatchedTypes.py' % self.dirname
         self.assertCompilerLogs(MismatchedTypes, path)
+        
+    def test_enumerator_concat(self):
+        path = '%s/boa3_test/test_sc/interop_test/enumerator/EnumeratorConcat.py' % self.dirname
+        self.compile_and_save(path)
+
+        engine = TestEngine(self.dirname)
+        result = self.run_smart_contract(engine, path, 'concat_enumerators', [1], ['4', '2'])
+        self.assertEqual(InteropInterface, result)  # returns an interop interface
+        # TODO: validate actual result when Enumerator.next() and Enumerator.value() are implemented
+
+    def test_enumerator_concat_with_defined_types(self):
+        path = '%s/boa3_test/test_sc/interop_test/enumerator/EnumeratorConcatWithDefinedTypes.py' % self.dirname
+        self.compile_and_save(path)
+
+        engine = TestEngine(self.dirname)
+        result = self.run_smart_contract(engine, path, 'concat_enumerators',
+                                         ['1', '2', '3'], [1, 10])
+        self.assertEqual(InteropInterface, result)  # returns an interop interface
+        # TODO: validate actual result when Enumerator.next() and Enumerator.value() are implemented
+
+    def test_enumerator_concat_mismatched_type(self):
+        path = '%s/boa3_test/test_sc/interop_test/enumerator/EnumeratorConcatMismatchedType.py' % self.dirname
+        self.assertCompilerLogs(MismatchedTypes, path)


### PR DESCRIPTION
**Summary or solution description**
Implemented the ``concat`` method for concatenating two ``Enumerator``s objects

**How to Reproduce**
```python
enumerator1 = Enumerator([1, 2, 3])
enumerator2 = Enumerator(('1', '2', '3'))
enumerator3 = enumerator1.concat(enumerator2)
```

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/80ca4ded72aae9552aa4e408de12d9b571dcfc0d/boa3_test/tests/test_interop/test_enumerator.py#L78-L99

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8.6
