### PR TITLE
Fix isinstance for UInt160

### DIFF
--- a/boa3/compiler/codegenerator/codegenerator.py
+++ b/boa3/compiler/codegenerator/codegenerator.py
@@ -951,15 +951,16 @@ class CodeGenerator:
         :param symbol_id: the symbol identifier
         :param params_addresses: a list with each function arguments' first addresses
         """
-        if not params_addresses:
-            params_addresses = []
         symbol = self.get_symbol(symbol_id)
         if symbol is not Type.none:
             if isinstance(symbol, Property):
                 symbol = symbol.getter
                 params_addresses = []
-            elif isinstance(symbol, ClassType):
+            elif isinstance(symbol, ClassType) and params_addresses is not None:
                 symbol = symbol.constructor_method()
+
+            if not params_addresses:
+                params_addresses = []
 
             if isinstance(symbol, Variable):
                 self.convert_load_variable(symbol_id, symbol)
@@ -1076,13 +1077,6 @@ class CodeGenerator:
             for arg in sorted(fix_negatives, reverse=True):
                 if len(addresses) > arg:
                     self.fix_negative_index(addresses[arg])
-
-        from boa3.model.builtin.method.isinstancemethod import IsInstanceMethod
-        if isinstance(function, IsInstanceMethod) and len(args_address) > 1:
-            # TODO: remove this if when isinstance with classes is fixed
-            for address in args_address:
-                if VMCodeMapping.instance().get_code(address).opcode is Opcode.PUSHNULL:
-                    self._opcodes_to_remove.append(address)
 
         for opcode, data in function.opcode:
             op_info = OpcodeInfo.get_info(opcode)

--- a/boa3/compiler/codegenerator/codegeneratorvisitor.py
+++ b/boa3/compiler/codegenerator/codegeneratorvisitor.py
@@ -576,18 +576,23 @@ class VisitorCodeGenerator(IAstAnalyser):
             # remove opcodes inserted during the evaluation of the symbol
             VMCodeMapping.instance().remove_opcodes(last_address, VMCodeMapping.instance().bytecode_size)
         if last_stack < self.generator.stack_size:
-            # remove any additional values pushed to the stack dutin the evalution of the symbol
+            # remove any additional values pushed to the stack during the evalution of the symbol
             for _ in range(self.generator.stack_size - last_stack):
                 self.generator._stack_pop()
 
+        if isinstance(symbol, Method):
+            args_to_generate = [arg for index, arg in enumerate(call.args) if index in symbol.args_to_be_generated()]
+        else:
+            args_to_generate = call.args
+
         if isinstance(symbol, IBuiltinMethod) and symbol.push_self_first():
-            args = call.args[1:]
+            args = args_to_generate[1:]
             args_addresses.append(
                 VMCodeMapping.instance().bytecode_size
             )
             self.visit_to_generate(call.args[0])
         else:
-            args = call.args
+            args = args_to_generate
 
         for arg in reversed(args):
             args_addresses.append(

--- a/boa3/model/builtin/method/isinstancemethod.py
+++ b/boa3/model/builtin/method/isinstancemethod.py
@@ -52,10 +52,15 @@ class IsInstanceMethod(IBuiltinMethod):
         types.sort()
         return '-{0}_of_{1}'.format(self._identifier, '_or_'.join(types))
 
+    def args_to_be_generated(self) -> List[int]:
+        args = [name for name, symbol in self.args.items() if isinstance(symbol, Variable)]
+        return [list(self.args).index(key) for key in args]
+
     @property
     def is_supported(self) -> bool:
         from boa3.model.type.classtype import ClassType
-        return not any(isinstance(param, ClassType) for param in self._instances_type)
+        return not any(isinstance(param, ClassType) and len(param.is_instance_opcodes()) == 0
+                       for param in self._instances_type)
 
     def not_supported_str(self, callable_id: str) -> str:
         types = (self._instances_type[0].identifier if len(self._instances_type) == 1
@@ -82,41 +87,40 @@ class IsInstanceMethod(IBuiltinMethod):
         else:
             opcodes = []
             from boa3.model.type.type import Type
+            from boa3.neo.vm.type.Integer import Integer
             types = self._instances_type.copy()
 
-            code, data = self._type_opcode(types[-1])
-            size = len(code + data)
-            opcodes.append((code, data))
+            jmps = []
+            for check_instance in types[:-1]:
+                opcodes.append((Opcode.DUP, b''))
+                opcodes.extend(check_instance.is_instance_opcodes())
 
-            from boa3.neo.vm.type.Integer import Integer
+                jmps.append(len(opcodes))
+                opcodes.append((Opcode.JMPIF, b''))
 
-            for instance_type in reversed(types[:-1]):
-                jmp_if_true_body = [
-                    (Opcode.DUP, b''),
-                    self._type_opcode(instance_type),
-                    (Opcode.JMPIF, Integer(size + 4).to_byte_array(min_length=1, signed=True))
-                ]
+            opcodes.extend(types[-1].is_instance_opcodes())
 
-                for opcode, code_data in jmp_if_true_body:
-                    size += len(opcode + code_data)
-
-                opcodes = jmp_if_true_body + opcodes
-
+            last_index = len(opcodes)
             if len(types) > 1:
                 opcodes.extend([
                     (Opcode.JMP, Integer(4).to_byte_array(min_length=1, signed=True)),
                     (Opcode.DROP, b''),
-                    (Opcode.PUSH1, b''),
                 ])
+                last_index = len(opcodes)
+                opcodes.append((Opcode.PUSH1, b''))
+
+            jmp_to = 0
+            for index in reversed(jmps):
+                for pos in range(index + 1, last_index):
+                    last_op, last_data = opcodes[pos - 1]
+                    op, data = opcodes[pos]
+                    jmp_to += len(last_data) + len(op)
+                jmp_to += 1
+
+                last_index = index + 1
+                opcodes[index] = opcodes[index][0], Integer(jmp_to).to_byte_array(min_length=1, signed=True)
 
             return opcodes
-
-    def _type_opcode(self, instance_type: Optional[IType]) -> Tuple[Opcode, bytes]:
-        from boa3.model.type.type import Type
-        if instance_type in (None, Type.none):
-            return Opcode.ISNULL, b''
-        else:
-            return Opcode.ISTYPE, instance_type.stack_item
 
     @property
     def _args_on_stack(self) -> int:

--- a/boa3/model/method.py
+++ b/boa3/model/method.py
@@ -125,3 +125,14 @@ class Method(Callable):
                            None)
         if instruction is not None:
             self._debug_map.remove(instruction)
+
+    def args_to_be_generated(self) -> List[int]:
+        """
+        Gets the indexes of the arguments that must be generated.
+        If method has `self` arg, it must be in this list.
+
+        By default, all the arguments are generated.
+
+        :return: A list with the indexes of the arguments that must be generated
+        """
+        return list(range(len(self.args)))

--- a/boa3/model/type/anytype.py
+++ b/boa3/model/type/anytype.py
@@ -1,6 +1,7 @@
-from typing import Any
+from typing import Any, List, Tuple
 
 from boa3.model.type.itype import IType
+from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.AbiType import AbiType
 
 
@@ -25,6 +26,9 @@ class __AnyType(IType):
     @classmethod
     def _is_type_of(cls, value: Any):
         return True
+
+    def is_instance_opcodes(self) -> List[Tuple[Opcode, bytes]]:
+        return [(Opcode.PUSH1, b'')]  # any is type of everything, so inserts True
 
 
 anyType: IType = __AnyType()

--- a/boa3/model/type/classtype.py
+++ b/boa3/model/type/classtype.py
@@ -1,11 +1,12 @@
 from abc import ABC, abstractmethod
-from typing import Dict
+from typing import Dict, List, Tuple
 
 from boa3.model.method import Method
 from boa3.model.property import Property
 from boa3.model.symbol import ISymbol
 from boa3.model.type.itype import IType
 from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.StackItem import StackItemType
 
 
@@ -51,5 +52,10 @@ class ClassType(IType, ABC):
     def constructor_method(self) -> Method:
         pass
 
+    @property
     def stack_item(self) -> StackItemType:
         return StackItemType.Array
+
+    def is_instance_opcodes(self) -> List[Tuple[Opcode, bytes]]:
+        # TODO: Implement when the validation of created types is fixed
+        return []

--- a/boa3/model/type/collection/sequence/uint160type.py
+++ b/boa3/model/type/collection/sequence/uint160type.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, List, Tuple
 
 from boa3.model.method import Method
 from boa3.model.property import Property
@@ -6,6 +6,7 @@ from boa3.model.type.classtype import ClassType
 from boa3.model.type.itype import IType
 from boa3.model.type.primitive.bytestype import BytesType
 from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.AbiType import AbiType
 from boa3.neo.vm.type.StackItem import StackItemType
 
@@ -63,6 +64,22 @@ class UInt160Type(BytesType, ClassType):
     @classmethod
     def _is_type_of(cls, value: Any):
         return isinstance(value, UInt160Type)
+
+    def is_instance_opcodes(self) -> List[Tuple[Opcode, bytes]]:
+        from boa3.neo.vm.type.Integer import Integer
+        push_int_opcode, size_data = Opcode.get_push_and_data(20)
+
+        return [
+            (Opcode.DUP, b''),                  # if isinstance(value, bytes):
+            (Opcode.ISTYPE, self.stack_item),
+            (Opcode.JMPIFNOT, Integer(7 + len(size_data)).to_byte_array(min_length=1)),
+            (Opcode.SIZE, b''),                     # return len(value) == 20
+            (push_int_opcode, size_data),
+            (Opcode.NUMEQUAL, b''),
+            (Opcode.JMP, Integer(4).to_byte_array(min_length=1)),
+            (Opcode.DROP, b''),
+            (Opcode.PUSH0, b''),                # return False
+        ]
 
 
 _UInt160 = UInt160Type()

--- a/boa3/model/type/itype.py
+++ b/boa3/model/type/itype.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Any, Dict
+from typing import Any, Dict, List, Tuple
 
 from boa3.model.identifiedsymbol import IdentifiedSymbol
 from boa3.model.symbol import ISymbol
+from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.AbiType import AbiType
 from boa3.neo.vm.type.StackItem import StackItemType
 
@@ -94,6 +95,14 @@ class IType(IdentifiedSymbol):
         :rtype: IType or None
         """
         pass
