### PR TITLE
Boa-166 Include generic extras in the metadata

### DIFF
--- a/boa3/builtin/__init__.py
+++ b/boa3/builtin/__init__.py
@@ -51,10 +51,6 @@ class NeoMetadata:
     """
     This class stores the smart contract manifest information.
 
-    :ivar has_storage: is a boolean value indicating whether the contract has a storage. False by default.
-    :type has_storage: bool
-    :ivar is_payable: is a boolean value indicating whether the contract accepts transfers. False by default.
-    :type is_payable: bool
     :ivar author: the smart contract author. None by default;
     :type author: str or None
     :ivar email: the smart contract author email. None by default;
@@ -66,14 +62,11 @@ class NeoMetadata:
     def __init__(self):
         from typing import Optional
 
-        # features
-        self.has_storage: bool = False
-        self.is_payable: bool = False
-
         # extras
         self.author: Optional[str] = None
         self.email: Optional[str] = None
         self.description: Optional[str] = None
+        self.extras: Dict[str, Any] = {}
 
     @property
     def extra(self) -> Dict[str, Any]:
@@ -82,7 +75,7 @@ class NeoMetadata:
 
         :return: a dictionary that maps each extra value with its name. Empty by default.
         """
-        extra = {}
+        extra = self.extras.copy()
         if isinstance(self.author, str):
             extra['Author'] = self.author
         if isinstance(self.email, str):

--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -147,7 +147,8 @@ class Builtin:
     metadata_fields: Dict[str, Union[type, Tuple[type]]] = {
         'author': (str, type(None)),
         'email': (str, type(None)),
-        'description': (str, type(None))
+        'description': (str, type(None)),
+        'extras': dict
     }
 
     @classmethod

--- a/boa3_test/test_sc/metadata_test/MetadataInfoNewExtras.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoNewExtras.py
@@ -1,0 +1,16 @@
+from boa3.builtin import NeoMetadata, metadata
+
+
+def Main() -> int:
+    return 5
+
+
+@metadata
+def extras_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+    meta.extras = {'unittest1': 'string',
+                   'unittest2': 123,
+                   'unittest3': True,
+                   'unittest4': ['list', 3210]
+                   }
+    return meta

--- a/boa3_test/tests/test_metadata.py
+++ b/boa3_test/tests/test_metadata.py
@@ -141,3 +141,23 @@ class TestMetadata(BoaTest):
         self.assertEqual('test@test.com', manifest['extra']['Email'])
         self.assertIn('Description', manifest['extra'])
         self.assertEqual('This is an example', manifest['extra']['Description'])
+
+    def test_metadata_info_extras(self):
+        expected_output = (
+            Opcode.PUSH5        # return 5
+            + Opcode.RET
+        )
+
+        path = '%s/boa3_test/test_sc/metadata_test/MetadataInfoNewExtras.py' % self.dirname
+        output, manifest = self.compile_and_save(path)
+        self.assertEqual(expected_output, output)
+        self.assertIn('extra', manifest)
+        self.assertIsNotNone(manifest['extra'])
+        self.assertIn('unittest1', manifest['extra'])
+        self.assertEqual('string', manifest['extra']['unittest1'])
+        self.assertIn('unittest2', manifest['extra'])
+        self.assertEqual(123, manifest['extra']['unittest2'])
+        self.assertIn('unittest3', manifest['extra'])
+        self.assertEqual(True, manifest['extra']['unittest3'])
+        self.assertIn('unittest4', manifest['extra'])
+        self.assertEqual(['list', 3210], manifest['extra']['unittest4'])


### PR DESCRIPTION
**Summary or solution description**
Implemented a way to add more data in the metadata if the user wants to.

**How to Reproduce**
Create a dictionary and attribute it to `extras`
```
@metadata
def extras_manifest() -> NeoMetadata:
    meta = NeoMetadata()
    meta.extras = {'unittest1': 'string',
                   'unittest2': 123,
                   'unittest3': True,
                   'unittest4': ['list', 3210]
                   }
    return meta
```

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/3c7056d3fc4361941984c32addc66eda85abf660/boa3_test/tests/test_metadata.py#L145-L163

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8