### PR TITLE
Fix BuiltinFunctionAnalyser log value

### DIFF
--- a/boa3/analyser/builtinfunctioncallanalyser.py
+++ b/boa3/analyser/builtinfunctioncallanalyser.py
@@ -10,10 +10,10 @@ from boa3.model.type.itype import IType
 
 
 class BuiltinFunctionCallAnalyser(IAstAnalyser):
-    def __init__(self, origin: IAstAnalyser, call: ast.Call, method_id: str, builtin_method: IBuiltinMethod):
+    def __init__(self, origin: IAstAnalyser, call: ast.Call, method_id: str, builtin_method: IBuiltinMethod, log: bool):
         self._method: IBuiltinMethod = builtin_method
         self.method_id: str = method_id
-        super().__init__(call)
+        super().__init__(call, log=log)
 
         self._origin: IAstAnalyser = origin
 

--- a/boa3/analyser/optimizer/__init__.py
+++ b/boa3/analyser/optimizer/__init__.py
@@ -36,7 +36,11 @@ class ScopeValue:
         different_values = []
 
         for key in common_keys:
-            values = {scope[key] for scope in other_scopes}
+            values = []
+            for scope in other_scopes:
+                if scope[key] not in values:
+                    values.append(scope[key])
+
             if len(values) == 1:
                 new_values[key] = values.pop()
             else:

--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -1018,7 +1018,7 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
 
     def validate_passed_arguments(self, call: ast.Call, args_types: List[IType], callable_id: str, callable: Callable):
         if isinstance(callable, IBuiltinMethod):
-            builtin_analyser = BuiltinFunctionCallAnalyser(self, call, callable_id, callable)
+            builtin_analyser = BuiltinFunctionCallAnalyser(self, call, callable_id, callable, self._log)
             if builtin_analyser.validate():
                 self.errors.extend(builtin_analyser.errors)
                 self.warnings.extend(builtin_analyser.warnings)

--- a/boa3_test/tests/boa_test.py
+++ b/boa3_test/tests/boa_test.py
@@ -94,6 +94,8 @@ class BoaTest(TestCase):
                     path_folder = '{0}/{1}/{2}'.format(root_path, self.default_test_folder, dir_folder)
 
             dir_folder = path_folder
+        else:
+            dir_folder = '{0}/{1}'.format(root_path, dir_folder)
 
         if not contract_name.endswith('.py'):
             contract_name = contract_name + '.py'


### PR DESCRIPTION
**Summary or solution description**
When there was an error in a built-in function analysis, it wasn't logged. That happened because the class responsible for this didn't receive the bool value for logging

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8