+
+    def is_instance_opcodes(self) -> List[Tuple[Opcode, bytes]]:
+        """
+        Get the list of opcodes to check if an value is of this type
+
+        :return: A list of opcodes to check a value type
+        """
+        return [(Opcode.ISTYPE, self.stack_item)]
 
     @property
     def symbols(self) -> Dict[str, ISymbol]:

--- a/boa3/model/type/primitive/nonetype.py
+++ b/boa3/model/type/primitive/nonetype.py
@@ -1,6 +1,7 @@
-from typing import Any
+from typing import Any, List, Tuple
 
 from boa3.model.type.itype import IType
+from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.AbiType import AbiType
 
 
@@ -27,3 +28,6 @@ class NoneType(IType):
     def _is_type_of(cls, value: Any):
         from boa3.model.type.type import Type
         return value is None or value is Type.none
+
+    def is_instance_opcodes(self) -> List[Tuple[Opcode, bytes]]:
+        return [(Opcode.ISNULL, b'')]

--- a/boa3/neo/vm/opcode/Opcode.py
+++ b/boa3/neo/vm/opcode/Opcode.py
@@ -61,11 +61,14 @@ class Opcode(bytes, Enum):
                 opcode = Opcode.PUSHINT8
             elif len(data) == 2:
                 opcode = Opcode.PUSHINT16
