### PR TITLE
Fix types in scope

### DIFF
--- a/boa3/analyser/symbolscope.py
+++ b/boa3/analyser/symbolscope.py
@@ -9,8 +9,21 @@ class SymbolScope:
     def __init__(self, symbols: Dict[str, ISymbol] = None):
         self._symbols = symbols.copy() if symbols is not None else {}
 
+    @property
+    def symbols(self) -> Dict[str, ISymbol]:
+        return self._symbols.copy()
+
     def copy(self) -> SymbolScope:
         return SymbolScope(self._symbols)
+
+    def include_symbol(self, symbol_id: str, symbol: ISymbol):
+        """
+        Includes a symbols into the scope
+
+        :param symbol_id: method identifier
+        :param symbol: method to be included
+        """
+        self._symbols[symbol_id] = symbol
 
     def __getitem__(self, item: str) -> ISymbol:
         return self._symbols[item]

--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -300,7 +300,13 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
 
         if self._current_scope is not None:
             if isinstance(node, ast.Name) and node.id not in self._current_scope:
-                target_type = value_type
+                if not isinstance(value_type, Collection):
+                    target_type = value_type
+                elif not (isinstance(type(value_type), type(target_type)) and
+                          (value_type.value_type is Type.any or value_type.valid_key is Type.any)):
+                    # if the collection is generic, let the validation for the outer scope
+                    value_type = target_type
+
                 self._current_scope.include_symbol(node.id, Variable(value_type))
 
         if not target_type.is_type_of(value_type) and value != target_type.default_value:

--- a/boa3_test/test_sc/if_test/VariablesInIfScopes.py
+++ b/boa3_test/test_sc/if_test/VariablesInIfScopes.py
@@ -1,0 +1,51 @@
+from boa3.builtin import public
+
+
+@public
+def main(operation: int) -> bool:
+
+    if operation == 1:
+
+        a = 'test_string'
+        b = bytearray(b'test_byte_array')
+
+        return a == b
+
+    elif operation == 2:
+
+        a = bytearray(b'unit_test')
+        b = 'unit_test'
+
+        return a == b
+
+    elif operation == 3:
+
+        a = b'test_bytes'
+        b = 'test_string'
+        return a == b
+
+    elif operation == 4:
+
+        a = 0
+        b = False
+        return a == b
+
+    elif operation == 5:
+
+        a = 0
+        b = ''
+        return a == b
+
+    elif operation == 6:
+
+        a = False
+        b = ''
+        return a == b
+
+    elif operation == 7:
+
+        a = False
+        b = b''
+        return a == b
+
+    return False

--- a/boa3_test/tests/test_if.py
+++ b/boa3_test/tests/test_if.py
@@ -431,3 +431,34 @@ class TestIf(BoaTest):
 
         result = self.run_smart_contract(engine, path, 'example', b'True')
         self.assertEqual(4, result)
+
+    def test_variable_in_if_scopes(self):
+        path = self.get_contract_path('VariablesInIfScopes.py')
+        self.compile_and_save(path)
+
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'main', 1, expected_result_type=bool)
+        self.assertEqual(False, result)
+
+        result = self.run_smart_contract(engine, path, 'main', 2, expected_result_type=bool)
+        self.assertEqual(True, result)
+
+        result = self.run_smart_contract(engine, path, 'main', 3, expected_result_type=bool)
+        self.assertEqual(False, result)
+
+        result = self.run_smart_contract(engine, path, 'main', 4, expected_result_type=bool)
+        self.assertEqual(True, result)
+
+        result = self.run_smart_contract(engine, path, 'main', 5, expected_result_type=bool)
+        self.assertEqual(False, result)
+
+        result = self.run_smart_contract(engine, path, 'main', 6, expected_result_type=bool)
+        self.assertEqual(False, result)
+
+        result = self.run_smart_contract(engine, path, 'main', 7, expected_result_type=bool)
+        self.assertEqual(False, result)
+
+        result = self.run_smart_contract(engine, path, 'main', 8, expected_result_type=bool)
+        self.assertEqual(False, result)
+


### PR DESCRIPTION
**Related issue**
#253 

**Summary or solution description**
Fixed the error in type checking that was using the type set for a variable in a different branch 

**How to Reproduce**
```python
from boa3.builtin import public


@public
def main(operation: int) -> bool:
    if operation == 1:
        # the other branches were evaluating the variables with the types of this branch
        a = 'deploy'
        b = bytearray(b'deploy\x00\x00')
        return a == b

    elif operation == 2:
        a = 'deploy'
        b = bytearray(b'deploy')
        return a == b

    elif operation == 3:
        a = b'deploy'
        b = 'deploy'
        return a == b

    elif operation == 4:
        a = 0
        b = False
        return a == b

    elif operation == 5:
        a = 0
        b = ''
        return a == b

    elif operation == 6:
        a = False
        b = ''
        return a == b

    elif operation == 7:
        a = False
        b = -1
        return a == b

    return False
```

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7