### PR TITLE
Fixed slices that should return empty sequences

### DIFF
--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -717,7 +717,8 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
         if operation is not None:
             return operation
         else:
-            expected_op: BinaryOperation = BinaryOp.get_operation_by_operator(operator, l_type)
+            expected_op: BinaryOperation = BinaryOp.get_operation_by_operator(operator,
+                                                                              l_type if left is not None else r_type)
             expected_types = (expected_op.left_type.identifier, expected_op.right_type.identifier)
             raise CompilerError.MismatchedTypes(0, 0, expected_types, actual_types)
 

--- a/boa3/compiler/codegenerator/codegenerator.py
+++ b/boa3/compiler/codegenerator/codegenerator.py
@@ -883,9 +883,11 @@ class CodeGenerator:
         # top: length, index, array
         if len(self._stack) > 2 and isinstance(self._stack[-3], SequenceType):
             if value_addresses is not None:
-                opcodes = [VMCodeMapping.instance().code_map[address] for address in value_addresses]
-                for code in opcodes:
-                    self.fix_negative_index(VMCodeMapping.instance().get_end_address(code) + 1)
+                # use the next value address to found where the opcodes to fix the value sign should be
+                end_value_opcodes = value_addresses[1:]
+                for code in reversed(end_value_opcodes):
+                    self.fix_negative_index(code)
+                self.fix_negative_index()  # fix the last value sign
 
             if self._stack[-3].stack_item in (StackItemType.ByteString,
                                               StackItemType.Buffer):

--- a/boa3/compiler/codegenerator/codegenerator.py
+++ b/boa3/compiler/codegenerator/codegenerator.py
@@ -820,10 +820,22 @@ class CodeGenerator:
         """
         Converts the end of get a substring
         """
+        # if given substring size is negative, return empty string
+        self.duplicate_stack_top_item()
+        self.convert_literal(0)
+        self.convert_operation(BinaryOp.GtE)
+
+        self._insert_jump(OpcodeInfo.JMPIF)
+        jmp_address = self.last_code_start_address
+        self.remove_stack_top_item()
+        self.convert_literal(0)
+
         self._stack_pop()  # length
         self._stack_pop()  # start
         self._stack_pop()  # original string
+
         self.__insert1(OpcodeInfo.SUBSTR)
+        self._update_jump(jmp_address, self.last_code_start_address)
         self._stack_append(Type.bytes)  # substr returns a buffer instead of a bytestring
         self.convert_cast(Type.str)
 

--- a/boa3/model/operation/binary/arithmetic/concat.py
+++ b/boa3/model/operation/binary/arithmetic/concat.py
@@ -27,7 +27,7 @@ class Concat(BinaryOperation):
         left: IType = types[0]
         right: IType = types[1]
 
