### PR TITLE
Boa-321 Simplify how to get smart contract's path in the unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,11 +169,13 @@ Debugger launch configuration example:
 
 #### Downloading
 
-Clone neo-devpack-dotnet on neo3-boa root folder and compile the TestEngine.
+Clone neo-devpack-dotnet project and compile the TestEngine.
+
+> Note: Until [neo-devpack-dotnet#365](https://github.com/neo-project/neo-devpack-dotnet/pull/365) is approved by Neo, you need to clone neo-devpack-dotnet from [simplitech:test-engine-executable](https://github.com/simplitech/neo-devpack-dotnet/tree/test-engine-executable) branch 
 
 ```shell
-$ git clone https://github.com/simplitech/neo-devpack-dotnet.git -b test-engine-executable --single-branch
-$ dotnet build ./neo-devpack-dotnet/src/Neo.TestEngine/Neo.TestEngine.csproj -o ./Neo.TestEngine
+$ git clone https://github.com/simplitech/neo-devpack-dotnet.git -b test-engine-executable
+$ dotnet build ./neo-devpack-dotnet/src/Neo.TestEngine/Neo.TestEngine.csproj
 ```
 
 #### Updating
@@ -181,7 +183,7 @@ $ dotnet build ./neo-devpack-dotnet/src/Neo.TestEngine/Neo.TestEngine.csproj -o 
 Go into the neo-devpack-dotnet, pull and recompile.
 ```shell
 ${path-to-folder}/neo-devpack-dotnet git pull
-${path-to-folder}/neo-devpack-dotnet dotnet build ./src/Neo.TestEngine/Neo.TestEngine.csproj -o ./Neo.TestEngine
+${path-to-folder}/neo-devpack-dotnet dotnet build ./src/Neo.TestEngine/Neo.TestEngine.csproj
 ```
 
 #### Testing
@@ -197,7 +199,7 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 from boa3.neo.smart_contract.VoidType import VoidType
 
 def test_hello_world_main():
-    root_folder = '{path-to-folder}'
+    root_folder = '{path-to-test-engine-folder}'
     path = '%s/boa3_test/examples/HelloWorld.nef' % root_folder
     engine = TestEngine(root_folder)
 
@@ -214,6 +216,16 @@ You can [read the docs here](https://docs.coz.io/neo3/boa/index.html). Please ch
 For an extensive collection of examples:
 - [Smart contract examples](/boa3_test/examples)
 - [Features tests](/boa3_test/test_sc)
+
+## Tests
+
+Install [`neo3-boa`](#installation) and the [`TestEngine`](#testengine) and run the following command
+
+> Note: If you didn't install TestEngine in neo3-boa's root folder, you need to change the value of `TEST_ENGINE_DIRECTORY` in [this file](/env.py)
+
+```
+python -m unittest discover boa3_test
+```
 
 ## Python Supported Features
 

--- a/boa3_test/tests/examples/test_HTLC.py
+++ b/boa3_test/tests/examples/test_HTLC.py
@@ -9,17 +9,19 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 class TestTemplate(BoaTest):
 
+    default_folder: str = 'examples'
+
     OWNER_SCRIPT_HASH = bytes(20)
     OTHER_ACCOUNT_1 = to_script_hash(b'NiNmXL8FjEUEs1nfX9uHFBNaenxDHJtmuB')
     OTHER_ACCOUNT_2 = bytes(range(20))
 
     def test_HTLC_compile(self):
-        path = '%s/boa3_test/examples/HTLC.py' % self.dirname
+        path = self.get_contract_path('HTLC.py')
         Boa3.compile(path)
 
     def test_HTLC_deploy(self):
-        path = '%s/boa3_test/examples/HTLC.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('HTLC.py')
+        engine = TestEngine()
 
         # deploying the smart contract
         result = self.run_smart_contract(engine, path, 'deploy',
@@ -34,8 +36,8 @@ class TestTemplate(BoaTest):
         self.assertEqual(False, result)
 
     def test_HTLC_atomic_swap(self):
-        path = '%s/boa3_test/examples/HTLC.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('HTLC.py')
+        engine = TestEngine()
 
         # can not atomic_swap() without deploying first
         result = self.run_smart_contract(engine, path, 'atomic_swap', self.OWNER_SCRIPT_HASH, NEO, 10 * 10**8,
@@ -58,10 +60,10 @@ class TestTemplate(BoaTest):
         self.assertEqual(True, result)
 
     def test_HTLC_onPayment(self):
-        path = '%s/boa3_test/examples/HTLC.py' % self.dirname
-        engine = TestEngine(self.dirname)
-        path_contract1 = '%s/boa3_test/examples/test_native/methods.py' % self.dirname
-        path_contract2 = '%s/boa3_test/examples/test_native/example_contract_for_htlc.py' % self.dirname
+        path = self.get_contract_path('HTLC.py')
+        engine = TestEngine()
+        path_contract1 = self.get_contract_path('test_native/methods.py')
+        path_contract2 = self.get_contract_path('test_native/example_contract_for_htlc.py')
         transferred_amount_neo = 10 * 10**8
         transferred_amount_gas = 10000 * 10**8
 
@@ -94,10 +96,10 @@ class TestTemplate(BoaTest):
         # TODO: Test if onPayment is successful when update the TestEngine to make Neo/Gas transfers
 
     def test_HTLC_withdraw(self):
-        path = '%s/boa3_test/examples/HTLC.py' % self.dirname
-        engine = TestEngine(self.dirname)
-        path_contract1 = '%s/boa3_test/examples/test_native/methods.py' % self.dirname
-        path_contract2 = '%s/boa3_test/examples/test_native/example_contract_for_htlc.py' % self.dirname
+        path = self.get_contract_path('HTLC.py')
+        engine = TestEngine()
+        path_contract1 = self.get_contract_path('test_native/methods.py')
+        path_contract2 = self.get_contract_path('test_native/example_contract_for_htlc.py')
         transferred_amount_neo = 10 * 10**8
         transferred_amount_gas = 10000 * 10**8
 
@@ -136,10 +138,10 @@ class TestTemplate(BoaTest):
         # TODO: Test if the withdraw is successful when update the TestEngine to make Neo/Gas transfers
 
     def test_HTLC_refund(self):
-        path = '%s/boa3_test/examples/HTLC.py' % self.dirname
-        engine = TestEngine(self.dirname)
-        path_contract1 = '%s/boa3_test/examples/test_native/methods.py' % self.dirname
-        path_contract2 = '%s/boa3_test/examples/test_native/example_contract_for_htlc.py' % self.dirname
+        path = self.get_contract_path('HTLC.py')
+        engine = TestEngine()
+        path_contract1 = self.get_contract_path('test_native/methods.py')
+        path_contract2 = self.get_contract_path('test_native/example_contract_for_htlc.py')
         transferred_amount_neo = 10 * 10**8
         transferred_amount_gas = 10000 * 10**8
 

--- a/boa3_test/tests/examples/test_NEP17.py
+++ b/boa3_test/tests/examples/test_NEP17.py
@@ -10,17 +10,19 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 class TestTemplate(BoaTest):
 
+    default_folder: str = 'examples'
+
     OWNER_SCRIPT_HASH = bytes(20)
     OTHER_ACCOUNT_1 = to_script_hash(b'NiNmXL8FjEUEs1nfX9uHFBNaenxDHJtmuB')
     OTHER_ACCOUNT_2 = bytes(range(20))
 
     def test_nep17_compile(self):
-        path = '%s/boa3_test/examples/NEP17.py' % self.dirname
+        path = self.get_contract_path('NEP17.py')
         Boa3.compile(path)
 
     def test_nep17_deploy(self):
-        path = '%s/boa3_test/examples/NEP17.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('NEP17.py')
+        engine = TestEngine()
 
         # needs the owner signature
         result = self.run_smart_contract(engine, path, method='deploy',
@@ -45,22 +47,22 @@ class TestTemplate(BoaTest):
         self.assertEqual(False, result)
 
     def test_nep17_symbol(self):
-        path = '%s/boa3_test/examples/NEP17.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('NEP17.py')
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'symbol')
         self.assertEqual('NEP17', result)
 
     def test_nep17_decimals(self):
-        path = '%s/boa3_test/examples/NEP17.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('NEP17.py')
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'decimals')
         self.assertEqual(8, result)
 
     def test_nep17_total_supply(self):
         total_supply = 10_000_000 * 10 ** 8
 
-        path = '%s/boa3_test/examples/NEP17.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('NEP17.py')
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'totalSupply')
         self.assertEqual(0, result)
         result = self.run_smart_contract(engine, path, 'deploy',
@@ -73,8 +75,8 @@ class TestTemplate(BoaTest):
     def test_nep17_total_balance_of(self):
         total_supply = 10_000_000 * 10 ** 8
 
-        path = '%s/boa3_test/examples/NEP17.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('NEP17.py')
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'balanceOf', self.OWNER_SCRIPT_HASH)
         self.assertEqual(0, result)
 
@@ -95,8 +97,8 @@ class TestTemplate(BoaTest):
     def test_nep17_total_transfer(self):
         transferred_amount = 10 * 10 ** 8  # 10 tokens
 
-        path = '%s/boa3_test/examples/NEP17.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('NEP17.py')
+        engine = TestEngine()
 
         # should fail before running deploy
         result = self.run_smart_contract(engine, path, 'transfer',
@@ -189,9 +191,9 @@ class TestTemplate(BoaTest):
     def test_nep17_onPayment(self):
         transferred_amount = 10 * 10 ** 8  # 10 tokens
 
-        path = '%s/boa3_test/examples/NEP17.py' % self.dirname
-        path_native_tokens = '%s/boa3_test/examples/test_native/methods.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('NEP17.py')
+        path_native_tokens = self.get_contract_path('examples/test_native', 'methods.py')
+        engine = TestEngine()
 
         engine.add_contract(path.replace('.py', '.nef'))
 
@@ -216,8 +218,8 @@ class TestTemplate(BoaTest):
         # TODO: Test if the onPayment method is successful when update the TestEngine to make Neo/Gas transfers
 
     def test_nep17_verify(self):
-        path = '%s/boa3_test/examples/NEP17.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('NEP17.py')
+        engine = TestEngine()
 
         # should fail without signature
         result = self.run_smart_contract(engine, path, 'verify',

--- a/boa3_test/tests/examples/test_hello_world.py
+++ b/boa3_test/tests/examples/test_hello_world.py
@@ -5,13 +5,15 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 class TestTemplate(BoaTest):
 
+    default_folder: str = 'examples'
+
     def test_hello_world_compile(self):
-        path = '%s/boa3_test/examples/HelloWorld.py' % self.dirname
+        path = self.get_contract_path('HelloWorld.py')
         Boa3.compile(path)
 
     def test_hello_world_main(self):
-        path = '%s/boa3_test/examples/HelloWorld.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('HelloWorld.py')
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertIsVoid(result)
 

--- a/boa3_test/tests/examples/test_ico.py
+++ b/boa3_test/tests/examples/test_ico.py
@@ -7,6 +7,8 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 class TestTemplate(BoaTest):
 
+    default_folder: str = 'examples'
+
     OWNER_SCRIPT_HASH = bytes(20)
     OTHER_ACCOUNT_1 = to_script_hash(b'NiNmXL8FjEUEs1nfX9uHFBNaenxDHJtmuB')
     OTHER_ACCOUNT_2 = bytes(range(20))
@@ -14,12 +16,12 @@ class TestTemplate(BoaTest):
     KYC_WHITELIST_PREFIX = b'KYCWhitelistApproved'
 
     def test_ico_compile(self):
-        path = '%s/boa3_test/examples/ico.py' % self.dirname
+        path = self.get_contract_path('ico.py')
         Boa3.compile(path)
 
     def test_ico_deploy(self):
-        path = '%s/boa3_test/examples/ico.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('ico.py')
+        engine = TestEngine()
 
         # needs the owner signature
         result = self.run_smart_contract(engine, path, 'deploy',
@@ -44,8 +46,8 @@ class TestTemplate(BoaTest):
         self.assertEqual(False, result)
 
     def test_ico_verify(self):
-        path = '%s/boa3_test/examples/ico.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('ico.py')
+        engine = TestEngine()
 
         result = self.run_smart_contract(engine, path, 'verify',
                                          signer_accounts=[self.OTHER_ACCOUNT_1],
@@ -58,8 +60,8 @@ class TestTemplate(BoaTest):
         self.assertEqual(True, result)
 
     def test_ico_totalSupply(self):
-        path = '%s/boa3_test/examples/ico.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('ico.py')
+        engine = TestEngine()
         total_supply = 10_000_000 * 10 ** 8
 
         result = self.run_smart_contract(engine, path, 'totalSupply',
@@ -76,22 +78,22 @@ class TestTemplate(BoaTest):
         self.assertEqual(total_supply, result)
 
     def test_ico_symbol(self):
-        path = '%s/boa3_test/examples/ico.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('ico.py')
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'symbol')
         self.assertEqual('ICO', result)
 
     def test_ico_decimals(self):
-        path = '%s/boa3_test/examples/ico.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('ico.py')
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'decimals')
         self.assertEqual(8, result)
 
     def test_ico_total_balance_of(self):
         total_supply = 10_000_000 * 10 ** 8
 
-        path = '%s/boa3_test/examples/ico.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('ico.py')
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'balanceOf', self.OWNER_SCRIPT_HASH)
         self.assertEqual(0, result)
 
@@ -110,8 +112,8 @@ class TestTemplate(BoaTest):
             self.run_smart_contract(engine, path, 'balanceOf', bytes(30))
 
     def test_ico_kyc_register(self):
-        path = '%s/boa3_test/examples/ico.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('ico.py')
+        engine = TestEngine()
 
         # don't include if not signed by the administrator
         result = self.run_smart_contract(engine, path, 'kyc_register',
@@ -133,8 +135,8 @@ class TestTemplate(BoaTest):
         self.assertTrue(self.KYC_WHITELIST_PREFIX + self.OTHER_ACCOUNT_1 in engine.storage)
 
     def test_ico_kyc_remove(self):
-        path = '%s/boa3_test/examples/ico.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('ico.py')
+        engine = TestEngine()
 
         # don't remove if not signed by the administrator
         result = self.run_smart_contract(engine, path, 'kyc_remove',
@@ -156,8 +158,8 @@ class TestTemplate(BoaTest):
         self.assertEqual(1, result)
 
     def test_ico_approve(self):
-        path = '%s/boa3_test/examples/ico.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('ico.py')
+        engine = TestEngine()
 
         approved_amount = 100 * 10 ** 8
 
@@ -219,8 +221,8 @@ class TestTemplate(BoaTest):
         self.assertEqual(True, result)
 
     def test_ico_allowance(self):
-        path = '%s/boa3_test/examples/ico.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('ico.py')
+        engine = TestEngine()
 
         approved_amount = 100 * 10 ** 8
 
@@ -247,8 +249,8 @@ class TestTemplate(BoaTest):
         self.assertEqual(approved_amount, result)
 
     def test_ico_transferFrom(self):
-        path = '%s/boa3_test/examples/ico.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('ico.py')
+        engine = TestEngine()
 
         transferred_amount = 100 * 10 ** 8
 
@@ -347,8 +349,8 @@ class TestTemplate(BoaTest):
         self.assertEqual(balance_receiver_before, balance_receiver_after)
 
     def test_ico_mint(self):
-        path = '%s/boa3_test/examples/ico.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('ico.py')
+        engine = TestEngine()
 
         result = self.run_smart_contract(engine, path, 'deploy',
                                          signer_accounts=[self.OWNER_SCRIPT_HASH],
@@ -379,8 +381,8 @@ class TestTemplate(BoaTest):
         self.assertEqual(owner_balance_before + minted_amount, owner_balance_after)
 
     def test_ico_refund(self):
-        path = '%s/boa3_test/examples/ico.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('ico.py')
+        engine = TestEngine()
         transferred_amount = 10_000
 
         # should fail script hash length is not 20

--- a/boa3_test/tests/examples/test_nep5.py
+++ b/boa3_test/tests/examples/test_nep5.py
@@ -8,16 +8,18 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 class TestTemplate(BoaTest):
 
+    default_folder: str = 'examples'
+
     OWNER_SCRIPT_HASH = bytes(20)
     OTHER_ACCOUNT_1 = to_script_hash(b'NiNmXL8FjEUEs1nfX9uHFBNaenxDHJtmuB')
 
     def test_nep5_compile(self):
-        path = '%s/boa3_test/examples/nep5.py' % self.dirname
+        path = self.get_contract_path('nep5.py')
         Boa3.compile(path)
 
     def test_nep5_deploy(self):
-        path = '%s/boa3_test/examples/nep5.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('nep5.py')
+        engine = TestEngine()
 
         # needs the owner signature
         result = self.run_smart_contract(engine, path, 'deploy',
@@ -42,36 +44,36 @@ class TestTemplate(BoaTest):
         self.assertEqual(False, result)
 
     def test_nep5_name(self):
-        path = '%s/boa3_test/examples/nep5.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('nep5.py')
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'name')
         self.assertEqual('NEP5 Standard', result)
 
     def test_nep5_symbol(self):
-        path = '%s/boa3_test/examples/nep5.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('nep5.py')
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'symbol')
         self.assertEqual('NEP5', result)
 
     def test_nep5_decimals(self):
-        path = '%s/boa3_test/examples/nep5.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('nep5.py')
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'decimals')
         self.assertEqual(8, result)
 
     def test_nep5_total_supply(self):
         total_supply = 10_000_000 * 10 ** 8
 
-        path = '%s/boa3_test/examples/nep5.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('nep5.py')
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'totalSupply')
         self.assertEqual(total_supply, result)
 
     def test_nep5_total_balance_of(self):
         total_supply = 10_000_000 * 10 ** 8
 
-        path = '%s/boa3_test/examples/nep5.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('nep5.py')
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'balanceOf', self.OWNER_SCRIPT_HASH)
         self.assertEqual(0, result)
 
@@ -92,8 +94,8 @@ class TestTemplate(BoaTest):
     def test_nep5_total_transfer(self):
         transferred_amount = 10 * 10 ** 8  # 10 tokens
 
-        path = '%s/boa3_test/examples/nep5.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('nep5.py')
+        engine = TestEngine()
 
         # should fail before running deploy
         result = self.run_smart_contract(engine, path, 'transfer',
@@ -174,8 +176,8 @@ class TestTemplate(BoaTest):
         self.assertEqual(balance_receiver_before + transferred_amount, balance_receiver_after)
 
     def test_nep5_verify(self):
-        path = '%s/boa3_test/examples/nep5.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('nep5.py')
+        engine = TestEngine()
 
         # should fail without signature
         result = self.run_smart_contract(engine, path, 'verify',

--- a/boa3_test/tests/test_any.py
+++ b/boa3_test/tests/test_any.py
@@ -8,9 +8,11 @@ from boa3_test.tests.boa_test import BoaTest
 
 class TestAny(BoaTest):
 
+    default_folder: str = 'test_sc/any_test'
+
     def test_any_variable_assignments(self):
         two = String('2').to_bytes()
-        path = '%s/boa3_test/test_sc/any_test/AnyVariableAssignments.py' % self.dirname
+        path = self.get_contract_path('AnyVariableAssignments.py')
 
         expected_output = (
             Opcode.INITSLOT     # function signature
@@ -35,12 +37,12 @@ class TestAny(BoaTest):
         self.assertEqual(expected_output, output)
 
     def test_variable_assignment_with_any(self):
-        path = '%s/boa3_test/test_sc/any_test/VariableAssignmentWithAny.py' % self.dirname
+        path = self.get_contract_path('VariableAssignmentWithAny.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_any_list(self):
         ok = String('ok').to_bytes()
-        path = '%s/boa3_test/test_sc/any_test/AnyList.py' % self.dirname
+        path = self.get_contract_path('AnyList.py')
 
         expected_output = (
             Opcode.INITSLOT     # function signature
@@ -60,7 +62,7 @@ class TestAny(BoaTest):
 
     def test_any_tuple(self):
         ok = String('ok').to_bytes()
-        path = '%s/boa3_test/test_sc/any_test/AnyTuple.py' % self.dirname
+        path = self.get_contract_path('AnyTuple.py')
 
         expected_output = (
             Opcode.INITSLOT     # function signature
@@ -79,7 +81,7 @@ class TestAny(BoaTest):
         self.assertEqual(expected_output, output)
 
     def test_any_operation(self):
-        path = '%s/boa3_test/test_sc/any_test/OperationWithAny.py' % self.dirname
+        path = self.get_contract_path('OperationWithAny.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_function_any_param(self):
@@ -135,7 +137,7 @@ class TestAny(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/any_test/FunctionAnyParam.py' % self.dirname
+        path = self.get_contract_path('FunctionAnyParam.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -186,16 +188,16 @@ class TestAny(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/any_test/AnySequenceAssignments.py' % self.dirname
+        path = self.get_contract_path('AnySequenceAssignments.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
     def test_int_sequence_any_assignments(self):
-        path = '%s/boa3_test/test_sc/any_test/IntSequenceAnyAssignment.py' % self.dirname
+        path = self.get_contract_path('IntSequenceAnyAssignment.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_str_sequence_any_assignments(self):
-        path = '%s/boa3_test/test_sc/any_test/StrSequenceAnyAssignment.py' % self.dirname
+        path = self.get_contract_path('StrSequenceAnyAssignment.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_str_sequence_str_assignment(self):
@@ -211,7 +213,7 @@ class TestAny(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/any_test/StrSequenceStrAssignment.py' % self.dirname
+        path = self.get_contract_path('StrSequenceStrAssignment.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -257,7 +259,7 @@ class TestAny(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/any_test/SequenceOfAnySequence.py' % self.dirname
+        path = self.get_contract_path('SequenceOfAnySequence.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -286,10 +288,10 @@ class TestAny(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/any_test/SequenceOfIntSequence.py' % self.dirname
+        path = self.get_contract_path('SequenceOfIntSequence.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
     def test_sequence_of_int_sequence_fail(self):
-        path = '%s/boa3_test/test_sc/any_test/SequenceOfAnyIntSequence.py' % self.dirname
+        path = self.get_contract_path('SequenceOfAnyIntSequence.py')
         self.assertCompilerLogs(MismatchedTypes, path)

--- a/boa3_test/tests/test_arithmetic.py
+++ b/boa3_test/tests/test_arithmetic.py
@@ -9,6 +9,8 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 class TestArithmetic(BoaTest):
 
+    default_folder: str = 'test_sc/arithmetic_test'
+
     def test_addition_operation(self):
         expected_output = (
             Opcode.INITSLOT
@@ -20,11 +22,11 @@ class TestArithmetic(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/arithmetic_test/Addition.py' % self.dirname
+        path = self.get_contract_path('Addition.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'add', 1, 2)
         self.assertEqual(3, result)
         result = self.run_smart_contract(engine, path, 'add', -42, -24)
@@ -38,11 +40,11 @@ class TestArithmetic(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/arithmetic_test/AdditionLiteral.py' % self.dirname
+        path = self.get_contract_path('AdditionLiteral.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'add_one_two')
         self.assertEqual(3, result)
 
@@ -57,11 +59,11 @@ class TestArithmetic(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/arithmetic_test/AdditionLiteralAndVariable.py' % self.dirname
+        path = self.get_contract_path('AdditionLiteralAndVariable.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'add_one', 1)
         self.assertEqual(2, result)
         result = self.run_smart_contract(engine, path, 'add_one', -10)
@@ -80,11 +82,11 @@ class TestArithmetic(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/arithmetic_test/AdditionVariableAndLiteral.py' % self.dirname
+        path = self.get_contract_path('AdditionVariableAndLiteral.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'add_one', 1)
         self.assertEqual(2, result)
         result = self.run_smart_contract(engine, path, 'add_one', -10)
@@ -103,11 +105,11 @@ class TestArithmetic(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/arithmetic_test/Subtraction.py' % self.dirname
+        path = self.get_contract_path('Subtraction.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'sub', 10, 3)
         self.assertEqual(7, result)
         result = self.run_smart_contract(engine, path, 'sub', -42, -24)
@@ -126,11 +128,11 @@ class TestArithmetic(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/arithmetic_test/Multiplication.py' % self.dirname
+        path = self.get_contract_path('Multiplication.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'mult', 10, 3)
         self.assertEqual(30, result)
         result = self.run_smart_contract(engine, path, 'mult', -42, -2)
@@ -141,7 +143,7 @@ class TestArithmetic(BoaTest):
         self.assertEqual(0, result)
 
     def test_division_operation(self):
-        path = '%s/boa3_test/test_sc/arithmetic_test/Division.py' % self.dirname
+        path = self.get_contract_path('Division.py')
         self.assertCompilerLogs(NotSupportedOperation, path)
 
     def test_integer_division_operation(self):
@@ -155,11 +157,11 @@ class TestArithmetic(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/arithmetic_test/IntegerDivision.py' % self.dirname
+        path = self.get_contract_path('IntegerDivision.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'floor_div', 10, 3)
         self.assertEqual(3, result)
         result = self.run_smart_contract(engine, path, 'floor_div', -42, -9)
@@ -178,11 +180,11 @@ class TestArithmetic(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/arithmetic_test/Modulo.py' % self.dirname
+        path = self.get_contract_path('Modulo.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'mod', 10, 3)
         self.assertEqual(1, result)
         result = self.run_smart_contract(engine, path, 'mod', -42, -9)
@@ -199,11 +201,11 @@ class TestArithmetic(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/arithmetic_test/Positive.py' % self.dirname
+        path = self.get_contract_path('Positive.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'plus', 10)
         self.assertEqual(10, result)
         result = self.run_smart_contract(engine, path, 'plus', -1)
@@ -221,11 +223,11 @@ class TestArithmetic(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/arithmetic_test/Negative.py' % self.dirname
+        path = self.get_contract_path('Negative.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'minus', 10)
         self.assertEqual(-10, result)
         result = self.run_smart_contract(engine, path, 'minus', -1)
@@ -246,18 +248,18 @@ class TestArithmetic(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/arithmetic_test/Concatenation.py' % self.dirname
+        path = self.get_contract_path('Concatenation.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'concat', 'a', 'b')
         self.assertEqual('ab', result)
         result = self.run_smart_contract(engine, path, 'concat', 'unit', 'test')
         self.assertEqual('unittest', result)
 
     def test_power_operation(self):
-        path = '%s/boa3_test/test_sc/arithmetic_test/Power.py' % self.dirname
+        path = self.get_contract_path('Power.py')
         self.assertCompilerLogs(NotSupportedOperation, path)
 
     def test_str_multiplication_operation(self):
@@ -271,22 +273,22 @@ class TestArithmetic(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/arithmetic_test/StringMultiplication.py' % self.dirname
+        path = self.get_contract_path('StringMultiplication.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'str_mult', 'a', 4)
         self.assertEqual('aaaa', result)
         result = self.run_smart_contract(engine, path, 'str_mult', 'unit', 50)
         self.assertEqual('unit' * 50, result)
 
     def test_mismatched_type_binary_operation(self):
-        path = '%s/boa3_test/test_sc/arithmetic_test/MismatchedOperandBinary.py' % self.dirname
+        path = self.get_contract_path('MismatchedOperandBinary.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_mismatched_type_unary_operation(self):
-        path = '%s/boa3_test/test_sc/arithmetic_test/MismatchedOperandUnary.py' % self.dirname
+        path = self.get_contract_path('MismatchedOperandUnary.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_sequence_addition(self):
@@ -302,11 +304,11 @@ class TestArithmetic(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/arithmetic_test/AdditionThreeElements.py' % self.dirname
+        path = self.get_contract_path('AdditionThreeElements.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'add_four', 1, 2)
         self.assertEqual(7, result)
         result = self.run_smart_contract(engine, path, 'add_four', -42, -24)
@@ -323,19 +325,19 @@ class TestArithmetic(BoaTest):
             + Opcode.ADD
             + Opcode.RET
         )
-        path_1 = '%s/boa3_test/test_sc/arithmetic_test/AdditionThreeValuesUnordered1.py' % self.dirname
+        path_1 = self.get_contract_path('AdditionThreeValuesUnordered1.py')
         output_1 = Boa3.compile(path_1)
         self.assertEqual(expected_output, output_1)
 
-        path_2 = '%s/boa3_test/test_sc/arithmetic_test/AdditionThreeValuesUnordered2.py' % self.dirname
+        path_2 = self.get_contract_path('AdditionThreeValuesUnordered2.py')
         output_2 = Boa3.compile(path_2)
         self.assertEqual(expected_output, output_2)
 
-        path_3 = '%s/boa3_test/test_sc/arithmetic_test/AdditionThreeValuesUnordered3.py' % self.dirname
+        path_3 = self.get_contract_path('AdditionThreeValuesUnordered3.py')
         output_3 = Boa3.compile(path_3)
         self.assertEqual(expected_output, output_3)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result_1 = self.run_smart_contract(engine, path_1, 'add_six', 5)
         result_2 = self.run_smart_contract(engine, path_2, 'add_six', 5)
         result_3 = self.run_smart_contract(engine, path_2, 'add_six', 5)
@@ -368,11 +370,11 @@ class TestArithmetic(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/arithmetic_test/MixedOperations.py' % self.dirname
+        path = self.get_contract_path('MixedOperations.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'mixed', 10, 20, 30, 40, 50)
         self.assertEqual(10 + 30 * 50 + 40 // 20, result)
 
@@ -394,11 +396,11 @@ class TestArithmetic(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/arithmetic_test/WithParentheses.py' % self.dirname
+        path = self.get_contract_path('WithParentheses.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'mixed', 10, 20, 30, 40, 50)
         self.assertEqual(10 + 30 * (50 + 40) // 20, result)
 
@@ -414,7 +416,7 @@ class TestArithmetic(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/arithmetic_test/AdditionAugmentedAssignment.py' % self.dirname
+        path = self.get_contract_path('AdditionAugmentedAssignment.py')
         output = Boa3.compile(path)
 
         self.assertEqual(expected_output, output)
@@ -431,7 +433,7 @@ class TestArithmetic(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/arithmetic_test/SubtractionAugmentedAssignment.py' % self.dirname
+        path = self.get_contract_path('SubtractionAugmentedAssignment.py')
         output = Boa3.compile(path)
 
         self.assertEqual(expected_output, output)
@@ -448,13 +450,13 @@ class TestArithmetic(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/arithmetic_test/MultiplicationAugmentedAssignment.py' % self.dirname
+        path = self.get_contract_path('MultiplicationAugmentedAssignment.py')
         output = Boa3.compile(path)
 
         self.assertEqual(expected_output, output)
 
     def test_division_augmented_assignment(self):
-        path = '%s/boa3_test/test_sc/arithmetic_test/DivisionAugmentedAssignment.py' % self.dirname
+        path = self.get_contract_path('DivisionAugmentedAssignment.py')
         self.assertCompilerLogs(NotSupportedOperation, path)
 
     def test_integer_division_augmented_assignment(self):
@@ -469,7 +471,7 @@ class TestArithmetic(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/arithmetic_test/IntegerDivisionAugmentedAssignment.py' % self.dirname
+        path = self.get_contract_path('IntegerDivisionAugmentedAssignment.py')
         output = Boa3.compile(path)
 
         self.assertEqual(expected_output, output)
@@ -486,7 +488,7 @@ class TestArithmetic(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/arithmetic_test/ModuloAugmentedAssignment.py' % self.dirname
+        path = self.get_contract_path('ModuloAugmentedAssignment.py')
         output = Boa3.compile(path)
 
         self.assertEqual(expected_output, output)
@@ -505,13 +507,13 @@ class TestArithmetic(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/arithmetic_test/ConcatenationAugmentedAssignment.py' % self.dirname
+        path = self.get_contract_path('ConcatenationAugmentedAssignment.py')
         output = Boa3.compile(path)
 
         self.assertEqual(expected_output, output)
 
     def test_power_augmented_assignment(self):
-        path = '%s/boa3_test/test_sc/arithmetic_test/PowerAugmentedAssignment.py' % self.dirname
+        path = self.get_contract_path('PowerAugmentedAssignment.py')
         self.assertCompilerLogs(NotSupportedOperation, path)
 
     def test_str_multiplication_operation_augmented_assignment(self):
@@ -526,7 +528,7 @@ class TestArithmetic(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/arithmetic_test/StringMultiplicationAugmentedAssignment.py' % self.dirname
+        path = self.get_contract_path('StringMultiplicationAugmentedAssignment.py')
         output = Boa3.compile(path)
 
         self.assertEqual(expected_output, output)

--- a/boa3_test/tests/test_assert.py
+++ b/boa3_test/tests/test_assert.py
@@ -10,6 +10,8 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 class TestAssert(BoaTest):
 
+    default_folder: str = 'test_sc/assert_test'
+
     def test_assert_unary_boolean_operation(self):
         expected_output = (
             Opcode.INITSLOT     # function signature
@@ -22,11 +24,11 @@ class TestAssert(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/assert_test/AssertUnaryOperation.py' % self.dirname
+        path = self.get_contract_path('AssertUnaryOperation.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', False, 10)
         self.assertEqual(10, result)
 
@@ -46,11 +48,11 @@ class TestAssert(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/assert_test/AssertBinaryOperation.py' % self.dirname
+        path = self.get_contract_path('AssertBinaryOperation.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 10, 20)
         self.assertEqual(10, result)
 
@@ -70,11 +72,11 @@ class TestAssert(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/assert_test/AssertWithMessage.py' % self.dirname
+        path = self.get_contract_path('AssertWithMessage.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 10)
         self.assertEqual(10, result)
 
@@ -92,11 +94,11 @@ class TestAssert(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/assert_test/AssertInt.py' % self.dirname
+        path = self.get_contract_path('AssertInt.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 10)
         self.assertEqual(10, result)
         result = self.run_smart_contract(engine, path, 'Main', -10)
@@ -116,11 +118,11 @@ class TestAssert(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/assert_test/AssertStr.py' % self.dirname
+        path = self.get_contract_path('AssertStr.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 'unittest')
         self.assertEqual('unittest', result)
 
@@ -138,11 +140,11 @@ class TestAssert(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/assert_test/AssertBytes.py' % self.dirname
+        path = self.get_contract_path('AssertBytes.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', b'unittest')
         self.assertEqual(b'unittest', String(result).to_bytes())
 
@@ -162,11 +164,11 @@ class TestAssert(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/assert_test/AssertList.py' % self.dirname
+        path = self.get_contract_path('AssertList.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', [1, 2, 3])
         self.assertEqual(3, result)
 
@@ -186,11 +188,11 @@ class TestAssert(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/assert_test/AssertDict.py' % self.dirname
+        path = self.get_contract_path('AssertDict.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', {1: 2, 2: 5})
         self.assertEqual(2, result)
 
@@ -217,10 +219,10 @@ class TestAssert(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/assert_test/AssertAny.py' % self.dirname
+        path = self.get_contract_path('AssertAny.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', True)
         self.assertIsVoid(result)

--- a/boa3_test/tests/test_boa_builtin_method.py
+++ b/boa3_test/tests/test_boa_builtin_method.py
@@ -5,10 +5,12 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 class TestBuiltinMethod(BoaTest):
 
-    def test_abort(self):
-        path = '%s/boa3_test/test_sc/boa_built_in_methods_test/Abort.py' % self.dirname
+    default_folder: str = 'test_sc/boa_built_in_methods_test'
 
-        engine = TestEngine(self.dirname)
+    def test_abort(self):
+        path = self.get_contract_path('Abort.py')
+
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'main', False)
         self.assertEqual(123, result)
 

--- a/boa3_test/tests/test_builtin_method.py
+++ b/boa3_test/tests/test_builtin_method.py
@@ -15,6 +15,8 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 class TestBuiltinMethod(BoaTest):
 
+    default_folder: str = 'test_sc/built_in_methods_test'
+
     # region len test
 
     def test_len_of_tuple(self):
@@ -34,12 +36,12 @@ class TestBuiltinMethod(BoaTest):
             + Opcode.LDLOC1     # return b
             + Opcode.RET
         )
-        path = '%s/boa3_test/test_sc/built_in_methods_test/LenTuple.py' % self.dirname
+        path = self.get_contract_path('LenTuple.py')
 
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(3, result)
 
@@ -60,12 +62,12 @@ class TestBuiltinMethod(BoaTest):
             + Opcode.LDLOC1     # return b
             + Opcode.RET
         )
-        path = '%s/boa3_test/test_sc/built_in_methods_test/LenList.py' % self.dirname
+        path = self.get_contract_path('LenList.py')
 
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(3, result)
 
@@ -86,33 +88,33 @@ class TestBuiltinMethod(BoaTest):
             + Opcode.SIZE
             + Opcode.RET
         )
-        path = '%s/boa3_test/test_sc/built_in_methods_test/LenString.py' % self.dirname
+        path = self.get_contract_path('LenString.py')
 
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(11, result)
 
     def test_len_of_bytes(self):
-        path = '%s/boa3_test/test_sc/built_in_methods_test/LenBytes.py' % self.dirname
+        path = self.get_contract_path('LenBytes.py')
         output = Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(3, result)
 
     def test_len_of_no_collection(self):
-        path = '%s/boa3_test/test_sc/built_in_methods_test/LenMismatchedType.py' % self.dirname
+        path = self.get_contract_path('LenMismatchedType.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_len_too_many_parameters(self):
-        path = '%s/boa3_test/test_sc/built_in_methods_test/LenTooManyParameters.py' % self.dirname
+        path = self.get_contract_path('LenTooManyParameters.py')
         self.assertCompilerLogs(UnexpectedArgument, path)
 
     def test_len_too_few_parameters(self):
-        path = '%s/boa3_test/test_sc/built_in_methods_test/LenTooFewParameters.py' % self.dirname
+        path = self.get_contract_path('LenTooFewParameters.py')
         self.assertCompilerLogs(UnfilledArgument, path)
 
     # endregion
@@ -120,11 +122,11 @@ class TestBuiltinMethod(BoaTest):
     # region append test
 
     def test_append_tuple(self):
-        path = '%s/boa3_test/test_sc/built_in_methods_test/AppendTuple.py' % self.dirname
+        path = self.get_contract_path('AppendTuple.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_append_sequence(self):
-        path = '%s/boa3_test/test_sc/built_in_methods_test/AppendSequence.py' % self.dirname
+        path = self.get_contract_path('AppendSequence.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_append_mutable_sequence(self):
@@ -155,12 +157,12 @@ class TestBuiltinMethod(BoaTest):
             + Opcode.LDLOC0     # return a
             + Opcode.RET
         )
-        path = '%s/boa3_test/test_sc/built_in_methods_test/AppendMutableSequence.py' % self.dirname
+        path = self.get_contract_path('AppendMutableSequence.py')
 
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'append_example')
         self.assertEqual([1, 2, 3, 4], result)
 
@@ -192,21 +194,21 @@ class TestBuiltinMethod(BoaTest):
             + Opcode.LDLOC0     # return a
             + Opcode.RET
         )
-        path = '%s/boa3_test/test_sc/built_in_methods_test/AppendMutableSequenceBuiltinCall.py' % self.dirname
+        path = self.get_contract_path('AppendMutableSequenceBuiltinCall.py')
 
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'append_example')
         self.assertEqual([1, 2, 3, 4], result)
 
     def test_append_too_many_parameters(self):
-        path = '%s/boa3_test/test_sc/built_in_methods_test/AppendTooManyParameters.py' % self.dirname
+        path = self.get_contract_path('AppendTooManyParameters.py')
         self.assertCompilerLogs(UnexpectedArgument, path)
 
     def test_append_too_few_parameters(self):
-        path = '%s/boa3_test/test_sc/built_in_methods_test/AppendTooFewParameters.py' % self.dirname
+        path = self.get_contract_path('AppendTooFewParameters.py')
         self.assertCompilerLogs(UnfilledArgument, path)
 
     # endregion
@@ -214,7 +216,7 @@ class TestBuiltinMethod(BoaTest):
     # region clear test
 
     def test_clear_tuple(self):
-        path = '%s/boa3_test/test_sc/built_in_methods_test/ClearTuple.py' % self.dirname
+        path = self.get_contract_path('ClearTuple.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_clear_mutable_sequence(self):
@@ -248,12 +250,12 @@ class TestBuiltinMethod(BoaTest):
             + Opcode.LDLOC0     # return a
             + Opcode.RET
         )
-        path = '%s/boa3_test/test_sc/built_in_methods_test/ClearMutableSequence.py' % self.dirname
+        path = self.get_contract_path('ClearMutableSequence.py')
 
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'clear_example')
         self.assertEqual([], result)
 
@@ -288,21 +290,21 @@ class TestBuiltinMethod(BoaTest):
             + Opcode.LDLOC0     # return a
             + Opcode.RET
         )
-        path = '%s/boa3_test/test_sc/built_in_methods_test/ClearMutableSequenceBuiltinCall.py' % self.dirname
+        path = self.get_contract_path('ClearMutableSequenceBuiltinCall.py')
 
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'clear_example')
         self.assertEqual([], result)
 
     def test_clear_too_many_parameters(self):
-        path = '%s/boa3_test/test_sc/built_in_methods_test/ClearTooManyParameters.py' % self.dirname
+        path = self.get_contract_path('ClearTooManyParameters.py')
         self.assertCompilerLogs(UnexpectedArgument, path)
 
     def test_clear_too_few_parameters(self):
-        path = '%s/boa3_test/test_sc/built_in_methods_test/ClearTooFewParameters.py' % self.dirname
+        path = self.get_contract_path('ClearTooFewParameters.py')
         self.assertCompilerLogs(UnfilledArgument, path)
 
     # endregion
@@ -310,7 +312,7 @@ class TestBuiltinMethod(BoaTest):
     # region reverse test
 
     def test_reverse_tuple(self):
-        path = '%s/boa3_test/test_sc/built_in_methods_test/ReverseTuple.py' % self.dirname
+        path = self.get_contract_path('ReverseTuple.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_reverse_mutable_sequence(self):
@@ -329,31 +331,31 @@ class TestBuiltinMethod(BoaTest):
             + Opcode.LDLOC0     # return a
             + Opcode.RET
         )
-        path = '%s/boa3_test/test_sc/built_in_methods_test/ReverseMutableSequence.py' % self.dirname
+        path = self.get_contract_path('ReverseMutableSequence.py')
 
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([3, 2, 1], result)
 
     @unittest.skip("reverse items doesn't work with bytestring")
     def test_reverse_mutable_sequence_with_builtin(self):
-        path = '%s/boa3_test/test_sc/built_in_methods_test/ReverseMutableSequenceBuiltinCall.py' % self.dirname
+        path = self.get_contract_path('ReverseMutableSequenceBuiltinCall.py')
         output = Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main',
                                          expected_result_type=bytes)
         self.assertEqual(b'\x03\x02\x01', result)
 
     def test_reverse_too_many_parameters(self):
-        path = '%s/boa3_test/test_sc/built_in_methods_test/ReverseTooManyParameters.py' % self.dirname
+        path = self.get_contract_path('ReverseTooManyParameters.py')
         self.assertCompilerLogs(UnexpectedArgument, path)
 
     def test_reverse_too_few_parameters(self):
-        path = '%s/boa3_test/test_sc/built_in_methods_test/ReverseTooFewParameters.py' % self.dirname
+        path = self.get_contract_path('ReverseTooFewParameters.py')
         self.assertCompilerLogs(UnfilledArgument, path)
 
     # endregion
@@ -361,35 +363,35 @@ class TestBuiltinMethod(BoaTest):
     # region extend test
 
     def test_extend_tuple(self):
-        path = '%s/boa3_test/test_sc/built_in_methods_test/ExtendTuple.py' % self.dirname
+        path = self.get_contract_path('ExtendTuple.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_extend_sequence(self):
-        path = '%s/boa3_test/test_sc/built_in_methods_test/ExtendSequence.py' % self.dirname
+        path = self.get_contract_path('ExtendSequence.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_extend_mutable_sequence(self):
-        path = '%s/boa3_test/test_sc/built_in_methods_test/ExtendMutableSequence.py' % self.dirname
+        path = self.get_contract_path('ExtendMutableSequence.py')
         output = Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([1, 2, 3, 4, 5, 6], result)
 
     def test_extend_mutable_sequence_with_builtin(self):
-        path = '%s/boa3_test/test_sc/built_in_methods_test/ExtendMutableSequenceBuiltinCall.py' % self.dirname
+        path = self.get_contract_path('ExtendMutableSequenceBuiltinCall.py')
         output = Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([1, 2, 3, 4, 5, 6], result)
 
     def test_extend_too_many_parameters(self):
-        path = '%s/boa3_test/test_sc/built_in_methods_test/ExtendTooManyParameters.py' % self.dirname
+        path = self.get_contract_path('ExtendTooManyParameters.py')
         self.assertCompilerLogs(UnexpectedArgument, path)
 
     def test_extend_too_few_parameters(self):
-        path = '%s/boa3_test/test_sc/built_in_methods_test/ExtendTooFewParameters.py' % self.dirname
+        path = self.get_contract_path('ExtendTooFewParameters.py')
         self.assertCompilerLogs(UnfilledArgument, path)
 
     # endregion
@@ -400,10 +402,10 @@ class TestBuiltinMethod(BoaTest):
         from boa3.neo import to_script_hash
         script_hash = to_script_hash(Integer(123).to_byte_array())
 
-        path = '%s/boa3_test/test_sc/built_in_methods_test/ScriptHashInt.py' % self.dirname
+        path = self.get_contract_path('ScriptHashInt.py')
         output = Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(script_hash, result)
 
@@ -411,10 +413,10 @@ class TestBuiltinMethod(BoaTest):
         from boa3.neo import to_script_hash
         script_hash = to_script_hash(Integer(123).to_byte_array())
 
-        path = '%s/boa3_test/test_sc/built_in_methods_test/ScriptHashIntBuiltinCall.py' % self.dirname
+        path = self.get_contract_path('ScriptHashIntBuiltinCall.py')
         output = Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(script_hash, result)
 
@@ -422,10 +424,10 @@ class TestBuiltinMethod(BoaTest):
         from boa3.neo import to_script_hash
         script_hash = to_script_hash(String('123').to_bytes())
 
-        path = '%s/boa3_test/test_sc/built_in_methods_test/ScriptHashStr.py' % self.dirname
+        path = self.get_contract_path('ScriptHashStr.py')
         output = Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(script_hash, result)
 
@@ -433,10 +435,10 @@ class TestBuiltinMethod(BoaTest):
         from boa3.neo import to_script_hash
         script_hash = to_script_hash(String('123').to_bytes())
 
-        path = '%s/boa3_test/test_sc/built_in_methods_test/ScriptHashStrBuiltinCall.py' % self.dirname
+        path = self.get_contract_path('ScriptHashStrBuiltinCall.py')
         output = Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(script_hash, result)
 
@@ -497,7 +499,7 @@ class TestBuiltinMethod(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/built_in_methods_test/ScriptHashVariable.py' % self.dirname
+        path = self.get_contract_path('ScriptHashVariable.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -554,24 +556,24 @@ class TestBuiltinMethod(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/built_in_methods_test/ScriptHashVariableBuiltinCall.py' % self.dirname
+        path = self.get_contract_path('ScriptHashVariableBuiltinCall.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
     def test_script_hahs_too_many_parameters(self):
-        path = '%s/boa3_test/test_sc/built_in_methods_test/ScriptHashTooManyParameters.py' % self.dirname
+        path = self.get_contract_path('ScriptHashTooManyParameters.py')
         self.assertCompilerLogs(UnexpectedArgument, path)
 
     def test_script_hash_too_few_parameters(self):
-        path = '%s/boa3_test/test_sc/built_in_methods_test/ScriptHashTooFewParameters.py' % self.dirname
+        path = self.get_contract_path('ScriptHashTooFewParameters.py')
         self.assertCompilerLogs(UnfilledArgument, path)
 
     def test_script_hash_mismatched_types(self):
-        path = '%s/boa3_test/test_sc/built_in_methods_test/ScriptHashMismatchedType.py' % self.dirname
+        path = self.get_contract_path('ScriptHashMismatchedType.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_script_hash_builtin_mismatched_types(self):
-        path = '%s/boa3_test/test_sc/built_in_methods_test/ScriptHashBuiltinMismatchedType.py' % self.dirname
+        path = self.get_contract_path('ScriptHashBuiltinMismatchedType.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     # endregion
@@ -591,11 +593,11 @@ class TestBuiltinMethod(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/built_in_methods_test/IntToBytes.py' % self.dirname
+        path = self.get_contract_path('IntToBytes.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'int_to_bytes',
                                          expected_result_type=bytes)
         self.assertEqual(value, result)
@@ -613,11 +615,11 @@ class TestBuiltinMethod(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/built_in_methods_test/IntToBytesWithBuiltin.py' % self.dirname
+        path = self.get_contract_path('IntToBytesWithBuiltin.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'int_to_bytes',
                                          expected_result_type=bytes)
         self.assertEqual(value, result)
@@ -633,11 +635,11 @@ class TestBuiltinMethod(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/built_in_methods_test/StrToBytes.py' % self.dirname
+        path = self.get_contract_path('StrToBytes.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'str_to_bytes',
                                          expected_result_type=bytes)
         self.assertEqual(value, result)
@@ -653,17 +655,17 @@ class TestBuiltinMethod(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/built_in_methods_test/StrToBytesWithBuiltin.py' % self.dirname
+        path = self.get_contract_path('StrToBytesWithBuiltin.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'str_to_bytes',
                                          expected_result_type=bytes)
         self.assertEqual(value, result)
 
     def test_to_bytes_mismatched_types(self):
-        path = '%s/boa3_test/test_sc/built_in_methods_test/ToBytesMismatchedType.py' % self.dirname
+        path = self.get_contract_path('ToBytesMismatchedType.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     # endregion
@@ -683,11 +685,11 @@ class TestBuiltinMethod(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/built_in_methods_test/PrintInt.py' % self.dirname
+        path = self.get_contract_path('PrintInt.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertIsVoid(result)
 
@@ -702,24 +704,24 @@ class TestBuiltinMethod(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/built_in_methods_test/PrintStr.py' % self.dirname
+        path = self.get_contract_path('PrintStr.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertIsVoid(result)
 
     def test_print_list(self):
-        path = '%s/boa3_test/test_sc/built_in_methods_test/PrintList.py' % self.dirname
+        path = self.get_contract_path('PrintList.py')
         self.assertCompilerLogs(NotSupportedOperation, path)
 
     def test_print_many_values(self):
-        path = '%s/boa3_test/test_sc/built_in_methods_test/PrintManyValues.py' % self.dirname
+        path = self.get_contract_path('PrintManyValues.py')
         self.assertCompilerLogs(NotSupportedOperation, path)
 
     def test_print_missing_outer_function_return(self):
-        path = '%s/boa3_test/test_sc/built_in_methods_test/PrintIntMissingFunctionReturn.py' % self.dirname
+        path = self.get_contract_path('PrintIntMissingFunctionReturn.py')
         self.assertCompilerLogs(MissingReturnStatement, path)
 
     # endregion
@@ -739,11 +741,11 @@ class TestBuiltinMethod(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/built_in_methods_test/IsInstanceIntLiteral.py' % self.dirname
+        path = self.get_contract_path('IsInstanceIntLiteral.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(True, result)
 
@@ -758,11 +760,11 @@ class TestBuiltinMethod(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/built_in_methods_test/IsInstanceIntVariable.py' % self.dirname
+        path = self.get_contract_path('IsInstanceIntVariable.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 10)
         self.assertEqual(True, result)
         result = self.run_smart_contract(engine, path, 'Main', False)
@@ -783,11 +785,11 @@ class TestBuiltinMethod(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/built_in_methods_test/IsInstanceBoolLiteral.py' % self.dirname
+        path = self.get_contract_path('IsInstanceBoolLiteral.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(False, result)
 
@@ -802,11 +804,11 @@ class TestBuiltinMethod(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/built_in_methods_test/IsInstanceBoolVariable.py' % self.dirname
+        path = self.get_contract_path('IsInstanceBoolVariable.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 10)
         self.assertEqual(False, result)
         result = self.run_smart_contract(engine, path, 'Main', False)
@@ -825,11 +827,11 @@ class TestBuiltinMethod(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/built_in_methods_test/IsInstanceStrLiteral.py' % self.dirname
+        path = self.get_contract_path('IsInstanceStrLiteral.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(True, result)
 
@@ -844,11 +846,11 @@ class TestBuiltinMethod(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/built_in_methods_test/IsInstanceStrVariable.py' % self.dirname
+        path = self.get_contract_path('IsInstanceStrVariable.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 10)
         self.assertEqual(False, result)
         result = self.run_smart_contract(engine, path, 'Main', False)
@@ -864,11 +866,11 @@ class TestBuiltinMethod(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/built_in_methods_test/IsInstanceListLiteral.py' % self.dirname
+        path = self.get_contract_path('IsInstanceListLiteral.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(True, result)
 
@@ -880,11 +882,11 @@ class TestBuiltinMethod(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/built_in_methods_test/IsInstanceTupleLiteral.py' % self.dirname
+        path = self.get_contract_path('IsInstanceTupleLiteral.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(True, result)
 
@@ -899,11 +901,11 @@ class TestBuiltinMethod(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/built_in_methods_test/IsInstanceTupleVariable.py' % self.dirname
+        path = self.get_contract_path('IsInstanceTupleVariable.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 10)
         self.assertEqual(False, result)
         result = self.run_smart_contract(engine, path, 'Main', False)
@@ -943,11 +945,11 @@ class TestBuiltinMethod(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/built_in_methods_test/IsInstanceManyTypes.py' % self.dirname
+        path = self.get_contract_path('IsInstanceManyTypes.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 10)
         self.assertEqual(True, result)
         result = self.run_smart_contract(engine, path, 'Main', False)
@@ -958,11 +960,11 @@ class TestBuiltinMethod(BoaTest):
         self.assertEqual(True, result)
 
     def test_isinstance_many_types_with_class(self):
-        path = '%s/boa3_test/test_sc/built_in_methods_test/IsInstanceManyTypesWithClass.py' % self.dirname
+        path = self.get_contract_path('IsInstanceManyTypesWithClass.py')
         self.assertCompilerLogs(NotSupportedOperation, path)
 
     def test_isinstance_class(self):
-        path = '%s/boa3_test/test_sc/built_in_methods_test/IsInstanceClass.py' % self.dirname
+        path = self.get_contract_path('IsInstanceClass.py')
         self.assertCompilerLogs(NotSupportedOperation, path)
 
     # endregion
@@ -970,8 +972,8 @@ class TestBuiltinMethod(BoaTest):
     # region exit test
 
     def test_exit(self):
-        path = '%s/boa3_test/test_sc/built_in_methods_test/Exit.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('Exit.py')
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'main', False)
         self.assertEqual(123, result)
 
@@ -983,8 +985,8 @@ class TestBuiltinMethod(BoaTest):
     # region max test
 
     def test_max_int(self):
-        path = '%s/boa3_test/test_sc/built_in_methods_test/MaxInt.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('MaxInt.py')
+        engine = TestEngine()
 
         value1 = 10
         value2 = 999
@@ -993,11 +995,11 @@ class TestBuiltinMethod(BoaTest):
         self.assertEqual(expected_result, result)
 
     def test_max_too_few_parameters(self):
-        path = '%s/boa3_test/test_sc/built_in_methods_test/MaxTooFewParameters.py' % self.dirname
+        path = self.get_contract_path('MaxTooFewParameters.py')
         self.assertCompilerLogs(UnfilledArgument, path)
 
     def test_max_mismatched_types(self):
-        path = '%s/boa3_test/test_sc/built_in_methods_test/MaxMismatchedTypes.py' % self.dirname
+        path = self.get_contract_path('MaxMismatchedTypes.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     # endregion
@@ -1005,8 +1007,8 @@ class TestBuiltinMethod(BoaTest):
     # region min test
 
     def test_min_int(self):
-        path = '%s/boa3_test/test_sc/built_in_methods_test/MinInt.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('MinInt.py')
+        engine = TestEngine()
 
         val1 = 50
         val2 = 1
@@ -1015,11 +1017,11 @@ class TestBuiltinMethod(BoaTest):
         self.assertEqual(expected_result, result)
 
     def test_min_too_few_parameters(self):
-        path = '%s/boa3_test/test_sc/built_in_methods_test/MinTooFewParameters.py' % self.dirname
+        path = self.get_contract_path('MinTooFewParameters.py')
         self.assertCompilerLogs(UnfilledArgument, path)
 
     def test_min_mismatched_types(self):
-        path = '%s/boa3_test/test_sc/built_in_methods_test/MinMismatchedTypes.py' % self.dirname
+        path = self.get_contract_path('MinMismatchedTypes.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     # endregion

--- a/boa3_test/tests/test_bytes.py
+++ b/boa3_test/tests/test_bytes.py
@@ -11,6 +11,8 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 class TestBytes(BoaTest):
 
+    default_folder: str = 'test_sc/bytes_test'
+
     def test_bytes_literal_value(self):
         data = b'\x01\x02\x03'
         expected_output = (
@@ -24,7 +26,7 @@ class TestBytes(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/bytes_test/BytesLiteral.py' % self.dirname
+        path = self.get_contract_path('BytesLiteral.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -47,11 +49,11 @@ class TestBytes(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/bytes_test/BytesGetValue.py' % self.dirname
+        path = self.get_contract_path('BytesGetValue.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', bytes([1, 2, 3]))
         self.assertEqual(1, result)
         result = self.run_smart_contract(engine, path, 'Main', b'0')
@@ -76,57 +78,57 @@ class TestBytes(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/bytes_test/BytesGetValueNegativeIndex.py' % self.dirname
+        path = self.get_contract_path('BytesGetValueNegativeIndex.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', bytes([1, 2, 3]))
         self.assertEqual(3, result)
         result = self.run_smart_contract(engine, path, 'Main', b'0')
         self.assertEqual(48, result)
 
     def test_bytes_set_value(self):
-        path = '%s/boa3_test/test_sc/bytes_test/BytesSetValue.py' % self.dirname
+        path = self.get_contract_path('BytesSetValue.py')
         self.assertCompilerLogs(UnresolvedOperation, path)
 
     def test_bytes_clear(self):
-        path = '%s/boa3_test/test_sc/bytes_test/BytesClear.py' % self.dirname
+        path = self.get_contract_path('BytesClear.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_bytes_reverse(self):
-        path = '%s/boa3_test/test_sc/bytes_test/BytesReverse.py' % self.dirname
+        path = self.get_contract_path('BytesReverse.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_bytes_to_int(self):
-        path = '%s/boa3_test/test_sc/bytes_test/BytesToInt.py' % self.dirname
+        path = self.get_contract_path('BytesToInt.py')
         output = Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'bytes_to_int')
         self.assertEqual(513, result)
 
     def test_bytes_to_int_with_builtin(self):
-        path = '%s/boa3_test/test_sc/bytes_test/BytesToIntWithBuiltin.py' % self.dirname
+        path = self.get_contract_path('BytesToIntWithBuiltin.py')
         output = Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'bytes_to_int')
         self.assertEqual(513, result)
 
     def test_bytes_to_int_mismatched_types(self):
-        path = '%s/boa3_test/test_sc/bytes_test/BytesToIntWithBuiltinMismatchedTypes.py' % self.dirname
+        path = self.get_contract_path('BytesToIntWithBuiltinMismatchedTypes.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_bytes_to_int_with_byte_array_builtin(self):
-        path = '%s/boa3_test/test_sc/bytes_test/BytesToIntWithBytearrayBuiltin.py' % self.dirname
+        path = self.get_contract_path('BytesToIntWithBytearrayBuiltin.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_bytes_to_bool(self):
-        path = '%s/boa3_test/test_sc/bytes_test/BytesToBool.py' % self.dirname
+        path = self.get_contract_path('BytesToBool.py')
         output = Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'bytes_to_bool', b'\x00')
         self.assertEqual(False, result)
 
@@ -137,10 +139,10 @@ class TestBytes(BoaTest):
         self.assertEqual(True, result)
 
     def test_bytes_to_bool_with_builtin(self):
-        path = '%s/boa3_test/test_sc/bytes_test/BytesToBoolWithBuiltin.py' % self.dirname
+        path = self.get_contract_path('BytesToBoolWithBuiltin.py')
         output = Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'bytes_to_bool', b'\x00')
         self.assertEqual(False, result)
 
@@ -151,43 +153,43 @@ class TestBytes(BoaTest):
         self.assertEqual(True, result)
 
     def test_bytes_to_bool_with_builtin_hard_coded_false(self):
-        path = '%s/boa3_test/test_sc/bytes_test/BytesToBoolWithBuiltinHardCodedFalse.py' % self.dirname
+        path = self.get_contract_path('BytesToBoolWithBuiltinHardCodedFalse.py')
         output = Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'bytes_to_bool', expected_result_type=bool)
         self.assertEqual(False, result)
 
     def test_bytes_to_bool_with_builtin_hard_coded_true(self):
-        path = '%s/boa3_test/test_sc/bytes_test/BytesToBoolWithBuiltinHardCodedTrue.py' % self.dirname
+        path = self.get_contract_path('BytesToBoolWithBuiltinHardCodedTrue.py')
         output = Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'bytes_to_bool')
         self.assertEqual(True, result)
 
     def test_bytes_to_bool_mismatched_types(self):
-        path = '%s/boa3_test/test_sc/bytes_test/BytesToBoolWithBuiltinMismatchedTypes.py' % self.dirname
+        path = self.get_contract_path('BytesToBoolWithBuiltinMismatchedTypes.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_bytes_to_str(self):
-        path = '%s/boa3_test/test_sc/bytes_test/BytesToStr.py' % self.dirname
+        path = self.get_contract_path('BytesToStr.py')
         output = Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'bytes_to_str')
         self.assertEqual('abc', result)
 
     def test_bytes_to_str_with_builtin(self):
-        path = '%s/boa3_test/test_sc/bytes_test/BytesToStrWithBuiltin.py' % self.dirname
+        path = self.get_contract_path('BytesToStrWithBuiltin.py')
         output = Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'bytes_to_str')
         self.assertEqual('123', result)
 
     def test_bytes_to_str_mismatched_types(self):
-        path = '%s/boa3_test/test_sc/bytes_test/BytesToStrWithBuiltinMismatchedTypes.py' % self.dirname
+        path = self.get_contract_path('BytesToStrWithBuiltinMismatchedTypes.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_bytes_from_byte_array(self):
@@ -205,14 +207,14 @@ class TestBytes(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/bytes_test/BytesFromBytearray.py' % self.dirname
+        path = self.get_contract_path('BytesFromBytearray.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
     def test_assign_with_slice(self):
-        path = '%s/boa3_test/test_sc/bytes_test/AssignSlice.py' % self.dirname
+        path = self.get_contract_path('AssignSlice.py')
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'main', b'unittest',
                                          expected_result_type=bytearray)
         self.assertEqual(b'unittest'[1:2], result)
@@ -243,11 +245,11 @@ class TestBytes(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/bytes_test/BytearrayGetValue.py' % self.dirname
+        path = self.get_contract_path('BytearrayGetValue.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', bytes([1, 2, 3]))
         self.assertEqual(1, result)
         result = self.run_smart_contract(engine, path, 'Main', b'0')
@@ -272,11 +274,11 @@ class TestBytes(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/bytes_test/BytearrayGetValueNegativeIndex.py' % self.dirname
+        path = self.get_contract_path('BytearrayGetValueNegativeIndex.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', bytes([1, 2, 3]))
         self.assertEqual(3, result)
         result = self.run_smart_contract(engine, path, 'Main', b'0')
@@ -304,11 +306,11 @@ class TestBytes(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/bytes_test/BytearraySetValue.py' % self.dirname
+        path = self.get_contract_path('BytearraySetValue.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', b'123')
         self.assertEqual(b'\x0123', result)
         result = self.run_smart_contract(engine, path, 'Main', b'0')
@@ -336,18 +338,18 @@ class TestBytes(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/bytes_test/BytearraySetValueNegativeIndex.py' % self.dirname
+        path = self.get_contract_path('BytearraySetValueNegativeIndex.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', b'123')
         self.assertEqual(b'12\x01', result)
         result = self.run_smart_contract(engine, path, 'Main', b'0')
         self.assertEqual(b'\x01', result)
 
     def test_byte_array_literal_value(self):
-        path = '%s/boa3_test/test_sc/bytes_test/BytearrayLiteral.py' % self.dirname
+        path = self.get_contract_path('BytearrayLiteral.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_byte_array_from_literal_bytes(self):
@@ -363,7 +365,7 @@ class TestBytes(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/bytes_test/BytearrayFromLiteralBytes.py' % self.dirname
+        path = self.get_contract_path('BytearrayFromLiteralBytes.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -384,98 +386,98 @@ class TestBytes(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/bytes_test/BytearrayFromVariableBytes.py' % self.dirname
+        path = self.get_contract_path('BytearrayFromVariableBytes.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
     def test_byte_array_string(self):
-        path = '%s/boa3_test/test_sc/bytes_test/BytearrayFromString.py' % self.dirname
+        path = self.get_contract_path('BytearrayFromString.py')
         self.assertCompilerLogs(NotSupportedOperation, path)
 
     def test_byte_array_append(self):
-        path = '%s/boa3_test/test_sc/bytes_test/BytearrayAppend.py' % self.dirname
+        path = self.get_contract_path('BytearrayAppend.py')
         output = Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main',
                                          expected_result_type=bytes)
         self.assertEqual(b'\x01\x02\x03\x04', result)
 
     def test_byte_array_append_with_builtin(self):
-        path = '%s/boa3_test/test_sc/bytes_test/BytearrayAppendWithBuiltin.py' % self.dirname
+        path = self.get_contract_path('BytearrayAppendWithBuiltin.py')
         output = Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main',
                                          expected_result_type=bytes)
         self.assertEqual(b'\x01\x02\x03\x04', result)
 
     def test_byte_array_append_mutable_sequence_with_builtin(self):
-        path = '%s/boa3_test/test_sc/bytes_test/BytearrayAppendWithMutableSequence.py' % self.dirname
+        path = self.get_contract_path('BytearrayAppendWithMutableSequence.py')
         output = Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main',
                                          expected_result_type=bytes)
         self.assertEqual(b'\x01\x02\x03\x04', result)
 
     def test_byte_array_clear(self):
-        path = '%s/boa3_test/test_sc/bytes_test/BytearrayClear.py' % self.dirname
+        path = self.get_contract_path('BytearrayClear.py')
         output = Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main',
                                          expected_result_type=bytes)
         self.assertEqual(b'', result)
 
     @unittest.skip("reverse items doesn't work with bytestring")
     def test_byte_array_reverse(self):
-        path = '%s/boa3_test/test_sc/bytes_test/BytearrayReverse.py' % self.dirname
+        path = self.get_contract_path('BytearrayReverse.py')
         Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main',
                                          expected_result_type=bytes)
         self.assertEqual(b'\x03\x02\x01', result)
 
     def test_byte_array_extend(self):
-        path = '%s/boa3_test/test_sc/bytes_test/BytearrayExtend.py' % self.dirname
+        path = self.get_contract_path('BytearrayExtend.py')
         Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main',
                                          expected_result_type=bytes)
         self.assertEqual(b'\x01\x02\x03\x04\x05\x06', result)
 
     def test_byte_array_extend_with_builtin(self):
-        path = '%s/boa3_test/test_sc/bytes_test/BytearrayExtendWithBuiltin.py' % self.dirname
+        path = self.get_contract_path('BytearrayExtendWithBuiltin.py')
         Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main',
                                          expected_result_type=bytes)
         self.assertEqual(b'\x01\x02\x03\x04\x05\x06', result)
 
     def test_byte_array_to_int(self):
-        path = '%s/boa3_test/test_sc/bytes_test/BytearrayToInt.py' % self.dirname
+        path = self.get_contract_path('BytearrayToInt.py')
         output = Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'bytes_to_int')
         self.assertEqual(513, result)
 
     def test_byte_array_to_int_with_builtin(self):
-        path = '%s/boa3_test/test_sc/bytes_test/BytearrayToIntWithBuiltin.py' % self.dirname
+        path = self.get_contract_path('BytearrayToIntWithBuiltin.py')
         output = Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'bytes_to_int')
         self.assertEqual(513, result)
 
     def test_byte_array_to_int_with_bytes_builtin(self):
-        path = '%s/boa3_test/test_sc/bytes_test/BytearrayToIntWithBytesBuiltin.py' % self.dirname
+        path = self.get_contract_path('BytearrayToIntWithBytesBuiltin.py')
         output = Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'bytes_to_int')
         self.assertEqual(513, result)

--- a/boa3_test/tests/test_class.py
+++ b/boa3_test/tests/test_class.py
@@ -6,13 +6,15 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 class TestClass(BoaTest):
 
+    default_folder: str = 'test_sc/class_test'
+
     def test_notification_get_variables(self):
-        path = '%s/boa3_test/test_sc/class_test/NotificationGetVariables.py' % self.dirname
+        path = self.get_contract_path('NotificationGetVariables.py')
         output, manifest = self.compile_and_save(path)
 
         script = hash160(output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'script_hash', [],
                                          expected_result_type=bytes)
         self.assertEqual(len(engine.notifications), 0)
@@ -43,12 +45,12 @@ class TestClass(BoaTest):
         self.assertEqual(['1'], result)
 
     def test_notification_set_variables(self):
-        path = '%s/boa3_test/test_sc/class_test/NotificationSetVariables.py' % self.dirname
+        path = self.get_contract_path('NotificationSetVariables.py')
         output, manifest = self.compile_and_save(path)
 
         script = hash160(output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'script_hash', script,
                                          expected_result_type=bytes)
         self.assertEqual(script, result)
@@ -60,10 +62,10 @@ class TestClass(BoaTest):
         self.assertEqual([1, 2, 3], result)
 
     def test_contract_constructor(self):
-        path = '%s/boa3_test/test_sc/class_test/ContractConstructor.py' % self.dirname
+        path = self.get_contract_path('ContractConstructor.py')
         output, manifest = self.compile_and_save(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'new_contract')
         self.assertEqual(5, len(result))
 

--- a/boa3_test/tests/test_classes/testengine.py
+++ b/boa3_test/tests/test_classes/testengine.py
@@ -14,14 +14,19 @@ from os import path
 
 
 class TestEngine:
-    def __init__(self, root_path: str):
-        if path.exists('{0}/Neo.TestEngine/Neo.TestEngine.dll'.format(root_path)):
-            self._test_engine_path = '{0}/Neo.TestEngine/Neo.TestEngine.dll'.format(root_path)
-        else:
-            raise FileNotFoundError("File at " + '{0}/Neo.TestEngine/Neo.TestEngine.dll'.format(root_path) + " was not "
-                                    "found.\nVisit the docs or the README file and search for 'TestEngine' to correctly"
-                                    " install it.")
+    def __init__(self, root_path: Optional[str] = None):
+        if root_path is None:
+            import env
+            root_path = env.TEST_ENGINE_DIRECTORY
 
+        engine_path = '{0}/Neo.TestEngine.dll'.format(root_path)
+        if not path.exists(engine_path):
+            raise FileNotFoundError(
+                "File at {0} was not found.\n"
+                "Visit the docs or the README file and search for 'TestEngine' to correctly install it."
+                .format(engine_path))
+
+        self._test_engine_path = engine_path
         self._vm_state: VMState = VMState.NONE
         self._gas_consumed: int = 0
         self._result_stack: List[Any] = []

--- a/boa3_test/tests/test_dict.py
+++ b/boa3_test/tests/test_dict.py
@@ -10,6 +10,8 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 class TestDict(BoaTest):
 
+    default_folder: str = 'test_sc/dict_test'
+
     def test_dict_int_keys(self):
         expected_output = (
             Opcode.INITSLOT
@@ -32,7 +34,7 @@ class TestDict(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/dict_test/IntKeyDict.py' % self.dirname
+        path = self.get_contract_path('IntKeyDict.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -68,7 +70,7 @@ class TestDict(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/dict_test/StrKeyDict.py' % self.dirname
+        path = self.get_contract_path('StrKeyDict.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -98,7 +100,7 @@ class TestDict(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/dict_test/AnyValueDict.py' % self.dirname
+        path = self.get_contract_path('AnyValueDict.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -148,7 +150,7 @@ class TestDict(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/dict_test/DictOfDict.py' % self.dirname
+        path = self.get_contract_path('DictOfDict.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -162,7 +164,7 @@ class TestDict(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/dict_test/EmptyDictAssignment.py' % self.dirname
+        path = self.get_contract_path('EmptyDictAssignment.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -188,7 +190,7 @@ class TestDict(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/dict_test/TypeHintAssignment.py' % self.dirname
+        path = self.get_contract_path('TypeHintAssignment.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -220,7 +222,7 @@ class TestDict(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/dict_test/VariableDict.py' % self.dirname
+        path = self.get_contract_path('VariableDict.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -235,11 +237,11 @@ class TestDict(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/dict_test/GetValue.py' % self.dirname
+        path = self.get_contract_path('GetValue.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', {0: 'zero'})
         self.assertEqual('zero', result)
 
@@ -247,7 +249,7 @@ class TestDict(BoaTest):
             self.run_smart_contract(engine, path, 'Main', {1: 'one'})
 
     def test_dict_get_value_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/dict_test/MismatchedTypeGetValue.py' % self.dirname
+        path = self.get_contract_path('MismatchedTypeGetValue.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_dict_set_value(self):
@@ -267,18 +269,18 @@ class TestDict(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/dict_test/SetValue.py' % self.dirname
+        path = self.get_contract_path('SetValue.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', {0: 'zero'})
         self.assertEqual({0: 'ok'}, result)
         result = self.run_smart_contract(engine, path, 'Main', {1: 'one'})
         self.assertEqual({0: 'ok', 1: 'one'}, result)
 
     def test_dict_set_value_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/dict_test/MismatchedTypeSetValue.py' % self.dirname
+        path = self.get_contract_path('MismatchedTypeSetValue.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_dict_keys(self):
@@ -317,16 +319,16 @@ class TestDict(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/dict_test/KeysDict.py' % self.dirname
+        path = self.get_contract_path('KeysDict.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(['one', 'two', 'three'], result)
 
     def test_dict_keys_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/dict_test/MismatchedTypeKeysDict.py' % self.dirname
+        path = self.get_contract_path('MismatchedTypeKeysDict.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_dict_values(self):
@@ -365,22 +367,22 @@ class TestDict(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/dict_test/ValuesDict.py' % self.dirname
+        path = self.get_contract_path('ValuesDict.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([1, 2, 3], result)
 
     def test_dict_values_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/dict_test/MismatchedTypeValuesDict.py' % self.dirname
+        path = self.get_contract_path('MismatchedTypeValuesDict.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_dict_boa2_test2(self):
-        path = '%s/boa3_test/test_sc/dict_test/DictBoa2Test2.py' % self.dirname
+        path = self.get_contract_path('DictBoa2Test2.py')
         Boa3.compile_and_save(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(7, result)

--- a/boa3_test/tests/test_event.py
+++ b/boa3_test/tests/test_event.py
@@ -10,6 +10,8 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 class TestEvent(BoaTest):
 
+    default_folder: str = 'test_sc/event_test'
+
     def test_event_without_arguments(self):
         event_id = 'Event'
         event_name = String(event_id).to_bytes(min_length=1)
@@ -23,11 +25,11 @@ class TestEvent(BoaTest):
             + Opcode.RET       # return
         )
 
-        path = '%s/boa3_test/test_sc/event_test/EventWithoutArguments.py' % self.dirname
+        path = self.get_contract_path('EventWithoutArguments.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertIsVoid(result)
         self.assertGreater(len(engine.notifications), 0)
@@ -51,11 +53,11 @@ class TestEvent(BoaTest):
             + Opcode.RET       # return
         )
 
-        path = '%s/boa3_test/test_sc/event_test/EventWithArgument.py' % self.dirname
+        path = self.get_contract_path('EventWithArgument.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertIsVoid(result)
         self.assertGreater(len(engine.notifications), 0)
@@ -79,11 +81,11 @@ class TestEvent(BoaTest):
             + Opcode.RET      # return
         )
 
-        path = '%s/boa3_test/test_sc/event_test/EventWithName.py' % self.dirname
+        path = self.get_contract_path('EventWithName.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertIsVoid(result)
         self.assertGreater(len(engine.notifications), 0)
@@ -111,11 +113,11 @@ class TestEvent(BoaTest):
             + Opcode.RET       # return
         )
 
-        path = '%s/boa3_test/test_sc/event_test/EventNep5Transfer.py' % self.dirname
+        path = self.get_contract_path('EventNep5Transfer.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', b'1', b'2', 10)
         self.assertIsVoid(result)
         self.assertGreater(len(engine.notifications), 0)
@@ -125,9 +127,9 @@ class TestEvent(BoaTest):
         self.assertEqual(('1', '2', 10), event_notifications[0].arguments)
 
     def test_event_with_return(self):
-        path = '%s/boa3_test/test_sc/event_test/EventWithoutTypes.py' % self.dirname
+        path = self.get_contract_path('EventWithoutTypes.py')
         self.assertCompilerLogs(UnfilledArgument, path)
 
     def test_event_call_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/event_test/MismatchedTypeCallEvent.py' % self.dirname
+        path = self.get_contract_path('MismatchedTypeCallEvent.py')
         self.assertCompilerLogs(MismatchedTypes, path)

--- a/boa3_test/tests/test_exception.py
+++ b/boa3_test/tests/test_exception.py
@@ -12,6 +12,8 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 class TestException(BoaTest):
 
+    default_folder: str = 'test_sc/exception_test'
+
     EXCEPTION_EMPTY_MESSAGE = String(Builtin.Exception.default_message).to_bytes()
 
     def test_raise_exception_empty_message(self):
@@ -31,11 +33,11 @@ class TestException(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/exception_test/RaiseExceptionEmptyMessage.py' % self.dirname
+        path = self.get_contract_path('RaiseExceptionEmptyMessage.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         self.run_smart_contract(engine, path, 'test_raise', 10)
 
         with self.assertRaises(TestExecutionException, msg=self.EXCEPTION_EMPTY_MESSAGE):
@@ -59,11 +61,11 @@ class TestException(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/exception_test/RaiseExceptionWithMessage.py' % self.dirname
+        path = self.get_contract_path('RaiseExceptionWithMessage.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         self.run_smart_contract(engine, path, 'test_raise', 10)
 
         with self.assertRaises(TestExecutionException, msg=self.EXCEPTION_EMPTY_MESSAGE):
@@ -86,11 +88,11 @@ class TestException(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/exception_test/RaiseExceptionWithoutCall.py' % self.dirname
+        path = self.get_contract_path('RaiseExceptionWithoutCall.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         self.run_smart_contract(engine, path, 'test_raise', 10)
 
         with self.assertRaises(TestExecutionException, msg=self.EXCEPTION_EMPTY_MESSAGE):
@@ -115,11 +117,11 @@ class TestException(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/exception_test/RaiseVariableException.py' % self.dirname
+        path = self.get_contract_path('RaiseVariableException.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         self.run_smart_contract(engine, path, 'test_raise', 10)
 
         with self.assertRaises(TestExecutionException, msg=self.EXCEPTION_EMPTY_MESSAGE):
@@ -148,11 +150,11 @@ class TestException(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/exception_test/RaiseExceptionVariableMessage.py' % self.dirname
+        path = self.get_contract_path('RaiseExceptionVariableMessage.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         self.run_smart_contract(engine, path, 'test_raise', 10)
 
         with self.assertRaises(TestExecutionException, msg=message):
@@ -175,18 +177,18 @@ class TestException(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/exception_test/RaiseSpecificException.py' % self.dirname
+        path = self.get_contract_path('RaiseSpecificException.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         self.run_smart_contract(engine, path, 'test_raise', 10)
 
         with self.assertRaises(TestExecutionException, msg=self.EXCEPTION_EMPTY_MESSAGE):
             self.run_smart_contract(engine, path, 'test_raise', -10)
 
     def test_raise_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/exception_test/RaiseMismatchedType.py' % self.dirname
+        path = self.get_contract_path('RaiseMismatchedType.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_try_except_without_exception(self):
@@ -210,11 +212,11 @@ class TestException(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/exception_test/TryExceptWithoutException.py' % self.dirname
+        path = self.get_contract_path('TryExceptWithoutException.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'test_try_except', 10)
         self.assertEqual(10, result)
         result = self.run_smart_contract(engine, path, 'test_try_except', -110)
@@ -241,11 +243,11 @@ class TestException(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/exception_test/TryExceptBaseException.py' % self.dirname
+        path = self.get_contract_path('TryExceptBaseException.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'test_try_except', 10)
         self.assertEqual(10, result)
         result = self.run_smart_contract(engine, path, 'test_try_except', -110)
@@ -272,18 +274,18 @@ class TestException(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/exception_test/TryExceptSpecificException.py' % self.dirname
+        path = self.get_contract_path('TryExceptSpecificException.py')
         output = self.assertCompilerLogs(UsingSpecificException, path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'test_try_except', 10)
         self.assertEqual(10, result)
         result = self.run_smart_contract(engine, path, 'test_try_except', -110)
         self.assertEqual(-110, result)
 
     def test_try_except_with_name(self):
-        path = '%s/boa3_test/test_sc/exception_test/TryExceptWithName.py' % self.dirname
+        path = self.get_contract_path('TryExceptWithName.py')
         self.assertCompilerLogs(NotSupportedOperation, path)
 
     def test_try_except_finally(self):
@@ -319,11 +321,11 @@ class TestException(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/exception_test/TryExceptFinally.py' % self.dirname
+        path = self.get_contract_path('TryExceptFinally.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'test_try_except', 10)
         self.assertEqual(24, result)
         result = self.run_smart_contract(engine, path, 'test_try_except', -110)

--- a/boa3_test/tests/test_file_generation.py
+++ b/boa3_test/tests/test_file_generation.py
@@ -14,8 +14,10 @@ from boa3_test.tests.boa_test import BoaTest
 
 class TestFileGeneration(BoaTest):
 
+    default_folder: str = 'test_sc/generation_test'
+
     def test_generate_files(self):
-        path = '%s/boa3_test/test_sc/generation_test/GenerationWithDecorator.py' % self.dirname
+        path = self.get_contract_path('GenerationWithDecorator.py')
         expected_nef_output = path.replace('.py', '.nef')
         expected_manifest_output = path.replace('.py', '.manifest.json')
         expected_debug_info_output = path.replace('.py', '.nefdbgnfo')
@@ -26,7 +28,7 @@ class TestFileGeneration(BoaTest):
         self.assertTrue(os.path.exists(expected_debug_info_output))
 
     def test_generate_nef_file(self):
-        path = '%s/boa3_test/test_sc/generation_test/GenerationWithDecorator.py' % self.dirname
+        path = self.get_contract_path('GenerationWithDecorator.py')
         expected_nef_output = path.replace('.py', '.nef')
         Boa3.compile_and_save(path)
 
@@ -53,7 +55,7 @@ class TestFileGeneration(BoaTest):
         self.assertEqual(version, nef.version.to_array())
 
     def test_generate_manifest_file_with_decorator(self):
-        path = '%s/boa3_test/test_sc/generation_test/GenerationWithDecorator.py' % self.dirname
+        path = self.get_contract_path('GenerationWithDecorator.py')
         expected_manifest_output = path.replace('.py', '.manifest.json')
         output, manifest = self.compile_and_save(path)
 
@@ -107,7 +109,7 @@ class TestFileGeneration(BoaTest):
         self.assertEqual(0, len(abi['events']))
 
     def test_generate_manifest_file_without_decorator(self):
-        path = '%s/boa3_test/test_sc/generation_test/GenerationWithoutDecorator.py' % self.dirname
+        path = self.get_contract_path('GenerationWithoutDecorator.py')
         expected_manifest_output = path.replace('.py', '.manifest.json')
         output, manifest = self.compile_and_save(path)
 
@@ -122,7 +124,7 @@ class TestFileGeneration(BoaTest):
         self.assertEqual(0, len(abi['events']))
 
     def test_generate_manifest_file_with_event(self):
-        path = '%s/boa3_test/test_sc/event_test/EventWithArgument.py' % self.dirname
+        path = self.get_contract_path('test_sc/event_test', 'EventWithArgument.py')
         expected_manifest_output = path.replace('.py', '.manifest.json')
         compiler = Compiler()
         compiler.compile_and_save(path, path.replace('.py', '.nef'))
@@ -157,7 +159,7 @@ class TestFileGeneration(BoaTest):
                                  event_param['type'])
 
     def test_generate_manifest_file_with_nep5_transfer_event(self):
-        path = '%s/boa3_test/test_sc/event_test/EventNep5Transfer.py' % self.dirname
+        path = self.get_contract_path('test_sc/event_test', 'EventNep5Transfer.py')
         expected_manifest_output = path.replace('.py', '.manifest.json')
         compiler = Compiler()
         compiler.compile_and_save(path, path.replace('.py', '.nef'))
@@ -192,7 +194,7 @@ class TestFileGeneration(BoaTest):
                                  event_param['type'])
 
     def test_generate_nefdbgnfo_file(self):
-        path = '%s/boa3_test/test_sc/generation_test/GenerationWithDecorator.py' % self.dirname
+        path = self.get_contract_path('GenerationWithDecorator.py')
 
         expected_nef_output = path.replace('.py', '.nefdbgnfo')
         compiler = Compiler()
@@ -239,7 +241,7 @@ class TestFileGeneration(BoaTest):
                 self.assertEqual(actual_method.locals[var_id].type.abi_type, var_type)
 
     def test_generate_nefdbgnfo_file_with_event(self):
-        path = '%s/boa3_test/test_sc/event_test/EventWithArgument.py' % self.dirname
+        path = self.get_contract_path('test_sc/event_test', 'EventWithArgument.py')
 
         expected_nef_output = path.replace('.py', '.nefdbgnfo')
         compiler = Compiler()
@@ -277,7 +279,7 @@ class TestFileGeneration(BoaTest):
                 self.assertEqual(param_type, actual_event.args[param_id].type.abi_type)
 
     def test_generate_manifest_file_with_notify_event(self):
-        path = '%s/boa3_test/test_sc/interop_test/runtime/NotifySequence.py' % self.dirname
+        path = self.get_contract_path('test_sc/interop_test/runtime', 'NotifySequence.py')
         expected_manifest_output = path.replace('.py', '.manifest.json')
         output, manifest = self.compile_and_save(path)
 
@@ -297,7 +299,7 @@ class TestFileGeneration(BoaTest):
         self.assertEqual(AbiType.Any, notify_event['parameters'][0]['type'])
 
     def test_generate_without_main(self):
-        path = '%s/boa3_test/test_sc/generation_test/GenerationWithoutMain.py' % self.dirname
+        path = self.get_contract_path('GenerationWithoutMain.py')
         expected_manifest_output = path.replace('.py', '.manifest.json')
         output, manifest = self.compile_and_save(path)
 
@@ -313,7 +315,7 @@ class TestFileGeneration(BoaTest):
         self.assertEqual(0, len(abi['events']))
 
     def test_generate_without_main_and_public_methods(self):
-        path = '%s/boa3_test/test_sc/generation_test/GenerationWithoutMainAndPublicMethods.py' % self.dirname
+        path = self.get_contract_path('GenerationWithoutMainAndPublicMethods.py')
         expected_manifest_output = path.replace('.py', '.manifest.json')
         output, manifest = self.compile_and_save(path)
 
@@ -329,7 +331,7 @@ class TestFileGeneration(BoaTest):
         self.assertEqual(0, len(abi['events']))
 
     def test_generate_manifest_file_abi_method_offset(self):
-        path = '%s/boa3_test/test_sc/generation_test/GenerationWithDecorator.py' % self.dirname
+        path = self.get_contract_path('GenerationWithDecorator.py')
         manifest_path = path.replace('.py', '.manifest.json')
 
         compiler = Compiler()
@@ -357,7 +359,7 @@ class TestFileGeneration(BoaTest):
             self.assertEqual(method['offset'], methods[method['name']].start_address)
 
     def test_generate_debug_info_with_multiple_flows(self):
-        path = '%s/boa3_test/test_sc/generation_test/GenerationWithMultipleFlows.py' % self.dirname
+        path = self.get_contract_path('GenerationWithMultipleFlows.py')
 
         compiler = Compiler()
         compiler.compile_and_save(path, path.replace('.py', '.nef'))
@@ -402,7 +404,7 @@ class TestFileGeneration(BoaTest):
                 self.assertEqual(actual_method.locals[var_id].type.abi_type, var_type)
 
     def test_generate_init_method(self):
-        path = '%s/boa3_test/test_sc/variable_test/GlobalAssignmentWithType.py' % self.dirname
+        path = self.get_contract_path('test_sc/variable_test', 'GlobalAssignmentWithType.py')
 
         compiler = Compiler()
         compiler.compile_and_save(path, path.replace('.py', '.nef'))

--- a/boa3_test/tests/test_for.py
+++ b/boa3_test/tests/test_for.py
@@ -8,6 +8,8 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 class TestFor(BoaTest):
 
+    default_folder: str = 'test_sc/for_test'
+
     def test_for_tuple_condition(self):
         jmpif_address = Integer(19).to_byte_array(min_length=1, signed=True)
         jmp_address = Integer(-22).to_byte_array(min_length=1, signed=True)
@@ -56,28 +58,28 @@ class TestFor(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/for_test/TupleCondition.py' % self.dirname
+        path = self.get_contract_path('TupleCondition.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(23, result)
 
     def test_for_string_condition(self):
-        path = '%s/boa3_test/test_sc/for_test/StringCondition.py' % self.dirname
+        path = self.get_contract_path('StringCondition.py')
         output = Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual('5', result)
 
     def test_for_mismatched_type_condition(self):
-        path = '%s/boa3_test/test_sc/for_test/MismatchedTypeCondition.py' % self.dirname
+        path = self.get_contract_path('MismatchedTypeCondition.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_for_no_condition(self):
-        path = '%s/boa3_test/test_sc/for_test/NoCondition.py' % self.dirname
+        path = self.get_contract_path('NoCondition.py')
 
         with self.assertRaises(SyntaxError):
             output = Boa3.compile(path)
@@ -163,11 +165,11 @@ class TestFor(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/for_test/NestedFor.py' % self.dirname
+        path = self.get_contract_path('NestedFor.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(529, result)
 
@@ -225,11 +227,11 @@ class TestFor(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/for_test/ForElse.py' % self.dirname
+        path = self.get_contract_path('ForElse.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(24, result)
 
@@ -292,11 +294,11 @@ class TestFor(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/for_test/ForContinue.py' % self.dirname
+        path = self.get_contract_path('ForContinue.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(20, result)
 
@@ -362,11 +364,11 @@ class TestFor(BoaTest):
             + Opcode.LDLOC0     # return a
             + Opcode.RET
         )
-        path = '%s/boa3_test/test_sc/for_test/ForBreak.py' % self.dirname
+        path = self.get_contract_path('ForBreak.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(6, result)
 
@@ -440,14 +442,14 @@ class TestFor(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/for_test/ForBreakElse.py' % self.dirname
+        path = self.get_contract_path('ForBreakElse.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(6, result)
 
     def test_for_iterate_dict(self):
-        path = '%s/boa3_test/test_sc/for_test/ForIterateDict.py' % self.dirname
+        path = self.get_contract_path('ForIterateDict.py')
         self.assertCompilerLogs(MismatchedTypes, path)

--- a/boa3_test/tests/test_function.py
+++ b/boa3_test/tests/test_function.py
@@ -10,6 +10,8 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 class TestFunction(BoaTest):
 
+    default_folder: str = 'test_sc/function_test'
+
     def test_integer_function(self):
         expected_output = (
             Opcode.INITSLOT     # function signature
@@ -19,11 +21,11 @@ class TestFunction(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/function_test/IntegerFunction.py' % self.dirname
+        path = self.get_contract_path('IntegerFunction.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 1)
         self.assertEqual(10, result)
         result = self.run_smart_contract(engine, path, 'Main', -1)
@@ -38,11 +40,11 @@ class TestFunction(BoaTest):
             + Opcode.RET            # return
         )
 
-        path = '%s/boa3_test/test_sc/function_test/StringFunction.py' % self.dirname
+        path = self.get_contract_path('StringFunction.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual('42', result)
 
@@ -53,20 +55,20 @@ class TestFunction(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/function_test/BoolFunction.py' % self.dirname
+        path = self.get_contract_path('BoolFunction.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(1, result)
 
     def test_none_function(self):
-        path = '%s/boa3_test/test_sc/function_test/NoneFunction.py' % self.dirname
+        path = self.get_contract_path('NoneFunction.py')
         self.assertCompilerLogs(InternalError, path)
 
     def test_arg_without_type_hint(self):
-        path = '%s/boa3_test/test_sc/function_test/ArgWithoutTypeHintFunction.py' % self.dirname
+        path = self.get_contract_path('ArgWithoutTypeHintFunction.py')
         self.assertCompilerLogs(TypeHintMissing, path)
 
     def test_no_return_hint_function_with_empty_return_statement(self):
@@ -77,11 +79,11 @@ class TestFunction(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/function_test/EmptyReturnFunction.py' % self.dirname
+        path = self.get_contract_path('EmptyReturnFunction.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 5)
         self.assertIsVoid(result)
 
@@ -103,11 +105,11 @@ class TestFunction(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/function_test/ConditionEmptyReturnFunction.py' % self.dirname
+        path = self.get_contract_path('ConditionEmptyReturnFunction.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 5)
         self.assertIsVoid(result)
 
@@ -134,11 +136,11 @@ class TestFunction(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/function_test/EmptyReturnWithOptionalReturnType.py' % self.dirname
+        path = self.get_contract_path('EmptyReturnWithOptionalReturnType.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 5)
         self.assertIsNone(result)
 
@@ -153,28 +155,28 @@ class TestFunction(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/function_test/NoReturnFunction.py' % self.dirname
+        path = self.get_contract_path('NoReturnFunction.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 5)
         self.assertIsVoid(result)
 
     def test_return_type_hint_function_with_empty_return(self):
-        path = '%s/boa3_test/test_sc/function_test/ExpectingReturnFunction.py' % self.dirname
+        path = self.get_contract_path('ExpectingReturnFunction.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_multiple_return_function(self):
-        path = '%s/boa3_test/test_sc/function_test/MultipleReturnFunction.py' % self.dirname
+        path = self.get_contract_path('MultipleReturnFunction.py')
         self.assertCompilerLogs(TooManyReturns, path)
 
     def test_tuple_function(self):
-        path = '%s/boa3_test/test_sc/function_test/TupleFunction.py' % self.dirname
+        path = self.get_contract_path('TupleFunction.py')
         self.assertCompilerLogs(TooManyReturns, path)
 
     def test_default_return(self):
-        path = '%s/boa3_test/test_sc/function_test/DefaultReturn.py' % self.dirname
+        path = self.get_contract_path('DefaultReturn.py')
         self.assertCompilerLogs(MissingReturnStatement, path)
 
     def test_empty_list_return(self):
@@ -183,20 +185,20 @@ class TestFunction(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/function_test/EmptyListReturn.py' % self.dirname
+        path = self.get_contract_path('EmptyListReturn.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([], result)
 
     def test_mismatched_return_type(self):
-        path = '%s/boa3_test/test_sc/function_test/MismatchedReturnType.py' % self.dirname
+        path = self.get_contract_path('MismatchedReturnType.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_mismatched_return_type_with_if(self):
-        path = '%s/boa3_test/test_sc/function_test/MismatchedReturnTypeWithIf.py' % self.dirname
+        path = self.get_contract_path('MismatchedReturnTypeWithIf.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_call_void_function_without_args(self):
@@ -215,11 +217,11 @@ class TestFunction(BoaTest):
             + Opcode.RET            # return
         )
 
-        path = '%s/boa3_test/test_sc/function_test/CallVoidFunctionWithoutArgs.py' % self.dirname
+        path = self.get_contract_path('CallVoidFunctionWithoutArgs.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(1, result)
 
@@ -239,11 +241,11 @@ class TestFunction(BoaTest):
             + Opcode.RET            # return 1
         )
 
-        path = '%s/boa3_test/test_sc/function_test/CallReturnFunctionWithoutArgs.py' % self.dirname
+        path = self.get_contract_path('CallReturnFunctionWithoutArgs.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(1, result)
 
@@ -267,11 +269,11 @@ class TestFunction(BoaTest):
             + Opcode.RET            # return
         )
 
-        path = '%s/boa3_test/test_sc/function_test/CallVoidFunctionWithLiteralArgs.py' % self.dirname
+        path = self.get_contract_path('CallVoidFunctionWithLiteralArgs.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(1, result)
 
@@ -298,11 +300,11 @@ class TestFunction(BoaTest):
             + Opcode.RET            # return
         )
 
-        path = '%s/boa3_test/test_sc/function_test/CallReturnFunctionWithLiteralArgs.py' % self.dirname
+        path = self.get_contract_path('CallReturnFunctionWithLiteralArgs.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(3, result)
 
@@ -333,11 +335,11 @@ class TestFunction(BoaTest):
             + Opcode.RET            # return
         )
 
-        path = '%s/boa3_test/test_sc/function_test/CallVoidFunctionWithVariableArgs.py' % self.dirname
+        path = self.get_contract_path('CallVoidFunctionWithVariableArgs.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(1, result)
 
@@ -368,11 +370,11 @@ class TestFunction(BoaTest):
             + Opcode.RET            # return
         )
 
-        path = '%s/boa3_test/test_sc/function_test/CallReturnFunctionWithVariableArgs.py' % self.dirname
+        path = self.get_contract_path('CallReturnFunctionWithVariableArgs.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         self.run_smart_contract(engine, path, 'TestAdd', 1, 2)
         self.assertEqual(1, len(engine.result_stack))
         self.assertEqual(3, engine.result_stack[-1])
@@ -402,11 +404,11 @@ class TestFunction(BoaTest):
             + Opcode.RET            # return
         )
 
-        path = '%s/boa3_test/test_sc/function_test/CallReturnFunctionOnReturn.py' % self.dirname
+        path = self.get_contract_path('CallReturnFunctionOnReturn.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(3, result)
 
@@ -447,11 +449,11 @@ class TestFunction(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/function_test/CallFunctionWithoutVariables.py' % self.dirname
+        path = self.get_contract_path('CallFunctionWithoutVariables.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 1)
         self.assertEqual(1, result)
         result = self.run_smart_contract(engine, path, 'Main', 2)
@@ -477,11 +479,11 @@ class TestFunction(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/function_test/CallFunctionWrittenBefore.py' % self.dirname
+        path = self.get_contract_path('CallFunctionWrittenBefore.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(3, result)
 
@@ -501,16 +503,16 @@ class TestFunction(BoaTest):
             + Opcode.RET            # return
         )
 
-        path = '%s/boa3_test/test_sc/function_test/ReturnVoidFunction.py' % self.dirname
+        path = self.get_contract_path('ReturnVoidFunction.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertIsNone(result)
 
     def test_return_void_function_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/function_test/ReturnVoidFunctionMismatchedType.py' % self.dirname
+        path = self.get_contract_path('ReturnVoidFunctionMismatchedType.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_return_inside_if(self):
@@ -544,11 +546,11 @@ class TestFunction(BoaTest):
             + Opcode.RET            # return arg0
         )
 
-        path = '%s/boa3_test/test_sc/function_test/ReturnIf.py' % self.dirname
+        path = self.get_contract_path('ReturnIf.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 4)
         self.assertEqual(3, result)
         result = self.run_smart_contract(engine, path, 'Main', 5)
@@ -557,28 +559,28 @@ class TestFunction(BoaTest):
         self.assertEqual(6, result)
 
     def test_missing_return_inside_if(self):
-        path = '%s/boa3_test/test_sc/function_test/ReturnIfMissing.py' % self.dirname
+        path = self.get_contract_path('ReturnIfMissing.py')
         self.assertCompilerLogs(MissingReturnStatement, path)
 
     def test_missing_return_inside_elif(self):
-        path = '%s/boa3_test/test_sc/function_test/ReturnElifMissing.py' % self.dirname
+        path = self.get_contract_path('ReturnElifMissing.py')
         self.assertCompilerLogs(MissingReturnStatement, path)
 
     def test_missing_return_inside_else(self):
-        path = '%s/boa3_test/test_sc/function_test/ReturnElseMissing.py' % self.dirname
+        path = self.get_contract_path('ReturnElseMissing.py')
         self.assertCompilerLogs(MissingReturnStatement, path)
 
     def test_return_inside_multiple_inner_if(self):
-        path = '%s/boa3_test/test_sc/function_test/ReturnMultipleInnerIf.py' % self.dirname
+        path = self.get_contract_path('ReturnMultipleInnerIf.py')
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', True)
         self.assertEqual(1, result)
         result = self.run_smart_contract(engine, path, 'Main', False)
         self.assertEqual(9, result)
 
     def test_missing_return_inside_multiple_inner_if(self):
-        path = '%s/boa3_test/test_sc/function_test/ReturnMultipleInnerIfMissing.py' % self.dirname
+        path = self.get_contract_path('ReturnMultipleInnerIfMissing.py')
         self.assertCompilerLogs(MissingReturnStatement, path)
 
     def test_return_if_expression(self):
@@ -596,18 +598,18 @@ class TestFunction(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/function_test/ReturnIfExpression.py' % self.dirname
+        path = self.get_contract_path('ReturnIfExpression.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', True)
         self.assertEqual(5, result)
         result = self.run_smart_contract(engine, path, 'Main', False)
         self.assertEqual(10, result)
 
     def test_return_if_expression_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/function_test/ReturnIfExpressionMismatched.py' % self.dirname
+        path = self.get_contract_path('ReturnIfExpressionMismatched.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_return_inside_for(self):
@@ -648,11 +650,11 @@ class TestFunction(BoaTest):
             + Opcode.RET          # return 5
         )
 
-        path = '%s/boa3_test/test_sc/function_test/ReturnFor.py' % self.dirname
+        path = self.get_contract_path('ReturnFor.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', [1, 2, 3])
         self.assertEqual(1, result)
         result = self.run_smart_contract(engine, path, 'Main', (2, 5, 7))
@@ -701,11 +703,11 @@ class TestFunction(BoaTest):
             + Opcode.RET          # return x
         )
 
-        path = '%s/boa3_test/test_sc/function_test/ReturnForOnlyOnElse.py' % self.dirname
+        path = self.get_contract_path('ReturnForOnlyOnElse.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', [1, 2, 3])
         self.assertEqual(6, result)
         result = self.run_smart_contract(engine, path, 'Main', (2, 5, 7))
@@ -714,7 +716,7 @@ class TestFunction(BoaTest):
         self.assertEqual(0, result)
 
     def test_missing_return_inside_for_else(self):
-        path = '%s/boa3_test/test_sc/function_test/ReturnForElseMissing.py' % self.dirname
+        path = self.get_contract_path('ReturnForElseMissing.py')
         self.assertCompilerLogs(MissingReturnStatement, path)
 
     def test_return_inside_while(self):
@@ -741,11 +743,11 @@ class TestFunction(BoaTest):
             + Opcode.RET            # return x
         )
 
-        path = '%s/boa3_test/test_sc/function_test/ReturnWhile.py' % self.dirname
+        path = self.get_contract_path('ReturnWhile.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 5)
         self.assertEqual(6, result)
         result = self.run_smart_contract(engine, path, 'Main', 3)
@@ -777,11 +779,11 @@ class TestFunction(BoaTest):
             + Opcode.RET            # return x
         )
 
-        path = '%s/boa3_test/test_sc/function_test/ReturnWhileOnlyOnElse.py' % self.dirname
+        path = self.get_contract_path('ReturnWhileOnlyOnElse.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 5)
         self.assertEqual(10, result)
         result = self.run_smart_contract(engine, path, 'Main', 3)
@@ -792,12 +794,12 @@ class TestFunction(BoaTest):
         self.assertEqual(100, result)
 
     def test_missing_return_inside_while_without_else(self):
-        path = '%s/boa3_test/test_sc/function_test/ReturnWhileWithoutElse.py' % self.dirname
+        path = self.get_contract_path('ReturnWhileWithoutElse.py')
         self.assertCompilerLogs(MissingReturnStatement, path)
 
     def test_multiple_function_large_call(self):
-        path = '%s/boa3_test/test_sc/function_test/MultipleFunctionLargeCall.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('MultipleFunctionLargeCall.py')
+        engine = TestEngine()
 
         result = self.run_smart_contract(engine, path, 'main', 'calculate', [1])
         self.assertIsNone(result)
@@ -862,11 +864,11 @@ class TestFunction(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/function_test/FunctionWithDefaultArgument.py' % self.dirname
+        path = self.get_contract_path('FunctionWithDefaultArgument.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([6, 11], result)
 
@@ -905,20 +907,20 @@ class TestFunction(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/function_test/FunctionWithOnlyDefaultArguments.py' % self.dirname
+        path = self.get_contract_path('FunctionWithOnlyDefaultArguments.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([6, 9, 11, 0], result)
 
     def test_function_with_default_argument_between_other_args(self):
-        path = '%s/boa3_test/test_sc/function_test/FunctionWithDefaultArgumentBetweenArgs.py' % self.dirname
+        path = self.get_contract_path('FunctionWithDefaultArgumentBetweenArgs.py')
 
         with self.assertRaises(SyntaxError):
             output = Boa3.compile(path)
 
     def test_call_function_with_kwargs(self):
-        path = '%s/boa3_test/test_sc/function_test/CallFunctionWithKwargs.py' % self.dirname
+        path = self.get_contract_path('CallFunctionWithKwargs.py')
         self.assertCompilerLogs(InternalError, path)

--- a/boa3_test/tests/test_if.py
+++ b/boa3_test/tests/test_if.py
@@ -9,6 +9,8 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 class TestIf(BoaTest):
 
+    default_folder: str = 'test_sc/if_test'
+
     def test_if_constant_condition(self):
         expected_output = (
             Opcode.INITSLOT
@@ -25,11 +27,11 @@ class TestIf(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/if_test/ConstantCondition.py' % self.dirname
+        path = self.get_contract_path('ConstantCondition.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(2, result)
 
@@ -49,28 +51,28 @@ class TestIf(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/if_test/VariableCondition.py' % self.dirname
+        path = self.get_contract_path('VariableCondition.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', True)
         self.assertEqual(2, result)
         result = self.run_smart_contract(engine, path, 'Main', False)
         self.assertEqual(0, result)
 
     def test_if_mismatched_type_condition(self):
-        path = '%s/boa3_test/test_sc/if_test/MismatchedTypeCondition.py' % self.dirname
+        path = self.get_contract_path('MismatchedTypeCondition.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_if_no_condition(self):
-        path = '%s/boa3_test/test_sc/if_test/IfWithoutCondition.py' % self.dirname
+        path = self.get_contract_path('IfWithoutCondition.py')
 
         with self.assertRaises(SyntaxError):
             output = Boa3.compile(path)
 
     def test_if_no_body(self):
-        path = '%s/boa3_test/test_sc/if_test/IfWithoutBody.py' % self.dirname
+        path = self.get_contract_path('IfWithoutBody.py')
 
         with self.assertRaises(SyntaxError):
             output = Boa3.compile(path)
@@ -102,11 +104,11 @@ class TestIf(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/if_test/NestedIf.py' % self.dirname
+        path = self.get_contract_path('NestedIf.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', True, True)
         self.assertEqual(5, result)
         result = self.run_smart_contract(engine, path, 'Main', True, False)
@@ -135,18 +137,18 @@ class TestIf(BoaTest):
             + Opcode.LDLOC0     # return a
             + Opcode.RET
         )
-        path = '%s/boa3_test/test_sc/if_test/IfElse.py' % self.dirname
+        path = self.get_contract_path('IfElse.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', True)
         self.assertEqual(2, result)
         result = self.run_smart_contract(engine, path, 'Main', False)
         self.assertEqual(10, result)
 
     def test_else_no_body(self):
-        path = '%s/boa3_test/test_sc/if_test/ElseWithoutBody.py' % self.dirname
+        path = self.get_contract_path('ElseWithoutBody.py')
 
         with self.assertRaises(SyntaxError):
             output = Boa3.compile(path)
@@ -174,24 +176,24 @@ class TestIf(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/if_test/IfElif.py' % self.dirname
+        path = self.get_contract_path('IfElif.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', True)
         self.assertEqual(2, result)
         result = self.run_smart_contract(engine, path, 'Main', False)
         self.assertEqual(0, result)
 
     def test_elif_no_condition(self):
-        path = '%s/boa3_test/test_sc/if_test/ElifWithoutCondition.py' % self.dirname
+        path = self.get_contract_path('ElifWithoutCondition.py')
 
         with self.assertRaises(SyntaxError):
             output = Boa3.compile(path)
 
     def test_elif_no_body(self):
-        path = '%s/boa3_test/test_sc/if_test/ElifWithoutBody.py' % self.dirname
+        path = self.get_contract_path('ElifWithoutBody.py')
 
         with self.assertRaises(SyntaxError):
             output = Boa3.compile(path)
@@ -216,11 +218,11 @@ class TestIf(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/if_test/RelationalCondition.py' % self.dirname
+        path = self.get_contract_path('RelationalCondition.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 5)
         self.assertEqual(2, result)
         result = self.run_smart_contract(engine, path, 'Main', 10)
@@ -278,11 +280,11 @@ class TestIf(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/if_test/MultipleBranches.py' % self.dirname
+        path = self.get_contract_path('MultipleBranches.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', -10)
         self.assertEqual(0, result)
         result = self.run_smart_contract(engine, path, 'Main', 2)
@@ -312,31 +314,31 @@ class TestIf(BoaTest):
             + Opcode.LDLOC0     # return a
             + Opcode.RET
         )
-        path = '%s/boa3_test/test_sc/if_test/IfExpVariableCondition.py' % self.dirname
+        path = self.get_contract_path('IfExpVariableCondition.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', True)
         self.assertEqual(2, result)
         result = self.run_smart_contract(engine, path, 'Main', False)
         self.assertEqual(3, result)
 
     def test_if_expression_without_else_branch(self):
-        path = '%s/boa3_test/test_sc/if_test/IfExpWithoutElse.py' % self.dirname
+        path = self.get_contract_path('IfExpWithoutElse.py')
 
         with self.assertRaises(SyntaxError):
             output = Boa3.compile(path)
 
     def test_if_expression_mismatched_types(self):
-        path = '%s/boa3_test/test_sc/if_test/MismatchedIfExp.py' % self.dirname
+        path = self.get_contract_path('MismatchedIfExp.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_inner_if_else(self):
-        path = '%s/boa3_test/test_sc/if_test/InnerIfElse.py' % self.dirname
+        path = self.get_contract_path('InnerIfElse.py')
         self.compile_and_save(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'main', 4, 3, 2, 1)
         self.assertEqual(3, result)
 
@@ -356,10 +358,10 @@ class TestIf(BoaTest):
         self.assertEqual(22, result)
 
     def test_if_is_instance_condition(self):
-        path = '%s/boa3_test/test_sc/if_test/IfIsInstanceCondition.py' % self.dirname
+        path = self.get_contract_path('IfIsInstanceCondition.py')
         self.compile_and_save(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'example', 4)
         self.assertEqual(4, result)
 
@@ -373,10 +375,10 @@ class TestIf(BoaTest):
         self.assertEqual(-1, result)
 
     def test_if_else_is_instance_condition(self):
-        path = '%s/boa3_test/test_sc/if_test/IfElseIsInstanceCondition.py' % self.dirname
+        path = self.get_contract_path('IfElseIsInstanceCondition.py')
         self.compile_and_save(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'example', 4)
         self.assertEqual(4, result)
 
@@ -390,10 +392,10 @@ class TestIf(BoaTest):
         self.assertEqual(-1, result)
 
     def test_if_else_is_instance_condition_with_union_variable(self):
-        path = '%s/boa3_test/test_sc/if_test/IfElseIsInstanceConditionWithUnionVariable.py' % self.dirname
+        path = self.get_contract_path('IfElseIsInstanceConditionWithUnionVariable.py')
         self.compile_and_save(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'example', 4,
                                          expected_result_type=bytes)
         self.assertEqual(b'\x04', result)
@@ -411,10 +413,10 @@ class TestIf(BoaTest):
         self.assertEqual(b'\x01', result)
 
     def test_if_else_multiple_is_instance_condition_with_union_variable(self):
-        path = '%s/boa3_test/test_sc/if_test/IfElseMultipleIsInstanceConditionWithUnionVariable.py' % self.dirname
+        path = self.get_contract_path('IfElseMultipleIsInstanceConditionWithUnionVariable.py')
         self.compile_and_save(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'example', 4)
         self.assertEqual(16, result)
 

--- a/boa3_test/tests/test_import.py
+++ b/boa3_test/tests/test_import.py
@@ -8,6 +8,8 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 class TestImport(BoaTest):
 
+    default_folder: str = 'test_sc/import_test'
+
     def test_import_typing(self):
         expected_output = (
             Opcode.INITSLOT     # function signature
@@ -17,7 +19,7 @@ class TestImport(BoaTest):
             + Opcode.STLOC0
             + Opcode.RET        # return
         )
-        path = '%s/boa3_test/test_sc/import_test/ImportTyping.py' % self.dirname
+        path = self.get_contract_path('ImportTyping.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -30,7 +32,7 @@ class TestImport(BoaTest):
             + Opcode.STLOC0
             + Opcode.RET        # return
         )
-        path = '%s/boa3_test/test_sc/import_test/ImportTypingWithAlias.py' % self.dirname
+        path = self.get_contract_path('ImportTypingWithAlias.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -47,11 +49,11 @@ class TestImport(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/import_test/ImportUserModule.py' % self.dirname
+        path = self.get_contract_path('ImportUserModule.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([], result)
 
@@ -68,11 +70,11 @@ class TestImport(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/import_test/ImportUserModuleWithAlias.py' % self.dirname
+        path = self.get_contract_path('ImportUserModuleWithAlias.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([], result)
 
@@ -89,11 +91,11 @@ class TestImport(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/import_test/FromImportWithGlobalVariables.py' % self.dirname
+        path = self.get_contract_path('FromImportWithGlobalVariables.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([], result)
 
@@ -109,16 +111,16 @@ class TestImport(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/import_test/FromImportVariable.py' % self.dirname
+        path = self.get_contract_path('FromImportVariable.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([], result)
 
     def test_typing_python_library(self):
-        path = '%s/boa3_test/test_sc/import_test/ImportPythonLib.py' % self.dirname
+        path = self.get_contract_path('ImportPythonLib.py')
         self.assertCompilerLogs(UnresolvedReference, path)
 
     def test_from_typing_import(self):
@@ -131,7 +133,7 @@ class TestImport(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/import_test/FromImportTyping.py' % self.dirname
+        path = self.get_contract_path('FromImportTyping.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -141,12 +143,12 @@ class TestImport(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/import_test/FromImportTypingWithAlias.py' % self.dirname
+        path = self.get_contract_path('FromImportTypingWithAlias.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
     def test_from_typing_import_not_supported_type(self):
-        path = '%s/boa3_test/test_sc/import_test/FromImportTypingNotImplementedType.py' % self.dirname
+        path = self.get_contract_path('FromImportTypingNotImplementedType.py')
         self.assertCompilerLogs(UnresolvedReference, path)
 
     def test_from_import_user_module(self):
@@ -163,11 +165,11 @@ class TestImport(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/import_test/FromImportUserModule.py' % self.dirname
+        path = self.get_contract_path('FromImportUserModule.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([], result)
 
@@ -185,14 +187,14 @@ class TestImport(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/import_test/FromImportUserModuleWithAlias.py' % self.dirname
+        path = self.get_contract_path('FromImportUserModuleWithAlias.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([], result)
 
     def test_import_non_existent_package(self):
-        path = '%s/boa3_test/test_sc/import_test/ImportNonExistantPackage.py' % self.dirname
+        path = self.get_contract_path('ImportNonExistantPackage.py')
         self.assertCompilerLogs(UnresolvedReference, path)

--- a/boa3_test/tests/test_interop/test_binary.py
+++ b/boa3_test/tests/test_interop/test_binary.py
@@ -10,6 +10,8 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 class TestBinaryInterop(BoaTest):
 
+    default_folder: str = 'test_sc/interop_test/binary'
+
     def test_base64_encode(self):
         expected_output = (
             Opcode.INITSLOT
@@ -20,12 +22,12 @@ class TestBinaryInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/binary/Base64Encode.py' % self.dirname
+        path = self.get_contract_path('Base64Encode.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
         import base64
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         expected_result = base64.b64encode(b'unit test')
         result = self.run_smart_contract(engine, path, 'Main', b'unit test',
                                          expected_result_type=bytes)
@@ -50,7 +52,7 @@ class TestBinaryInterop(BoaTest):
         self.assertEqual(expected_result, result)
 
     def test_base64_encode_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/interop_test/binary/Base64EncodeMismatchedType.py' % self.dirname
+        path = self.get_contract_path('Base64EncodeMismatchedType.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_base64_decode(self):
@@ -63,12 +65,12 @@ class TestBinaryInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/binary/Base64Decode.py' % self.dirname
+        path = self.get_contract_path('Base64Decode.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
         import base64
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         arg = String.from_bytes(base64.b64encode(b'unit test'))
         result = self.run_smart_contract(engine, path, 'Main', arg,
                                          expected_result_type=bytes)
@@ -93,7 +95,7 @@ class TestBinaryInterop(BoaTest):
         self.assertEqual(String(long_string).to_bytes(), result)
 
     def test_base64_decode_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/interop_test/binary/Base64DecodeMismatchedType.py' % self.dirname
+        path = self.get_contract_path('Base64DecodeMismatchedType.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_base58_encode(self):
@@ -106,12 +108,12 @@ class TestBinaryInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/binary/Base58Encode.py' % self.dirname
+        path = self.get_contract_path('Base58Encode.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
         import base58
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         expected_result = base58.b58encode('unit test')
         result = self.run_smart_contract(engine, path, 'Main', 'unit test',
                                          expected_result_type=bytes)
@@ -136,7 +138,7 @@ class TestBinaryInterop(BoaTest):
         self.assertEqual(expected_result, result)
 
     def test_base58_encode_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/interop_test/binary/Base58EncodeMismatchedType.py' % self.dirname
+        path = self.get_contract_path('Base58EncodeMismatchedType.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_base58_decode(self):
@@ -149,12 +151,12 @@ class TestBinaryInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/binary/Base58Decode.py' % self.dirname
+        path = self.get_contract_path('Base58Decode.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
         import base58
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         arg = base58.b58encode('unit test')
         result = self.run_smart_contract(engine, path, 'Main', arg)
         self.assertEqual('unit test', result)
@@ -176,64 +178,64 @@ class TestBinaryInterop(BoaTest):
         self.assertEqual(long_string, result)
 
     def test_base58_decode_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/interop_test/binary/Base58DecodeMismatchedType.py' % self.dirname
+        path = self.get_contract_path('Base58DecodeMismatchedType.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_serialize_int(self):
-        path = '%s/boa3_test/test_sc/interop_test/binary/SerializeInt.py' % self.dirname
+        path = self.get_contract_path('SerializeInt.py')
         self.compile_and_save(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'serialize_int',
                                          expected_result_type=bytes)
         expected_result = serialize(42)
         self.assertEqual(expected_result, result)
 
     def test_serialize_bool(self):
-        path = '%s/boa3_test/test_sc/interop_test/binary/SerializeBool.py' % self.dirname
+        path = self.get_contract_path('SerializeBool.py')
         self.compile_and_save(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'serialize_bool',
                                          expected_result_type=bytes)
         expected_result = serialize(True)
         self.assertEqual(expected_result, result)
 
     def test_serialize_str(self):
-        path = '%s/boa3_test/test_sc/interop_test/binary/SerializeStr.py' % self.dirname
+        path = self.get_contract_path('SerializeStr.py')
         self.compile_and_save(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'serialize_str',
                                          expected_result_type=bytes)
         expected_result = serialize('42')
         self.assertEqual(expected_result, result)
 
     def test_serialize_sequence(self):
-        path = '%s/boa3_test/test_sc/interop_test/binary/SerializeSequence.py' % self.dirname
+        path = self.get_contract_path('SerializeSequence.py')
         self.compile_and_save(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'serialize_sequence',
                                          expected_result_type=bytes)
         expected_result = serialize([2, 3, 5, 7])
         self.assertEqual(expected_result, result)
 
     def test_serialize_dict(self):
-        path = '%s/boa3_test/test_sc/interop_test/binary/SerializeDict.py' % self.dirname
+        path = self.get_contract_path('SerializeDict.py')
         self.compile_and_save(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'serialize_dict',
                                          expected_result_type=bytes)
         expected_result = serialize({1: 1, 2: 1, 3: 2})
         self.assertEqual(expected_result, result)
 
     def test_deserialize(self):
-        path = '%s/boa3_test/test_sc/interop_test/binary/Deserialize.py' % self.dirname
+        path = self.get_contract_path('Deserialize.py')
         self.compile_and_save(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
 
         expected_result = 42
         value = serialize(expected_result)
@@ -279,5 +281,5 @@ class TestBinaryInterop(BoaTest):
         self.assertEqual(expected_result, result)
 
     def test_deserialize_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/interop_test/binary/DeserializeMismatchedType.py' % self.dirname
+        path = self.get_contract_path('DeserializeMismatchedType.py')
         self.assertCompilerLogs(MismatchedTypes, path)

--- a/boa3_test/tests/test_interop/test_blockchain.py
+++ b/boa3_test/tests/test_interop/test_blockchain.py
@@ -13,6 +13,8 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 class TestBlockchainInterop(BoaTest):
 
+    default_folder: str = 'test_sc/interop_test/blockchain'
+
     def test_get_current_height(self):
         expected_output = (
             Opcode.SYSCALL
@@ -20,7 +22,7 @@ class TestBlockchainInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/blockchain/CurrentHeight.py' % self.dirname
+        path = self.get_contract_path('CurrentHeight.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -34,7 +36,7 @@ class TestBlockchainInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/blockchain/CurrentHeightCantAssign.py' % self.dirname
+        path = self.get_contract_path('CurrentHeightCantAssign.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -62,15 +64,15 @@ class TestBlockchainInterop(BoaTest):
             + Interop.CallContract.interop_method_hash
             + Opcode.RET
         )
-        path = '%s/boa3_test/test_sc/interop_test/blockchain/GetContract.py' % self.dirname
+        path = self.get_contract_path('GetContract.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'main', bytes(20))
         self.assertIsNone(result)
 
-        call_contract_path = '%s/boa3_test/test_sc/arithmetic_test/Addition.py' % self.dirname
+        call_contract_path = self.get_contract_path('test_sc/arithmetic_test', 'Addition.py')
         Boa3.compile_and_save(call_contract_path)
 
         script, manifest = self.get_output(call_contract_path)

--- a/boa3_test/tests/test_interop/test_contract.py
+++ b/boa3_test/tests/test_interop/test_contract.py
@@ -18,6 +18,8 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 class TestContractInterop(BoaTest):
 
+    default_folder: str = 'test_sc/interop_test/contract'
+
     def test_call_contract(self):
         call_flag = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
         expected_output = (
@@ -37,18 +39,18 @@ class TestContractInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/contract/CallScriptHash.py' % self.dirname
+        path = self.get_contract_path('CallScriptHash.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        call_contract_path = '%s/boa3_test/test_sc/arithmetic_test/Addition.py' % self.dirname
+        call_contract_path = self.get_contract_path('test_sc/arithmetic_test', 'Addition.py')
         Boa3.compile_and_save(call_contract_path)
 
         contract, manifest = self.get_output(call_contract_path)
         call_hash = hash160(contract)
         call_contract_path = call_contract_path.replace('.py', '.nef')
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         with self.assertRaises(TestExecutionException, msg=self.CALLED_CONTRACT_DOES_NOT_EXIST_MSG):
             self.run_smart_contract(engine, path, 'Main', call_hash, 'add', [1, 2])
         engine.add_contract(call_contract_path)
@@ -79,18 +81,18 @@ class TestContractInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/contract/CallScriptHashWithoutArgs.py' % self.dirname
+        path = self.get_contract_path('CallScriptHashWithoutArgs.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        call_contract_path = '%s/boa3_test/test_sc/list_test/IntList.py' % self.dirname
+        call_contract_path = self.get_contract_path('test_sc/list_test', 'IntList.py')
         Boa3.compile_and_save(call_contract_path)
 
         contract, manifest = self.get_output(call_contract_path)
         call_hash = hash160(contract)
         call_contract_path = call_contract_path.replace('.py', '.nef')
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         with self.assertRaises(TestExecutionException, msg=self.CALLED_CONTRACT_DOES_NOT_EXIST_MSG):
             self.run_smart_contract(engine, path, 'Main', call_hash, 'Main')
         engine.add_contract(call_contract_path)
@@ -99,11 +101,11 @@ class TestContractInterop(BoaTest):
         self.assertEqual([1, 2, 3], result)
 
     def test_call_contract_too_many_parameters(self):
-        path = '%s/boa3_test/test_sc/interop_test/contract/CallScriptHashTooManyArguments.py' % self.dirname
+        path = self.get_contract_path('CallScriptHashTooManyArguments.py')
         self.assertCompilerLogs(UnexpectedArgument, path)
 
     def test_call_contract_too_few_parameters(self):
-        path = '%s/boa3_test/test_sc/interop_test/contract/CallScriptHashTooFewArguments.py' % self.dirname
+        path = self.get_contract_path('CallScriptHashTooFewArguments.py')
         self.assertCompilerLogs(UnfilledArgument, path)
 
     def test_create_contract(self):
@@ -135,17 +137,17 @@ class TestContractInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/contract/CreateContract.py' % self.dirname
+        path = self.get_contract_path('CreateContract.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        call_contract_path = '%s/boa3_test/test_sc/arithmetic_test/Addition.py' % self.dirname
+        call_contract_path = self.get_contract_path('test_sc/arithmetic_test', 'Addition.py')
         Boa3.compile_and_save(call_contract_path)
 
         nef_file, manifest = self.get_bytes_output(call_contract_path)
         arg_manifest = String(json.dumps(manifest, separators=(',', ':'))).to_bytes()
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', nef_file, arg_manifest)
 
         self.assertEqual(5, len(result))
@@ -153,11 +155,11 @@ class TestContractInterop(BoaTest):
         self.assertEqual(manifest, json.loads(result[4]))
 
     def test_create_contract_too_many_parameters(self):
-        path = '%s/boa3_test/test_sc/interop_test/contract/CreateContractTooManyArguments.py' % self.dirname
+        path = self.get_contract_path('CreateContractTooManyArguments.py')
         self.assertCompilerLogs(UnexpectedArgument, path)
 
     def test_create_contract_too_few_parameters(self):
-        path = '%s/boa3_test/test_sc/interop_test/contract/CreateContractTooFewArguments.py' % self.dirname
+        path = self.get_contract_path('CreateContractTooFewArguments.py')
         self.assertCompilerLogs(UnfilledArgument, path)
 
     def test_update_contract(self):
@@ -186,16 +188,16 @@ class TestContractInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/contract/UpdateContract.py' % self.dirname
+        path = self.get_contract_path('UpdateContract.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
     def test_update_contract_too_many_parameters(self):
-        path = '%s/boa3_test/test_sc/interop_test/contract/UpdateContractTooManyArguments.py' % self.dirname
+        path = self.get_contract_path('UpdateContractTooManyArguments.py')
         self.assertCompilerLogs(UnexpectedArgument, path)
 
     def test_update_contract_too_few_parameters(self):
-        path = '%s/boa3_test/test_sc/interop_test/contract/UpdateContractTooFewArguments.py' % self.dirname
+        path = self.get_contract_path('UpdateContractTooFewArguments.py')
         self.assertCompilerLogs(UnfilledArgument, path)
 
     def test_destroy_contract(self):
@@ -218,12 +220,12 @@ class TestContractInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/contract/DestroyContract.py' % self.dirname
+        path = self.get_contract_path('DestroyContract.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
     def test_destroy_contract_too_many_parameters(self):
-        path = '%s/boa3_test/test_sc/interop_test/contract/DestroyContractTooManyArguments.py' % self.dirname
+        path = self.get_contract_path('DestroyContractTooManyArguments.py')
         self.assertCompilerLogs(UnexpectedArgument, path)
 
     def test_get_neo_native_script_hash(self):
@@ -235,11 +237,11 @@ class TestContractInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/contract/NeoScriptHash.py' % self.dirname
+        path = self.get_contract_path('NeoScriptHash.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(value, result)
 
@@ -253,7 +255,7 @@ class TestContractInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/contract/NeoScriptHashCantAssign.py' % self.dirname
+        path = self.get_contract_path('NeoScriptHashCantAssign.py')
         output = self.assertCompilerLogs(NameShadowing, path)
         self.assertEqual(expected_output, output)
 
@@ -266,11 +268,11 @@ class TestContractInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/contract/GasScriptHash.py' % self.dirname
+        path = self.get_contract_path('GasScriptHash.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(value, result)
 
@@ -284,6 +286,6 @@ class TestContractInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/contract/GasScriptHashCantAssign.py' % self.dirname
+        path = self.get_contract_path('GasScriptHashCantAssign.py')
         output = self.assertCompilerLogs(NameShadowing, path)
         self.assertEqual(expected_output, output)

--- a/boa3_test/tests/test_interop/test_crypto.py
+++ b/boa3_test/tests/test_interop/test_crypto.py
@@ -10,6 +10,8 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 class TestCryptoInterop(BoaTest):
 
+    default_folder: str = 'test_sc/interop_test/crypto'
+
     def test_ripemd160_str(self):
         expected_output = (
             Opcode.INITSLOT
@@ -20,12 +22,12 @@ class TestCryptoInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/crypto/Ripemd160Str.py' % self.dirname
+        path = self.get_contract_path('Ripemd160Str.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
         import hashlib
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         expected_result = hashlib.new('ripemd160', b'unit test')
         result = self.run_smart_contract(engine, path, 'Main', 'unit test')
         self.assertEqual(expected_result.digest(), result)
@@ -36,56 +38,56 @@ class TestCryptoInterop(BoaTest):
 
     def test_ripemd160_int(self):
         import hashlib
-        path = '%s/boa3_test/test_sc/interop_test/crypto/Ripemd160Int.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('Ripemd160Int.py')
+        engine = TestEngine()
         expected_result = hashlib.new('ripemd160', Integer(10).to_byte_array())
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(expected_result.digest(), result)
 
     def test_ripemd160_bool(self):
         import hashlib
-        path = '%s/boa3_test/test_sc/interop_test/crypto/Ripemd160Bool.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('Ripemd160Bool.py')
+        engine = TestEngine()
         expected_result = hashlib.new('ripemd160', Integer(1).to_byte_array())
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(expected_result.digest(), result)
 
     def test_ripemd160_bytes(self):
         import hashlib
-        path = '%s/boa3_test/test_sc/interop_test/crypto/Ripemd160Bytes.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('Ripemd160Bytes.py')
+        engine = TestEngine()
         expected_result = hashlib.new('ripemd160', b'unit test')
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(expected_result.digest(), result)
 
     def test_hash160_str(self):
         import hashlib
-        path = '%s/boa3_test/test_sc/interop_test/crypto/Hash160Str.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('Hash160Str.py')
+        engine = TestEngine()
         expected_result = hashlib.new('ripemd160', (hashlib.sha256(b'unit test').digest())).digest()
         result = self.run_smart_contract(engine, path, 'Main', 'unit test')
         self.assertEqual(expected_result, result)
 
     def test_hash160_int(self):
         import hashlib
-        path = '%s/boa3_test/test_sc/interop_test/crypto/Hash160Int.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('Hash160Int.py')
+        engine = TestEngine()
         expected_result = hashlib.new('ripemd160', (hashlib.sha256(Integer(10).to_byte_array()).digest())).digest()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(expected_result, result)
 
     def test_hash160_bool(self):
         import hashlib
-        path = '%s/boa3_test/test_sc/interop_test/crypto/Hash160Bool.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('Hash160Bool.py')
+        engine = TestEngine()
         expected_result = hashlib.new('ripemd160', (hashlib.sha256(Integer(1).to_byte_array()).digest())).digest()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(expected_result, result)
 
     def test_hash160_bytes(self):
         import hashlib
-        path = '%s/boa3_test/test_sc/interop_test/crypto/Hash160Bytes.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('Hash160Bytes.py')
+        engine = TestEngine()
         expected_result = hashlib.new('ripemd160', (hashlib.sha256(b'unit test').digest())).digest()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(expected_result, result)
@@ -100,12 +102,12 @@ class TestCryptoInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/crypto/Sha256Str.py' % self.dirname
+        path = self.get_contract_path('Sha256Str.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
         import hashlib
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         expected_result = hashlib.sha256(b'unit test')
         result = self.run_smart_contract(engine, path, 'Main', 'unit test')
         self.assertEqual(expected_result.digest(), result)
@@ -116,56 +118,56 @@ class TestCryptoInterop(BoaTest):
 
     def test_sha256_int(self):
         import hashlib
-        path = '%s/boa3_test/test_sc/interop_test/crypto/Sha256Int.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('Sha256Int.py')
+        engine = TestEngine()
         expected_result = hashlib.sha256(Integer(10).to_byte_array())
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(expected_result.digest(), result)
 
     def test_sha256_bool(self):
         import hashlib
-        path = '%s/boa3_test/test_sc/interop_test/crypto/Sha256Bool.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('Sha256Bool.py')
+        engine = TestEngine()
         expected_result = hashlib.sha256(Integer(1).to_byte_array())
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(expected_result.digest(), result)
 
     def test_sha256_bytes(self):
         import hashlib
-        path = '%s/boa3_test/test_sc/interop_test/crypto/Sha256Bytes.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('Sha256Bytes.py')
+        engine = TestEngine()
         expected_result = hashlib.sha256(b'unit test')
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(expected_result.digest(), result)
 
     def test_hash256_str(self):
         import hashlib
-        path = '%s/boa3_test/test_sc/interop_test/crypto/Hash256Str.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('Hash256Str.py')
+        engine = TestEngine()
         expected_result = hashlib.sha256(hashlib.sha256(b'unit test').digest()).digest()
         result = self.run_smart_contract(engine, path, 'Main', 'unit test')
         self.assertEqual(expected_result, result)
 
     def test_hash256_int(self):
         import hashlib
-        path = '%s/boa3_test/test_sc/interop_test/crypto/Hash256Int.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('Hash256Int.py')
+        engine = TestEngine()
         expected_result = hashlib.sha256(hashlib.sha256(Integer(10).to_byte_array()).digest()).digest()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(expected_result, result)
 
     def test_hash256_bool(self):
         import hashlib
-        path = '%s/boa3_test/test_sc/interop_test/crypto/Hash256Bool.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('Hash256Bool.py')
+        engine = TestEngine()
         expected_result = hashlib.sha256(hashlib.sha256(Integer(1).to_byte_array()).digest()).digest()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(expected_result, result)
 
     def test_hash256_bytes(self):
         import hashlib
-        path = '%s/boa3_test/test_sc/interop_test/crypto/Hash256Bytes.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('Hash256Bytes.py')
+        engine = TestEngine()
         expected_result = hashlib.sha256(hashlib.sha256(b'unit test').digest()).digest()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(expected_result, result)
@@ -210,7 +212,7 @@ class TestCryptoInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/crypto/CheckMultisigWithECDsaSecp256r1Str.py' % self.dirname
+        path = self.get_contract_path('CheckMultisigWithECDsaSecp256r1Str.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -251,7 +253,7 @@ class TestCryptoInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/crypto/CheckMultisigWithECDsaSecp256r1Int.py' % self.dirname
+        path = self.get_contract_path('CheckMultisigWithECDsaSecp256r1Int.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -292,7 +294,7 @@ class TestCryptoInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/crypto/CheckMultisigWithECDsaSecp256r1Bool.py' % self.dirname
+        path = self.get_contract_path('CheckMultisigWithECDsaSecp256r1Bool.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -336,7 +338,7 @@ class TestCryptoInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/crypto/CheckMultisigWithECDsaSecp256r1Byte.py' % self.dirname
+        path = self.get_contract_path('CheckMultisigWithECDsaSecp256r1Byte.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -380,7 +382,7 @@ class TestCryptoInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/crypto/CheckMultisigWithECDsaSecp256k1Str.py' % self.dirname
+        path = self.get_contract_path('CheckMultisigWithECDsaSecp256k1Str.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -421,7 +423,7 @@ class TestCryptoInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/crypto/CheckMultisigWithECDsaSecp256k1Int.py' % self.dirname
+        path = self.get_contract_path('CheckMultisigWithECDsaSecp256k1Int.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -462,7 +464,7 @@ class TestCryptoInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/crypto/CheckMultisigWithECDsaSecp256k1Bool.py' % self.dirname
+        path = self.get_contract_path('CheckMultisigWithECDsaSecp256k1Bool.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -506,7 +508,7 @@ class TestCryptoInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/crypto/CheckMultisigWithECDsaSecp256k1Byte.py' % self.dirname
+        path = self.get_contract_path('CheckMultisigWithECDsaSecp256k1Byte.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -530,7 +532,7 @@ class TestCryptoInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/crypto/VerifyWithECDsaSecp256r1Str.py' % self.dirname
+        path = self.get_contract_path('VerifyWithECDsaSecp256r1Str.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -551,7 +553,7 @@ class TestCryptoInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/crypto/VerifyWithECDsaSecp256r1Bool.py' % self.dirname
+        path = self.get_contract_path('VerifyWithECDsaSecp256r1Bool.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -572,7 +574,7 @@ class TestCryptoInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/crypto/VerifyWithECDsaSecp256r1Int.py' % self.dirname
+        path = self.get_contract_path('VerifyWithECDsaSecp256r1Int.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -596,12 +598,12 @@ class TestCryptoInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/crypto/VerifyWithECDsaSecp256r1Bytes.py' % self.dirname
+        path = self.get_contract_path('VerifyWithECDsaSecp256r1Bytes.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
     def test_verify_with_ecdsa_secp256r1_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/interop_test/crypto/VerifyWithECDsaSecp256r1MismatchedType.py' % self.dirname
+        path = self.get_contract_path('VerifyWithECDsaSecp256r1MismatchedType.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_verify_with_ecdsa_secp256k1_str(self):
@@ -624,7 +626,7 @@ class TestCryptoInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/crypto/VerifyWithECDsaSecp256k1Str.py' % self.dirname
+        path = self.get_contract_path('VerifyWithECDsaSecp256k1Str.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -645,7 +647,7 @@ class TestCryptoInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/crypto/VerifyWithECDsaSecp256k1Bool.py' % self.dirname
+        path = self.get_contract_path('VerifyWithECDsaSecp256k1Bool.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -666,7 +668,7 @@ class TestCryptoInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/crypto/VerifyWithECDsaSecp256k1Int.py' % self.dirname
+        path = self.get_contract_path('VerifyWithECDsaSecp256k1Int.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -690,10 +692,10 @@ class TestCryptoInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/crypto/VerifyWithECDsaSecp256k1Bytes.py' % self.dirname
+        path = self.get_contract_path('VerifyWithECDsaSecp256k1Bytes.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
     def test_verify_with_ecdsa_secp256k1_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/interop_test/crypto/VerifyWithECDsaSecp256k1MismatchedType.py' % self.dirname
+        path = self.get_contract_path('VerifyWithECDsaSecp256k1MismatchedType.py')
         self.assertCompilerLogs(MismatchedTypes, path)

--- a/boa3_test/tests/test_interop/test_iterator.py
+++ b/boa3_test/tests/test_interop/test_iterator.py
@@ -8,6 +8,8 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 class TestIteratorInterop(BoaTest):
 
+    default_folder: str = 'test_sc/interop_test/iterator'
+
     def test_create_iterator_list(self):
         expected_output = (
             Opcode.INITSLOT
@@ -18,11 +20,11 @@ class TestIteratorInterop(BoaTest):
             + Interop.IteratorCreate.interop_method_hash
             + Opcode.RET
         )
-        path = '%s/boa3_test/test_sc/interop_test/iterator/IteratorCreateList.py' % self.dirname
+        path = self.get_contract_path('IteratorCreateList.py')
         output, manifest = self.compile_and_save(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'list_iterator', [])
         self.assertEqual(InteropInterface, result)  # returns an interop interface
 
@@ -39,11 +41,11 @@ class TestIteratorInterop(BoaTest):
             + Interop.IteratorCreate.interop_method_hash
             + Opcode.RET
         )
-        path = '%s/boa3_test/test_sc/interop_test/iterator/IteratorCreateDict.py' % self.dirname
+        path = self.get_contract_path('IteratorCreateDict.py')
         output, manifest = self.compile_and_save(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'dict_iterator', {})
         self.assertEqual(InteropInterface, result)  # returns an interop interface
 
@@ -51,14 +53,14 @@ class TestIteratorInterop(BoaTest):
         self.assertEqual(InteropInterface, result)  # returns an interop interface
 
     def test_create_iterator_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/interop_test/iterator/IteratorCreateMismatchedTypes.py' % self.dirname
+        path = self.get_contract_path('IteratorCreateMismatchedTypes.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_iterator_next(self):
-        path = '%s/boa3_test/test_sc/interop_test/iterator/IteratorNext.py' % self.dirname
+        path = self.get_contract_path('IteratorNext.py')
         self.compile_and_save(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'has_next', [1])
         self.assertEqual(True, result)
 
@@ -72,10 +74,10 @@ class TestIteratorInterop(BoaTest):
         self.assertEqual(False, result)
 
     def test_iterator_value(self):
-        path = '%s/boa3_test/test_sc/interop_test/iterator/IteratorValue.py' % self.dirname
+        path = self.get_contract_path('IteratorValue.py')
         self.compile_and_save(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'list_iterator', [1])
         self.assertEqual(1, result)
 
@@ -89,9 +91,9 @@ class TestIteratorInterop(BoaTest):
         self.assertIsNone(result)
 
     def test_iterator_value_dict_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/interop_test/iterator/IteratorDictValueMismatchedType.py' % self.dirname
+        path = self.get_contract_path('IteratorDictValueMismatchedType.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_iterator_value_list_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/interop_test/iterator/IteratorListValueMismatchedType.py' % self.dirname
+        path = self.get_contract_path('IteratorListValueMismatchedType.py')
         self.assertCompilerLogs(MismatchedTypes, path)

--- a/boa3_test/tests/test_interop/test_json.py
+++ b/boa3_test/tests/test_interop/test_json.py
@@ -7,10 +7,12 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 class TestJsonInterop(BoaTest):
 
-    def test_json_serialize(self):
-        path = '%s/boa3_test/test_sc/interop_test/json/JsonSerialize.py' % self.dirname
+    default_folder: str = 'test_sc/interop_test/json'
 
-        engine = TestEngine(self.dirname)
+    def test_json_serialize(self):
+        path = self.get_contract_path('JsonSerialize.py')
+
+        engine = TestEngine()
         test_input = {"one": 1, "two": 2, "three": 3}
         expected_result = String(json.dumps(test_input, separators=(',', ':'))).to_bytes()
         result = self.run_smart_contract(engine, path, 'main', test_input,
@@ -18,45 +20,45 @@ class TestJsonInterop(BoaTest):
         self.assertEqual(expected_result, result)
 
     def test_json_serialize_int(self):
-        path = '%s/boa3_test/test_sc/interop_test/json/JsonSerializeInt.py' % self.dirname
+        path = self.get_contract_path('JsonSerializeInt.py')
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         expected_result = String(json.dumps(10)).to_bytes()
         result = self.run_smart_contract(engine, path, 'main',
                                          expected_result_type=bytes)
         self.assertEqual(expected_result, result)
 
     def test_json_serialize_bool(self):
-        path = '%s/boa3_test/test_sc/interop_test/json/JsonSerializeBool.py' % self.dirname
+        path = self.get_contract_path('JsonSerializeBool.py')
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         expected_result = String(json.dumps(1)).to_bytes()
         result = self.run_smart_contract(engine, path, 'main',
                                          expected_result_type=bytes)
         self.assertEqual(expected_result, result)
 
     def test_json_serialize_str(self):
-        path = '%s/boa3_test/test_sc/interop_test/json/JsonSerializeStr.py' % self.dirname
+        path = self.get_contract_path('JsonSerializeStr.py')
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         expected_result = String(json.dumps('unit test')).to_bytes()
         result = self.run_smart_contract(engine, path, 'main',
                                          expected_result_type=bytes)
         self.assertEqual(expected_result, result)
 
     def test_json_serialize_bytes(self):
-        path = '%s/boa3_test/test_sc/interop_test/json/JsonSerializeBytes.py' % self.dirname
+        path = self.get_contract_path('JsonSerializeBytes.py')
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         expected_result = b'"unit test"'
         result = self.run_smart_contract(engine, path, 'main',
                                          expected_result_type=bytes)
         self.assertEqual(expected_result, result)
 
     def test_json_deserialize(self):
-        path = '%s/boa3_test/test_sc/interop_test/json/JsonDeserialize.py' % self.dirname
+        path = self.get_contract_path('JsonDeserialize.py')
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         test_input = String(json.dumps(12345)).to_bytes()
         expected_result = json.loads(test_input)
         result = self.run_smart_contract(engine, path, 'main', test_input)

--- a/boa3_test/tests/test_interop/test_runtime.py
+++ b/boa3_test/tests/test_interop/test_runtime.py
@@ -15,11 +15,13 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 class TestRuntimeInterop(BoaTest):
 
+    default_folder: str = 'test_sc/interop_test/runtime'
+
     def test_check_witness(self):
-        path = '%s/boa3_test/test_sc/interop_test/runtime/CheckWitness.py' % self.dirname
+        path = self.get_contract_path('CheckWitness.py')
         account = to_script_hash(b'NiNmXL8FjEUEs1nfX9uHFBNaenxDHJtmuB')
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', account)
         self.assertEqual(False, result)
 
@@ -28,10 +30,10 @@ class TestRuntimeInterop(BoaTest):
         self.assertEqual(True, result)
 
     def test_check_witness_imported_as(self):
-        path = '%s/boa3_test/test_sc/interop_test/runtime/CheckWitnessImportedAs.py' % self.dirname
+        path = self.get_contract_path('CheckWitnessImportedAs.py')
         account = to_script_hash(b'NiNmXL8FjEUEs1nfX9uHFBNaenxDHJtmuB')
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', account)
         self.assertEqual(False, result)
 
@@ -40,7 +42,7 @@ class TestRuntimeInterop(BoaTest):
         self.assertEqual(True, result)
 
     def test_check_witness_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/interop_test/runtime/CheckWitnessMismatchedType.py' % self.dirname
+        path = self.get_contract_path('CheckWitnessMismatchedType.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_notify_str(self):
@@ -61,11 +63,11 @@ class TestRuntimeInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/runtime/NotifyStr.py' % self.dirname
+        path = self.get_contract_path('NotifyStr.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertIsVoid(result)
         self.assertGreater(len(engine.notifications), 0)
@@ -88,11 +90,11 @@ class TestRuntimeInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/runtime/NotifyInt.py' % self.dirname
+        path = self.get_contract_path('NotifyInt.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertIsVoid(result)
         self.assertGreater(len(engine.notifications), 0)
@@ -115,11 +117,11 @@ class TestRuntimeInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/runtime/NotifyBool.py' % self.dirname
+        path = self.get_contract_path('NotifyBool.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertIsVoid(result)
         self.assertGreater(len(engine.notifications), 0)
@@ -142,11 +144,11 @@ class TestRuntimeInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/runtime/NotifyNone.py' % self.dirname
+        path = self.get_contract_path('NotifyNone.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertIsVoid(result)
         self.assertGreater(len(engine.notifications), 0)
@@ -174,11 +176,11 @@ class TestRuntimeInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/runtime/NotifySequence.py' % self.dirname
+        path = self.get_contract_path('NotifySequence.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertIsVoid(result)
         self.assertGreater(len(engine.notifications), 0)
@@ -188,7 +190,7 @@ class TestRuntimeInterop(BoaTest):
         self.assertEqual(([2, 3, 5, 7],), event_notifications[0].arguments)
 
     def test_log_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/interop_test/runtime/LogMismatchedValueInt.py' % self.dirname
+        path = self.get_contract_path('LogMismatchedValueInt.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_log_str(self):
@@ -202,11 +204,11 @@ class TestRuntimeInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/runtime/LogStr.py' % self.dirname
+        path = self.get_contract_path('LogStr.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertIsVoid(result)
 
@@ -217,11 +219,11 @@ class TestRuntimeInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/runtime/Trigger.py' % self.dirname
+        path = self.get_contract_path('Trigger.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(TriggerType.APPLICATION, result)
 
@@ -239,11 +241,11 @@ class TestRuntimeInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/runtime/TriggerApplication.py' % self.dirname
+        path = self.get_contract_path('TriggerApplication.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(True, result)
 
@@ -261,11 +263,11 @@ class TestRuntimeInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/runtime/TriggerVerification.py' % self.dirname
+        path = self.get_contract_path('TriggerVerification.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(False, result)
 
@@ -276,7 +278,7 @@ class TestRuntimeInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/runtime/CallingScriptHash.py' % self.dirname
+        path = self.get_contract_path('CallingScriptHash.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -290,7 +292,7 @@ class TestRuntimeInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/runtime/CallingScriptHashCantAssign.py' % self.dirname
+        path = self.get_contract_path('CallingScriptHashCantAssign.py')
         output = self.assertCompilerLogs(NameShadowing, path)
         self.assertEqual(expected_output, output)
 
@@ -301,7 +303,7 @@ class TestRuntimeInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/runtime/ExecutingScriptHash.py' % self.dirname
+        path = self.get_contract_path('ExecutingScriptHash.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -315,7 +317,7 @@ class TestRuntimeInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/runtime/ExecutingScriptHashCantAssign.py' % self.dirname
+        path = self.get_contract_path('ExecutingScriptHashCantAssign.py')
         output = self.assertCompilerLogs(NameShadowing, path)
         self.assertEqual(expected_output, output)
 
@@ -326,11 +328,11 @@ class TestRuntimeInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/runtime/BlockTime.py' % self.dirname
+        path = self.get_contract_path('BlockTime.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         new_block = engine.increase_block()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(new_block.timestamp, result)
@@ -345,7 +347,7 @@ class TestRuntimeInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/runtime/BlockTimeCantAssign.py' % self.dirname
+        path = self.get_contract_path('BlockTimeCantAssign.py')
         output = self.assertCompilerLogs(NameShadowing, path)
         self.assertEqual(expected_output, output)
 
@@ -356,7 +358,7 @@ class TestRuntimeInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/runtime/GasLeft.py' % self.dirname
+        path = self.get_contract_path('GasLeft.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -370,7 +372,7 @@ class TestRuntimeInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/runtime/GasLeftCantAssign.py' % self.dirname
+        path = self.get_contract_path('GasLeftCantAssign.py')
         output = self.assertCompilerLogs(NameShadowing, path)
         self.assertEqual(expected_output, output)
 
@@ -381,7 +383,7 @@ class TestRuntimeInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/runtime/InvocationCounter.py' % self.dirname
+        path = self.get_contract_path('InvocationCounter.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -395,20 +397,20 @@ class TestRuntimeInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/runtime/InvocationCounterCantAssign.py' % self.dirname
+        path = self.get_contract_path('InvocationCounterCantAssign.py')
         output = self.assertCompilerLogs(NameShadowing, path)
         self.assertEqual(expected_output, output)
 
     def test_get_notifications(self):
-        path = '%s/boa3_test/test_sc/interop_test/runtime/GetNotifications.py' % self.dirname
+        path = self.get_contract_path('GetNotifications.py')
         output, manifest = self.compile_and_save(path)
         script = hash160(output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'without_param', [])
         self.assertEqual([], result)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'without_param', [1, 2, 3])
         expected_result = []
         for x in [1, 2, 3]:
@@ -417,11 +419,11 @@ class TestRuntimeInterop(BoaTest):
                                     [x]])
         self.assertEqual(expected_result, result)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'with_param', [], script)
         self.assertEqual([], result)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'with_param', [1, 2, 3], script)
         expected_result = []
         for x in [1, 2, 3]:
@@ -430,7 +432,7 @@ class TestRuntimeInterop(BoaTest):
                                     [x]])
         self.assertEqual(expected_result, result)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'with_param', [1, 2, 3], b'\x01' * 20)
         self.assertEqual([], result)
 
@@ -441,7 +443,7 @@ class TestRuntimeInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/runtime/EntryScriptHash.py' % self.dirname
+        path = self.get_contract_path('EntryScriptHash.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -455,7 +457,7 @@ class TestRuntimeInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/runtime/EntryScriptHashCantAssign.py' % self.dirname
+        path = self.get_contract_path('EntryScriptHashCantAssign.py')
         output = self.assertCompilerLogs(NameShadowing, path)
         self.assertEqual(expected_output, output)
 
@@ -466,11 +468,11 @@ class TestRuntimeInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/runtime/GetPlatform.py' % self.dirname
+        path = self.get_contract_path('GetPlatform.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'main')
         self.assertEqual('NEO', result)
 
@@ -484,6 +486,6 @@ class TestRuntimeInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/runtime/GetPlatformCantAssign.py' % self.dirname
+        path = self.get_contract_path('GetPlatformCantAssign.py')
         output = self.assertCompilerLogs(NameShadowing, path)
         self.assertEqual(expected_output, output)

--- a/boa3_test/tests/test_interop/test_storage.py
+++ b/boa3_test/tests/test_interop/test_storage.py
@@ -12,6 +12,8 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 class TestStorageInterop(BoaTest):
 
+    default_folder: str = 'test_sc/interop_test/storage'
+
     def test_storage_get_bytes_key(self):
         expected_output = (
             Opcode.INITSLOT
@@ -34,7 +36,7 @@ class TestStorageInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/storage/StorageGetBytesKey.py' % self.dirname
+        path = self.get_contract_path('StorageGetBytesKey.py')
         output, manifest = self.compile_and_save(path)
         self.assertEqual(expected_output, output)
 
@@ -60,11 +62,11 @@ class TestStorageInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/storage/StorageGetStrKey.py' % self.dirname
+        path = self.get_contract_path('StorageGetStrKey.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 'example',
                                          expected_result_type=bytes)
         self.assertEqual(b'', result)
@@ -82,7 +84,7 @@ class TestStorageInterop(BoaTest):
         self.assertEqual(Integer(42).to_byte_array(), result)
 
     def test_storage_get_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/interop_test/storage/StorageGetMismatchedType.py' % self.dirname
+        path = self.get_contract_path('StorageGetMismatchedType.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_storage_get_context(self):
@@ -91,19 +93,19 @@ class TestStorageInterop(BoaTest):
             + Interop.StorageGetContext.interop_method_hash
             + Opcode.RET
         )
-        path = '%s/boa3_test/test_sc/interop_test/storage/StorageGetContext.py' % self.dirname
+        path = self.get_contract_path('StorageGetContext.py')
         output, manifest = self.compile_and_save(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'main')
         self.assertEqual(InteropInterface, result)  # returns an interop interface
 
     def test_storage_put_bytes_key_bytes_value(self):
-        path = '%s/boa3_test/test_sc/interop_test/storage/StoragePutBytesKeyBytesValue.py' % self.dirname
+        path = self.get_contract_path('StoragePutBytesKeyBytesValue.py')
         output = Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         stored_value = b'\x01\x02\x03'
         result = self.run_smart_contract(engine, path, 'Main', b'test1')
         self.assertIsVoid(result)
@@ -146,11 +148,11 @@ class TestStorageInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/storage/StoragePutBytesKeyIntValue.py' % self.dirname
+        path = self.get_contract_path('StoragePutBytesKeyIntValue.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         stored_value = Integer(123).to_byte_array()
         result = self.run_smart_contract(engine, path, 'Main', b'test1')
         self.assertIsVoid(result)
@@ -191,11 +193,11 @@ class TestStorageInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/storage/StoragePutBytesKeyStrValue.py' % self.dirname
+        path = self.get_contract_path('StoragePutBytesKeyStrValue.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         stored_value = String('123').to_bytes()
         result = self.run_smart_contract(engine, path, 'Main', 'test1')
         self.assertIsVoid(result)
@@ -216,10 +218,10 @@ class TestStorageInterop(BoaTest):
         self.assertEqual(stored_value, engine.storage[b'test2'])
 
     def test_storage_put_str_key_bytes_value(self):
-        path = '%s/boa3_test/test_sc/interop_test/storage/StoragePutStrKeyBytesValue.py' % self.dirname
+        path = self.get_contract_path('StoragePutStrKeyBytesValue.py')
         output = Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         stored_value = b'\x01\x02\x03'
         result = self.run_smart_contract(engine, path, 'Main', b'test1')
         self.assertIsVoid(result)
@@ -262,11 +264,11 @@ class TestStorageInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/storage/StoragePutStrKeyIntValue.py' % self.dirname
+        path = self.get_contract_path('StoragePutStrKeyIntValue.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         stored_value = Integer(123).to_byte_array()
         result = self.run_smart_contract(engine, path, 'Main', 'test1')
         self.assertIsVoid(result)
@@ -307,11 +309,11 @@ class TestStorageInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/storage/StoragePutStrKeyStrValue.py' % self.dirname
+        path = self.get_contract_path('StoragePutStrKeyStrValue.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         stored_value = String('123').to_bytes()
         result = self.run_smart_contract(engine, path, 'Main', 'test1')
         self.assertIsVoid(result)
@@ -332,11 +334,11 @@ class TestStorageInterop(BoaTest):
         self.assertEqual(stored_value, engine.storage[b'test2'])
 
     def test_storage_put_mismatched_type_key(self):
-        path = '%s/boa3_test/test_sc/interop_test/storage/StoragePutMismatchedTypeKey.py' % self.dirname
+        path = self.get_contract_path('StoragePutMismatchedTypeKey.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_storage_put_mismatched_type_value(self):
-        path = '%s/boa3_test/test_sc/interop_test/storage/StoragePutMismatchedTypeValue.py' % self.dirname
+        path = self.get_contract_path('StoragePutMismatchedTypeValue.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_storage_delete_bytes_key(self):
@@ -352,11 +354,11 @@ class TestStorageInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/storage/StorageDeleteBytesKey.py' % self.dirname
+        path = self.get_contract_path('StorageDeleteBytesKey.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', b'example')
         self.assertIsVoid(result)
         self.assertFalse(b'example' in engine.storage)
@@ -380,11 +382,11 @@ class TestStorageInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/interop_test/storage/StorageDeleteStrKey.py' % self.dirname
+        path = self.get_contract_path('StorageDeleteStrKey.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 'example')
         self.assertIsVoid(result)
         self.assertFalse(b'example' in engine.storage)
@@ -396,27 +398,27 @@ class TestStorageInterop(BoaTest):
         self.assertFalse(b'example' in engine.storage)
 
     def test_storage_delete_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/interop_test/storage/StorageDeleteMismatchedType.py' % self.dirname
+        path = self.get_contract_path('StorageDeleteMismatchedType.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_storage_find_bytes_prefix(self):
-        path = '%s/boa3_test/test_sc/interop_test/storage/StorageFindBytesPrefix.py' % self.dirname
+        path = self.get_contract_path('StorageFindBytesPrefix.py')
         self.compile_and_save(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'find_by_prefix', b'example')
         self.assertEqual(InteropInterface, result)  # returns an interop interface
         # TODO: validate actual result when Enumerator.next() and Enumerator.value() are implemented
 
     def test_storage_find_str_prefix(self):
-        path = '%s/boa3_test/test_sc/interop_test/storage/StorageFindStrPrefix.py' % self.dirname
+        path = self.get_contract_path('StorageFindStrPrefix.py')
         self.compile_and_save(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'find_by_prefix', 'example')
         self.assertEqual(InteropInterface, result)  # returns an interop interface
         # TODO: validate actual result when Enumerator.next() and Enumerator.value() are implemented
 
     def test_storage_find_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/interop_test/storage/StorageFindMismatchedType.py' % self.dirname
+        path = self.get_contract_path('StorageFindMismatchedType.py')
         self.assertCompilerLogs(MismatchedTypes, path)

--- a/boa3_test/tests/test_list.py
+++ b/boa3_test/tests/test_list.py
@@ -13,6 +13,8 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 class TestList(BoaTest):
 
+    default_folder: str = 'test_sc/list_test'
+
     def test_list_int_values(self):
         expected_output = (
             Opcode.INITSLOT     # function signature
@@ -28,7 +30,7 @@ class TestList(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/list_test/IntList.py' % self.dirname
+        path = self.get_contract_path('IntList.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -56,7 +58,7 @@ class TestList(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/list_test/StrList.py' % self.dirname
+        path = self.get_contract_path('StrList.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -74,7 +76,7 @@ class TestList(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/list_test/BoolList.py' % self.dirname
+        path = self.get_contract_path('BoolList.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -98,12 +100,12 @@ class TestList(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/list_test/VariableList.py' % self.dirname
+        path = self.get_contract_path('VariableList.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
     def test_non_sequence_get_value(self):
-        path = '%s/boa3_test/test_sc/list_test/MismatchedTypeGetValue.py' % self.dirname
+        path = self.get_contract_path('MismatchedTypeGetValue.py')
         self.assertCompilerLogs(UnresolvedOperation, path)
 
     def test_list_get_value(self):
@@ -125,11 +127,11 @@ class TestList(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/list_test/GetValue.py' % self.dirname
+        path = self.get_contract_path('GetValue.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', [1, 2, 3, 4])
         self.assertEqual(1, result)
         result = self.run_smart_contract(engine, path, 'Main', [5, 3, 2])
@@ -157,11 +159,11 @@ class TestList(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/list_test/GetValueNegativeIndex.py' % self.dirname
+        path = self.get_contract_path('GetValueNegativeIndex.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', [1, 2, 3, 4])
         self.assertEqual(4, result)
         result = self.run_smart_contract(engine, path, 'Main', [5, 3, 2])
@@ -184,7 +186,7 @@ class TestList(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/list_test/TypeHintAssignment.py' % self.dirname
+        path = self.get_contract_path('TypeHintAssignment.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -198,7 +200,7 @@ class TestList(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/list_test/EmptyListAssignment.py' % self.dirname
+        path = self.get_contract_path('EmptyListAssignment.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -223,11 +225,11 @@ class TestList(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/list_test/SetValue.py' % self.dirname
+        path = self.get_contract_path('SetValue.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', [1, 2, 3, 4])
         self.assertEqual([1, 2, 3, 4], result)
         result = self.run_smart_contract(engine, path, 'Main', [5, 3, 2])
@@ -257,11 +259,11 @@ class TestList(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/list_test/SetValueNegativeIndex.py' % self.dirname
+        path = self.get_contract_path('SetValueNegativeIndex.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', [1, 2, 3, 4])
         self.assertEqual([1, 2, 3, 1], result)
         result = self.run_smart_contract(engine, path, 'Main', [5, 3, 2])
@@ -271,18 +273,18 @@ class TestList(BoaTest):
             self.run_smart_contract(engine, path, 'Main', [])
 
     def test_non_sequence_set_value(self):
-        path = '%s/boa3_test/test_sc/list_test/MismatchedTypeSetValue.py' % self.dirname
+        path = self.get_contract_path('MismatchedTypeSetValue.py')
         self.assertCompilerLogs(UnresolvedOperation, path)
 
     def test_list_index_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/list_test/MismatchedTypeListIndex.py' % self.dirname
+        path = self.get_contract_path('MismatchedTypeListIndex.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_array_boa2_test1(self):
-        path = '%s/boa3_test/test_sc/list_test/ArrayBoa2Test1.py' % self.dirname
+        path = self.get_contract_path('ArrayBoa2Test1.py')
         Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main',
                                          expected_result_type=bool)
         self.assertEqual(True, result)
@@ -317,11 +319,11 @@ class TestList(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/list_test/ListOfList.py' % self.dirname
+        path = self.get_contract_path('ListOfList.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', [[1, 2], [3, 4]])
         self.assertEqual(1, result)
 
@@ -349,11 +351,11 @@ class TestList(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/list_test/Nep5Main.py' % self.dirname
+        path = self.get_contract_path('Nep5Main.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 'op', [1, 2, 3, 4])
         self.assertEqual(1, result)
         result = self.run_smart_contract(engine, path, 'Main', 'op', ['a', False])
@@ -449,11 +451,11 @@ class TestList(BoaTest):
             + Opcode.DROP
             + Opcode.RET        # return
         )
-        path = '%s/boa3_test/test_sc/list_test/ListSlicingLiteralValues.py' % self.dirname
+        path = self.get_contract_path('ListSlicingLiteralValues.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([2], result)
 
@@ -546,11 +548,11 @@ class TestList(BoaTest):
             + Opcode.DROP
             + Opcode.RET        # return
         )
-        path = '%s/boa3_test/test_sc/list_test/ListSlicingVariableValues.py' % self.dirname
+        path = self.get_contract_path('ListSlicingVariableValues.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([2], result)
 
@@ -631,11 +633,11 @@ class TestList(BoaTest):
             + Opcode.DROP
             + Opcode.RET        # return
         )
-        path = '%s/boa3_test/test_sc/list_test/ListSlicingNegativeStart.py' % self.dirname
+        path = self.get_contract_path('ListSlicingNegativeStart.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([2, 3, 4, 5], result)
 
@@ -714,11 +716,11 @@ class TestList(BoaTest):
             + Opcode.DROP
             + Opcode.RET        # return
         )
-        path = '%s/boa3_test/test_sc/list_test/ListSlicingNegativeEnd.py' % self.dirname
+        path = self.get_contract_path('ListSlicingNegativeEnd.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([0, 1], result)
 
@@ -796,11 +798,11 @@ class TestList(BoaTest):
             + Opcode.DROP
             + Opcode.RET        # return
         )
-        path = '%s/boa3_test/test_sc/list_test/ListSlicingStartOmitted.py' % self.dirname
+        path = self.get_contract_path('ListSlicingStartOmitted.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([0, 1, 2], result)
 
@@ -823,11 +825,11 @@ class TestList(BoaTest):
             + Opcode.PACK
             + Opcode.RET        # return
         )
-        path = '%s/boa3_test/test_sc/list_test/ListSlicingOmitted.py' % self.dirname
+        path = self.get_contract_path('ListSlicingOmitted.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([0, 1, 2, 3, 4, 5], result)
 
@@ -906,20 +908,20 @@ class TestList(BoaTest):
             + Opcode.DROP
             + Opcode.RET        # return
         )
-        path = '%s/boa3_test/test_sc/list_test/ListSlicingEndOmitted.py' % self.dirname
+        path = self.get_contract_path('ListSlicingEndOmitted.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([2, 3, 4, 5], result)
 
     def test_list_slicing_omitted_stride(self):
-        path = '%s/boa3_test/test_sc/list_test/ListSlicingWithStride.py' % self.dirname
+        path = self.get_contract_path('ListSlicingWithStride.py')
         self.assertCompilerLogs(InternalError, path)
 
     def test_list_slicing_omitted_with_stride(self):
-        path = '%s/boa3_test/test_sc/list_test/ListSlicingOmittedWithStride.py' % self.dirname
+        path = self.get_contract_path('ListSlicingOmittedWithStride.py')
         self.assertCompilerLogs(InternalError, path)
 
     # endregion
@@ -955,11 +957,11 @@ class TestList(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/list_test/AppendIntValue.py' % self.dirname
+        path = self.get_contract_path('AppendIntValue.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([1, 2, 3, 4], result)
 
@@ -996,16 +998,16 @@ class TestList(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/list_test/AppendAnyValue.py' % self.dirname
+        path = self.get_contract_path('AppendAnyValue.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([1, 2, 3, '4'], result)
 
     def test_list_append_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/list_test/MismatchedTypeAppendValue.py' % self.dirname
+        path = self.get_contract_path('MismatchedTypeAppendValue.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_list_append_with_builtin(self):
@@ -1037,22 +1039,22 @@ class TestList(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/list_test/AppendIntWithBuiltin.py' % self.dirname
+        path = self.get_contract_path('AppendIntWithBuiltin.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([1, 2, 3, 4], result)
 
     def test_list_append_with_builtin_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/list_test/MismatchedTypeAppendWithBuiltin.py' % self.dirname
+        path = self.get_contract_path('MismatchedTypeAppendWithBuiltin.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     # endregion
 
     def test_list_clear(self):
-        path = '%s/boa3_test/test_sc/list_test/ClearList.py' % self.dirname
+        path = self.get_contract_path('ClearList.py')
 
         expected_output = (
             Opcode.INITSLOT     # function signature
@@ -1088,7 +1090,7 @@ class TestList(BoaTest):
         self.assertEqual(expected_output, output)
 
     def test_list_reverse(self):
-        path = '%s/boa3_test/test_sc/list_test/ReverseList.py' % self.dirname
+        path = self.get_contract_path('ReverseList.py')
 
         expected_output = (
             Opcode.INITSLOT     # function signature
@@ -1111,39 +1113,39 @@ class TestList(BoaTest):
     # region TestExtend
 
     def test_list_extend_tuple_value(self):
-        path = '%s/boa3_test/test_sc/list_test/ExtendTupleValue.py' % self.dirname
+        path = self.get_contract_path('ExtendTupleValue.py')
         output = Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([1, 2, 3, 4, 5, 6], result)
 
     def test_list_extend_any_value(self):
-        path = '%s/boa3_test/test_sc/list_test/ExtendAnyValue.py' % self.dirname
+        path = self.get_contract_path('ExtendAnyValue.py')
         output = Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([1, 2, 3, '4', 5, 1], result)
 
     def test_list_extend_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/list_test/MismatchedTypeExtendValue.py' % self.dirname
+        path = self.get_contract_path('MismatchedTypeExtendValue.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_list_extend_mismatched_iterable_value_type(self):
-        path = '%s/boa3_test/test_sc/list_test/MismatchedTypeExtendTupleValue.py' % self.dirname
+        path = self.get_contract_path('MismatchedTypeExtendTupleValue.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_list_extend_with_builtin(self):
-        path = '%s/boa3_test/test_sc/list_test/ExtendWithBuiltin.py' % self.dirname
+        path = self.get_contract_path('ExtendWithBuiltin.py')
         output = Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([1, 2, 3, 4, 5, 6], result)
 
     def test_list_extend_with_builtin_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/list_test/MismatchedTypeExtendWithBuiltin.py' % self.dirname
+        path = self.get_contract_path('MismatchedTypeExtendWithBuiltin.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     # endregion
@@ -1183,7 +1185,7 @@ class TestList(BoaTest):
             + Opcode.LDLOC1     # return b
             + Opcode.RET
         )
-        path = '%s/boa3_test/test_sc/list_test/PopList.py' % self.dirname
+        path = self.get_contract_path('PopList.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -1220,7 +1222,7 @@ class TestList(BoaTest):
             + Opcode.LDLOC0     # return a
             + Opcode.RET
         )
-        path = '%s/boa3_test/test_sc/list_test/PopListWithoutAssignment.py' % self.dirname
+        path = self.get_contract_path('PopListWithoutAssignment.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -1257,7 +1259,7 @@ class TestList(BoaTest):
             + Opcode.LDLOC1     # return b
             + Opcode.RET
         )
-        path = '%s/boa3_test/test_sc/list_test/PopListLiteralArgument.py' % self.dirname
+        path = self.get_contract_path('PopListLiteralArgument.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -1295,7 +1297,7 @@ class TestList(BoaTest):
             + Opcode.LDLOC1     # return b
             + Opcode.RET
         )
-        path = '%s/boa3_test/test_sc/list_test/PopListLiteralNegativeArgument.py' % self.dirname
+        path = self.get_contract_path('PopListLiteralNegativeArgument.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -1332,20 +1334,20 @@ class TestList(BoaTest):
             + Opcode.LDLOC1     # return b
             + Opcode.RET
         )
-        path = '%s/boa3_test/test_sc/list_test/PopListVariableArgument.py' % self.dirname
+        path = self.get_contract_path('PopListVariableArgument.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
     def test_list_pop_mismatched_type_argument(self):
-        path = '%s/boa3_test/test_sc/list_test/PopListMismatchedTypeArgument.py' % self.dirname
+        path = self.get_contract_path('PopListMismatchedTypeArgument.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_list_pop_mismatched_type_result(self):
-        path = '%s/boa3_test/test_sc/list_test/PopListMismatchedTypeResult.py' % self.dirname
+        path = self.get_contract_path('PopListMismatchedTypeResult.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_list_pop_too_many_arguments(self):
-        path = '%s/boa3_test/test_sc/list_test/PopListTooManyArguments.py' % self.dirname
+        path = self.get_contract_path('PopListTooManyArguments.py')
         self.assertCompilerLogs(UnexpectedArgument, path)
 
     # endregion

--- a/boa3_test/tests/test_logical.py
+++ b/boa3_test/tests/test_logical.py
@@ -7,6 +7,8 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 class TestLogical(BoaTest):
 
+    default_folder: str = 'test_sc/logical_test'
+
     def test_boolean_and(self):
         expected_output = (
             Opcode.INITSLOT
@@ -18,11 +20,11 @@ class TestLogical(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/logical_test/BoolAnd.py' % self.dirname
+        path = self.get_contract_path('BoolAnd.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', True, True)
         self.assertEqual(True, result)
         result = self.run_smart_contract(engine, path, 'Main', True, False)
@@ -43,11 +45,11 @@ class TestLogical(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/logical_test/BoolOr.py' % self.dirname
+        path = self.get_contract_path('BoolOr.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', True, True)
         self.assertEqual(True, result)
         result = self.run_smart_contract(engine, path, 'Main', True, False)
@@ -67,11 +69,11 @@ class TestLogical(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/logical_test/BoolNot.py' % self.dirname
+        path = self.get_contract_path('BoolNot.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', True)
         self.assertEqual(False, result)
         result = self.run_smart_contract(engine, path, 'Main', False)
@@ -90,11 +92,11 @@ class TestLogical(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/logical_test/BoolOrThreeElements.py' % self.dirname
+        path = self.get_contract_path('BoolOrThreeElements.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', True, False, False)
         self.assertEqual(True, result)
         result = self.run_smart_contract(engine, path, 'Main', False, True, False)
@@ -105,11 +107,11 @@ class TestLogical(BoaTest):
         self.assertEqual(True, result)
 
     def test_mismatched_type_binary_operation(self):
-        path = '%s/boa3_test/test_sc/logical_test/MismatchedOperandAnd.py' % self.dirname
+        path = self.get_contract_path('MismatchedOperandAnd.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_mismatched_type_unary_operation(self):
-        path = '%s/boa3_test/test_sc/logical_test/MismatchedOperandNot.py' % self.dirname
+        path = self.get_contract_path('MismatchedOperandNot.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_mixed_operations(self):
@@ -126,11 +128,11 @@ class TestLogical(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/logical_test/MixedOperations.py' % self.dirname
+        path = self.get_contract_path('MixedOperations.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', True, False, False)
         self.assertEqual(False, result)
         result = self.run_smart_contract(engine, path, 'Main', False, True, False)
@@ -151,11 +153,11 @@ class TestLogical(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/logical_test/LogicAndBool.py' % self.dirname
+        path = self.get_contract_path('LogicAndBool.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', True, True)
         self.assertEqual(True, result)
         result = self.run_smart_contract(engine, path, 'Main', True, False)
@@ -174,11 +176,11 @@ class TestLogical(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/logical_test/LogicAndInt.py' % self.dirname
+        path = self.get_contract_path('LogicAndInt.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 4, 6)
         self.assertEqual(4 & 6, result)
         result = self.run_smart_contract(engine, path, 'Main', 40, 6)
@@ -187,7 +189,7 @@ class TestLogical(BoaTest):
         self.assertEqual(-4 & 32, result)
 
     def test_mismatched_type_logic_and(self):
-        path = '%s/boa3_test/test_sc/logical_test/MismatchedOperandLogicAnd.py' % self.dirname
+        path = self.get_contract_path('MismatchedOperandLogicAnd.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_logic_or_with_bool_operand(self):
@@ -201,11 +203,11 @@ class TestLogical(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/logical_test/LogicOrBool.py' % self.dirname
+        path = self.get_contract_path('LogicOrBool.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', True, True)
         self.assertEqual(True, result)
         result = self.run_smart_contract(engine, path, 'Main', True, False)
@@ -224,11 +226,11 @@ class TestLogical(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/logical_test/LogicOrInt.py' % self.dirname
+        path = self.get_contract_path('LogicOrInt.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 4, 6)
         self.assertEqual(4 | 6, result)
         result = self.run_smart_contract(engine, path, 'Main', 40, 6)
@@ -237,7 +239,7 @@ class TestLogical(BoaTest):
         self.assertEqual(-4 | 32, result)
 
     def test_mismatched_type_logic_or(self):
-        path = '%s/boa3_test/test_sc/logical_test/MismatchedOperandLogicOr.py' % self.dirname
+        path = self.get_contract_path('MismatchedOperandLogicOr.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_logic_not_with_bool_operand(self):
@@ -250,11 +252,11 @@ class TestLogical(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/logical_test/LogicNotBool.py' % self.dirname
+        path = self.get_contract_path('LogicNotBool.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', True)
         self.assertEqual(-2, result)
         result = self.run_smart_contract(engine, path, 'Main', False)
@@ -270,11 +272,11 @@ class TestLogical(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/logical_test/LogicNotInt.py' % self.dirname
+        path = self.get_contract_path('LogicNotInt.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 4)
         self.assertEqual(-5, result)
         result = self.run_smart_contract(engine, path, 'Main', 40)
@@ -283,7 +285,7 @@ class TestLogical(BoaTest):
         self.assertEqual(3, result)
 
     def test_mismatched_type_logic_not(self):
-        path = '%s/boa3_test/test_sc/logical_test/MismatchedOperandLogicNot.py' % self.dirname
+        path = self.get_contract_path('MismatchedOperandLogicNot.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_logic_xor_with_bool_operand(self):
@@ -297,11 +299,11 @@ class TestLogical(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/logical_test/LogicXorBool.py' % self.dirname
+        path = self.get_contract_path('LogicXorBool.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', True, True)
         self.assertEqual(False, result)
         result = self.run_smart_contract(engine, path, 'Main', True, False)
@@ -320,11 +322,11 @@ class TestLogical(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/logical_test/LogicXorInt.py' % self.dirname
+        path = self.get_contract_path('LogicXorInt.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 4, 6)
         self.assertEqual(4 ^ 6, result)
         result = self.run_smart_contract(engine, path, 'Main', 40, 6)
@@ -333,7 +335,7 @@ class TestLogical(BoaTest):
         self.assertEqual(-4 ^ 32, result)
 
     def test_mismatched_type_logic_xor(self):
-        path = '%s/boa3_test/test_sc/logical_test/MismatchedOperandLogicXor.py' % self.dirname
+        path = self.get_contract_path('MismatchedOperandLogicXor.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_logic_left_shift(self):
@@ -347,11 +349,11 @@ class TestLogical(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/logical_test/LogicLeftShift.py' % self.dirname
+        path = self.get_contract_path('LogicLeftShift.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', int('100', 2), 2)
         self.assertEqual(int('10000', 2), result)
         result = self.run_smart_contract(engine, path, 'Main', int('11', 2), 1)
@@ -360,7 +362,7 @@ class TestLogical(BoaTest):
         self.assertEqual(int('1010100000', 2), result)
 
     def test_mismatched_type_logic_left_shift(self):
-        path = '%s/boa3_test/test_sc/logical_test/MismatchedOperandLogicLeftShift.py' % self.dirname
+        path = self.get_contract_path('MismatchedOperandLogicLeftShift.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_logic_right_shift(self):
@@ -374,11 +376,11 @@ class TestLogical(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/logical_test/LogicRightShift.py' % self.dirname
+        path = self.get_contract_path('LogicRightShift.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', int('10000', 2), 2)
         self.assertEqual(int('100', 2), result)
         result = self.run_smart_contract(engine, path, 'Main', int('110', 2), 1)
@@ -387,5 +389,5 @@ class TestLogical(BoaTest):
         self.assertEqual(int('101010', 2), result)
 
     def test_mismatched_type_logic_right_shift(self):
-        path = '%s/boa3_test/test_sc/logical_test/MismatchedOperandLogicRightShift.py' % self.dirname
+        path = self.get_contract_path('MismatchedOperandLogicRightShift.py')
         self.assertCompilerLogs(MismatchedTypes, path)

--- a/boa3_test/tests/test_metadata.py
+++ b/boa3_test/tests/test_metadata.py
@@ -7,13 +7,15 @@ from boa3_test.tests.boa_test import BoaTest
 
 class TestMetadata(BoaTest):
 
+    default_folder: str = 'test_sc/metadata_test'
+
     def test_metadata_info_method(self):
         expected_output = (
             Opcode.PUSH5        # return 5
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/metadata_test/MetadataInfoMethod.py' % self.dirname
+        path = self.get_contract_path('MetadataInfoMethod.py')
         output, manifest = self.compile_and_save(path)
         self.assertEqual(expected_output, output)
 
@@ -26,11 +28,11 @@ class TestMetadata(BoaTest):
         self.assertIsNone(manifest['extra'])
 
     def test_metadata_info_method_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/metadata_test/MetadataInfoMethodMismatchedReturn.py' % self.dirname
+        path = self.get_contract_path('MetadataInfoMethodMismatchedReturn.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_metadata_info_method_no_return(self):
-        path = '%s/boa3_test/test_sc/metadata_test/MetadataInfoMethodNoReturn.py' % self.dirname
+        path = self.get_contract_path('MetadataInfoMethodNoReturn.py')
         self.assertCompilerLogs(MissingReturnStatement, path)
 
     def test_metadata_info_multiple_method(self):
@@ -39,7 +41,7 @@ class TestMetadata(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/metadata_test/MetadataInfoMultipleMethod.py' % self.dirname
+        path = self.get_contract_path('MetadataInfoMultipleMethod.py')
         self.assertCompilerLogs(RedeclaredSymbol, path)
 
         output, manifest = self.compile_and_save(path)
@@ -51,19 +53,19 @@ class TestMetadata(BoaTest):
         self.assertEqual('func1', manifest['extra']['Description'])
 
     def test_metadata_method_with_args(self):
-        path = '%s/boa3_test/test_sc/metadata_test/MetadataMethodWithArgs.py' % self.dirname
+        path = self.get_contract_path('MetadataMethodWithArgs.py')
         self.assertCompilerLogs(UnexpectedArgument, path)
 
     def test_metadata_method_called_by_user_method(self):
-        path = '%s/boa3_test/test_sc/metadata_test/MetadataMethodCalledByUserMethod.py' % self.dirname
+        path = self.get_contract_path('MetadataMethodCalledByUserMethod.py')
         self.assertCompilerLogs(UnresolvedReference, path)
 
     def test_metadata_object_call_user_method(self):
-        path = '%s/boa3_test/test_sc/metadata_test/MetadataObjectCallUserMethod.py' % self.dirname
+        path = self.get_contract_path('MetadataObjectCallUserMethod.py')
         self.assertCompilerLogs(UnresolvedReference, path)
 
     def test_metadata_object_type_user_method(self):
-        path = '%s/boa3_test/test_sc/metadata_test/MetadataObjectTypeUserMethod.py' % self.dirname
+        path = self.get_contract_path('MetadataObjectTypeUserMethod.py')
         self.assertCompilerLogs(UnresolvedReference, path)
 
     def test_metadata_info_author(self):
@@ -72,7 +74,7 @@ class TestMetadata(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/metadata_test/MetadataInfoAuthor.py' % self.dirname
+        path = self.get_contract_path('MetadataInfoAuthor.py')
         output, manifest = self.compile_and_save(path)
         self.assertEqual(expected_output, output)
 
@@ -82,7 +84,7 @@ class TestMetadata(BoaTest):
         self.assertEqual('Test', manifest['extra']['Author'])
 
     def test_metadata_info_author_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/metadata_test/MetadataInfoAuthorMismatchedType.py' % self.dirname
+        path = self.get_contract_path('MetadataInfoAuthorMismatchedType.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_metadata_info_email(self):
@@ -91,7 +93,7 @@ class TestMetadata(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/metadata_test/MetadataInfoEmail.py' % self.dirname
+        path = self.get_contract_path('MetadataInfoEmail.py')
         output, manifest = self.compile_and_save(path)
         self.assertEqual(expected_output, output)
 
@@ -101,7 +103,7 @@ class TestMetadata(BoaTest):
         self.assertEqual('test@test.com', manifest['extra']['Email'])
 
     def test_metadata_info_email_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/metadata_test/MetadataInfoEmailMismatchedType.py' % self.dirname
+        path = self.get_contract_path('MetadataInfoEmailMismatchedType.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_metadata_info_description(self):
@@ -110,7 +112,7 @@ class TestMetadata(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/metadata_test/MetadataInfoDescription.py' % self.dirname
+        path = self.get_contract_path('MetadataInfoDescription.py')
         output, manifest = self.compile_and_save(path)
         self.assertEqual(expected_output, output)
 
@@ -120,7 +122,7 @@ class TestMetadata(BoaTest):
         self.assertEqual('This is an example', manifest['extra']['Description'])
 
     def test_metadata_info_description_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/metadata_test/MetadataInfoDescriptionMismatchedType.py' % self.dirname
+        path = self.get_contract_path('MetadataInfoDescriptionMismatchedType.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_metadata_info_extras(self):
@@ -129,7 +131,7 @@ class TestMetadata(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/metadata_test/MetadataInfoExtras.py' % self.dirname
+        path = self.get_contract_path('MetadataInfoExtras.py')
         output, manifest = self.compile_and_save(path)
         self.assertEqual(expected_output, output)
 

--- a/boa3_test/tests/test_multiple_expressions.py
+++ b/boa3_test/tests/test_multiple_expressions.py
@@ -8,6 +8,8 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 class TestMultipleExpressions(BoaTest):
 
+    default_folder: str = 'test_sc'
+
     def test_multiple_arithmetic_expressions(self):
         expected_output = (
             Opcode.INITSLOT     # function signature
@@ -25,11 +27,11 @@ class TestMultipleExpressions(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/arithmetic_test/MultipleExpressionsInLine.py' % self.dirname
+        path = self.get_contract_path('arithmetic_test', 'MultipleExpressionsInLine.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 1, 2)
         self.assertEqual(3, result)
         result = self.run_smart_contract(engine, path, 'Main', 5, -7)
@@ -57,11 +59,11 @@ class TestMultipleExpressions(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/relational_test/MultipleExpressionsInLine.py' % self.dirname
+        path = self.get_contract_path('relational_test', 'MultipleExpressionsInLine.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 1, 2)
         self.assertEqual(True, result)
         result = self.run_smart_contract(engine, path, 'Main', 5, -7)
@@ -95,11 +97,11 @@ class TestMultipleExpressions(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/logical_test/MultipleExpressionsInLine.py' % self.dirname
+        path = self.get_contract_path('logical_test', 'MultipleExpressionsInLine.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', True, False, False)
         self.assertEqual(False, result)
         result = self.run_smart_contract(engine, path, 'Main', False, True, False)
@@ -151,11 +153,11 @@ class TestMultipleExpressions(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/tuple_test/MultipleExpressionsInLine.py' % self.dirname
+        path = self.get_contract_path('tuple_test', 'MultipleExpressionsInLine.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', [1, 2])
         self.assertEqual(5, result)
         result = self.run_smart_contract(engine, path, 'Main', [-5, -7])
@@ -200,11 +202,11 @@ class TestMultipleExpressions(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/list_test/MultipleExpressionsInLine.py' % self.dirname
+        path = self.get_contract_path('list_test', 'MultipleExpressionsInLine.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', [2, 1])
         self.assertEqual(7, result)
         result = self.run_smart_contract(engine, path, 'Main', [-7, 5])

--- a/boa3_test/tests/test_neo_types.py
+++ b/boa3_test/tests/test_neo_types.py
@@ -6,10 +6,12 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 class TestNeoTypes(BoaTest):
 
-    def test_uint160_call_bytes(self):
-        path = '%s/boa3_test/test_sc/neo_type_test/UInt160CallBytes.py' % self.dirname
+    default_folder: str = 'test_sc/neo_type_test'
 
-        engine = TestEngine(self.dirname)
+    def test_uint160_call_bytes(self):
+        path = self.get_contract_path('UInt160CallBytes.py')
+
+        engine = TestEngine()
         value = bytes(20)
         result = self.run_smart_contract(engine, path, 'uint160', value,
                                          expected_result_type=bytes)
@@ -29,10 +31,10 @@ class TestNeoTypes(BoaTest):
                                     expected_result_type=bytes)
 
     def test_uint160_call_int(self):
-        path = '%s/boa3_test/test_sc/neo_type_test/UInt160CallInt.py' % self.dirname
+        path = self.get_contract_path('UInt160CallInt.py')
         self.compile_and_save(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'uint160', 0,
                                          expected_result_type=bytes)
         self.assertEqual(bytes(20), result)
@@ -51,17 +53,17 @@ class TestNeoTypes(BoaTest):
                                     expected_result_type=bytes)
 
     def test_uint160_call_without_args(self):
-        path = '%s/boa3_test/test_sc/neo_type_test/UInt160CallWithoutArgs.py' % self.dirname
+        path = self.get_contract_path('UInt160CallWithoutArgs.py')
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'uint160',
                                          expected_result_type=bytes)
         self.assertEqual(bytes(20), result)
 
     def test_uint160_return_bytes(self):
-        path = '%s/boa3_test/test_sc/neo_type_test/UInt160ReturnBytes.py' % self.dirname
+        path = self.get_contract_path('UInt160ReturnBytes.py')
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         value = bytes(20)
         result = self.run_smart_contract(engine, path, 'uint160', value,
                                          expected_result_type=bytes)
@@ -81,10 +83,10 @@ class TestNeoTypes(BoaTest):
                                     expected_result_type=bytes)
 
     def test_uint160_concat_with_bytes(self):
-        path = '%s/boa3_test/test_sc/neo_type_test/UInt160ConcatWithBytes.py' % self.dirname
+        path = self.get_contract_path('UInt160ConcatWithBytes.py')
         self.compile_and_save(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         value = bytes(20)
         result = self.run_smart_contract(engine, path, 'uint160_method', value,
                                          expected_result_type=bytes)

--- a/boa3_test/tests/test_none.py
+++ b/boa3_test/tests/test_none.py
@@ -7,8 +7,10 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 class TestNone(BoaTest):
 
+    default_folder: str = 'test_sc/none_test'
+
     def test_variable_none(self):
-        path = '%s/boa3_test/test_sc/none_test/VariableNone.py' % self.dirname
+        path = self.get_contract_path('VariableNone.py')
 
         expected_output = (
             Opcode.INITSLOT     # function signature
@@ -22,7 +24,7 @@ class TestNone(BoaTest):
         self.assertEqual(expected_output, output)
 
     def test_none_tuple(self):
-        path = '%s/boa3_test/test_sc/none_test/NoneTuple.py' % self.dirname
+        path = self.get_contract_path('NoneTuple.py')
 
         expected_output = (
             Opcode.INITSLOT     # function signature
@@ -49,11 +51,11 @@ class TestNone(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/none_test/NoneIdentity.py' % self.dirname
+        path = self.get_contract_path('NoneIdentity.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', None)
         self.assertEqual(True, result)
         result = self.run_smart_contract(engine, path, 'Main', 5)
@@ -72,11 +74,11 @@ class TestNone(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/none_test/NoneNotIdentity.py' % self.dirname
+        path = self.get_contract_path('NoneNotIdentity.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', None)
         self.assertEqual(False, result)
         result = self.run_smart_contract(engine, path, 'Main', 5)
@@ -85,17 +87,17 @@ class TestNone(BoaTest):
         self.assertEqual(True, result)
 
     def test_none_equality(self):
-        path = '%s/boa3_test/test_sc/none_test/NoneEquality.py' % self.dirname
+        path = self.get_contract_path('NoneEquality.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_mismatched_type_int_operation(self):
-        path = '%s/boa3_test/test_sc/none_test/MismatchedTypesInOperation.py' % self.dirname
+        path = self.get_contract_path('MismatchedTypesInOperation.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_mismatched_type_assign(self):
-        path = '%s/boa3_test/test_sc/none_test/MismatchedTypesAssign.py' % self.dirname
+        path = self.get_contract_path('MismatchedTypesAssign.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_mismatched_type_after_reassign(self):
-        path = '%s/boa3_test/test_sc/none_test/MismatchedTypesAfterReassign.py' % self.dirname
+        path = self.get_contract_path('MismatchedTypesAfterReassign.py')
         self.assertCompilerLogs(MismatchedTypes, path)

--- a/boa3_test/tests/test_range.py
+++ b/boa3_test/tests/test_range.py
@@ -14,6 +14,8 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 class TestRange(BoaTest):
 
+    default_folder: str = 'test_sc/range_test'
+
     RANGE_ERROR_MESSAGE = String('range() arg 3 must not be zero').to_bytes()
 
     def test_range_given_length(self):
@@ -65,11 +67,11 @@ class TestRange(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/range_test/RangeGivenLen.py' % self.dirname
+        path = self.get_contract_path('RangeGivenLen.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'range_example', 5)
         self.assertEqual([0, 1, 2, 3, 4], result)
         result = self.run_smart_contract(engine, path, 'range_example', 10)
@@ -126,11 +128,11 @@ class TestRange(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/range_test/RangeGivenStart.py' % self.dirname
+        path = self.get_contract_path('RangeGivenStart.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'range_example', 2, 6)
         self.assertEqual([2, 3, 4, 5], result)
         result = self.run_smart_contract(engine, path, 'range_example', -10, 0)
@@ -185,18 +187,18 @@ class TestRange(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/range_test/RangeGivenStep.py' % self.dirname
+        path = self.get_contract_path('RangeGivenStep.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'range_example', 2, 10, 3)
         self.assertEqual([2, 5, 8], result)
         result = self.run_smart_contract(engine, path, 'range_example', -2, 10, 3)
         self.assertEqual([-2, 1, 4, 7], result)
 
     def test_range_parameter_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/range_test/RangeParameterMismatchedType.py' % self.dirname
+        path = self.get_contract_path('RangeParameterMismatchedType.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_range_as_sequence(self):
@@ -248,26 +250,26 @@ class TestRange(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/range_test/RangeExpectedSequence.py' % self.dirname
+        path = self.get_contract_path('RangeExpectedSequence.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'range_example', 2, 6)
         self.assertEqual([2, 3, 4, 5], result)
         result = self.run_smart_contract(engine, path, 'range_example', -10, 0)
         self.assertEqual([-10, -9, -8, -7, -6, -5, -4, -3, -2, -1], result)
 
     def test_range_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/range_test/RangeMismatchedType.py' % self.dirname
+        path = self.get_contract_path('RangeMismatchedType.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_range_too_few_parameters(self):
-        path = '%s/boa3_test/test_sc/range_test/RangeTooFewParameters.py' % self.dirname
+        path = self.get_contract_path('RangeTooFewParameters.py')
         self.assertCompilerLogs(UnfilledArgument, path)
 
     def test_range_too_many_parameters(self):
-        path = '%s/boa3_test/test_sc/range_test/RangeTooManyParameters.py' % self.dirname
+        path = self.get_contract_path('RangeTooManyParameters.py')
         self.assertCompilerLogs(UnexpectedArgument, path)
 
     def test_range_get_value(self):
@@ -289,11 +291,11 @@ class TestRange(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/range_test/GetValue.py' % self.dirname
+        path = self.get_contract_path('GetValue.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', [1, 2, 3, 4])
         self.assertEqual(1, result)
         result = self.run_smart_contract(engine, path, 'Main', [5, 3, 2])
@@ -303,7 +305,7 @@ class TestRange(BoaTest):
             self.run_smart_contract(engine, path, 'Main', [])
 
     def test_range_set_value(self):
-        path = '%s/boa3_test/test_sc/range_test/SetValue.py' % self.dirname
+        path = self.get_contract_path('SetValue.py')
         self.assertCompilerLogs(UnresolvedOperation, path)
 
     def test_range_slicing(self):
@@ -425,11 +427,11 @@ class TestRange(BoaTest):
             + Opcode.DROP
             + Opcode.RET        # return
         )
-        path = '%s/boa3_test/test_sc/range_test/RangeSlicingLiteralValues.py' % self.dirname
+        path = self.get_contract_path('RangeSlicingLiteralValues.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([2], result)
 
@@ -555,11 +557,11 @@ class TestRange(BoaTest):
             + Opcode.DROP
             + Opcode.RET        # return
         )
-        path = '%s/boa3_test/test_sc/range_test/RangeSlicingVariableValues.py' % self.dirname
+        path = self.get_contract_path('RangeSlicingVariableValues.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([2], result)
 
@@ -673,11 +675,11 @@ class TestRange(BoaTest):
             + Opcode.DROP
             + Opcode.RET        # return
         )
-        path = '%s/boa3_test/test_sc/range_test/RangeSlicingNegativeStart.py' % self.dirname
+        path = self.get_contract_path('RangeSlicingNegativeStart.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([2, 3, 4, 5], result)
 
@@ -789,11 +791,11 @@ class TestRange(BoaTest):
             + Opcode.DROP
             + Opcode.RET        # return
         )
-        path = '%s/boa3_test/test_sc/range_test/RangeSlicingNegativeEnd.py' % self.dirname
+        path = self.get_contract_path('RangeSlicingNegativeEnd.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([0, 1], result)
 
@@ -904,11 +906,11 @@ class TestRange(BoaTest):
             + Opcode.DROP
             + Opcode.RET        # return
         )
-        path = '%s/boa3_test/test_sc/range_test/RangeSlicingStartOmitted.py' % self.dirname
+        path = self.get_contract_path('RangeSlicingStartOmitted.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([0, 1, 2], result)
 
@@ -964,11 +966,11 @@ class TestRange(BoaTest):
             + Opcode.PACK
             + Opcode.RET        # return
         )
-        path = '%s/boa3_test/test_sc/range_test/RangeSlicingOmitted.py' % self.dirname
+        path = self.get_contract_path('RangeSlicingOmitted.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([0, 1, 2, 3, 4, 5], result)
 
@@ -1080,18 +1082,18 @@ class TestRange(BoaTest):
             + Opcode.DROP
             + Opcode.RET        # return
         )
-        path = '%s/boa3_test/test_sc/range_test/RangeSlicingEndOmitted.py' % self.dirname
+        path = self.get_contract_path('RangeSlicingEndOmitted.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([2, 3, 4, 5], result)
 
     def test_range_slicing_omitted_stride(self):
-        path = '%s/boa3_test/test_sc/range_test/RangeSlicingWithStride.py' % self.dirname
+        path = self.get_contract_path('RangeSlicingWithStride.py')
         self.assertCompilerLogs(InternalError, path)
 
     def test_range_slicing_omitted_with_stride(self):
-        path = '%s/boa3_test/test_sc/range_test/RangeSlicingOmittedWithStride.py' % self.dirname
+        path = self.get_contract_path('RangeSlicingOmittedWithStride.py')
         self.assertCompilerLogs(InternalError, path)

--- a/boa3_test/tests/test_relational.py
+++ b/boa3_test/tests/test_relational.py
@@ -9,6 +9,8 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 class TestRelational(BoaTest):
 
+    default_folder: str = 'test_sc/relational_test'
+
     def test_number_equality_operation(self):
         expected_output = (
             Opcode.INITSLOT
@@ -20,11 +22,11 @@ class TestRelational(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/relational_test/NumEquality.py' % self.dirname
+        path = self.get_contract_path('NumEquality.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 1, 2)
         self.assertEqual(False, result)
         result = self.run_smart_contract(engine, path, 'Main', 2, 2)
@@ -41,18 +43,18 @@ class TestRelational(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/relational_test/NumInequality.py' % self.dirname
+        path = self.get_contract_path('NumInequality.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 1, 2)
         self.assertEqual(True, result)
         result = self.run_smart_contract(engine, path, 'Main', 2, 2)
         self.assertEqual(False, result)
 
     def test_number_inequality_operation_2(self):
-        path = '%s/boa3_test/test_sc/relational_test/NumInequalityPython2.py' % self.dirname
+        path = self.get_contract_path('NumInequalityPython2.py')
 
         with self.assertRaises(SyntaxError):
             output = Boa3.compile(path)
@@ -68,11 +70,11 @@ class TestRelational(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/relational_test/NumLessThan.py' % self.dirname
+        path = self.get_contract_path('NumLessThan.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 1, 2)
         self.assertEqual(True, result)
         result = self.run_smart_contract(engine, path, 'Main', 2, 2)
@@ -91,11 +93,11 @@ class TestRelational(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/relational_test/NumLessOrEqual.py' % self.dirname
+        path = self.get_contract_path('NumLessOrEqual.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 1, 2)
         self.assertEqual(True, result)
         result = self.run_smart_contract(engine, path, 'Main', 2, 2)
@@ -114,11 +116,11 @@ class TestRelational(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/relational_test/NumGreaterThan.py' % self.dirname
+        path = self.get_contract_path('NumGreaterThan.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 1, 2)
         self.assertEqual(False, result)
         result = self.run_smart_contract(engine, path, 'Main', 2, 2)
@@ -137,11 +139,11 @@ class TestRelational(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/relational_test/NumGreaterOrEqual.py' % self.dirname
+        path = self.get_contract_path('NumGreaterOrEqual.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 1, 2)
         self.assertEqual(False, result)
         result = self.run_smart_contract(engine, path, 'Main', 2, 2)
@@ -150,7 +152,7 @@ class TestRelational(BoaTest):
         self.assertEqual(True, result)
 
     def test_identity_operation(self):
-        path = '%s/boa3_test/test_sc/relational_test/NumIdentity.py' % self.dirname
+        path = self.get_contract_path('NumIdentity.py')
         self.assertCompilerLogs(NotSupportedOperation, path)
 
     def test_boolean_equality_operation(self):
@@ -164,11 +166,11 @@ class TestRelational(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/relational_test/BoolEquality.py' % self.dirname
+        path = self.get_contract_path('BoolEquality.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', True, False)
         self.assertEqual(False, result)
         result = self.run_smart_contract(engine, path, 'Main', True, True)
@@ -185,11 +187,11 @@ class TestRelational(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/relational_test/BoolInequality.py' % self.dirname
+        path = self.get_contract_path('BoolInequality.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', True, False)
         self.assertEqual(True, result)
         result = self.run_smart_contract(engine, path, 'Main', True, True)
@@ -210,11 +212,11 @@ class TestRelational(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/relational_test/NumRange.py' % self.dirname
+        path = self.get_contract_path('NumRange.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 1, 2, 5)
         self.assertEqual(False, result)
         result = self.run_smart_contract(engine, path, 'Main', 2, 1, 5)
@@ -235,11 +237,11 @@ class TestRelational(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/relational_test/StrEquality.py' % self.dirname
+        path = self.get_contract_path('StrEquality.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 'unit', 'test')
         self.assertEqual(False, result)
         result = self.run_smart_contract(engine, path, 'Main', 'unit', 'unit')
@@ -256,11 +258,11 @@ class TestRelational(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/relational_test/StrInequality.py' % self.dirname
+        path = self.get_contract_path('StrInequality.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 'unit', 'test')
         self.assertEqual(True, result)
         result = self.run_smart_contract(engine, path, 'Main', 'unit', 'unit')
@@ -277,11 +279,11 @@ class TestRelational(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/relational_test/StrLessThan.py' % self.dirname
+        path = self.get_contract_path('StrLessThan.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 'test', 'unit')
         self.assertEqual(False, result)
         result = self.run_smart_contract(engine, path, 'Main', 'unit', 'unit')
@@ -300,11 +302,11 @@ class TestRelational(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/relational_test/StrLessOrEqual.py' % self.dirname
+        path = self.get_contract_path('StrLessOrEqual.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 'test', 'unit')
         self.assertEqual(False, result)
         result = self.run_smart_contract(engine, path, 'Main', 'unit', 'unit')
@@ -323,11 +325,11 @@ class TestRelational(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/relational_test/StrGreaterThan.py' % self.dirname
+        path = self.get_contract_path('StrGreaterThan.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 'test', 'unit')
         self.assertEqual(True, result)
         result = self.run_smart_contract(engine, path, 'Main', 'unit', 'unit')
@@ -346,11 +348,11 @@ class TestRelational(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/relational_test/StrGreaterOrEqual.py' % self.dirname
+        path = self.get_contract_path('StrGreaterOrEqual.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 'test', 'unit')
         self.assertEqual(True, result)
         result = self.run_smart_contract(engine, path, 'Main', 'unit', 'unit')
@@ -369,11 +371,11 @@ class TestRelational(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/relational_test/MixedEquality.py' % self.dirname
+        path = self.get_contract_path('MixedEquality.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 1, 'unit')
         self.assertEqual(False, result)
         result = self.run_smart_contract(engine, path, 'Main', 123, '123')
@@ -392,11 +394,11 @@ class TestRelational(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/relational_test/MixedInequality.py' % self.dirname
+        path = self.get_contract_path('MixedInequality.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 1, 'unit')
         self.assertEqual(True, result)
         result = self.run_smart_contract(engine, path, 'Main', 123, '123')
@@ -405,25 +407,25 @@ class TestRelational(BoaTest):
         self.assertEqual(True, result)
 
     def test_mixed_less_than_operation(self):
-        path = '%s/boa3_test/test_sc/relational_test/MixedLessThan.py' % self.dirname
+        path = self.get_contract_path('MixedLessThan.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_mixed_less_or_equal_than_operation(self):
-        path = '%s/boa3_test/test_sc/relational_test/MixedLessOrEqual.py' % self.dirname
+        path = self.get_contract_path('MixedLessOrEqual.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_mixed_greater_than_operation(self):
-        path = '%s/boa3_test/test_sc/relational_test/MixedGreaterThan.py' % self.dirname
+        path = self.get_contract_path('MixedGreaterThan.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_mixed_greater_or_equal_than_operation(self):
-        path = '%s/boa3_test/test_sc/relational_test/MixedGreaterOrEqual.py' % self.dirname
+        path = self.get_contract_path('MixedGreaterOrEqual.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_list_equality_with_slice(self):
-        path = '%s/boa3_test/test_sc/relational_test/ListEqualityWithSlice.py' % self.dirname
+        path = self.get_contract_path('ListEqualityWithSlice.py')
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'main', ['unittest', '123'], 'unittest',
                                          expected_result_type=bool)
         self.assertEqual(True, result)
@@ -436,19 +438,19 @@ class TestRelational(BoaTest):
             self.run_smart_contract(engine, path, 'main', [], '')
 
     def test_compare_same_value_hard_coded(self):
-        path = '%s/boa3_test/test_sc/relational_test/CompareSameValueHardCoded.py' % self.dirname
+        path = self.get_contract_path('CompareSameValueHardCoded.py')
         Boa3.compile_and_save(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'testing_something',
                                          expected_result_type=bool)
         self.assertEqual(True, result)
 
     def test_compare_same_value_argument(self):
-        path = '%s/boa3_test/test_sc/relational_test/CompareSameValueArgument.py' % self.dirname
+        path = self.get_contract_path('CompareSameValueArgument.py')
         Boa3.compile_and_save(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'testing_something', bytes(20),
                                          expected_result_type=bool)
         self.assertEqual(True, result)

--- a/boa3_test/tests/test_string.py
+++ b/boa3_test/tests/test_string.py
@@ -12,11 +12,13 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 class TestString(BoaTest):
 
+    default_folder: str = 'test_sc/string_test'
+
     def test_string_get_value(self):
-        path = '%s/boa3_test/test_sc/string_test/GetValue.py' % self.dirname
+        path = self.get_contract_path('GetValue.py')
         output = Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 'unit')
         self.assertEqual('u', result)
         result = self.run_smart_contract(engine, path, 'Main', '123')
@@ -26,10 +28,10 @@ class TestString(BoaTest):
             self.run_smart_contract(engine, path, 'Main', '')
 
     def test_string_get_value_to_variable(self):
-        path = '%s/boa3_test/test_sc/string_test/GetValueToVariable.py' % self.dirname
+        path = self.get_contract_path('GetValueToVariable.py')
         output = Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 'unit')
         self.assertEqual('u', result)
         result = self.run_smart_contract(engine, path, 'Main', '123')
@@ -39,22 +41,22 @@ class TestString(BoaTest):
             self.run_smart_contract(engine, path, 'Main', '')
 
     def test_string_set_value(self):
-        path = '%s/boa3_test/test_sc/string_test/SetValue.py' % self.dirname
+        path = self.get_contract_path('SetValue.py')
         self.assertCompilerLogs(UnresolvedOperation, path)
 
     def test_string_slicing(self):
-        path = '%s/boa3_test/test_sc/string_test/StringSlicingLiteralValues.py' % self.dirname
+        path = self.get_contract_path('StringSlicingLiteralValues.py')
         output = Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual('i', result)
 
     def test_string_slicing_with_variables(self):
-        path = '%s/boa3_test/test_sc/string_test/StringSlicingVariableValues.py' % self.dirname
+        path = self.get_contract_path('StringSlicingVariableValues.py')
         output = Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual('i', result)
 
@@ -86,11 +88,11 @@ class TestString(BoaTest):
             + Opcode.LEFT
             + Opcode.RET        # return
         )
-        path = '%s/boa3_test/test_sc/string_test/StringSlicingNegativeStart.py' % self.dirname
+        path = self.get_contract_path('StringSlicingNegativeStart.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main',
                                          expected_result_type=bytes)
         self.assertEqual(b'unit_', result)
@@ -127,11 +129,11 @@ class TestString(BoaTest):
             + Opcode.RIGHT
             + Opcode.RET        # return
         )
-        path = '%s/boa3_test/test_sc/string_test/StringSlicingNegativeEnd.py' % self.dirname
+        path = self.get_contract_path('StringSlicingNegativeEnd.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(b'test', result)
 
@@ -162,11 +164,11 @@ class TestString(BoaTest):
             + Opcode.LEFT
             + Opcode.RET        # return
         )
-        path = '%s/boa3_test/test_sc/string_test/StringSlicingStartOmitted.py' % self.dirname
+        path = self.get_contract_path('StringSlicingStartOmitted.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main',
                                          expected_result_type=bytes)
         self.assertEqual(b'uni', result)
@@ -188,11 +190,11 @@ class TestString(BoaTest):
             + byte_input
             + Opcode.RET
         )
-        path = '%s/boa3_test/test_sc/string_test/StringSlicingOmitted.py' % self.dirname
+        path = self.get_contract_path('StringSlicingOmitted.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual('unit_test', result)
 
@@ -226,19 +228,19 @@ class TestString(BoaTest):
             + Opcode.RIGHT
             + Opcode.RET        # return
         )
-        path = '%s/boa3_test/test_sc/string_test/StringSlicingEndOmitted.py' % self.dirname
+        path = self.get_contract_path('StringSlicingEndOmitted.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main',
                                          expected_result_type=bytes)
         self.assertEqual(b'it_test', result)
 
     def test_string_slicing_omitted_stride(self):
-        path = '%s/boa3_test/test_sc/string_test/StringSlicingWithStride.py' % self.dirname
+        path = self.get_contract_path('StringSlicingWithStride.py')
         self.assertCompilerLogs(InternalError, path)
 
     def test_string_slicing_omitted_with_stride(self):
-        path = '%s/boa3_test/test_sc/string_test/StringSlicingOmittedWithStride.py' % self.dirname
+        path = self.get_contract_path('StringSlicingOmittedWithStride.py')
         self.assertCompilerLogs(InternalError, path)

--- a/boa3_test/tests/test_test_engine.py
+++ b/boa3_test/tests/test_test_engine.py
@@ -347,19 +347,21 @@ class TestTestEngine(BoaTest):
         self.assertEqual(expected_result, result)
 
     def test_run(self):
-        path = '%s/boa3_test/test_sc/generation_test/GenerationWithDecorator.py' % self.dirname
+        path = self.get_contract_path('test_sc/generation_test', 'GenerationWithDecorator.py')
         self.compile_and_save(path)
         path = path.replace('.py', '.nef')
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = engine.run(path, 'Sub', 50, 20)
         self.assertEqual(30, result)
 
     def test_test_engine_not_found_error(self):
         # if the TestEngine is correctly installed a error should not occur
-        engine = TestEngine(self.dirname)
+        import env
+        engine_path = env.TEST_ENGINE_DIRECTORY
+        engine = TestEngine(engine_path)
 
         # however, if the TestEngine is not in the directory it will raise an Exception
         with self.assertRaises(FileNotFoundError):
-            engine = TestEngine('%s/boa3_test' % self.dirname)
+            engine = TestEngine('{0}/boa3_test'.format(engine_path))
 

--- a/boa3_test/tests/test_tuple.py
+++ b/boa3_test/tests/test_tuple.py
@@ -13,6 +13,8 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 class TestTuple(BoaTest):
 
+    default_folder: str = 'test_sc/tuple_test'
+
     def test_tuple_int_values(self):
         expected_output = (
             Opcode.INITSLOT     # function signature
@@ -27,7 +29,7 @@ class TestTuple(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/tuple_test/IntTuple.py' % self.dirname
+        path = self.get_contract_path('IntTuple.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -55,7 +57,7 @@ class TestTuple(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/tuple_test/StrTuple.py' % self.dirname
+        path = self.get_contract_path('StrTuple.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -73,7 +75,7 @@ class TestTuple(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/tuple_test/BoolTuple.py' % self.dirname
+        path = self.get_contract_path('BoolTuple.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -97,7 +99,7 @@ class TestTuple(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/tuple_test/VariableTuple.py' % self.dirname
+        path = self.get_contract_path('VariableTuple.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -111,7 +113,7 @@ class TestTuple(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/tuple_test/EmptyTupleAssignment.py' % self.dirname
+        path = self.get_contract_path('EmptyTupleAssignment.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -134,11 +136,11 @@ class TestTuple(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/tuple_test/GetValue.py' % self.dirname
+        path = self.get_contract_path('GetValue.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', [1, 2, 3, 4])
         self.assertEqual(1, result)
         result = self.run_smart_contract(engine, path, 'Main', [5, 3, 2])
@@ -148,19 +150,19 @@ class TestTuple(BoaTest):
             self.run_smart_contract(engine, path, 'Main', [])
 
     def test_non_sequence_get_value(self):
-        path = '%s/boa3_test/test_sc/tuple_test/MismatchedTypeGetValue.py' % self.dirname
+        path = self.get_contract_path('MismatchedTypeGetValue.py')
         self.assertCompilerLogs(UnresolvedOperation, path)
 
     def test_tuple_set_value(self):
-        path = '%s/boa3_test/test_sc/tuple_test/SetValue.py' % self.dirname
+        path = self.get_contract_path('SetValue.py')
         self.assertCompilerLogs(UnresolvedOperation, path)
 
     def test_non_sequence_set_value(self):
-        path = '%s/boa3_test/test_sc/tuple_test/MismatchedTypeSetValue.py' % self.dirname
+        path = self.get_contract_path('MismatchedTypeSetValue.py')
         self.assertCompilerLogs(UnresolvedOperation, path)
 
     def test_tuple_index_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/tuple_test/MismatchedTypeTupleIndex.py' % self.dirname
+        path = self.get_contract_path('MismatchedTypeTupleIndex.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     @unittest.skip("get values from inner arrays is not working as expected")
@@ -193,11 +195,11 @@ class TestTuple(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/tuple_test/TupleOfTuple.py' % self.dirname
+        path = self.get_contract_path('TupleOfTuple.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', ((1, 2), (3, 4)))
         self.assertEqual(1, result)
 
@@ -225,11 +227,11 @@ class TestTuple(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/tuple_test/Nep5Main.py' % self.dirname
+        path = self.get_contract_path('Nep5Main.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 'op', (1, 2, 3, 4))
         self.assertEqual(1, result)
         result = self.run_smart_contract(engine, path, 'Main', 'op', ('a', False))
@@ -323,11 +325,11 @@ class TestTuple(BoaTest):
             + Opcode.DROP
             + Opcode.RET        # return
         )
-        path = '%s/boa3_test/test_sc/tuple_test/TupleSlicingLiteralValues.py' % self.dirname
+        path = self.get_contract_path('TupleSlicingLiteralValues.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([2], result)
 
@@ -420,11 +422,11 @@ class TestTuple(BoaTest):
             + Opcode.DROP
             + Opcode.RET        # return
         )
-        path = '%s/boa3_test/test_sc/tuple_test/TupleSlicingVariableValues.py' % self.dirname
+        path = self.get_contract_path('TupleSlicingVariableValues.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([2], result)
 
@@ -505,11 +507,11 @@ class TestTuple(BoaTest):
             + Opcode.DROP
             + Opcode.RET        # return
         )
-        path = '%s/boa3_test/test_sc/tuple_test/TupleSlicingNegativeStart.py' % self.dirname
+        path = self.get_contract_path('TupleSlicingNegativeStart.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([2, 3, 4, 5], result)
 
@@ -588,11 +590,11 @@ class TestTuple(BoaTest):
             + Opcode.DROP
             + Opcode.RET        # return
         )
-        path = '%s/boa3_test/test_sc/tuple_test/TupleSlicingNegativeEnd.py' % self.dirname
+        path = self.get_contract_path('TupleSlicingNegativeEnd.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([0, 1], result)
 
@@ -671,11 +673,11 @@ class TestTuple(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/tuple_test/TupleSlicingStartOmitted.py' % self.dirname
+        path = self.get_contract_path('TupleSlicingStartOmitted.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([0, 1, 2], result)
 
@@ -698,11 +700,11 @@ class TestTuple(BoaTest):
             + Opcode.PACK
             + Opcode.RET        # return
         )
-        path = '%s/boa3_test/test_sc/tuple_test/TupleSlicingOmitted.py' % self.dirname
+        path = self.get_contract_path('TupleSlicingOmitted.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([0, 1, 2, 3, 4, 5], result)
 
@@ -781,18 +783,18 @@ class TestTuple(BoaTest):
             + Opcode.DROP
             + Opcode.RET        # return
         )
-        path = '%s/boa3_test/test_sc/tuple_test/TupleSlicingEndOmitted.py' % self.dirname
+        path = self.get_contract_path('TupleSlicingEndOmitted.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([2, 3, 4, 5], result)
 
     def test_tuple_slicing_omitted_stride(self):
-        path = '%s/boa3_test/test_sc/tuple_test/TupleSlicingWithStride.py' % self.dirname
+        path = self.get_contract_path('TupleSlicingWithStride.py')
         self.assertCompilerLogs(InternalError, path)
 
     def test_tuple_slicing_omitted_with_stride(self):
-        path = '%s/boa3_test/test_sc/tuple_test/TupleSlicingOmittedWithStride.py' % self.dirname
+        path = self.get_contract_path('TupleSlicingOmittedWithStride.py')
         self.assertCompilerLogs(InternalError, path)

--- a/boa3_test/tests/test_union.py
+++ b/boa3_test/tests/test_union.py
@@ -9,6 +9,8 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 class TestUnion(BoaTest):
 
+    default_folder: str = 'test_sc/union_test'
+
     def test_union_return(self):
         integer = Integer(42).to_byte_array()
         string = String('42').to_bytes()
@@ -31,11 +33,11 @@ class TestUnion(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/union_test/UnionReturn.py' % self.dirname
+        path = self.get_contract_path('UnionReturn.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'main', True)
         self.assertEqual(42, result)
 
@@ -61,15 +63,15 @@ class TestUnion(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/union_test/UnionVariableReassign.py' % self.dirname
+        path = self.get_contract_path('UnionVariableReassign.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
     def test_union_variable_argument(self):
-        path = '%s/boa3_test/test_sc/union_test/UnionVariableArgument.py' % self.dirname
+        path = self.get_contract_path('UnionVariableArgument.py')
         output = Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'main', 'unittest')
         self.assertEqual('string', result)
 
@@ -77,10 +79,10 @@ class TestUnion(BoaTest):
         self.assertEqual('boolean', result)
 
     def test_union_isinstance_validation(self):
-        path = '%s/boa3_test/test_sc/union_test/UnionIsInstanceValidation.py' % self.dirname
+        path = self.get_contract_path('UnionIsInstanceValidation.py')
         output = Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'main', 'unittest')
         self.assertEqual('unittest', result)
 
@@ -88,9 +90,9 @@ class TestUnion(BoaTest):
         self.assertEqual('boolean', result)
 
     def test_union_int_none(self):
-        path = '%s/boa3_test/test_sc/union_test/UnionIntNone.py' % self.dirname
+        path = self.get_contract_path('UnionIntNone.py')
         output = Boa3.compile(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'main')
         self.assertEqual(42, result)

--- a/boa3_test/tests/test_variable.py
+++ b/boa3_test/tests/test_variable.py
@@ -15,8 +15,10 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 class TestVariable(BoaTest):
 
+    default_folder: str = 'test_sc/variable_test'
+
     def test_declaration_with_type(self):
-        path = '%s/boa3_test/test_sc/variable_test/DeclarationWithType.py' % self.dirname
+        path = self.get_contract_path('DeclarationWithType.py')
 
         test_variable_id = 'a'
         test_method_id = 'Main'
@@ -44,7 +46,7 @@ class TestVariable(BoaTest):
         self.assertTrue(test_variable_id in method_symbol_table)
 
     def test_declaration_without_type(self):
-        path = '%s/boa3_test/test_sc/variable_test/DeclarationWithoutType.py' % self.dirname
+        path = self.get_contract_path('DeclarationWithoutType.py')
         self.assertCompilerLogs(UnresolvedReference, path)
 
     def test_assignment_with_type(self):
@@ -61,7 +63,7 @@ class TestVariable(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/variable_test/AssignmentWithType.py' % self.dirname
+        path = self.get_contract_path('AssignmentWithType.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -75,7 +77,7 @@ class TestVariable(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/variable_test/AssignmentWithoutType.py' % self.dirname
+        path = self.get_contract_path('AssignmentWithoutType.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -93,7 +95,7 @@ class TestVariable(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/variable_test/ArgumentAssignment.py' % self.dirname
+        path = self.get_contract_path('ArgumentAssignment.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -111,7 +113,7 @@ class TestVariable(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/variable_test/MultipleAssignments.py' % self.dirname
+        path = self.get_contract_path('MultipleAssignments.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -146,7 +148,7 @@ class TestVariable(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/variable_test/MultipleAssignmentsSetSequence.py' % self.dirname
+        path = self.get_contract_path('MultipleAssignmentsSetSequence.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -181,16 +183,16 @@ class TestVariable(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = '%s/boa3_test/test_sc/variable_test/MultipleAssignmentsSetSequenceLast.py' % self.dirname
+        path = self.get_contract_path('MultipleAssignmentsSetSequenceLast.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
     def test_multiple_assignments_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/variable_test/MismatchedTypeMultipleAssignments.py' % self.dirname
+        path = self.get_contract_path('MismatchedTypeMultipleAssignments.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_tuple_multiple_assignments(self):
-        path = '%s/boa3_test/test_sc/variable_test/AssignmentWithTuples.py' % self.dirname
+        path = self.get_contract_path('AssignmentWithTuples.py')
         self.assertCompilerLogs(NotSupportedOperation, path)
 
     def test_many_assignments(self):
@@ -218,7 +220,7 @@ class TestVariable(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/variable_test/ManyAssignments.py' % self.dirname
+        path = self.get_contract_path('ManyAssignments.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -231,11 +233,11 @@ class TestVariable(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/variable_test/ReturnArgument.py' % self.dirname
+        path = self.get_contract_path('ReturnArgument.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 10)
         self.assertEqual(10, result)
         result = self.run_smart_contract(engine, path, 'Main', -140)
@@ -252,11 +254,11 @@ class TestVariable(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/variable_test/ReturnLocalVariable.py' % self.dirname
+        path = self.get_contract_path('ReturnLocalVariable.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 10)
         self.assertEqual(1, result)
         result = self.run_smart_contract(engine, path, 'Main', -140)
@@ -273,50 +275,50 @@ class TestVariable(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/variable_test/AssignLocalWithArgument.py' % self.dirname
+        path = self.get_contract_path('AssignLocalWithArgument.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 10)
         self.assertEqual(10, result)
         result = self.run_smart_contract(engine, path, 'Main', -140)
         self.assertEqual(-140, result)
 
     def test_using_undeclared_variable(self):
-        path = '%s/boa3_test/test_sc/variable_test/UsingUndeclaredVariable.py' % self.dirname
+        path = self.get_contract_path('UsingUndeclaredVariable.py')
         self.assertCompilerLogs(UnresolvedReference, path)
 
     def test_return_undeclared_variable(self):
-        path = '%s/boa3_test/test_sc/variable_test/ReturnUndeclaredVariable.py' % self.dirname
+        path = self.get_contract_path('ReturnUndeclaredVariable.py')
         self.assertCompilerLogs(UnresolvedReference, path)
 
     def test_assign_value_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/variable_test/MismatchedTypeAssignValue.py' % self.dirname
+        path = self.get_contract_path('MismatchedTypeAssignValue.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_assign_binary_operation_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/variable_test/MismatchedTypeAssignBinOp.py' % self.dirname
+        path = self.get_contract_path('MismatchedTypeAssignBinOp.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_assign_unary_operation_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/variable_test/MismatchedTypeAssignUnOp.py' % self.dirname
+        path = self.get_contract_path('MismatchedTypeAssignUnOp.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_assign_mixed_operations_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/variable_test/MismatchedTypeAssignMixedOp.py' % self.dirname
+        path = self.get_contract_path('MismatchedTypeAssignMixedOp.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_assign_sequence_get_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/variable_test/MismatchedTypeAssignSequenceGet.py' % self.dirname
+        path = self.get_contract_path('MismatchedTypeAssignSequenceGet.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_assign_sequence_set_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/variable_test/MismatchedTypeAssignSequenceSet.py' % self.dirname
+        path = self.get_contract_path('MismatchedTypeAssignSequenceSet.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_aug_assign_mismatched_type(self):
-        path = '%s/boa3_test/test_sc/variable_test/MismatchedTypeAugAssign.py' % self.dirname
+        path = self.get_contract_path('MismatchedTypeAugAssign.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_global_declaration_with_assignment(self):
@@ -329,16 +331,16 @@ class TestVariable(BoaTest):
             + Opcode.STSFLD0    # a = 10
             + Opcode.RET
         )
-        path = '%s/boa3_test/test_sc/variable_test/GlobalDeclarationWithArgumentWrittenAfter.py' % self.dirname
+        path = self.get_contract_path('GlobalDeclarationWithArgumentWrittenAfter.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(10, result)
 
     def test_global_declaration_without_assignment(self):
-        path = '%s/boa3_test/test_sc/variable_test/GlobalDeclarationWithoutAssignment.py' % self.dirname
+        path = self.get_contract_path('GlobalDeclarationWithoutAssignment.py')
         self.assertCompilerLogs(UnresolvedReference, path)
 
     def test_global_assignment_with_type(self):
@@ -351,11 +353,11 @@ class TestVariable(BoaTest):
             + Opcode.STSFLD0    # a = 10
             + Opcode.RET
         )
-        path = '%s/boa3_test/test_sc/variable_test/GlobalAssignmentWithType.py' % self.dirname
+        path = self.get_contract_path('GlobalAssignmentWithType.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(10, result)
 
@@ -369,16 +371,16 @@ class TestVariable(BoaTest):
             + Opcode.STSFLD0    # a = 10
             + Opcode.RET
         )
-        path = '%s/boa3_test/test_sc/variable_test/GlobalAssignmentWithoutType.py' % self.dirname
+        path = self.get_contract_path('GlobalAssignmentWithoutType.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(10, result)
 
     def test_global_tuple_multiple_assignments(self):
-        path = '%s/boa3_test/test_sc/variable_test/GlobalAssignmentWithTuples.py' % self.dirname
+        path = self.get_contract_path('GlobalAssignmentWithTuples.py')
         self.assertCompilerLogs(NotSupportedOperation, path)
 
     def test_many_global_assignments(self):
@@ -415,11 +417,11 @@ class TestVariable(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/variable_test/ManyGlobalAssignments.py' % self.dirname
+        path = self.get_contract_path('ManyGlobalAssignments.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([0, 1, 2, 3, 4, 5, 6, 7], result)
 
@@ -437,11 +439,11 @@ class TestVariable(BoaTest):
             + Opcode.STSFLD1
             + Opcode.RET
         )
-        path = '%s/boa3_test/test_sc/variable_test/GlobalAssignmentBetweenFunctions.py' % self.dirname
+        path = self.get_contract_path('GlobalAssignmentBetweenFunctions.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(10, result)
         result = self.run_smart_contract(engine, path, 'example')
@@ -480,11 +482,11 @@ class TestVariable(BoaTest):
             + Opcode.STSFLD + b'\x07'   # variable index greater than 6 uses another opcode
             + Opcode.RET
         )
-        path = '%s/boa3_test/test_sc/variable_test/GetGlobalValueWrittenAfter.py' % self.dirname
+        path = self.get_contract_path('GetGlobalValueWrittenAfter.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([0, 1, 2, 3, 4, 5, 6, 7], result)
 
@@ -503,11 +505,11 @@ class TestVariable(BoaTest):
             + Opcode.STSFLD0
             + Opcode.RET
         )
-        path = '%s/boa3_test/test_sc/variable_test/AssignLocalWithArgumentShadowingGlobal.py' % self.dirname
+        path = self.get_contract_path('AssignLocalWithArgumentShadowingGlobal.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 10)
         self.assertEqual(10, result)
         result = self.run_smart_contract(engine, path, 'Main', -140)
@@ -528,11 +530,11 @@ class TestVariable(BoaTest):
             + Opcode.STSFLD0
             + Opcode.RET
         )
-        path = '%s/boa3_test/test_sc/variable_test/GlobalAssignmentInFunctionWithArgument.py' % self.dirname
+        path = self.get_contract_path('GlobalAssignmentInFunctionWithArgument.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 10)
         self.assertEqual(10, result)
 
@@ -540,9 +542,9 @@ class TestVariable(BoaTest):
         self.assertEqual(-140, result)
 
     def test_assign_void_function_call(self):
-        path = '%s/boa3_test/test_sc/variable_test/AssignVoidFunctionCall.py' % self.dirname
+        path = self.get_contract_path('AssignVoidFunctionCall.py')
         self.compile_and_save(path)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(None, result)

--- a/boa3_test/tests/test_while.py
+++ b/boa3_test/tests/test_while.py
@@ -8,6 +8,8 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 class TestWhile(BoaTest):
 
+    default_folder: str = 'test_sc/while_test'
+
     def test_while_constant_condition(self):
         jmpif_address = Integer(6).to_byte_array(min_length=1, signed=True)
         jmp_address = Integer(-5).to_byte_array(min_length=1, signed=True)
@@ -31,11 +33,11 @@ class TestWhile(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/while_test/ConstantCondition.py' % self.dirname
+        path = self.get_contract_path('ConstantCondition.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(0, result)
 
@@ -72,11 +74,11 @@ class TestWhile(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/while_test/VariableCondition.py' % self.dirname
+        path = self.get_contract_path('VariableCondition.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', -2)
         self.assertEqual(0, result)
         result = self.run_smart_contract(engine, path, 'Main', 5)
@@ -85,11 +87,11 @@ class TestWhile(BoaTest):
         self.assertEqual(16, result)
 
     def test_while_mismatched_type_condition(self):
-        path = '%s/boa3_test/test_sc/while_test/MismatchedTypeCondition.py' % self.dirname
+        path = self.get_contract_path('MismatchedTypeCondition.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
     def test_while_no_condition(self):
-        path = '%s/boa3_test/test_sc/while_test/NoCondition.py' % self.dirname
+        path = self.get_contract_path('NoCondition.py')
 
         with self.assertRaises(SyntaxError):
             output = Boa3.compile(path)
@@ -143,11 +145,11 @@ class TestWhile(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/while_test/NestedWhile.py' % self.dirname
+        path = self.get_contract_path('NestedWhile.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(8, result)
 
@@ -178,11 +180,11 @@ class TestWhile(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/while_test/WhileElse.py' % self.dirname
+        path = self.get_contract_path('WhileElse.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(1, result)
 
@@ -217,11 +219,11 @@ class TestWhile(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/while_test/RelationalCondition.py' % self.dirname
+        path = self.get_contract_path('RelationalCondition.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(20, result)
 
@@ -260,11 +262,11 @@ class TestWhile(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/while_test/MultipleRelationalCondition.py' % self.dirname
+        path = self.get_contract_path('MultipleRelationalCondition.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', '', 1)
         self.assertEqual(0, result)
         result = self.run_smart_contract(engine, path, 'Main', '', 10)
@@ -331,11 +333,11 @@ class TestWhile(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/while_test/WhileContinue.py' % self.dirname
+        path = self.get_contract_path('WhileContinue.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(20, result)
 
@@ -402,28 +404,28 @@ class TestWhile(BoaTest):
             + Opcode.RET
         )
 
-        path = '%s/boa3_test/test_sc/while_test/WhileBreak.py' % self.dirname
+        path = self.get_contract_path('WhileBreak.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine(self.dirname)
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(6, result)
 
     def test_boa2_while_test(self):
-        path = '%s/boa3_test/test_sc/while_test/WhileBoa2Test.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('WhileBoa2Test.py')
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(24, result)
 
     def test_boa2_while_test1(self):
-        path = '%s/boa3_test/test_sc/while_test/WhileBoa2Test1.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('WhileBoa2Test1.py')
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(6, result)
 
     def test_boa2_while_test2(self):
-        path = '%s/boa3_test/test_sc/while_test/WhileBoa2Test2.py' % self.dirname
-        engine = TestEngine(self.dirname)
+        path = self.get_contract_path('WhileBoa2Test2.py')
+        engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(6, result)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,9 +20,9 @@
 import os
 import sys
 
-import boa3
-
 sys.path.insert(0, os.path.abspath('../../'))
+
+import boa3
 
 # -- General configuration ------------------------------------------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,6 +16,7 @@ Welcome to neo3-boa's documentation!
    compiling-your-smart-contract
    debugger-ready
    testengine
+   unit-tests
    examples
    python-supported-features
    package-reference

--- a/docs/source/testengine.rst
+++ b/docs/source/testengine.rst
@@ -4,12 +4,15 @@ TestEngine
 Downloading
 ^^^^^^^^^^^
 
-Clone neo-devpack-dotnet on neo3-boa root folder and compile the TestEngine.
+Clone neo-devpack-dotnet project and compile the TestEngine.
+
+.. note::
+    Until `neo-devpack-dotnet#365 <https://github.com/neo-project/neo-devpack-dotnet/pull/365)>`_ is approved by Neo, you need to clone neo-devpack-dotnet from `simplitech:test-engine-executable <https://github.com/simplitech/neo-devpack-dotnet/tree/test-engine-executable>`_ branch
 
 ::
 
-    $ git clone https://github.com/simplitech/neo-devpack-dotnet.git -b test-engine-executable --single-branch
-    $ dotnet build ./neo-devpack-dotnet/src/Neo.TestEngine/Neo.TestEngine.csproj -o ./Neo.TestEngine
+    $ git clone https://github.com/simplitech/neo-devpack-dotnet.git -b test-engine-executable
+    $ dotnet build ./neo-devpack-dotnet/src/Neo.TestEngine/Neo.TestEngine.csproj
 
 Updating
 ^^^^^^^^
@@ -19,13 +22,13 @@ Go into the neo-devpack-dotnet, pull and recompile.
 ::
 
     ${path-to-folder}/neo-devpack-dotnet git pull
-    ${path-to-folder}/neo-devpack-dotnet dotnet build ./src/Neo.TestEngine/Neo.TestEngine.csproj -o ./Neo.TestEngine
+    ${path-to-folder}/neo-devpack-dotnet dotnet build ./src/Neo.TestEngine/Neo.TestEngine.csproj
 
 Testing
 ^^^^^^^
 
 Create a Python Script, import the TestEngine class, and define a function to test your smart contract. In this function
-you'll need to call the method `run()`. Its parameters are the path of the compiled smart contract, the smart
+you'll need to call the method ``run()``. Its parameters are the path of the compiled smart contract, the smart
 contract's method, and the arguments if necessary. Then assert your result to see if it's correct.
 
 Your Python Script should look something like this:
@@ -36,7 +39,7 @@ Your Python Script should look something like this:
     from boa3.neo.smart_contract.VoidType import VoidType
 
     def test_hello_world_main():
-        root_folder = '{path-to-folder}'
+        root_folder = '{path-to-test-engine-folder}'
         path = '%s/boa3_test/examples/HelloWorld.nef' % root_folder
         engine = TestEngine(root_folder)
 

--- a/docs/source/unit-tests.rst
+++ b/docs/source/unit-tests.rst
@@ -1,0 +1,11 @@
+Tests
+=====
+
+Install `neo3-boa <install.html>`_ and the `TestEngine <testengine.html>`_ and run the following command
+
+.. note::
+   If you didn't install TestEngine in neo3-boa's root folder, you need to change the value of `TEST_ENGINE_DIRECTORY` in [this file](/env.py)
+
+::
+
+    python -m unittest discover boa3_test

--- a/env.py
+++ b/env.py
@@ -1,0 +1,6 @@
+import os
+
+PROJECT_ROOT_DIRECTORY = '/'.join(os.path.dirname(__file__).split(os.sep))
+
+# If you didn't install TestEngine in this project's root folder, change this to the path of your .dll folder
+TEST_ENGINE_DIRECTORY = '{0}/Neo.TestEngine'.format(PROJECT_ROOT_DIRECTORY)


### PR DESCRIPTION
**Summary or solution description**
Created a generic method for boa tests so we can get the path of test files without needing to write their absolute path

**How to Reproduce**
```python
def test_addition_operation(self):
    path = self.get_contract_path('Addition.py')
    output = Boa3.compile(path)
    self.assertEqual(expected_output, output)
```

**Tests**
Changed the str paths to call to the new method in all the unit tests and rerun they

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8.6