### PR TITLE
Fix dictionary being created as Any

### DIFF
--- a/boa3/analyser/moduleanalyser.py
+++ b/boa3/analyser/moduleanalyser.py
@@ -588,8 +588,6 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
         """
         value = self.visit(subscript.value)
         symbol = self.get_symbol(value) if isinstance(value, str) else value
-        # if isinstance(symbol, IExpression):
-        #     symbol = symbol.type
 
         if isinstance(subscript.ctx, ast.Load):
             if isinstance(symbol, Collection):

--- a/boa3/analyser/moduleanalyser.py
+++ b/boa3/analyser/moduleanalyser.py
@@ -588,6 +588,8 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
         """
         value = self.visit(subscript.value)
         symbol = self.get_symbol(value) if isinstance(value, str) else value
+        # if isinstance(symbol, IExpression):
+        #     symbol = symbol.type
 
         if isinstance(subscript.ctx, ast.Load):
             if isinstance(symbol, Collection):
@@ -609,8 +611,8 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
                     union_types = self.visit(index)
                 return symbol_type.build(union_types)
 
-            if isinstance(symbol_type, SequenceType):
-                return symbol_type.value_type
+            if isinstance(symbol_type, Collection):
+                return symbol_type.item_type
 
         return value
 

--- a/boa3_test/test_sc/dict_test/DictAnyKeyAndValue.py
+++ b/boa3_test/test_sc/dict_test/DictAnyKeyAndValue.py
@@ -1,0 +1,32 @@
+from boa3.builtin import public
+
+
+@public
+def main() -> int:
+    j = 10
+
+    d = {
+        'a': 32,
+        'b': 12,
+        4: 'blah',
+        'm': j,
+        'c': [12, 31, 44, 52, 'abcd', j],
+        'fcall': mymethod(10, 4)
+    }
+
+    value1 = d['fcall']
+
+    if isinstance(value1, int):
+        value2 = d['c']
+
+        if isinstance(value2, list):
+            value3 = value2[3]
+
+            if isinstance(value3, int):
+                return value1 + value3
+
+    return -1
+
+
+def mymethod(a: int, b: int) -> int:
+    return a + b

--- a/boa3_test/tests/test_dict.py
+++ b/boa3_test/tests/test_dict.py
@@ -386,3 +386,11 @@ class TestDict(BoaTest):
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(7, result)
+
+    def test_dict_any_key_and_value(self):
+        path = self.get_contract_path('DictAnyKeyAndValue.py')
+        Boa3.compile_and_save(path)
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'main')
+        self.assertEqual(66, result)


### PR DESCRIPTION
**Related issue**
#247 

**Summary or solution description**
Fixed the incorrect assigned type to variables assigned with dictionary getters

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/c686c020ca98855d6b943c4ba17d2c06e0dbe429/boa3_test/test_sc/dict_test/DictAnyKeyAndValue.py#L5-L28

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7