-            elif len(data) == 4:
+            elif len(data) <= 4:
+                data = Integer(integer).to_byte_array(signed=True, min_length=4)
                 opcode = Opcode.PUSHINT32
-            elif len(data) == 8:
+            elif len(data) <= 8:
+                data = Integer(integer).to_byte_array(signed=True, min_length=8)
                 opcode = Opcode.PUSHINT64
-            elif len(data) == 16:
+            elif len(data) <= 16:
+                data = Integer(integer).to_byte_array(signed=True, min_length=16)
                 opcode = Opcode.PUSHINT128
             else:
                 data = data[:32]

--- a/boa3/neo/vm/opcode/Opcode.py
+++ b/boa3/neo/vm/opcode/Opcode.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Dict, Optional
+from typing import Dict, Optional, Tuple
 
 from boa3.neo.vm.type.Integer import Integer
 
@@ -42,6 +42,36 @@ class Opcode(bytes, Enum):
             return Opcode(Integer(opcode_value).to_byte_array())
         else:
             return None
+
+    @staticmethod
+    def get_push_and_data(integer: int) -> Tuple[Opcode, bytes]:
+        """
+        Gets the push opcode and data to the respective integer
+
+        :param integer: value that will be pushed
+        :return: the respective opcode and its required data
+        :rtype: Tuple[Opcode, bytes]
+        """
+        if -1 <= integer <= 16:
+            opcode_value: int = Integer.from_bytes(Opcode.PUSH0) + integer
+            return Opcode(Integer(opcode_value).to_byte_array()), b''
+        else:
+            data = Integer(integer).to_byte_array(signed=True, min_length=1)
+            if len(data) == 1:
+                opcode = Opcode.PUSHINT8
+            elif len(data) == 2:
+                opcode = Opcode.PUSHINT16
+            elif len(data) == 4:
+                opcode = Opcode.PUSHINT32
+            elif len(data) == 8:
+                opcode = Opcode.PUSHINT64
+            elif len(data) == 16:
+                opcode = Opcode.PUSHINT128
+            else:
+                data = data[:32]
+                opcode = Opcode.PUSHINT256
+
+            return opcode, data
 
     # The number -1 is pushed onto the stack.
     PUSHM1 = b'\x0F'