-        if left == right and left in self._valid_types:
+        if left == right and any(valid_type.is_type_of(left) for valid_type in self._valid_types):
             return True
 
         left_valid_type = next((valid_type for valid_type in self._valid_types

--- a/boa3/model/operation/binary/binaryoperation.py
+++ b/boa3/model/operation/binary/binaryoperation.py
@@ -70,4 +70,7 @@ class BinaryOperation(IOperation, ABC):
         :return: The built operation if the operands are valid. None otherwise
         :rtype: BinaryOperation or None
         """
-        return cls(left, right)
+        operation = cls(left, right)
+        if operation.validate_type(left, right):
+            return operation
+        return cls(left, left)

--- a/boa3/model/operation/binaryop.py
+++ b/boa3/model/operation/binaryop.py
@@ -103,7 +103,9 @@ class BinaryOp:
         valid_operations: List[BinaryOperation] = []
         for id, op in vars(cls).items():
             if isinstance(op, BinaryOperation) and op.operator is operator:
-                if left_operand in op._valid_types:
+                left = next((valid_type for valid_type in op._valid_types if valid_type.is_type_of(left_operand)),
+                            None)
+                if left is not None:
                     return op.build(left_operand, op.right_type)
                 else:
                     valid_operations.append(op)

--- a/boa3_test/test_sc/list_test/ListSlicingStartLargerThanEnding.py
+++ b/boa3_test/test_sc/list_test/ListSlicingStartLargerThanEnding.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+
+
+@public
+def Main() -> list:
+    a = [0, 1, 2, 3, 4, 5]
+    return a[3:1]   # expect []

--- a/boa3_test/test_sc/range_test/RangeSlicingStartLargerThanEnding.py
+++ b/boa3_test/test_sc/range_test/RangeSlicingStartLargerThanEnding.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+
+
+@public
+def Main() -> range:
+    a = range(6)
+    return a[3:2]   # expect range(2, 3)

--- a/boa3_test/test_sc/range_test/RangeSlicingStartLargerThanEnding.py
+++ b/boa3_test/test_sc/range_test/RangeSlicingStartLargerThanEnding.py
@@ -4,4 +4,4 @@ from boa3.builtin import public
 @public
 def Main() -> range:
     a = range(6)
-    return a[3:2]   # expect range(2, 3)
+    return a[3:2]   # expect range(3, 2)

--- a/boa3_test/test_sc/string_test/StringSlicingStartLargerThanEnding.py
+++ b/boa3_test/test_sc/string_test/StringSlicingStartLargerThanEnding.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+
+
+@public
+def Main() -> str:
+    a = 'unit_test'
+    return a[3:2]   # expect ''

--- a/boa3_test/test_sc/tuple_test/TupleSlicingStartLargerThanEnding.py
+++ b/boa3_test/test_sc/tuple_test/TupleSlicingStartLargerThanEnding.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+
+
+@public
+def Main() -> tuple:
+    a = (0, 1, 2, 3, 4, 5)
+    return a[3:2]   # expect ()

--- a/boa3_test/tests/test_list.py
+++ b/boa3_test/tests/test_list.py
@@ -329,6 +329,13 @@ class TestList(BoaTest):
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([2], result)
 
+    def test_list_slicing_start_larger_than_ending(self):
+        path = self.get_contract_path('ListSlicingStartLargerThanEnding.py')
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'Main')
+        self.assertEqual([], result)
+
     def test_list_slicing_with_variables(self):
         path = self.get_contract_path('ListSlicingVariableValues.py')
 

--- a/boa3_test/tests/test_range.py
+++ b/boa3_test/tests/test_range.py
@@ -313,6 +313,13 @@ class TestRange(BoaTest):
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([2], result)
 
+    def test_range_slicing_start_larger_than_ending(self):
+        path = self.get_contract_path('RangeSlicingStartLargerThanEnding.py')
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'Main')
+        self.assertEqual([], result)
+
     def test_range_slicing_with_variables(self):
         path = self.get_contract_path('RangeSlicingVariableValues.py')
 

--- a/boa3_test/tests/test_string.py
+++ b/boa3_test/tests/test_string.py
@@ -50,6 +50,15 @@ class TestString(BoaTest):
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual('i', result)
 
+    def test_string_slicing_start_larger_than_ending(self):
+        from boa3.compiler.codegenerator.vmcodemapping import VMCodeMapping
+        path = self.get_contract_path('StringSlicingStartLargerThanEnding.py')
+        self.compile_and_save(path)
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'Main')
+        self.assertEqual('', result)
+
     def test_string_slicing_with_variables(self):
         path = self.get_contract_path('StringSlicingVariableValues.py')
 

--- a/boa3_test/tests/test_tuple.py
+++ b/boa3_test/tests/test_tuple.py
@@ -247,6 +247,13 @@ class TestTuple(BoaTest):
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([2], result)
 
+    def test_tuple_slicing_start_larger_than_ending(self):
+        path = self.get_contract_path('TupleSlicingStartLargerThanEnding.py')
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'Main')
+        self.assertEqual([], result)
+
     def test_tuple_slicing_with_variables(self):
         path = self.get_contract_path('TupleSlicingVariableValues.py')
 


### PR DESCRIPTION
**Related issue**
#238 

**Summary or solution description**
Fixed the slice execution when it should return an empty sequence. It was raising an exception for slices of `str` and `bytes` types.

**How to Reproduce**
```python
@public
def Main() -> str:
    a = 'unit_test'
    return a[3:2]   # expect ''

```

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7