### PR TITLE
Fix TestEngine's Fake Balance

### DIFF
--- a/boa3_test/tests/test_classes/nativetokenprefix.py
+++ b/boa3_test/tests/test_classes/nativetokenprefix.py
@@ -21,8 +21,8 @@ def get_native_token_data(token_script: bytes) -> Tuple[Optional[bytes], Optiona
 
 
 class NativeTokenId(IntEnum):
-    NEO = -1
-    GAS = -2
+    NEO = -2
+    GAS = -3
 
 
 class NativeTokenPrefix(IntEnum):


### PR DESCRIPTION
**Summary or solution description**
Fix the creation of fake balances for unit tests

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8.6