### PR TITLE
Add "in" support for collections

### DIFF
--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -717,8 +717,14 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
         if operation is not None:
             return operation
         else:
-            expected_op: BinaryOperation = BinaryOp.get_operation_by_operator(operator,
-                                                                              l_type if left is not None else r_type)
+            if operator.requires_right_operand_for_validation():
+                left = l_type
+                right = r_type
+            else:
+                left = l_type if left is not None else r_type
+                right = None
+
+            expected_op: BinaryOperation = BinaryOp.get_operation_by_operator(operator, left, right)
             expected_types = (expected_op.left_type.identifier, expected_op.right_type.identifier)
             raise CompilerError.MismatchedTypes(0, 0, expected_types, actual_types)
 

--- a/boa3/model/operation/binary/additional/__init__.py
+++ b/boa3/model/operation/binary/additional/__init__.py
@@ -1,0 +1,6 @@
+__all__ = ['CollectionMembership',
+           'CollectionNotMembership'
+           ]
+
+from boa3.model.operation.binary.additional.membership import CollectionMembership
+from boa3.model.operation.binary.additional.notmembership import CollectionNotMembership

--- a/boa3/model/operation/binary/additional/membership.py
+++ b/boa3/model/operation/binary/additional/membership.py
@@ -1,0 +1,122 @@
+from typing import List, Optional, Tuple
+
+from boa3.model.operation.binary.binaryoperation import BinaryOperation
+from boa3.model.operation.operator import Operator
+from boa3.model.type.collection.icollection import ICollectionType
+from boa3.model.type.collection.mapping.mappingtype import MappingType
+from boa3.model.type.primitive.primitivetype import PrimitiveType
+from boa3.model.type.type import IType, Type
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class CollectionMembership(BinaryOperation):
+    """
+    A class used to represent a collection membership operation
+
+    :ivar operator: the operator of the operation. Inherited from :class:`IOperation`
+    :ivar left: the left operand type. Inherited from :class:`BinaryOperation`
+    :ivar right: the left operand type. Inherited from :class:`BinaryOperation`
+    :ivar result: the result type of the operation.  Inherited from :class:`IOperation`
+    """
+    _valid_types: List[IType] = [Type.collection]
+
+    def __init__(self, left: IType = Type.any, right: IType = None):
+        self.operator: Operator = Operator.In
+
+        if not isinstance(right, ICollectionType):
+            right = Type.collection
+
+        reference_type = right.key_type if isinstance(right, MappingType) else right.item_type
+        if not reference_type.is_type_of(left) or (reference_type is Type.any and left is not Type.any):
+            if Type.sequence.is_type_of(left):
+                right = Type.collection.build(left)
+            else:
+                right = Type.collection.build(Type.list.build([left]))
+
+        super().__init__(left, right)
+
+    def validate_type(self, *types: IType) -> bool:
+        if len(types) != self.number_of_operands:
+            return False
+        left: IType = types[0]
+        right: IType = types[1]
+
+        if not isinstance(right, ICollectionType):
+            return False
+
+        if isinstance(right, PrimitiveType) and (right.is_type_of(left) or left.is_type_of(right)):
+            return True
+
+        if isinstance(right, MappingType):
+            reference_type = right.key_type
+        else:
+            reference_type = right.item_type
+
+        return reference_type.is_type_of(left)
+
+    def _get_result(self, left: IType, right: IType) -> IType:
+        return Type.bool
+
+    def get_valid_operand_for_validation(self, left_operand: IType,
+                                         right_operand: IType = None) -> Tuple[Optional[IType], Optional[IType]]:
+        if isinstance(right_operand, ICollectionType):
+            left = right_operand.item_type if not isinstance(right_operand, MappingType) else right_operand.key_type
+            return left, right_operand
+
+        return left_operand, self.right_type
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        from boa3.neo.vm.type.Integer import Integer
+        return [
+            (Opcode.DUP, b''),
+            (Opcode.ISTYPE, Type.mapping.stack_item),   # if isinstance(arg1, dict)
+            (Opcode.JMPIFNOT, Integer(6).to_byte_array(signed=True, min_length=1)),
+            (Opcode.SWAP, b''),
+            (Opcode.HASKEY, b''),                           # return value.has_key(arg0)
+            (Opcode.JMP, Integer(54).to_byte_array(signed=True, min_length=1)),
+            (Opcode.DUP, b''),
+            (Opcode.DUP, b''),
+            (Opcode.ISTYPE, Type.str.stack_item),       # is_bytestr = isinstance(arg1, (str, bytes))
+            (Opcode.SWAP, b''),
+            (Opcode.SIZE, b''),                         # limit = len(arg1)
+            (Opcode.OVER, b''),                         # if is_bytestr:
+            (Opcode.JMPIFNOT, Integer(7).to_byte_array(signed=True, min_length=1)),
+            (Opcode.PUSH3, b''),                            # limit = limit - len(arg0) + 1
+            (Opcode.PICK, b''),
+            (Opcode.SIZE, b''),
+            (Opcode.SUB, b''),
+            (Opcode.INC, b''),
+            (Opcode.PUSH0, b''),                        # index = 0
+            (Opcode.DUP, b''),                          # while index < limit:
+            (Opcode.PUSH2, b''),
+            (Opcode.PICK, b''),
+            (Opcode.LT, b''),
+            (Opcode.JMPIFNOT, Integer(28).to_byte_array(signed=True, min_length=1)),
+            (Opcode.PUSH4, b''),                            # aux = arg0
+            (Opcode.PICK, b''),
+            (Opcode.PUSH4, b''),
+            (Opcode.PICK, b''),
+            (Opcode.PUSH2, b''),
+            (Opcode.PICK, b''),
+            (Opcode.PUSH5, b''),
+            (Opcode.PICK, b''),                             # if is_bytestr:
+            (Opcode.JMPIFNOT, Integer(10).to_byte_array(signed=True, min_length=1)),
+            (Opcode.PUSH2, b''),                                # if arg1[index:len(arg0)] == arg0:
+            (Opcode.PICK, b''),
+            (Opcode.SIZE, b''),
+            (Opcode.SUBSTR, b''),
+            (Opcode.CONVERT, Type.str.stack_item),
+            (Opcode.NUMEQUAL, b''),                                 # break
+            (Opcode.JMP, Integer(4).to_byte_array(signed=True, min_length=1)),
+            (Opcode.PICKITEM, b''),                         # elif arg1[index] == arg0:
+            (Opcode.EQUAL, b''),                                    # break
+            (Opcode.JMPIF, Integer(5).to_byte_array(signed=True, min_length=1)),
+            (Opcode.INC, b''),                              # index += 1
+            (Opcode.JMP, Integer(-30).to_byte_array(signed=True, min_length=1)),
+            (Opcode.GT, b''),                       # return index < limit
+            (Opcode.REVERSE4, b''),                     # if the value is found, index won't reach the limit
+            (Opcode.DROP, b''),                     # remove auxiliar values from stack
+            (Opcode.DROP, b''),
+            (Opcode.DROP, b''),
+        ]

