### PR TITLE
Change base58_encode and base58_decode parameters

### DIFF
--- a/boa3/builtin/interop/binary/__init__.py
+++ b/boa3/builtin/interop/binary/__init__.py
@@ -1,33 +1,33 @@
 from typing import Any
 
 
-def base58_encode(key: str) -> bytes:
+def base58_encode(key: bytes) -> str:
     """
-    Encodes a string value using base58
+    Encodes a bytes value using base58
 
     :param key: string value to be encoded
-    :type key: str
+    :type key: bytes
     :return: the encoded string as bytes.
-    :rtype: bytes
+    :rtype: str
     """
     pass
 
 
-def base58_decode(key: bytes) -> str:
+def base58_decode(key: str) -> bytes:
     """
-    Decodes a bytes value encoded with base58
+    Decodes a string value encoded with base58
 
     :param key: bytes value to be decoded
-    :type key: bytes
+    :type key: str
     :return: the decoded bytes as string.
-    :rtype: str
+    :rtype: bytes
     """
     pass
 
 
 def base64_encode(key: bytes) -> str:
     """
-    Encodes a string value using base64
+    Encodes a bytes value using base64
 
     :param key: bytes value to be encoded
     :type key: bytes
@@ -39,7 +39,7 @@ def base64_encode(key: bytes) -> str:
 
 def base64_decode(key: str) -> bytes:
     """
-    Decodes a bytes value encoded with base64
+    Decodes a string value encoded with base64
 
     :param key: string value to be decoded
     :type key: string

--- a/boa3/model/builtin/interop/binary/base58decodemethod.py
+++ b/boa3/model/builtin/interop/binary/base58decodemethod.py
@@ -10,5 +10,5 @@ class Base58DecodeMethod(InteropMethod):
         from boa3.model.type.type import Type
         identifier = 'base58_decode'
         syscall = 'System.Binary.Base58Decode'
-        args: Dict[str, Variable] = {'key': Variable(Type.bytes)}
-        super().__init__(identifier, syscall, args, return_type=Type.str)
+        args: Dict[str, Variable] = {'key': Variable(Type.str)}
+        super().__init__(identifier, syscall, args, return_type=Type.bytes)

--- a/boa3/model/builtin/interop/binary/base58encodemethod.py
+++ b/boa3/model/builtin/interop/binary/base58encodemethod.py
@@ -10,5 +10,5 @@ class Base58EncodeMethod(InteropMethod):
         from boa3.model.type.type import Type
         identifier = 'base58_encode'
         syscall = 'System.Binary.Base58Encode'
-        args: Dict[str, Variable] = {'key': Variable(Type.str)}
-        super().__init__(identifier, syscall, args, return_type=Type.bytes)
+        args: Dict[str, Variable] = {'key': Variable(Type.bytes)}
+        super().__init__(identifier, syscall, args, return_type=Type.str)

--- a/boa3_test/test_sc/interop_test/binary/Base58Decode.py
+++ b/boa3_test/test_sc/interop_test/binary/Base58Decode.py
@@ -3,5 +3,5 @@ from boa3.builtin.interop.binary import base58_decode
 
 
 @public
-def Main(key: bytes) -> str:
+def Main(key: str) -> bytes:
     return base58_decode(key)

--- a/boa3_test/test_sc/interop_test/binary/Base58DecodeMismatchedType.py
+++ b/boa3_test/test_sc/interop_test/binary/Base58DecodeMismatchedType.py
@@ -1,5 +1,5 @@
 from boa3.builtin.interop.binary import base58_decode
 
 
-def Main(key: int) -> str:
+def Main(key: int) -> bytes:
     return base58_decode(key)

--- a/boa3_test/test_sc/interop_test/binary/Base58Encode.py
+++ b/boa3_test/test_sc/interop_test/binary/Base58Encode.py
@@ -3,5 +3,5 @@ from boa3.builtin.interop.binary import base58_encode
 
 
 @public
-def Main(key: str) -> bytes:
+def Main(key: bytes) -> str:
     return base58_encode(key)

--- a/boa3_test/test_sc/interop_test/binary/Base58EncodeMismatchedType.py
+++ b/boa3_test/test_sc/interop_test/binary/Base58EncodeMismatchedType.py
@@ -1,5 +1,5 @@
 from boa3.builtin.interop.binary import base58_encode
 
 
-def Main(key: int) -> bytes:
+def Main(key: int) -> str:
     return base58_encode(key)


### PR DESCRIPTION
**Related issue**
#274 

**Summary or solution description**
Changed the parameters and return types of `base58_encode` and `base58_decode` interop functions, that were implemented wrongly.

**How to Reproduce**
```python
from boa3.builtin.interop.binary import base58_decode, base58_encode


def encode(key: bytes) -> str:
    return base58_encode(key)
    
def decode(key: str) -> bytes:
    return base58_decode(key)
```

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7