@@ -662,3 +692,6 @@ class Opcode(bytes, Enum):
     CONVERT = b'\xDB'
 
     # endregion
+
+    def __repr__(self) -> str:
+        return str(self)

--- a/boa3_test/test_sc/built_in_methods_test/IsInstanceClass.py
+++ b/boa3_test/test_sc/built_in_methods_test/IsInstanceClass.py
@@ -1,11 +1,10 @@
+from typing import Any
+
 from boa3.builtin import public
-from boa3.builtin.type import UInt160
+from boa3.builtin.interop.contract.contract import Contract
 
 
 @public
-def Main(value: bytes) -> bool:
-    if len(value) == 20:
-        value = UInt160(value)
-
+def Main(value: Any) -> bool:
     # not supported because boa builtin classes don't work with isinstance yet
-    return isinstance(value, UInt160)
+    return isinstance(value, Contract)

--- a/boa3_test/test_sc/built_in_methods_test/IsInstanceUInt160.py
+++ b/boa3_test/test_sc/built_in_methods_test/IsInstanceUInt160.py
@@ -1,0 +1,10 @@
+from boa3.builtin import public
+from boa3.builtin.type import UInt160
+
+
+@public
+def Main(value: bytes) -> bool:
+    if len(value) == 20:
+        value = UInt160(value)
+
+    return isinstance(value, UInt160)

--- a/boa3_test/tests/test_builtin_method.py
+++ b/boa3_test/tests/test_builtin_method.py
@@ -729,40 +729,14 @@ class TestBuiltinMethod(BoaTest):
     # region isinstance test
 
     def test_isinstance_int_literal(self):
-        value = Integer(123).to_byte_array()
-        expected_output = (
-            Opcode.PUSHDATA1        # isinstance(123, int)
-            + Integer(len(value)).to_byte_array(min_length=1)
-            + value
-            + Opcode.CONVERT
-            + Type.int.stack_item
-            + Opcode.ISTYPE
-            + Type.int.stack_item
-            + Opcode.RET
-        )
-
         path = self.get_contract_path('IsInstanceIntLiteral.py')