--- a/boa3/model/operation/binary/additional/notmembership.py
+++ b/boa3/model/operation/binary/additional/notmembership.py
@@ -1,0 +1,67 @@
+from typing import List, Optional, Tuple
+
+from boa3.model.operation.binary.binaryoperation import BinaryOperation
+from boa3.model.operation.operator import Operator
+from boa3.model.type.collection.icollection import ICollectionType
+from boa3.model.type.collection.mapping.mappingtype import MappingType
+from boa3.model.type.primitive.primitivetype import PrimitiveType
+from boa3.model.type.type import IType, Type
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class CollectionNotMembership(BinaryOperation):
+    """
+    A class used to represent a collection not membership operation
+
+    :ivar operator: the operator of the operation. Inherited from :class:`IOperation`
+    :ivar left: the left operand type. Inherited from :class:`BinaryOperation`
+    :ivar right: the left operand type. Inherited from :class:`BinaryOperation`
+    :ivar result: the result type of the operation.  Inherited from :class:`IOperation`
+    """
+    _valid_types: List[IType] = [Type.collection]
+
+    def __init__(self, left: IType = Type.any, right: IType = None):
+        self.operator: Operator = Operator.NotIn
+
+        if not isinstance(right, ICollectionType):
+            right = Type.collection
+
+        if not right.item_type.is_type_of(left) or right.item_type is Type.any and left is not Type.any:
+            right = Type.collection.build(Type.sequence.build(left))
+
+        super().__init__(left, right)
+
+    def validate_type(self, *types: IType) -> bool:
+        if len(types) != self.number_of_operands:
+            return False
+        left: IType = types[0]
+        right: IType = types[1]
+
+        if not isinstance(right, ICollectionType):
+            return False
+
+        if isinstance(right, PrimitiveType) and (right.is_type_of(left) or left.is_type_of(right)):
+            return True
+
+        if isinstance(right, MappingType):
+            reference_type = right.key_type
+        else:
+            reference_type = right.item_type
+
+        return reference_type.is_type_of(left)
+
+    def _get_result(self, left: IType, right: IType) -> IType:
+        return Type.bool
+
+    def get_valid_operand_for_validation(self, left_operand: IType,
+                                         right_operand: IType = None) -> Tuple[Optional[IType], Optional[IType]]:
+        if isinstance(right_operand, ICollectionType):
+            left = right_operand.item_type if not isinstance(right_operand, MappingType) else right_operand.key_type
+            return left, right_operand
+
+        return left_operand, self.right_type
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        from boa3.model.operation.binary.additional import CollectionMembership
+        return CollectionMembership().opcode + [(Opcode.NOT, b'')]

