### PR TITLE
Boa-320 Raise NotSupportedException when using isinstance with boa builtin types

### DIFF
--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -935,7 +935,8 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
                     callable_target: IBuiltinMethod = callable_target.build(args)
                     if not callable_target.is_supported:
                         self._log_error(
-                            CompilerError.NotSupportedOperation(call.lineno, call.col_offset, callable_id)
+                            CompilerError.NotSupportedOperation(call.lineno, call.col_offset,
+                                                                callable_target.not_supported_str(callable_id))
                         )
                         return callable_target.return_type
 

--- a/boa3/model/builtin/method/builtinmethod.py
+++ b/boa3/model/builtin/method/builtinmethod.py
@@ -150,3 +150,7 @@ class IBuiltinMethod(IBuiltinCallable, Method, ABC):
         :rtype: IBuiltinMethod
         """
         return self
+
+    def not_supported_str(self, callable_id: str) -> str:
+        return '{0}({1})'.format(callable_id,
+                                 ','.join([arg.type.identifier for arg in self.args.values()]))

--- a/boa3/neo/vm/VMCode.py
+++ b/boa3/neo/vm/VMCode.py
@@ -104,3 +104,6 @@ class VMCode:
 
     def __str__(self) -> str:
         return self.opcode.name + ' ' + self.data.hex()
+
+    def __repr__(self) -> str:
+        return str(self)

--- a/boa3_test/test_sc/built_in_methods_test/IsInstanceClass.py
+++ b/boa3_test/test_sc/built_in_methods_test/IsInstanceClass.py
@@ -1,0 +1,11 @@
+from boa3.builtin import public
+from boa3.builtin.type import UInt160
+
+
+@public
+def Main(value: bytes) -> bool:
+    if len(value) == 20:
+        value = UInt160(value)
+
+    # not supported because boa builtin classes don't work with isinstance yet
+    return isinstance(value, UInt160)

--- a/boa3_test/test_sc/built_in_methods_test/IsInstanceManyTypesWithClass.py
+++ b/boa3_test/test_sc/built_in_methods_test/IsInstanceManyTypesWithClass.py
@@ -1,0 +1,10 @@
+from typing import Any
+
+from boa3.builtin import public
+from boa3.builtin.type import UInt160
+
+
+@public
+def Main(a: Any) -> bool:
+    # not supported because boa builtin classes don't work with isinstance yet
+    return isinstance(a, (list, int, UInt160, dict))

--- a/boa3_test/tests/test_builtin_method.py
+++ b/boa3_test/tests/test_builtin_method.py
@@ -957,6 +957,14 @@ class TestBuiltinMethod(BoaTest):
         result = self.run_smart_contract(engine, path, 'Main', {})
         self.assertEqual(True, result)
 
+    def test_isinstance_many_types_with_class(self):
+        path = '%s/boa3_test/test_sc/built_in_methods_test/IsInstanceManyTypesWithClass.py' % self.dirname
+        self.assertCompilerLogs(NotSupportedOperation, path)
+
+    def test_isinstance_class(self):
+        path = '%s/boa3_test/test_sc/built_in_methods_test/IsInstanceClass.py' % self.dirname
+        self.assertCompilerLogs(NotSupportedOperation, path)
+
     # endregion
 
     # region exit test
@@ -970,7 +978,7 @@ class TestBuiltinMethod(BoaTest):
         with self.assertRaises(TestExecutionException, msg=self.ABORTED_CONTRACT_MSG):
             self.run_smart_contract(engine, path, 'main', True)
 
-    # end region
+    # endregion
 
     # region max test
 
@@ -992,7 +1000,7 @@ class TestBuiltinMethod(BoaTest):
         path = '%s/boa3_test/test_sc/built_in_methods_test/MaxMismatchedTypes.py' % self.dirname
         self.assertCompilerLogs(MismatchedTypes, path)
 
-    # end region
+    # endregion
 
     # region min test
 
@@ -1014,4 +1022,4 @@ class TestBuiltinMethod(BoaTest):
         path = '%s/boa3_test/test_sc/built_in_methods_test/MinMismatchedTypes.py' % self.dirname
         self.assertCompilerLogs(MismatchedTypes, path)
 
-    # end region
+    # endregion


### PR DESCRIPTION
**Summary or solution description**
``isinstance`` with boa builtin types were not having the expected behavior.
After an evaluation, we arrived to the conclusion that it'll need a big refactor, so until there the usage of ``isinstance`` in those cases will raise an ``NotSupportedException``

**How to Reproduce**
```python
value = UInt160(value)

# not supported because boa builtin classes don't work with isinstance yet
return isinstance(value, UInt160)
```

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/919d39e8f37da40b6d99fcb5d80a03ab3464e847/boa3_test/tests/test_builtin_method.py#L960-L966

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8.6