### PR TITLE
Change trigger() to get_trigger()

### DIFF
--- a/boa3/builtin/interop/runtime/__init__.py
+++ b/boa3/builtin/interop/runtime/__init__.py
@@ -37,7 +37,7 @@ def log(message: str):
     pass
 
 
-def trigger() -> TriggerType:
+def get_trigger() -> TriggerType:
     """
     Return the smart contract trigger type.
 

--- a/boa3/model/builtin/interop/interop.py
+++ b/boa3/model/builtin/interop/interop.py
@@ -88,7 +88,7 @@ class Interop:
     ExecutingScriptHash = ExecutingScriptHashProperty()
     GasLeft = GasLeftProperty()
     GetNotifications = GetNotificationsMethod(NotificationType)
-    GetTrigger = TriggerMethod(TriggerType)
+    GetTrigger = GetTriggerMethod(TriggerType)
     InvocationCounter = InvocationCounterProperty()
     Log = LogMethod()
     Notify = NotifyMethod()

--- a/boa3/model/builtin/interop/runtime/__init__.py
+++ b/boa3/model/builtin/interop/runtime/__init__.py
@@ -10,7 +10,7 @@ __all__ = ['BlockTimeProperty',
            'NotificationType',
            'NotifyMethod',
            'PlatformProperty',
-           'TriggerMethod',
+           'GetTriggerMethod',
            'TriggerType',
            ]
 
@@ -23,8 +23,8 @@ from boa3.model.builtin.interop.runtime.getgasleftmethod import GasLeftProperty
 from boa3.model.builtin.interop.runtime.getinvocationcountermethod import InvocationCounterProperty
 from boa3.model.builtin.interop.runtime.getnotificationsmethod import GetNotificationsMethod
 from boa3.model.builtin.interop.runtime.getplatformmethod import PlatformProperty
+from boa3.model.builtin.interop.runtime.gettriggermethod import GetTriggerMethod
 from boa3.model.builtin.interop.runtime.logmethod import LogMethod
 from boa3.model.builtin.interop.runtime.notificationtype import NotificationType
 from boa3.model.builtin.interop.runtime.notifymethod import NotifyMethod
-from boa3.model.builtin.interop.runtime.triggermethod import TriggerMethod
 from boa3.model.builtin.interop.runtime.triggertype import TriggerType

--- a/boa3/model/builtin/interop/runtime/gettriggermethod.py
+++ b/boa3/model/builtin/interop/runtime/gettriggermethod.py
@@ -5,10 +5,10 @@ from boa3.model.builtin.interop.runtime.triggertype import TriggerType
 from boa3.model.variable import Variable
 
 
-class TriggerMethod(InteropMethod):
+class GetTriggerMethod(InteropMethod):
 
     def __init__(self, trigger_type: TriggerType):
-        identifier = 'trigger'
+        identifier = 'get_trigger'
         syscall = 'System.Runtime.GetTrigger'
         args: Dict[str, Variable] = {}
         super().__init__(identifier, syscall, args, return_type=trigger_type)

--- a/boa3_test/test_sc/bytes_test/BytearrayBoa2Test.py
+++ b/boa3_test/test_sc/bytes_test/BytearrayBoa2Test.py
@@ -1,5 +1,6 @@
 from boa3.builtin import public
 
+
 @public
 def main() -> bytes:
     c = b'\x01\x04\xaf\x09'

--- a/boa3_test/test_sc/bytes_test/BytearrayBoa2Test2.py
+++ b/boa3_test/test_sc/bytes_test/BytearrayBoa2Test2.py
@@ -1,5 +1,6 @@
 from boa3.builtin import public
 
+
 @public
 def main(ba1: bytearray, ba2: bytearray) -> bytearray:
 

--- a/boa3_test/test_sc/bytes_test/BytearrayBoa2Test3.py
+++ b/boa3_test/test_sc/bytes_test/BytearrayBoa2Test3.py
@@ -1,5 +1,6 @@
 from boa3.builtin import public
 
+
 @public
 def main() -> bytes:
     m = b'\x01\x02'

--- a/boa3_test/test_sc/function_test/RecursiveFunction.py
+++ b/boa3_test/test_sc/function_test/RecursiveFunction.py
@@ -4,7 +4,7 @@ from boa3.builtin import public
 def fact(f: int) -> int:
     if f <= 1:
         return 1
-    return f * fact(f-1)
+    return f * fact(f - 1)
 
 
 @public

--- a/boa3_test/test_sc/interop_test/runtime/NotifyBool.py
+++ b/boa3_test/test_sc/interop_test/runtime/NotifyBool.py
@@ -1,5 +1,4 @@
 from boa3.builtin import public
-
 from boa3.builtin.interop.runtime import notify
 
 

--- a/boa3_test/test_sc/interop_test/runtime/NotifyInt.py
+++ b/boa3_test/test_sc/interop_test/runtime/NotifyInt.py
@@ -1,5 +1,4 @@
 from boa3.builtin import public
-
 from boa3.builtin.interop.runtime import notify
 
 

--- a/boa3_test/test_sc/interop_test/runtime/NotifyNone.py
+++ b/boa3_test/test_sc/interop_test/runtime/NotifyNone.py
@@ -1,5 +1,4 @@
 from boa3.builtin import public
-
 from boa3.builtin.interop.runtime import notify
 
 

--- a/boa3_test/test_sc/interop_test/runtime/NotifySequence.py
+++ b/boa3_test/test_sc/interop_test/runtime/NotifySequence.py
@@ -1,5 +1,4 @@
 from boa3.builtin import public
-
 from boa3.builtin.interop.runtime import notify
 
 

--- a/boa3_test/test_sc/interop_test/runtime/NotifyStr.py
+++ b/boa3_test/test_sc/interop_test/runtime/NotifyStr.py
@@ -1,5 +1,4 @@
 from boa3.builtin import public
-
 from boa3.builtin.interop.runtime import notify
 
 

--- a/boa3_test/test_sc/interop_test/runtime/RuntimeBoa2Test.py
+++ b/boa3_test/test_sc/interop_test/runtime/RuntimeBoa2Test.py
@@ -1,14 +1,14 @@
 from typing import Any
 
 from boa3.builtin import public
-from boa3.builtin.interop.runtime import check_witness, get_time, log, notify, trigger
+from boa3.builtin.interop.runtime import check_witness, get_time, get_trigger, log, notify
 
 
 @public
 def main(operation: str, arg: Any) -> Any:
 
     if operation == 'get_trigger':
-        return trigger()
+        return get_trigger()
 
     elif operation == 'check_witness' and isinstance(arg, bytes):
         return check_witness(arg)

--- a/boa3_test/test_sc/interop_test/runtime/Trigger.py
+++ b/boa3_test/test_sc/interop_test/runtime/Trigger.py
@@ -1,8 +1,7 @@
 from boa3.builtin import public
-
-from boa3.builtin.interop.runtime import TriggerType, trigger
+from boa3.builtin.interop.runtime import TriggerType, get_trigger
 
 
 @public
 def Main() -> TriggerType:
-    return trigger()
+    return get_trigger()

--- a/boa3_test/test_sc/interop_test/runtime/TriggerApplication.py
+++ b/boa3_test/test_sc/interop_test/runtime/TriggerApplication.py
@@ -1,8 +1,7 @@
 from boa3.builtin import public
-
-from boa3.builtin.interop.runtime import TriggerType, trigger
+from boa3.builtin.interop.runtime import TriggerType, get_trigger
 
 
 @public
 def Main() -> bool:
-    return trigger() == TriggerType.APPLICATION
+    return get_trigger() == TriggerType.APPLICATION

--- a/boa3_test/test_sc/interop_test/runtime/TriggerNotSystem.py
+++ b/boa3_test/test_sc/interop_test/runtime/TriggerNotSystem.py
@@ -1,5 +1,5 @@
-from boa3.builtin.interop.runtime import TriggerType, trigger
+from boa3.builtin.interop.runtime import TriggerType, get_trigger
 
 
 def Main() -> bool:
-    return trigger() != TriggerType.SYSTEM
+    return get_trigger() != TriggerType.SYSTEM

--- a/boa3_test/test_sc/interop_test/runtime/TriggerTypeBoa2Test.py
+++ b/boa3_test/test_sc/interop_test/runtime/TriggerTypeBoa2Test.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from boa3.builtin import public
-from boa3.builtin.interop.runtime import TriggerType, trigger
+from boa3.builtin.interop.runtime import TriggerType, get_trigger
 
 
 @public
@@ -15,7 +15,7 @@ def main(arg: int) -> Any:
 
     elif arg == 3:
 
-        if trigger() == TriggerType.APPLICATION:
+        if get_trigger() == TriggerType.APPLICATION:
             return b'\x20'
 
     return -1

--- a/boa3_test/test_sc/interop_test/runtime/TriggerVerification.py
+++ b/boa3_test/test_sc/interop_test/runtime/TriggerVerification.py
@@ -1,8 +1,7 @@
 from boa3.builtin import public
-
-from boa3.builtin.interop.runtime import TriggerType as Trigger, trigger
+from boa3.builtin.interop.runtime import TriggerType as Trigger, get_trigger
 
 
 @public
 def Main() -> bool:
-    return trigger() == Trigger.VERIFICATION
+    return get_trigger() == Trigger.VERIFICATION


### PR DESCRIPTION
**Related issue**
#264

**Summary or solution description**
Changed ``trigger`` interop function to ``get_trigger``

**How to Reproduce**
```python
from boa3.builtin import public
from boa3.builtin.interop.runtime import TriggerType, get_trigger


@public
def Main() -> TriggerType:
    return get_trigger()
```

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7