--- a/boa3/model/operation/binary/arithmetic/__init__.py
+++ b/boa3/model/operation/binary/arithmetic/__init__.py
@@ -1,0 +1,20 @@
+__all__ = ['Addition',
+           'Concat',
+           'Division',
+           'FloorDivision',
+           'Modulo',
+           'Multiplication',
+           'Power',
+           'StrMultiplication',
+           'Subtraction'
+           ]
+
+from boa3.model.operation.binary.arithmetic.addition import Addition
+from boa3.model.operation.binary.arithmetic.concat import Concat
+from boa3.model.operation.binary.arithmetic.division import Division
+from boa3.model.operation.binary.arithmetic.floordivision import FloorDivision
+from boa3.model.operation.binary.arithmetic.modulo import Modulo
+from boa3.model.operation.binary.arithmetic.multiplication import Multiplication
+from boa3.model.operation.binary.arithmetic.power import Power
+from boa3.model.operation.binary.arithmetic.strmultiplication import StrMultiplication
+from boa3.model.operation.binary.arithmetic.subtraction import Subtraction

--- a/boa3/model/operation/binary/binaryoperation.py
+++ b/boa3/model/operation/binary/binaryoperation.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from boa3.model.operation.operation import IOperation
 from boa3.model.type.itype import IType
@@ -74,3 +74,14 @@ class BinaryOperation(IOperation, ABC):
         if operation.validate_type(left, right):
             return operation
         return cls(left, left)
+
+    def get_valid_operand_for_validation(self, left_operand: IType,
+                                         right_operand: IType = None) -> Tuple[Optional[IType], Optional[IType]]:
+        """
+        Returns a valid operand type for the given types.
+
+        :param left_operand: reference type
+        :param right_operand: reference type
+        """
+        return next((valid_type for valid_type in self._valid_types if valid_type.is_type_of(left_operand)),
+                    None), self.right_type

--- a/boa3/model/operation/binary/logical/__init__.py
+++ b/boa3/model/operation/binary/logical/__init__.py
@@ -1,0 +1,16 @@
+__all__ = ['BooleanAnd',
+           'BooleanOr',
+           'LeftShift',
+           'LogicAnd',
+           'LogicOr',
+           'LogicXor',
+           'RightShift'
+           ]
+
+from boa3.model.operation.binary.logical.booleanand import BooleanAnd
+from boa3.model.operation.binary.logical.booleanor import BooleanOr
+from boa3.model.operation.binary.logical.leftshift import LeftShift
+from boa3.model.operation.binary.logical.logicand import LogicAnd
+from boa3.model.operation.binary.logical.logicor import LogicOr
+from boa3.model.operation.binary.logical.logicxor import LogicXor
+from boa3.model.operation.binary.logical.rightshift import RightShift

--- a/boa3/model/operation/binary/relational/__init__.py
+++ b/boa3/model/operation/binary/relational/__init__.py
@@ -1,0 +1,22 @@
+__all__ = ['LessThan',
+           'LessThanOrEqual',
+           'GreaterThan',
+           'GreaterThanOrEqual',
+           'Identity',
+           'NotIdentity',
+           'NumericEquality',
+           'NumericInequality',
+           'ObjectEquality',
+           'ObjectInequality'
+           ]
+
+from boa3.model.operation.binary.relational.LessThan import LessThan
+from boa3.model.operation.binary.relational.Lessthanorequal import LessThanOrEqual
+from boa3.model.operation.binary.relational.greaterthan import GreaterThan
+from boa3.model.operation.binary.relational.greaterthanorequal import GreaterThanOrEqual
+from boa3.model.operation.binary.relational.identity import Identity
+from boa3.model.operation.binary.relational.notidentity import NotIdentity
+from boa3.model.operation.binary.relational.numericequality import NumericEquality
+from boa3.model.operation.binary.relational.numericinequality import NumericInequality
+from boa3.model.operation.binary.relational.objectequality import ObjectEquality
+from boa3.model.operation.binary.relational.objectinequality import ObjectInequality

