### PR TITLE
Boa-323 Change the TestEngine error when the executable is not found

### DIFF
--- a/boa3_test/tests/test_classes/testengine.py
+++ b/boa3_test/tests/test_classes/testengine.py
@@ -10,11 +10,16 @@ from boa3.neo3.vm import VMState
 from boa3_test.tests.test_classes.block import Block
 from boa3_test.tests.test_classes.storage import Storage
 from boa3_test.tests.test_classes.transaction import Transaction
+from os import path
 
 
 class TestEngine:
     def __init__(self, root_path: str):
-        self._test_engine_path = '{0}/Neo.TestEngine/Neo.TestEngine.dll'.format(root_path)
+        if path.exists('{0}/Neo.TestEngine/Neo.TestEngine.dll'.format(root_path)):
+            self._test_engine_path = '{0}/Neo.TestEngine/Neo.TestEngine.dll'.format(root_path)
+        else:
+            raise Exception("Can not open file 'Neo.TestEngine/Neo.TestEngine.dll'. No such file exists."
+                            "\nVisit the docs or the README file and search for 'TestEngine' to correctly install it.")
 
         self._vm_state: VMState = VMState.NONE
         self._gas_consumed: int = 0

--- a/boa3_test/tests/test_classes/testengine.py
+++ b/boa3_test/tests/test_classes/testengine.py
@@ -18,8 +18,9 @@ class TestEngine:
         if path.exists('{0}/Neo.TestEngine/Neo.TestEngine.dll'.format(root_path)):
             self._test_engine_path = '{0}/Neo.TestEngine/Neo.TestEngine.dll'.format(root_path)
         else:
-            raise Exception("Can not open file 'Neo.TestEngine/Neo.TestEngine.dll'. No such file exists."
-                            "\nVisit the docs or the README file and search for 'TestEngine' to correctly install it.")
+            raise FileNotFoundError("File at " + '{0}/Neo.TestEngine/Neo.TestEngine.dll'.format(root_path) + " was not "
+                                    "found.\nVisit the docs or the README file and search for 'TestEngine' to correctly"
+                                    " install it.")
 
         self._vm_state: VMState = VMState.NONE
         self._gas_consumed: int = 0

--- a/boa3_test/tests/test_test_engine.py
+++ b/boa3_test/tests/test_test_engine.py
@@ -354,3 +354,12 @@ class TestTestEngine(BoaTest):
         engine = TestEngine(self.dirname)
         result = engine.run(path, 'Sub', 50, 20)
         self.assertEqual(30, result)
+
+    def test_test_engine_not_found_error(self):
+        # if the TestEngine is correctly installed a error should not occur
+        engine = TestEngine(self.dirname)
+
+        # however, if the TestEngine is not in the directory it will raise an Exception
+        with self.assertRaises(FileNotFoundError):
+            engine = TestEngine('%s/boa3_test' % self.dirname)
+


### PR DESCRIPTION
**Related issue**
#193 

**Summary or solution description**
Checked if the TestEngine path exists and if not raise an Exception explaining why.

**Tests**
Deleted the folder and changed the name to see if an Exception would occur.

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8