-        output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(True, result)
 
     def test_isinstance_int_variable(self):
-        expected_output = (
-            Opcode.INITSLOT
-            + b'\x00'
-            + b'\x01'
-            + Opcode.LDARG0         # isinstance(a, int)
-            + Opcode.ISTYPE
-            + Type.int.stack_item
-            + Opcode.RET
-        )
-
         path = self.get_contract_path('IsInstanceIntVariable.py')
-        output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 10)
@@ -773,40 +747,14 @@ class TestBuiltinMethod(BoaTest):
         self.assertEqual(False, result)
 
     def test_isinstance_bool_literal(self):
-        value = Integer(123).to_byte_array()
-        expected_output = (
-            Opcode.PUSHDATA1        # isinstance(123, bool)
-            + Integer(len(value)).to_byte_array(min_length=1)
-            + value
-            + Opcode.CONVERT
-            + Type.int.stack_item
-            + Opcode.ISTYPE
-            + Type.bool.stack_item
-            + Opcode.RET
-        )
-
         path = self.get_contract_path('IsInstanceBoolLiteral.py')
-        output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(False, result)
 
     def test_isinstance_bool_variable(self):
-        expected_output = (
-            Opcode.INITSLOT
-            + b'\x00'
-            + b'\x01'
-            + Opcode.LDARG0         # isinstance(a, bool)
-            + Opcode.ISTYPE
-            + Type.bool.stack_item
-            + Opcode.RET
-        )
-
         path = self.get_contract_path('IsInstanceBoolVariable.py')
-        output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 10)
@@ -817,38 +765,14 @@ class TestBuiltinMethod(BoaTest):
         self.assertEqual(False, result)
 
     def test_isinstance_str_literal(self):
-        value = String('123').to_bytes()
-        expected_output = (
-            Opcode.PUSHDATA1        # isinstance('123', str)
-            + Integer(len(value)).to_byte_array(min_length=1)
-            + value
-            + Opcode.ISTYPE
-            + Type.str.stack_item
-            + Opcode.RET
-        )
-
         path = self.get_contract_path('IsInstanceStrLiteral.py')
-        output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(True, result)
 
     def test_isinstance_str_variable(self):
-        expected_output = (
-            Opcode.INITSLOT
-            + b'\x00'
-            + b'\x01'
-            + Opcode.LDARG0         # isinstance(a, str)
-            + Opcode.ISTYPE
-            + Type.str.stack_item
-            + Opcode.RET
-        )
-
         path = self.get_contract_path('IsInstanceStrVariable.py')
-        output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 10)
@@ -859,51 +783,21 @@ class TestBuiltinMethod(BoaTest):
         self.assertEqual(True, result)
 
     def test_isinstance_list_literal(self):
-        expected_output = (
-            Opcode.NEWARRAY0        # isinstance([], list)
-            + Opcode.ISTYPE
-            + Type.list.stack_item
-            + Opcode.RET
-        )
-
         path = self.get_contract_path('IsInstanceListLiteral.py')
-        output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(True, result)
 
     def test_isinstance_tuple_literal(self):
-        expected_output = (
-            Opcode.NEWARRAY0        # isinstance([], tuple)
-            + Opcode.ISTYPE
-            + Type.tuple.stack_item
-            + Opcode.RET
-        )
-
         path = self.get_contract_path('IsInstanceTupleLiteral.py')
-        output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(True, result)
 
     def test_isinstance_tuple_variable(self):
-        expected_output = (
-            Opcode.INITSLOT
-            + b'\x00'
-            + b'\x01'
-            + Opcode.LDARG0         # isinstance(a, tuple)
-            + Opcode.ISTYPE
-            + Type.tuple.stack_item
-            + Opcode.RET
-        )
-
         path = self.get_contract_path('IsInstanceTupleVariable.py')
-        output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 10)
@@ -916,38 +810,7 @@ class TestBuiltinMethod(BoaTest):
         self.assertEqual(True, result)
 
     def test_isinstance_many_types(self):