--- a/boa3/model/operation/operator.py
+++ b/boa3/model/operation/operator.py
@@ -38,6 +38,8 @@ class Operator(str, Enum):
 
     # Other operators
     Subscript = '[]'
+    In = 'in'
+    NotIn = 'not in'
 
     @classmethod
     def get_operation(cls, node: ast.operator) -> Optional[Operator]:
@@ -59,6 +61,8 @@ class Operator(str, Enum):
             ast.GtE: Operator.GtE,
             ast.Is: Operator.Is,
             ast.IsNot: Operator.IsNot,
+            ast.In: Operator.In,
+            ast.NotIn: Operator.NotIn,
             ast.And: Operator.And,
             ast.Or: Operator.Or,
             ast.Not: Operator.Not,
@@ -76,5 +80,13 @@ class Operator(str, Enum):
         else:
             return None
 
+    def requires_right_operand_for_validation(self) -> bool:
+        return self in [Operator.In,
+                        Operator.NotIn
+                        ]
+
     def __str__(self) -> str:
+        return self.value
+
+    def __repr__(self) -> str:
         return self.value

--- a/boa3/model/operation/unary/__init__.py
+++ b/boa3/model/operation/unary/__init__.py
@@ -1,0 +1,11 @@
+__all__ = ['BooleanNot',
+           'LogicNot',
+           'Negative',
+           'Positive'
+           ]
+
+from boa3.model.operation.unary.booleannot import BooleanNot
+from boa3.model.operation.unary.logicnot import LogicNot
+from boa3.model.operation.unary.negative import Negative
+from boa3.model.operation.unary.positive import Positive
+from boa3.model.operation.unary.unaryoperation import UnaryOperation

--- a/boa3/model/operation/unaryop.py
+++ b/boa3/model/operation/unaryop.py
@@ -1,10 +1,7 @@
 from typing import Optional
 
 from boa3.model.operation.operator import Operator
-from boa3.model.operation.unary.booleannot import BooleanNot
-from boa3.model.operation.unary.logicnot import LogicNot
-from boa3.model.operation.unary.negative import Negative
-from boa3.model.operation.unary.positive import Positive
+from boa3.model.operation.unary import *
 from boa3.model.operation.unary.unaryoperation import UnaryOperation
 from boa3.model.type.itype import IType
 

--- a/boa3_test/test_sc/dict_test/DictBoa2Test1.py
+++ b/boa3_test/test_sc/dict_test/DictBoa2Test1.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any, Dict
 
 from boa3.builtin import public
 

--- a/boa3_test/test_sc/dict_test/DictBoa2Test2.py
+++ b/boa3_test/test_sc/dict_test/DictBoa2Test2.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any, Dict
 
 from boa3.builtin import public
 

--- a/boa3_test/test_sc/dict_test/DictBoa2Test3.py
+++ b/boa3_test/test_sc/dict_test/DictBoa2Test3.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 
 from boa3.builtin import public
 

--- a/boa3_test/test_sc/dict_test/DictBoa2Test5ShouldNotCompile.py
+++ b/boa3_test/test_sc/dict_test/DictBoa2Test5ShouldNotCompile.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 
 from boa3.builtin import public
 

--- a/boa3_test/test_sc/dict_test/DictBoa2Test6ShouldNotCompile.py
+++ b/boa3_test/test_sc/dict_test/DictBoa2Test6ShouldNotCompile.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any, Dict
 
 from boa3.builtin import public
 

--- a/boa3_test/test_sc/event_test/EventBoa2Test.py
+++ b/boa3_test/test_sc/event_test/EventBoa2Test.py
@@ -1,7 +1,5 @@
 # tested
-from boa3.builtin import public
-
-from boa3.builtin import CreateNewEvent
+from boa3.builtin import CreateNewEvent, public
 
 Transfer = CreateNewEvent([('from', int), ('to', int), ('amount', int)], 'transfer_test')
 

--- a/boa3_test/test_sc/interop_test/runtime/RuntimeBoa2Test.py
+++ b/boa3_test/test_sc/interop_test/runtime/RuntimeBoa2Test.py
@@ -1,8 +1,7 @@
 from typing import Any
 
 from boa3.builtin import public
-
-from boa3.builtin.interop.runtime import notify, get_time, check_witness, log, trigger
+from boa3.builtin.interop.runtime import check_witness, get_time, log, notify, trigger
 
 
 @public

--- a/boa3_test/test_sc/interop_test/storage/StorageBoa2Test.py
+++ b/boa3_test/test_sc/interop_test/storage/StorageBoa2Test.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from boa3.builtin import public
-from boa3.builtin.interop.storage import put, delete, get
+from boa3.builtin.interop.storage import delete, get, put
 
 
 @public

