### PR TITLE
Boa-326 Match all documentation Python requirements to 3.7 as minimum

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The diagram bellow shows the basic building blocks of the Neo3-Boa project.
 
 ## Quickstart
 
-Installation requires Python 3.8 or later.
+Installation requires Python 3.7 or later.
 
 ### Installation 
 Make sure you have installed MSVC v142 - Build tools VS 2019 C++ x64/x86 (v14.24). You can do this by installing Visual Studio 2019 and add C++ development features.
@@ -96,7 +96,7 @@ On Windows:
 
 ```shell
 $ python3 -m venv venv
-$ venv/Scripts/activate.bat
+$ venv\Scripts\activate.bat
 ```
 
 ##### Pip (Recomended)

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -1,7 +1,7 @@
 Installation
 ============
 
-This version of the compiler requires Python 3.8 or later
+This version of the compiler requires Python 3.7 or later
 
 .. note::
    Make sure you have installed MSVC v142 - Build tools VS 2019 C++ x64/x86 (v14.24). You can do this by installing `Visual Studio`_ and adding C++ development features.
@@ -11,27 +11,28 @@ Set Virtual Environment
 
 Make a Python 3 virtual environment and activate it:
 
-Linux/Mac OS::
+On Linux/Mac OS::
 
     $ python3 -m venv venv
     $ source venv/bin/activate
 
-Windows::
+
+On Windows::
 
     $ python3 -m venv venv
-    $ venv/Scripts/activate.bat
+    $ venv\Scripts\activate.bat
 
-Using pip (Recomended)
-^^^^^^^^^^^^^^^^^^^^^^
+Pip (Recomended)
+^^^^^^^^^^^^^^^^
 
 ::
 
     pip install neo3-boa
 
-If neo3-boa is not available via pip, you can build it from source.
 
-Build from Source
-^^^^^^^^^^^^^^^^^
+Build from Source (Optional)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+If neo3-boa is not available via pip, you can build it from source.
 
 ::
 


### PR DESCRIPTION
**Summary or solution description**
Changed neo3-boa documentation to require at least Python 3.7 instead of 3.8 and tested all unit tests to see if there was a compatibility problem.

**Tests**
Tested it using the TestEngine and Opcodes

**Platform:**
 - OS:  Windows 10 x64
 - Python version: Python 3.7