### PR TITLE
Fix unit tests passing that were expected to fail

### DIFF
--- a/boa3/analyser/astanalyser.py
+++ b/boa3/analyser/astanalyser.py
@@ -37,16 +37,18 @@ class IAstAnalyser(ABC, ast.NodeVisitor):
         return len(self.errors) > 0
 
     def _log_error(self, error: CompilerError):
-        if self._log and not any(err == error for err in self.errors):
+        if not any(err == error for err in self.errors):
             # don't include duplicated errors
             self.errors.append(error)
-            logging.error(error)
+            if self._log:
+                logging.error(error)
 
     def _log_warning(self, warning: CompilerWarning):
-        if self._log and not any(warn == warning for warn in self.errors):
+        if not any(warn == warning for warn in self.errors):
             # don't include duplicated warnings
             self.warnings.append(warning)
-            logging.warning(warning)
+            if self._log:
+                logging.warning(warning)
 
     def visit(self, node: ast.AST) -> Any:
         try:

--- a/boa3/analyser/builtinfunctioncallanalyser.py
+++ b/boa3/analyser/builtinfunctioncallanalyser.py
@@ -72,8 +72,14 @@ class BuiltinFunctionCallAnalyser(IAstAnalyser):
                 self.call.args[-1] = last_arg.elts[-1]
                 return
 
-        if not isinstance(last_arg, ast.Name) or (last_arg.id != args_types[-1].identifier
-                                                  and last_arg.id != args_types[-1].raw_identifier):
+        from boa3.model.type.type import Type
+        is_ast_valid = (isinstance(last_arg, ast.Name)
+                        or (isinstance(last_arg, ast.NameConstant) and args_types[-1] is Type.none))
+        is_id_valid = (hasattr(last_arg, 'id')
+                       and last_arg.id != args_types[-1].identifier
+                       and last_arg.id != args_types[-1].raw_identifier)
+
+        if not is_ast_valid or is_id_valid:
             # if the value is not the identifier of a type
             self._log_error(
                 CompilerError.MismatchedTypes(

--- a/boa3_test/tests/test_file_generation.py
+++ b/boa3_test/tests/test_file_generation.py
@@ -5,6 +5,7 @@ from boa3 import constants
 from boa3.boa3 import Boa3
 from boa3.compiler.compiler import Compiler
 from boa3.constants import BYTEORDER, ENCODING
+from boa3.exception.NotLoadedException import NotLoadedException
 from boa3.model.event import Event
 from boa3.model.method import Method
 from boa3.neo.contracts.neffile import NefFile
@@ -457,3 +458,15 @@ class TestFileGeneration(BoaTest):
         # validate sequence points
         self.assertIn('sequence-points', debug_method)
         self.assertEqual(0, len(debug_method['sequence-points']))
+
+    def test_compiler_error(self):
+        path = self.get_contract_path('test_sc/built_in_methods_test', 'ClearTooManyParameters.py')
+
+        with self.assertRaises(NotLoadedException):
+            Boa3.compile(path)
+
+        with self.assertRaises(NotLoadedException):
+            Boa3.compile_and_save(path)
+
+        with self.assertRaises(NotLoadedException):
+            self.compile_and_save(path)


### PR DESCRIPTION
**Summary or solution description**
Some unit tests should be failing because compilation wasn't successful, but they're passing.
The problem was with the logging in the unit tests. This doesn't happen if using in the command line,

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7