### PR TITLE
The byte[] eventName parameter is missing at notify()

### DIFF
--- a/boa3/builtin/interop/runtime/__init__.py
+++ b/boa3/builtin/interop/runtime/__init__.py
@@ -17,11 +17,12 @@ def check_witness(hash_or_pubkey: Union[bytes, UInt160]) -> bool:
     pass
 
 
-def notify(state: Any):
+def notify(state: Any, notification_name: str = None):
     """
     Notifies the client from the executing smart contract.
 
     :param state: the notification message
+    :param notification_name: name that'll be linked to the notification
     """
     pass
 

--- a/boa3/compiler/codegenerator/codegenerator.py
+++ b/boa3/compiler/codegenerator/codegenerator.py
@@ -1115,8 +1115,12 @@ class CodeGenerator:
         :param event_id: called event identifier
         :param event: called event
         """
-        self.convert_new_array(len(event.args), Type.list)
-        self.convert_literal(event.name)
+        self.convert_new_array(len(event.args_to_generate), Type.list)
+        if event.generate_name:
+            self.convert_literal(event.name)
+        else:
+            self.swap_reverse_stack_items(2)
+
         from boa3.model.builtin.interop.interop import Interop
         for opcode, data in Interop.Notify.opcode:
             info = OpcodeInfo.get_info(opcode)

--- a/boa3/compiler/filegenerator.py
+++ b/boa3/compiler/filegenerator.py
@@ -161,7 +161,7 @@ class FileGenerator:
                     {
                         "name": arg_id,
                         "type": arg.type.abi_type
-                    } for arg_id, arg in event.args.items()
+                    } for arg_id, arg in event.args_to_generate.items()
                 ],
             } for name, event in self._events.items()
         ]

--- a/boa3/model/builtin/interop/runtime/notifymethod.py
+++ b/boa3/model/builtin/interop/runtime/notifymethod.py
@@ -7,8 +7,25 @@ from boa3.model.variable import Variable
 class NotifyMethod(InteropEvent):
 
     def __init__(self):
+        self._event_name_key = 'notification_name'
+
         from boa3.model.type.type import Type
         identifier = 'notify'
         syscall = 'System.Runtime.Notify'
-        args: Dict[str, Variable] = {'state': Variable(Type.any)}
-        super().__init__(identifier, syscall, args)
+        args: Dict[str, Variable] = {'state': Variable(Type.any),
+                                     self._event_name_key: Variable(Type.str)
+                                     }
+        import ast
+        event_name_default = ast.parse("'{0}'".format(identifier)
+                                       ).body[0].value
+        super().__init__(identifier, syscall, args, defaults=[event_name_default])
+
+    @property
+    def generate_name(self) -> bool:
+        return False
+
+    @property
+    def args_to_generate(self) -> Dict[str, Variable]:
+        return {key_name: value_type
+                for key_name, value_type in self.args.items()
+                if key_name != self._event_name_key}

--- a/boa3/model/event.py
+++ b/boa3/model/event.py
@@ -22,3 +22,11 @@ class Event(Callable, IdentifiedSymbol):
     @property
     def identifier(self) -> str:
         return self.name
+
+    @property
+    def args_to_generate(self) -> Dict[str, Variable]:
+        return self.args.copy()
+
+    @property
+    def generate_name(self) -> bool:
+        return True

--- a/boa3_test/test_sc/dict_test/DictBoa2Test1.py
+++ b/boa3_test/test_sc/dict_test/DictBoa2Test1.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any, Dict
 
 from boa3.builtin import public
 

--- a/boa3_test/test_sc/dict_test/DictBoa2Test2.py
+++ b/boa3_test/test_sc/dict_test/DictBoa2Test2.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any, Dict
 
 from boa3.builtin import public
 

--- a/boa3_test/test_sc/dict_test/DictBoa2Test3.py
+++ b/boa3_test/test_sc/dict_test/DictBoa2Test3.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 
 from boa3.builtin import public
 

--- a/boa3_test/test_sc/dict_test/DictBoa2Test5ShouldNotCompile.py
+++ b/boa3_test/test_sc/dict_test/DictBoa2Test5ShouldNotCompile.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 
 from boa3.builtin import public
 

--- a/boa3_test/test_sc/dict_test/DictBoa2Test6ShouldNotCompile.py
+++ b/boa3_test/test_sc/dict_test/DictBoa2Test6ShouldNotCompile.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any, Dict
 
 from boa3.builtin import public
 

--- a/boa3_test/test_sc/event_test/EventBoa2Test.py
+++ b/boa3_test/test_sc/event_test/EventBoa2Test.py
@@ -1,7 +1,5 @@
 # tested
-from boa3.builtin import public
-
-from boa3.builtin import CreateNewEvent
+from boa3.builtin import CreateNewEvent, public
 
 Transfer = CreateNewEvent([('from', int), ('to', int), ('amount', int)], 'transfer_test')
 

--- a/boa3_test/test_sc/interop_test/runtime/NotifyWithName.py
+++ b/boa3_test/test_sc/interop_test/runtime/NotifyWithName.py
@@ -1,0 +1,8 @@
+from boa3.builtin import public
+
+from boa3.builtin.interop.runtime import notify
+
+
+@public
+def Main(notify_name: str):
+    notify(10, notify_name)

--- a/boa3_test/test_sc/interop_test/runtime/RuntimeBoa2Test.py
+++ b/boa3_test/test_sc/interop_test/runtime/RuntimeBoa2Test.py
@@ -1,8 +1,7 @@
 from typing import Any
 
 from boa3.builtin import public
-
-from boa3.builtin.interop.runtime import notify, get_time, check_witness, log, trigger
+from boa3.builtin.interop.runtime import check_witness, get_time, log, notify, trigger
 
 
 @public

--- a/boa3_test/test_sc/interop_test/storage/StorageBoa2Test.py
+++ b/boa3_test/test_sc/interop_test/storage/StorageBoa2Test.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from boa3.builtin import public
-from boa3.builtin.interop.storage import put, delete, get
+from boa3.builtin.interop.storage import delete, get, put
 
 
 @public

--- a/boa3_test/test_sc/list_test/ReverseBoa2Test.py
+++ b/boa3_test/test_sc/list_test/ReverseBoa2Test.py
@@ -1,4 +1,4 @@
-from typing import List, Any
+from typing import Any, List
 
 from boa3.builtin import public
 

--- a/boa3_test/tests/test_if.py
+++ b/boa3_test/tests/test_if.py
@@ -525,7 +525,7 @@ class TestIf(BoaTest):
         result = self.run_smart_contract(engine, path, 'main', 'omin', -4, 4)
         self.assertEqual(-4, result)
 
-        result = self.run_smart_contract(engine, path, 'main', 'omin',16, 0)
+        result = self.run_smart_contract(engine, path, 'main', 'omin', 16, 0)
         self.assertEqual(0, result)
 
         result = self.run_smart_contract(engine, path, 'main', 'omax', 4, 4)


### PR DESCRIPTION
**Related issue**
#272 

**Summary or solution description**
Included an optional argument in the `notify` interop function to allow to modify the notification's event name.

**How to Reproduce**
```python
from boa3.builtin import public

from boa3.builtin.interop.runtime import notify


@public
def Main():
    notify(10, 'example_notification')
```

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7