### PR TITLE
change InternalError message

### DIFF
--- a/boa3/analyser/astanalyser.py
+++ b/boa3/analyser/astanalyser.py
@@ -136,7 +136,7 @@ class IAstAnalyser(ABC, ast.NodeVisitor):
         :return: the parsed node
         :rtype: ast.AST or Sequence[ast.AST]
         """
-        node = ast.parse(expression)
+        node = ast.parse(expression, filename='<{0}>'.format(type(self).__name__))
         if origin is not None:
             self.update_line_and_col(node, origin)
 

--- a/boa3/compiler/codegenerator/codegeneratorvisitor.py
+++ b/boa3/compiler/codegenerator/codegeneratorvisitor.py
@@ -2,6 +2,7 @@ import ast
 from inspect import isclass
 from typing import Dict, List, Optional, Tuple
 
+from boa3.analyser.astanalyser import IAstAnalyser
 from boa3.compiler.codegenerator.codegenerator import CodeGenerator
 from boa3.compiler.codegenerator.vmcodemapping import VMCodeMapping
 from boa3.model.builtin.builtin import Builtin
@@ -12,13 +13,12 @@ from boa3.model.operation.binary.binaryoperation import BinaryOperation
 from boa3.model.operation.binaryop import BinaryOp
 from boa3.model.operation.operation import IOperation
 from boa3.model.operation.unary.unaryoperation import UnaryOperation
-from boa3.model.symbol import ISymbol
 from boa3.model.type.classtype import ClassType
 from boa3.model.type.type import IType, Type
 from boa3.model.variable import Variable
 
 
-class VisitorCodeGenerator(ast.NodeVisitor):
+class VisitorCodeGenerator(IAstAnalyser):
     """
     This class is responsible for walk through the ast.
 
@@ -29,12 +29,10 @@ class VisitorCodeGenerator(ast.NodeVisitor):
     """
 
     def __init__(self, generator: CodeGenerator):
+        super().__init__(ast.parse(""), log=True)
         self.generator = generator
         self.current_method: Optional[Method] = None
-
-    @property
-    def symbols(self) -> Dict[str, ISymbol]:
-        return self.generator.symbol_table
+        self.symbols = generator.symbol_table
 
     def include_instruction(self, node: ast.AST, address: int):
         if self.current_method is not None and address in VMCodeMapping.instance().code_map:

--- a/boa3/exception/CompilerError.py
+++ b/boa3/exception/CompilerError.py
@@ -74,9 +74,7 @@ class InternalError(CompilerError):
     def _error_message(self) -> Optional[str]:
         message = "Internal compiler error"
         if self.raised_exception is not None:
-            message += ". %s" % type(self.raised_exception).__name__
-            if len(self.raised_exception.args) > 0:
-                message += ": %s" % self.raised_exception.args
+            message += ". {0}: {1}".format(type(self.raised_exception).__name__, str(self.raised_exception))
         return message
 
 

--- a/boa3_test/test_sc/string_test/StringSimpleConcat.py
+++ b/boa3_test/test_sc/string_test/StringSimpleConcat.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main() -> str:
+    return "bye world" + "hi"

--- a/boa3_test/tests/test_string.py
+++ b/boa3_test/tests/test_string.py
@@ -149,3 +149,10 @@ class TestString(BoaTest):
     def test_string_slicing_omitted_with_stride(self):
         path = self.get_contract_path('StringSlicingOmittedWithStride.py')
         self.assertCompilerLogs(InternalError, path)
+
+    def test_string_simple_concat(self):
+        path = self.get_contract_path('StringSimpleConcat.py')
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'main')
+        self.assertEqual('bye worldhi', result)


### PR DESCRIPTION
**Related issue**
#230

**Summary or solution description**
The error reported in the issue was already fixed in a later pull request (#235). Changed the message of InternalError to prevent showing exceptions' stack traces to the user.

**Screenshots**
Before
![image](https://user-images.githubusercontent.com/19419485/106932194-34472d80-66f6-11eb-81de-479d8fe0ddaf.png)
After
![image](https://user-images.githubusercontent.com/19419485/106933867-301c0f80-66f8-11eb-94e3-8004c32937f6.png)

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7