-        expected_output = (
-            Opcode.INITSLOT
-            + b'\x00'
-            + b'\x01'
-            + Opcode.LDARG0         # isinstance(a, tuple)
-            + Opcode.DUP
-            + Opcode.ISTYPE
-            + Type.list.stack_item
-            + Opcode.JMPIF
-            + Integer(16).to_byte_array(min_length=1, signed=True)
-            + Opcode.DUP
-            + Opcode.ISTYPE
-            + Type.int.stack_item
-            + Opcode.JMPIF
-            + Integer(11).to_byte_array(min_length=1, signed=True)
-            + Opcode.DUP
-            + Opcode.ISTYPE
-            + Type.bool.stack_item
-            + Opcode.JMPIF
-            + Integer(6).to_byte_array(min_length=1, signed=True)
-            + Opcode.ISTYPE
-            + Type.dict.stack_item
-            + Opcode.JMP
-            + Integer(4).to_byte_array(min_length=1, signed=True)
-            + Opcode.DROP
-            + Opcode.PUSH1
-            + Opcode.RET
-        )
-
         path = self.get_contract_path('IsInstanceManyTypes.py')
-        output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 10)
@@ -961,7 +824,46 @@ class TestBuiltinMethod(BoaTest):
 
     def test_isinstance_many_types_with_class(self):
         path = self.get_contract_path('IsInstanceManyTypesWithClass.py')
-        self.assertCompilerLogs(NotSupportedOperation, path)
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'Main', 42,
+                                         expected_result_type=bool)
+        self.assertEqual(True, result)
+        result = self.run_smart_contract(engine, path, 'Main', bytes(10),
+                                         expected_result_type=bool)
+        self.assertEqual(False, result)
+        result = self.run_smart_contract(engine, path, 'Main', [],
+                                         expected_result_type=bool)
+        self.assertEqual(True, result)
+        result = self.run_smart_contract(engine, path, 'Main', 'some string',
+                                         expected_result_type=bool)
+        self.assertEqual(False, result)
+        result = self.run_smart_contract(engine, path, 'Main', bytes(20),
+                                         expected_result_type=bool)
+        self.assertEqual(True, result)
+        result = self.run_smart_contract(engine, path, 'Main', None,
+                                         expected_result_type=bool)
+        self.assertEqual(False, result)
+        result = self.run_smart_contract(engine, path, 'Main', {1: 2, 2: 4},
+                                         expected_result_type=bool)
+        self.assertEqual(True, result)
+
+    def test_isinstance_uint160(self):
+        path = self.get_contract_path('IsInstanceUInt160.py')
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'Main', bytes(10),
+                                         expected_result_type=bool)
+        self.assertEqual(False, result)
+        result = self.run_smart_contract(engine, path, 'Main', bytes(20),
+                                         expected_result_type=bool)
+        self.assertEqual(True, result)
+        result = self.run_smart_contract(engine, path, 'Main', bytes(30),
+                                         expected_result_type=bool)
+        self.assertEqual(False, result)
+        result = self.run_smart_contract(engine, path, 'Main', 42,
+                                         expected_result_type=bool)
+        self.assertEqual(False, result)
 
     def test_isinstance_class(self):
         path = self.get_contract_path('IsInstanceClass.py')

--- a/boa3_test/tests/test_string.py
+++ b/boa3_test/tests/test_string.py
@@ -51,7 +51,6 @@ class TestString(BoaTest):
         self.assertEqual('i', result)
 
     def test_string_slicing_start_larger_than_ending(self):
-        from boa3.compiler.codegenerator.vmcodemapping import VMCodeMapping
         path = self.get_contract_path('StringSlicingStartLargerThanEnding.py')
         self.compile_and_save(path)
 


### PR DESCRIPTION
**Related issue**
#314

**Summary or solution description**
Fixed Python built-in ``isinstance`` to work with neo3-boa built-in ``UInt160``.

**How to Reproduce**
```python
from boa3.builtin import public
from boa3.builtin.type import UInt160


@public
def Main(value: Any) -> bool:
    return isinstance(value, UInt160)
```

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7