### PR TITLE
Boa-322 Verify why does the neo3-boa requires C++ Build tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ The diagram bellow shows the basic building blocks of the Neo3-Boa project.
 Installation requires Python 3.7 or later.
 
 ### Installation 
-Make sure you have installed MSVC v142 - Build tools VS 2019 C++ x64/x86 (v14.24). You can do this by installing Visual Studio 2019 and add C++ development features.
 
 ##### Make a Python 3 virtual environment and activate it:
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -1,10 +1,7 @@
 Installation
 ============
 
-This version of the compiler requires Python 3.7 or later
-
-.. note::
-   Make sure you have installed MSVC v142 - Build tools VS 2019 C++ x64/x86 (v14.24). You can do this by installing `Visual Studio`_ and adding C++ development features.
+This version of the compiler requires Python 3.7 or later.
 
 Set Virtual Environment
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,9 @@
 autopep8==1.4.4
 base58==1.0.3
-bitarray==1.0.1
 bitcoin==1.1.42
 coverage==4.5.4
 ecdsa==0.15
 Events==0.3
-mmh3==2.5.1
 mpmath==1.1.0
 pycodestyle==2.5.0
 Sphinx==1.6.4

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,12 +1,10 @@
 autopep8==1.4.4
 base58==1.0.3
-bitarray==1.0.1
 bitcoin==1.1.42
 bump2version==1.0.0
 coverage==4.5.4
 ecdsa==0.15
 Events==0.3
-mmh3==2.5.1
 mpmath==1.1.0
 pycodestyle==2.5.0
 Sphinx==1.6.4


### PR DESCRIPTION
**Related issue**
#194 

**Summary or solution description**
Removed `Make sure you have installed MSVC v142 - Build tools VS 2019 C++ x64/x86 (v14.24). You can do this by installing Visual Studio 2019 and add C++ development features.` at README and docs, and removed bitarray and mmh3 as required packages to install.

**Tests**
Tested all unit test with the TestEngine and/or Opcode.

**Screenshots**
![image](https://user-images.githubusercontent.com/49196318/105080112-23988580-5a6f-11eb-93c9-8d0945488711.png)

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8