--- a/boa3_test/test_sc/list_test/ReverseBoa2Test.py
+++ b/boa3_test/test_sc/list_test/ReverseBoa2Test.py
@@ -1,4 +1,4 @@
-from typing import List, Any
+from typing import Any, List
 
 from boa3.builtin import public
 

--- a/boa3_test/test_sc/python_operation_test/BytesIn.py
+++ b/boa3_test/test_sc/python_operation_test/BytesIn.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main(value: bytes, some_bytes: bytes) -> bool:
+    return value in some_bytes

--- a/boa3_test/test_sc/python_operation_test/BytesMembershipMismatchedType.py
+++ b/boa3_test/test_sc/python_operation_test/BytesMembershipMismatchedType.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main(value: str, some_bytes: bytes) -> bool:
+    return value not in some_bytes

--- a/boa3_test/test_sc/python_operation_test/BytesMembershipWithInt.py
+++ b/boa3_test/test_sc/python_operation_test/BytesMembershipWithInt.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main(value: int, some_bytes: bytes) -> bool:
+    return value in some_bytes

--- a/boa3_test/test_sc/python_operation_test/BytesNotIn.py
+++ b/boa3_test/test_sc/python_operation_test/BytesNotIn.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main(value: bytes, some_bytes: bytes) -> bool:
+    return value not in some_bytes

--- a/boa3_test/test_sc/python_operation_test/DictIn.py
+++ b/boa3_test/test_sc/python_operation_test/DictIn.py
@@ -1,0 +1,8 @@
+from typing import Any
+
+from boa3.builtin import public
+
+
+@public
+def main(value: Any, some_dict: dict) -> bool:
+    return value in some_dict

--- a/boa3_test/test_sc/python_operation_test/DictMembershipMismatchedType.py
+++ b/boa3_test/test_sc/python_operation_test/DictMembershipMismatchedType.py
@@ -1,0 +1,8 @@
+from typing import Dict
+
+from boa3.builtin import public
+
+
+@public
+def main(value: int, some_dict: Dict[str, int]) -> bool:
+    return value in some_dict

--- a/boa3_test/test_sc/python_operation_test/DictNotIn.py
+++ b/boa3_test/test_sc/python_operation_test/DictNotIn.py
@@ -1,0 +1,8 @@
+from typing import Any
+
+from boa3.builtin import public
+
+
+@public
+def main(value: Any, some_dict: dict) -> bool:
+    return value not in some_dict

--- a/boa3_test/test_sc/python_operation_test/ListIn.py
+++ b/boa3_test/test_sc/python_operation_test/ListIn.py
@@ -1,0 +1,8 @@
+from typing import Any
+
+from boa3.builtin import public
+
+
+@public
+def main(value: Any, some_list: list) -> bool:
+    return value in some_list

--- a/boa3_test/test_sc/python_operation_test/ListMembershipMismatchedType.py
+++ b/boa3_test/test_sc/python_operation_test/ListMembershipMismatchedType.py
@@ -1,0 +1,8 @@
+from typing import List
+
+from boa3.builtin import public
+
+
+@public
+def main(value: int, some_list: List[str]) -> bool:
+    return value not in some_list

--- a/boa3_test/test_sc/python_operation_test/ListNotIn.py
+++ b/boa3_test/test_sc/python_operation_test/ListNotIn.py
@@ -1,0 +1,8 @@
+from typing import Any
+
+from boa3.builtin import public
+
+
+@public
+def main(value: Any, some_list: list) -> bool:
+    return value not in some_list

--- a/boa3_test/test_sc/python_operation_test/StringIn.py
+++ b/boa3_test/test_sc/python_operation_test/StringIn.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main(value: str, some_string: str) -> bool:
+    return value in some_string

--- a/boa3_test/test_sc/python_operation_test/StringMembershipMismatchedType.py
+++ b/boa3_test/test_sc/python_operation_test/StringMembershipMismatchedType.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main(value: bytes, some_string: str) -> bool:
+    return value not in some_string

--- a/boa3_test/test_sc/python_operation_test/StringNotIn.py
+++ b/boa3_test/test_sc/python_operation_test/StringNotIn.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main(value: str, some_string: str) -> bool:
+    return value not in some_string

--- a/boa3_test/test_sc/python_operation_test/TupleIn.py
+++ b/boa3_test/test_sc/python_operation_test/TupleIn.py
@@ -1,0 +1,8 @@
+from typing import Any
+
+from boa3.builtin import public
+
+
+@public
+def main(value: Any, some_tuple: tuple) -> bool:
+    return value in some_tuple

