### PR TITLE
Boa-299 Fix bytes_to_bool_with_builtin

### DIFF
--- a/boa3_test/tests/test_bytes.py
+++ b/boa3_test/tests/test_bytes.py
@@ -155,7 +155,7 @@ class TestBytes(BoaTest):
         output = Boa3.compile(path)
 
         engine = TestEngine(self.dirname)
-        result = self.run_smart_contract(engine, path, 'bytes_to_bool')
+        result = self.run_smart_contract(engine, path, 'bytes_to_bool', expected_result_type=bool)
         self.assertEqual(False, result)
 
     def test_bytes_to_bool_with_builtin_hard_coded_true(self):


### PR DESCRIPTION
**Summary or solution description**
The is no need to fix bytes.to_bool(), it's returning exactly what it should return.

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/de91e51c8b7125ce53393039ad101a0352ec9314/boa3_test/tests/test_bytes.py#L153-L159

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8