### PR TITLE
Convert list remove method

### DIFF
--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -63,6 +63,7 @@ class Builtin:
     SequenceExtend = ExtendMethod()
     SequenceInsert = InsertMethod()
     SequencePop = PopMethod()
+    SequenceRemove = RemoveMethod()
     SequenceReverse = ReverseMethod()
     DictKeys = MapKeysMethod()
     DictValues = MapValuesMethod()
@@ -92,6 +93,7 @@ class Builtin:
                                                 SequenceExtend,
                                                 SequenceInsert,
                                                 SequencePop,
+                                                SequenceRemove,
                                                 SequenceReverse
                                                 ]
 

--- a/boa3/model/builtin/classmethod/__init__.py
+++ b/boa3/model/builtin/classmethod/__init__.py
@@ -5,6 +5,7 @@ __all__ = ['AppendMethod',
            'MapKeysMethod',
            'MapValuesMethod',
            'PopMethod',
+           'RemoveMethod',
            'ReverseMethod',
            'ToBoolMethod',
            'ToBytesMethod',
@@ -18,6 +19,7 @@ from boa3.model.builtin.classmethod.insertmethod import InsertMethod
 from boa3.model.builtin.classmethod.mapkeysmethod import MapKeysMethod
 from boa3.model.builtin.classmethod.mapvaluesmethod import MapValuesMethod
 from boa3.model.builtin.classmethod.popmethod import PopMethod
+from boa3.model.builtin.classmethod.removemethod import RemoveMethod
 from boa3.model.builtin.classmethod.reversemethod import ReverseMethod
 from boa3.model.builtin.classmethod.toboolmethod import ToBool as ToBoolMethod
 from boa3.model.builtin.classmethod.tobytesmethod import ToBytes as ToBytesMethod

--- a/boa3/model/builtin/classmethod/removemethod.py
+++ b/boa3/model/builtin/classmethod/removemethod.py
@@ -1,0 +1,82 @@
+from typing import Any, Dict, List, Optional, Tuple
+
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.expression import IExpression
+from boa3.model.type.collection.sequence.mutable.mutablesequencetype import MutableSequenceType
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class RemoveMethod(IBuiltinMethod):
+    def __init__(self, sequence_type: MutableSequenceType = None):
+        if not isinstance(sequence_type, MutableSequenceType):
+            from boa3.model.type.type import Type
+            sequence_type = Type.mutableSequence
+
+        self_arg = Variable(sequence_type)
+        item_arg = Variable(sequence_type.value_type)
+
+        identifier = 'remove'
+        args: Dict[str, Variable] = {'self': self_arg,
+                                     '__value': item_arg}
+        super().__init__(identifier, args)
+
+    @property
+    def _arg_self(self) -> Variable:
+        return self.args['self']
+
+    def validate_parameters(self, *params: IExpression) -> bool:
+        if len(params) != 2:
+            return False
+        if not all(isinstance(param, IExpression) for param in params):
+            return False
+
+        from boa3.model.type.itype import IType
+        sequence_type: IType = params[0].type
+        value_type: IType = params[1].type
+
+        if not isinstance(sequence_type, MutableSequenceType):
+            return False
+        return sequence_type.value_type.is_type_of(value_type)
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        from boa3.neo.vm.type.Integer import Integer
+        return [
+            (Opcode.PUSH0, b''),  # need to find the index to use REMOVE opcode
+            (Opcode.DUP, b''),      # while index < len(array):
+            (Opcode.PUSH3, b''),
+            (Opcode.PICK, b''),
+            (Opcode.SIZE, b''),
+            (Opcode.GE, b''),
+            (Opcode.JMPIF, Integer(13).to_byte_array(signed=True, min_length=1)),
+            (Opcode.PUSH2, b''),        # if array[index] == value
+            (Opcode.PICK, b''),
+            (Opcode.OVER, b''),
+            (Opcode.PICKITEM, b''),
+            (Opcode.PUSH2, b''),
+            (Opcode.PICK, b''),             # break
+            (Opcode.JMPEQ, Integer(5).to_byte_array(signed=True, min_length=1)),
+            (Opcode.INC, b''),          # index = index + 1
+            (Opcode.JMP, Integer(-16).to_byte_array(signed=True, min_length=1)),
+            (Opcode.NIP, b''),
+            (Opcode.REMOVE, b''),
+        ]
+
+    def push_self_first(self) -> bool:
+        return self.has_self_argument
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> Optional[str]:
+        return None
+
+    def build(self, value: Any) -> IBuiltinMethod:
+        if type(value) == type(self.args['self'].type):
+            return self
+        if isinstance(value, MutableSequenceType):
+            return RemoveMethod(value)
+        return super().build(value)

--- a/boa3_test/test_sc/list_test/RemoveIntValue.py
+++ b/boa3_test/test_sc/list_test/RemoveIntValue.py
@@ -1,0 +1,10 @@
+from typing import List
+
+from boa3.builtin import public
+
+
+@public
+def Main() -> List[int]:
+    a = [10, 20, 30]
+    a.remove(20)
+    return a  # expected [10, 30]

--- a/boa3_test/test_sc/list_test/RemoveIntWithBuiltin.py
+++ b/boa3_test/test_sc/list_test/RemoveIntWithBuiltin.py
@@ -1,0 +1,10 @@
+from typing import List
+
+from boa3.builtin import public
+
+
+@public
+def Main() -> List[int]:
+    a = [10, 20, 30]
+    list.remove(a, 30)
+    return a  # expected [10, 20]

--- a/boa3_test/test_sc/list_test/RemoveValue.py
+++ b/boa3_test/test_sc/list_test/RemoveValue.py
@@ -1,0 +1,9 @@
+from typing import List
+
+from boa3.builtin import public
+
+
+@public
+def Main(a: List[int], value: int) -> List[int]:
+    a.remove(value)
+    return a

--- a/boa3_test/tests/test_list.py
+++ b/boa3_test/tests/test_list.py
@@ -1013,3 +1013,35 @@ class TestList(BoaTest):
         self.assertEqual([1, 2, 4, 3], result)
 
     # endregion
+
+    # region TestRemove
+
+    def test_list_remove_value(self):
+        path = self.get_contract_path('RemoveValue.py')
+        self.compile_and_save(path)
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'Main', [1, 2, 3, 4], 3)
+        self.assertEqual([1, 2, 4], result)
+
+        result = self.run_smart_contract(engine, path, 'Main', [1, 2, 3, 2, 3], 3)
+        self.assertEqual([1, 2, 2, 3], result)
+
+        with self.assertRaises(TestExecutionException):
+            self.run_smart_contract(engine, path, 'Main', [1, 2, 3, 4], 6)
+
+    def test_list_remove_int_value(self):
+        path = self.get_contract_path('RemoveIntValue.py')
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'Main')
+        self.assertEqual([10, 30], result)
+
+    def test_list_remove_int_with_builtin(self):
+        path = self.get_contract_path('RemoveIntWithBuiltin.py')
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'Main')
+        self.assertEqual([10, 20], result)
+
+    # endregion

--- a/boa3_test/tests/test_list.py
+++ b/boa3_test/tests/test_list.py
@@ -1018,7 +1018,6 @@ class TestList(BoaTest):
 
     def test_list_remove_value(self):
         path = self.get_contract_path('RemoveValue.py')
-        self.compile_and_save(path)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', [1, 2, 3, 4], 3)


### PR DESCRIPTION
**Related issue**
#241

**Summary or solution description**
Implemented Python built-in `list` `remove` method.

**How to Reproduce**
```python
from typing import List


def Main(op: str, args: list) -> List[str]:
    a = ['1', '2', '3']
    a.remove('2')
    return a  # expected ['1', '3']
```

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7