--- a/boa3_test/test_sc/python_operation_test/TupleMembershipMismatchedType.py
+++ b/boa3_test/test_sc/python_operation_test/TupleMembershipMismatchedType.py
@@ -1,0 +1,8 @@
+from typing import Tuple
+
+from boa3.builtin import public
+
+
+@public
+def main(value: bytes, some_tuple: Tuple[str]) -> bool:
+    return value in some_tuple

--- a/boa3_test/test_sc/python_operation_test/TupleNotIn.py
+++ b/boa3_test/test_sc/python_operation_test/TupleNotIn.py
@@ -1,0 +1,8 @@
+from typing import Any
+
+from boa3.builtin import public
+
+
+@public
+def main(value: Any, some_tuple: tuple) -> bool:
+    return value not in some_tuple

--- a/boa3_test/test_sc/python_operation_test/TypedDictIn.py
+++ b/boa3_test/test_sc/python_operation_test/TypedDictIn.py
@@ -1,0 +1,8 @@
+from typing import Dict
+
+from boa3.builtin import public
+
+
+@public
+def main(value: int, some_dict: Dict[int, str]) -> bool:
+    return value in some_dict

--- a/boa3_test/test_sc/python_operation_test/TypedDictNotIn.py
+++ b/boa3_test/test_sc/python_operation_test/TypedDictNotIn.py
@@ -1,0 +1,8 @@
+from typing import Dict
+
+from boa3.builtin import public
+
+
+@public
+def main(value: int, some_dict: Dict[int, str]) -> bool:
+    return value not in some_dict

--- a/boa3_test/test_sc/python_operation_test/TypedListIn.py
+++ b/boa3_test/test_sc/python_operation_test/TypedListIn.py
@@ -1,0 +1,8 @@
+from typing import List
+
+from boa3.builtin import public
+
+
+@public
+def main(value: int, some_list: List[int]) -> bool:
+    return value in some_list

--- a/boa3_test/test_sc/python_operation_test/TypedListNotIn.py
+++ b/boa3_test/test_sc/python_operation_test/TypedListNotIn.py
@@ -1,0 +1,8 @@
+from typing import List
+
+from boa3.builtin import public
+
+
+@public
+def main(value: int, some_list: List[int]) -> bool:
+    return value not in some_list

--- a/boa3_test/test_sc/python_operation_test/TypedTupleIn.py
+++ b/boa3_test/test_sc/python_operation_test/TypedTupleIn.py
@@ -1,0 +1,8 @@
+from typing import Tuple
+
+from boa3.builtin import public
+
+
+@public
+def main(value: int, some_tuple: Tuple[int]) -> bool:
+    return value in some_tuple

--- a/boa3_test/test_sc/python_operation_test/TypedTupleNotIn.py
+++ b/boa3_test/test_sc/python_operation_test/TypedTupleNotIn.py
@@ -1,0 +1,8 @@
+from typing import Tuple
+
+from boa3.builtin import public
+
+
+@public
+def main(value: int, some_tuple: Tuple[int]) -> bool:
+    return value not in some_tuple

--- a/boa3_test/tests/test_if.py
+++ b/boa3_test/tests/test_if.py
@@ -525,7 +525,7 @@ class TestIf(BoaTest):
         result = self.run_smart_contract(engine, path, 'main', 'omin', -4, 4)
         self.assertEqual(-4, result)
 
-        result = self.run_smart_contract(engine, path, 'main', 'omin',16, 0)
+        result = self.run_smart_contract(engine, path, 'main', 'omin', 16, 0)
         self.assertEqual(0, result)
 
         result = self.run_smart_contract(engine, path, 'main', 'omax', 4, 4)

