### PR TITLE
Support reassign types to existing variables

### DIFF
--- a/boa3/compiler/filegenerator.py
+++ b/boa3/compiler/filegenerator.py
@@ -206,6 +206,8 @@ class FileGenerator:
 
     def _get_method_debug_info(self, method_id: str, method: Method) -> Dict[str, Any]:
         from boa3.compiler.codegenerator.vmcodemapping import VMCodeMapping
+        from boa3.neo.vm.type.AbiType import AbiType
+        from boa3.model.type.itype import IType
         return {
             "id": str(id(method)),
             "name": ',{0}'.format(method_id),  # TODO: include module name
@@ -215,7 +217,8 @@ class FileGenerator:
             ],
             "return": method.return_type.abi_type,
             "variables": [
-                '{0},{1}'.format(name, var.type.abi_type) for name, var in method.locals.items()
+                '{0},{1}'.format(name, var.type.abi_type if isinstance(var.type, IType) else AbiType.Any)
+                for name, var in method.locals.items()
             ],
             "sequence-points": [
                 '{0}[{1}]{2}:{3}-{4}:{5}'.format(VMCodeMapping.instance().get_start_address(instruction.code),

--- a/boa3/model/variable.py
+++ b/boa3/model/variable.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ast
 from typing import Optional
 
@@ -15,6 +17,9 @@ class Variable(IExpression):
     def __init__(self, var_type: Optional[IType], origin_node: Optional[ast.AST] = None):
         super().__init__(origin_node)
         self._var_type: Optional[IType] = var_type
+
+    def copy(self) -> Variable:
+        return Variable(self._var_type, self._origin_node)
 
     @property
     def shadowing_name(self) -> str:

--- a/boa3_test/test_sc/none_test/MismatchedTypesAssign.py
+++ b/boa3_test/test_sc/none_test/MismatchedTypesAssign.py
@@ -1,4 +1,0 @@
-def Main():
-    a = 2
-    a = None
-    b = a * 2

--- a/boa3_test/test_sc/none_test/ReassignVariableAfterNone.py
+++ b/boa3_test/test_sc/none_test/ReassignVariableAfterNone.py
@@ -1,3 +1,7 @@
+from boa3.builtin import public
+
+
+@public
 def Main():
     a = None
     a = 2

--- a/boa3_test/test_sc/none_test/ReassignVariableWithNone.py
+++ b/boa3_test/test_sc/none_test/ReassignVariableWithNone.py
@@ -1,0 +1,8 @@
+from boa3.builtin import public
+
+
+@public
+def Main():
+    a = 2
+    b = a * 2
+    a = None

--- a/boa3_test/test_sc/variable_test/ReassignVariableType.py
+++ b/boa3_test/test_sc/variable_test/ReassignVariableType.py
@@ -1,0 +1,9 @@
+from boa3.builtin import public
+
+
+@public
+def Main() -> int:
+    x = '1234'
+    y = x
+    x = 1234
+    return x

--- a/boa3_test/tests/test_bytes.py
+++ b/boa3_test/tests/test_bytes.py
@@ -501,6 +501,7 @@ class TestBytes(BoaTest):
 
     def test_boa2_slice_test(self):
         path = self.get_contract_path('SliceBoa2Test.py')
+        self.compile_and_save(path)
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'main',
                                          expected_result_type=bytes)

--- a/boa3_test/tests/test_file_generation.py
+++ b/boa3_test/tests/test_file_generation.py
@@ -195,6 +195,7 @@ class TestFileGeneration(BoaTest):
                                  event_param['type'])
 
     def test_generate_nefdbgnfo_file(self):
+        from boa3.model.type.itype import IType
         path = self.get_contract_path('GenerationWithDecorator.py')
 
         expected_nef_output = path.replace('.py', '.nefdbgnfo')
@@ -239,7 +240,8 @@ class TestFileGeneration(BoaTest):
                 self.assertEqual(2, len(var.split(',')))
                 var_id, var_type = var.split(',')
                 self.assertIn(var_id, actual_method.locals)
-                self.assertEqual(actual_method.locals[var_id].type.abi_type, var_type)
+                local_type = actual_method.locals[var_id].type
+                self.assertEqual(local_type.abi_type if isinstance(local_type, IType) else AbiType.Any, var_type)
 
     def test_generate_nefdbgnfo_file_with_event(self):
         path = self.get_contract_path('test_sc/event_test', 'EventWithArgument.py')

--- a/boa3_test/tests/test_none.py
+++ b/boa3_test/tests/test_none.py
@@ -94,13 +94,48 @@ class TestNone(BoaTest):
         path = self.get_contract_path('MismatchedTypesInOperation.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
-    def test_mismatched_type_assign(self):
-        path = self.get_contract_path('MismatchedTypesAssign.py')
-        self.assertCompilerLogs(MismatchedTypes, path)
+    def test_reassign_variable_with_none(self):
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x02'
+            + b'\x00'
+            + Opcode.PUSH2          # a = 2
+            + Opcode.STLOC0
+            + Opcode.PUSH4          # b = a * 2
+            + Opcode.STLOC1
+            + Opcode.PUSHNULL       # a = None
+            + Opcode.STLOC0
+            + Opcode.RET        # return
+        )
 
-    def test_mismatched_type_after_reassign(self):
-        path = self.get_contract_path('MismatchedTypesAfterReassign.py')
-        self.assertCompilerLogs(MismatchedTypes, path)
+        path = self.get_contract_path('ReassignVariableWithNone.py')
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'Main')
+        self.assertIsVoid(result)
+
+    def test_reassign_variable_after_none(self):
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x02'
+            + b'\x00'
+            + Opcode.PUSHNULL       # a = None
+            + Opcode.STLOC0
+            + Opcode.PUSH2          # a = 2
+            + Opcode.STLOC0
+            + Opcode.PUSH4          # b = a * 2
+            + Opcode.STLOC1
+            + Opcode.RET        # return
+        )
+        path = self.get_contract_path('ReassignVariableAfterNone.py')
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'Main')
+        self.assertIsVoid(result)
 
     def test_boa2_none_test(self):
         path = self.get_contract_path('NoneBoa2Test.py')

--- a/boa3_test/tests/test_variable.py
+++ b/boa3_test/tests/test_variable.py
@@ -188,8 +188,27 @@ class TestVariable(BoaTest):
         self.assertEqual(expected_output, output)
 
     def test_multiple_assignments_mismatched_type(self):
+        string = String('str').to_bytes()
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x03'
+            + b'\x00'
+            + Opcode.PUSHDATA1      # c = 'str'
+            + Integer(len(string)).to_byte_array(min_length=1)
+            + string
+            + Opcode.STLOC0
+            + Opcode.PUSH1      # a = b = c = True
+            + Opcode.DUP            # c = True
+            + Opcode.STLOC0
+            + Opcode.DUP            # b = True
+            + Opcode.STLOC2
+            + Opcode.STLOC1         # a = True
+            + Opcode.RET        # return
+        )
+
         path = self.get_contract_path('MismatchedTypeMultipleAssignments.py')
-        self.assertCompilerLogs(MismatchedTypes, path)
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
 
     def test_tuple_multiple_assignments(self):
         path = self.get_contract_path('AssignmentWithTuples.py')


### PR DESCRIPTION
**Related issue**
#239

**Summary or solution description**
Included support to reassign variables with values which types are different from the previously assigned type. Also, this new type is used during operation type validation, without conflicting with the first one.

**How to Reproduce**
```python
from boa3.builtin import public


@public
def Main() -> int:
    x = 'example'
    y: str = 'code ' + x
    x = 1234
    return x
```

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7