### PR TITLE
Change Contract script attribute to nef

### DIFF
--- a/boa3/builtin/interop/contract/contract.py
+++ b/boa3/builtin/interop/contract/contract.py
@@ -8,5 +8,5 @@ class Contract:
         self.id: int = 0
         self.update_counter: int = 0
         self.hash: UInt160 = UInt160()
-        self.script: bytes = bytes()
+        self.nef: bytes = bytes()
         self.manifest: Dict[str, Any] = {}

--- a/boa3/model/builtin/interop/contract/contracttype.py
+++ b/boa3/model/builtin/interop/contract/contracttype.py
@@ -25,7 +25,7 @@ class ContractType(ClassType):
             'id': Variable(Type.int),
             'update_counter': Variable(Type.int),
             'hash': Variable(UInt160Type.build()),
-            'script': Variable(Type.bytes),
+            'nef': Variable(Type.bytes),
             'manifest': Variable(Type.dict)
         }
         self._constructor: Method = None


### PR DESCRIPTION
**Related issue**
#275 

**Summary or solution description**
Renamed `Contract`'s `script` variable to `nef`

**How to Reproduce**
```python
contract = Contract()
x = contract.nef
```

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7