--- a/boa3_test/tests/test_python_operation.py
+++ b/boa3_test/tests/test_python_operation.py
@@ -1,0 +1,242 @@
+from boa3.exception.CompilerError import MismatchedTypes
+from boa3_test.tests.boa_test import BoaTest
+from boa3_test.tests.test_classes.testengine import TestEngine
+
+
+class TestPythonOperation(BoaTest):
+
+    default_folder: str = 'test_sc/python_operation_test'
+
+    def test_in_str(self):
+        path = self.get_contract_path('StringIn.py')
+        self.compile_and_save(path)
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'main', '123', '1234')
+        self.assertEqual('123' in '1234', result)
+
+        result = self.run_smart_contract(engine, path, 'main', '42', '1234')
+        self.assertEqual('42' in '1234', result)
+
+    def test_not_in_str(self):
+        path = self.get_contract_path('StringNotIn.py')
+        self.compile_and_save(path)
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'main', '123', '1234')
+        self.assertEqual('123' not in '1234', result)
+
+        result = self.run_smart_contract(engine, path, 'main', '42', '1234')
+        self.assertEqual('42' not in '1234', result)
+
+    def test_str_membership_mismatched_type(self):
+        path = self.get_contract_path('StringMembershipMismatchedType.py')
+        self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_in_bytes(self):
+        path = self.get_contract_path('BytesIn.py')
+        self.compile_and_save(path)
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'main', b'123', b'1234')
+        self.assertEqual(b'123' in b'1234', result)
+
+        result = self.run_smart_contract(engine, path, 'main', b'42', b'1234')
+        self.assertEqual(b'42' in b'1234', result)
+
+        result = self.run_smart_contract(engine, path, 'main', b'34', b'1234')
+        self.assertEqual(b'34' in b'1234', result)
+
+    def test_not_in_bytes(self):
+        path = self.get_contract_path('BytesNotIn.py')
+        self.compile_and_save(path)
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'main', b'123', b'1234')
+        self.assertEqual(b'123' not in b'1234', result)
+
+        result = self.run_smart_contract(engine, path, 'main', b'42', b'1234')
+        self.assertEqual(b'42' not in b'1234', result)
+
+    def test_int_in_bytes(self):
+        path = self.get_contract_path('BytesMembershipWithInt.py')
+        self.compile_and_save(path)
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'main', 1, b'1234')
+        self.assertEqual(1 in b'1234', result)
+
+        result = self.run_smart_contract(engine, path, 'main', 50, b'1234')
+        self.assertEqual(50 in b'1234', result)
+
+    def test_bytes_membership_mismatched_type(self):
+        path = self.get_contract_path('BytesMembershipMismatchedType.py')
+        self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_in_list(self):
+        path = self.get_contract_path('ListIn.py')
+        self.compile_and_save(path)
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'main', 1, [1, 2, '3', '4'])
+        self.assertEqual(1 in [1, 2, '3', '4'], result)
+
+        result = self.run_smart_contract(engine, path, 'main', 3, [1, 2, '3', '4'])
+        self.assertEqual(3 in [1, 2, '3', '4'], result)
+
+        result = self.run_smart_contract(engine, path, 'main', '4', [1, 2, '3', '4'])
+        self.assertEqual('4' in [1, 2, '3', '4'], result)
+
+    def test_in_typed_list(self):
+        path = self.get_contract_path('TypedListIn.py')
+        self.compile_and_save(path)
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'main', 1, [1, 2, 3, 4])
+        self.assertEqual(1 in [1, 2, 3, 4], result)
+
+        result = self.run_smart_contract(engine, path, 'main', 6, [1, 2, 3, 4])
+        self.assertEqual(6 in [1, 2, 3, 4], result)
+
+    def test_not_in_list(self):
+        path = self.get_contract_path('ListNotIn.py')
+        self.compile_and_save(path)
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'main', 1, [1, 2, '3', '4'])
+        self.assertEqual(1 not in [1, 2, '3', '4'], result)
+
+        result = self.run_smart_contract(engine, path, 'main', 3, [1, 2, '3', '4'])
+        self.assertEqual(3 not in [1, 2, '3', '4'], result)
+
+        result = self.run_smart_contract(engine, path, 'main', '4', [1, 2, '3', '4'])
+        self.assertEqual('4' not in [1, 2, '3', '4'], result)
+
+    def test_not_in_typed_list(self):
+        path = self.get_contract_path('TypedListNotIn.py')
+        self.compile_and_save(path)
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'main', 1, [1, 2, 3, 4])
+        self.assertEqual(1 not in [1, 2, 3, 4], result)
+
+        result = self.run_smart_contract(engine, path, 'main', 6, [1, 2, 3, 4])
+        self.assertEqual(6 not in [1, 2, 3, 4], result)
+
+    def test_list_membership_mismatched_type(self):
+        path = self.get_contract_path('ListMembershipMismatchedType.py')
+        self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_in_tuple(self):
+        path = self.get_contract_path('TupleIn.py')
+        self.compile_and_save(path)
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'main', 1, (1, 2, '3', '4'))
+        self.assertEqual(1 in (1, 2, '3', '4'), result)
+
+        result = self.run_smart_contract(engine, path, 'main', 3, (1, 2, '3', '4'))
+        self.assertEqual(3 in (1, 2, '3', '4'), result)
+
+        result = self.run_smart_contract(engine, path, 'main', '4', (1, 2, '3', '4'))
+        self.assertEqual('4' in (1, 2, '3', '4'), result)
+
+    def test_in_typed_tuple(self):
+        path = self.get_contract_path('TypedTupleIn.py')
+        self.compile_and_save(path)
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'main', 1, (1, 2, 3, 4))
+        self.assertEqual(1 in (1, 2, 3, 4), result)
+
+        result = self.run_smart_contract(engine, path, 'main', 6, (1, 2, 3, 4))
+        self.assertEqual(6 in (1, 2, 3, 4), result)
+
+    def test_not_in_tuple(self):
+        path = self.get_contract_path('TupleNotIn.py')
+        self.compile_and_save(path)
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'main', 1, (1, 2, '3', '4'))
+        self.assertEqual(1 not in (1, 2, '3', '4'), result)
+
+        result = self.run_smart_contract(engine, path, 'main', 3, (1, 2, '3', '4'))
+        self.assertEqual(3 not in (1, 2, '3', '4'), result)
+
+        result = self.run_smart_contract(engine, path, 'main', '4', (1, 2, '3', '4'))
+        self.assertEqual('4' not in (1, 2, '3', '4'), result)
+
+    def test_not_in_typed_tuple(self):
+        path = self.get_contract_path('TypedTupleNotIn.py')
+        self.compile_and_save(path)
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'main', 1, (1, 2, 3, 4))
+        self.assertEqual(1 not in (1, 2, 3, 4), result)
+
+        result = self.run_smart_contract(engine, path, 'main', 6, (1, 2, 3, 4))
+        self.assertEqual(6 not in (1, 2, 3, 4), result)
+
+    def test_tuple_membership_mismatched_type(self):
+        path = self.get_contract_path('TupleMembershipMismatchedType.py')
+        self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_in_dict(self):
+        path = self.get_contract_path('DictIn.py')
+        self.compile_and_save(path)
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'main', 1, {1: '2', '4': 8})
+        self.assertEqual(1 in {1: '2', '4': 8}, result)
+
+        result = self.run_smart_contract(engine, path, 'main', '1', {1: '2', '4': 8})
+        self.assertEqual('1' in {1: '2', '4': 8}, result)
+
+        result = self.run_smart_contract(engine, path, 'main', 8, {1: '2', '4': 8})
+        self.assertEqual(8 in {1: '2', '4': 8}, result)
+
+        result = self.run_smart_contract(engine, path, 'main', '4', {1: '2', '4': 8})
+        self.assertEqual('4' in {1: '2', '4': 8}, result)
+
+    def test_in_typed_dict(self):
+        path = self.get_contract_path('TypedDictIn.py')
+        self.compile_and_save(path)
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'main', 1, {1: '2', 4: '8'})
+        self.assertEqual(1 in {1: '2', 4: '8'}, result)
+
+        result = self.run_smart_contract(engine, path, 'main', 3, {1: '2', 4: '8'})
+        self.assertEqual(3 in {1: '2', 4: '8'}, result)
+
+    def test_not_in_dict(self):
+        path = self.get_contract_path('DictNotIn.py')
+        self.compile_and_save(path)
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'main', 1, {1: '2', '4': 8})
+        self.assertEqual(1 not in {1: '2', '4': 8}, result)
+
+        result = self.run_smart_contract(engine, path, 'main', '1', {1: '2', '4': 8})
+        self.assertEqual('1' not in {1: '2', '4': 8}, result)
+
+        result = self.run_smart_contract(engine, path, 'main', 8, {1: '2', '4': 8})
+        self.assertEqual(8 not in {1: '2', '4': 8}, result)
+
+        result = self.run_smart_contract(engine, path, 'main', '4', {1: '2', '4': 8})
+        self.assertEqual('4' not in {1: '2', '4': 8}, result)
+
+    def test_not_in_typed_dict(self):
+        path = self.get_contract_path('TypedDictNotIn.py')
+        self.compile_and_save(path)
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'main', 1, {1: '2', 4: '8'})
+        self.assertEqual(1 not in {1: '2', 4: '8'}, result)
+
+        result = self.run_smart_contract(engine, path, 'main', 3, {1: '2', 4: '8'})
+        self.assertEqual(3 not in {1: '2', 4: '8'}, result)
+
+    def test_dict_membership_mismatched_type(self):
+        path = self.get_contract_path('DictMembershipMismatchedType.py')
+        self.assertCompilerLogs(MismatchedTypes, path)


### PR DESCRIPTION
**Related issue**
#231

**Summary or solution description**
Implemented `in` and `not in` operator for collections.

**How to Reproduce**
```python
x = [1,2,3]
if 1 in x:
   # do something
else:
   # do something else
```

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
