### PR TITLE
Fix smart-contract storage access in test engine execution

### DIFF
--- a/boa3_test/test_sc/interop_test/storage/StorageGetAndPut1.py
+++ b/boa3_test/test_sc/interop_test/storage/StorageGetAndPut1.py
@@ -1,0 +1,12 @@
+from boa3.builtin import public
+from boa3.builtin.interop.storage import get, put
+
+
+@public
+def put_value(key: str, value: int):
+    put(key, value)
+
+
+@public
+def get_value(key: str) -> int:
+    return get(key).to_int()

--- a/boa3_test/test_sc/interop_test/storage/StorageGetAndPut2.py
+++ b/boa3_test/test_sc/interop_test/storage/StorageGetAndPut2.py
@@ -1,0 +1,12 @@
+from boa3.builtin import public
+from boa3.builtin.interop.storage import get, put
+
+
+@public
+def get_value(key: str) -> int:
+    return get(key).to_int()
+
+
+@public
+def put_value(key: str, value: int):
+    put(key, value)

--- a/boa3_test/tests/boa_test.py
+++ b/boa3_test/tests/boa_test.py
@@ -181,7 +181,7 @@ class BoaTest(TestCase):
 
     def run_smart_contract(self, test_engine: TestEngine, smart_contract_path: Union[str, bytes], method: str,
                            *arguments: Any, reset_engine: bool = False,
-                           fake_storage: Dict[str, Any] = None,
+                           fake_storage: Dict[Tuple[str, str], Any] = None,
                            signer_accounts: Iterable[bytes] = (),
                            expected_result_type: Type = None,
                            rollback_on_fault: bool = True) -> Any:

--- a/boa3_test/tests/examples/test_hello_world.py
+++ b/boa3_test/tests/examples/test_hello_world.py
@@ -17,5 +17,6 @@ class TestTemplate(BoaTest):
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertIsVoid(result)
 
-        self.assertTrue(b'hello' in engine.storage)
-        self.assertEqual(b'world', engine.storage[b'hello'])
+        storage_value = engine.storage_get(b'hello', path)
+        self.assertIsNotNone(storage_value)
+        self.assertEqual(b'world', storage_value)

--- a/boa3_test/tests/examples/test_ico.py
+++ b/boa3_test/tests/examples/test_ico.py
@@ -125,14 +125,16 @@ class TestTemplate(BoaTest):
                                          [bytes(40), self.OWNER_SCRIPT_HASH, bytes(12)],
                                          signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(1, result)
-        self.assertTrue(self.KYC_WHITELIST_PREFIX + self.OWNER_SCRIPT_HASH in engine.storage)
+        storage_value = engine.storage_get(self.KYC_WHITELIST_PREFIX + self.OWNER_SCRIPT_HASH, path)
+        self.assertIsNotNone(storage_value)
 
         # script hashes already registered are returned as well
         result = self.run_smart_contract(engine, path, 'kyc_register',
                                          [self.OWNER_SCRIPT_HASH, self.OTHER_ACCOUNT_1],
                                          signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(2, result)
-        self.assertTrue(self.KYC_WHITELIST_PREFIX + self.OTHER_ACCOUNT_1 in engine.storage)
+        storage_value = engine.storage_get(self.KYC_WHITELIST_PREFIX + self.OTHER_ACCOUNT_1, path)
+        self.assertIsNotNone(storage_value)
 
     def test_ico_kyc_remove(self):
         path = self.get_contract_path('ico.py')

--- a/boa3_test/tests/test_classes/storage.py
+++ b/boa3_test/tests/test_classes/storage.py
@@ -67,28 +67,30 @@ class Storage:
         self._dict[key] = StorageItem(NativeAccountState(balance).serialize())
         return True
 
-    def __contains__(self, item: bytes) -> bool:
-        return StorageKey(item) in self._dict
+    def __contains__(self, item: StorageKey) -> bool:
+        return item in self._dict
 
-    def __getitem__(self, item: bytes) -> Any:
-        storage_key = StorageKey(item)
-        return self._dict[storage_key].value
+    def __getitem__(self, item: StorageKey) -> Any:
+        return self._dict[item].value
 
-    def __setitem__(self, key: bytes, value: Any):
+    def __setitem__(self, key: StorageKey, value: Any):
         from boa3.neo.vm.type import StackItem
-        storage_key = StorageKey(key)
         if isinstance(value, int):
             storage_value = Integer(value).to_byte_array()
         elif isinstance(value, str):
             storage_value = String(value).to_bytes()
         else:
             storage_value = StackItem.serialize(value)
-        self._dict[storage_key] = StorageItem(storage_value)
+        self._dict[key] = StorageItem(storage_value)
+
+    @staticmethod
+    def build_key(key: bytes, index: int) -> StorageKey:
+        return StorageKey(key, index)
 
 
 class StorageKey:
-    def __init__(self, key: bytes):
-        self._ID = 0
+    def __init__(self, key: bytes, _id: int = 0):
+        self._ID: int = _id
         self._key: bytes = key
 
     def to_json(self) -> Dict[str, Any]:
@@ -108,10 +110,10 @@ class StorageKey:
         return key
 
     def __eq__(self, other) -> bool:
-        return isinstance(other, StorageKey) and self._key == other._key
+        return isinstance(other, StorageKey) and self._key == other._key and self._ID == other._ID
 
     def __str__(self) -> str:
-        return self._key.__str__()
+        return '({0}, {1})'.format(self._key, self._ID)
 
     def __hash__(self) -> int:
         return self._key.__hash__()

--- a/boa3_test/tests/test_classes/testengine.py
+++ b/boa3_test/tests/test_classes/testengine.py
@@ -1,5 +1,5 @@
 from os import path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from boa3 import constants
 from boa3.neo import to_hex_str
@@ -70,31 +70,52 @@ class TestEngine:
     def storage(self) -> Storage:
         return self._storage.copy()
 
-    def storage_get(self, key: Union[str, bytes]) -> Any:
+    def storage_get(self, key: Union[str, bytes], contract_path: str) -> Any:
         if isinstance(key, str):
             key = String(key).to_bytes()
 
-        if key in self._storage:
-            return self._storage[key]
+        if contract_path.endswith('.py'):
+            contract_path = contract_path.replace('.py', '.nef')
+        if contract_path not in self._contract_paths:
+            return None
+
+        index = self._contract_paths.index(contract_path)
+        storage_key = Storage.build_key(key, index)
+        if storage_key in self._storage:
+            return self._storage[storage_key]
         else:
             return None
 
-    def storage_put(self, key: Union[str, bytes], value: Any):
+    def storage_put(self, key: Union[str, bytes], value: Any, contract_path: str):
         if isinstance(key, str):
             key = String(key).to_bytes()
 
-        self._storage[key] = value
+        if contract_path.endswith('.py'):
+            contract_path = contract_path.replace('.py', '.nef')
+        if contract_path in self._contract_paths:
+            index = self._contract_paths.index(contract_path)
+            storage_key = Storage.build_key(key, index)
 
-    def set_storage(self, storage: Dict[Union[str, bytes], Any]):
+            self._storage[storage_key] = value
+
+    def set_storage(self, storage: Dict[Tuple[Union[str, bytes], str], Any]):
         self._storage.clear()
-        for key, value in storage.items():
-            self.storage_put(key, value)
+        for (key, contract_path), value in storage.items():
+            self.storage_put(key, value, contract_path)
 
-    def storage_delete(self, key: Union[str, bytes]):
+    def storage_delete(self, key: Union[str, bytes], contract_path: str):
         if isinstance(key, str):
             key = String(key).to_bytes()
 
-        if key in self._storage:
+        if contract_path.endswith('.py'):
+            contract_path = contract_path.replace('.py', '.nef')
+        if contract_path not in self._contract_paths:
+            return None
+
+        index = self._contract_paths.index(contract_path)
+        storage_key = Storage.build_key(key, index)
+
+        if storage_key in self._storage:
             self._storage.pop(key)
 
     def add_neo(self, script_hash: bytes, amount: int) -> bool:
@@ -165,6 +186,9 @@ class TestEngine:
         import json
         import subprocess
 
+        if isinstance(nef_path, str) and nef_path not in self._contract_paths:
+            self._contract_paths.append(nef_path)
+
         test_engine_args = self.to_json(nef_path, method, *arguments)
         param_json = json.dumps(test_engine_args, separators=(',', ':'))
         process = subprocess.Popen(['dotnet', self._test_engine_path, param_json],
@@ -184,6 +208,7 @@ class TestEngine:
             result = json.loads(stdout)
 
             self._error_message = result['error'] if 'error' in result else None
+
             if 'vm_state' in result:
                 self._vm_state = VMState.get_vm_state(result['vm_state'])
 

--- a/boa3_test/tests/test_interop/test_storage.py
+++ b/boa3_test/tests/test_interop/test_storage.py
@@ -71,13 +71,13 @@ class TestStorageInterop(BoaTest):
                                          expected_result_type=bytes)
         self.assertEqual(b'', result)
 
-        storage = {'example': 23}
+        storage = {('example', path): 23}
         result = self.run_smart_contract(engine, path, 'Main', 'example',
                                          fake_storage=storage,
                                          expected_result_type=bytes)
         self.assertEqual(Integer(23).to_byte_array(), result)
 
-        storage = {'test1': 23, 'test2': 42}
+        storage = {('test1', path): 23, ('test2', path): 42}
         result = self.run_smart_contract(engine, path, 'Main', 'test2',
                                          fake_storage=storage,
                                          expected_result_type=bytes)
@@ -109,21 +109,26 @@ class TestStorageInterop(BoaTest):
         stored_value = b'\x01\x02\x03'
         result = self.run_smart_contract(engine, path, 'Main', b'test1')
         self.assertIsVoid(result)
-        self.assertTrue(b'test1' in engine.storage)
-        self.assertEqual(stored_value, engine.storage[b'test1'])
+        storage_value = engine.storage_get(b'test1', path)
+        self.assertIsNotNone(storage_value)
+        self.assertEqual(stored_value, storage_value)
 
         result = self.run_smart_contract(engine, path, 'Main', b'test2')
         self.assertIsVoid(result)
-        self.assertTrue(b'test1' in engine.storage)
-        self.assertEqual(stored_value, engine.storage[b'test1'])
-        self.assertTrue(b'test2' in engine.storage)
-        self.assertEqual(stored_value, engine.storage[b'test2'])
+        storage_value = engine.storage_get(b'test1', path)
+        self.assertIsNotNone(storage_value)
+        self.assertEqual(stored_value, storage_value)
+        storage_value = engine.storage_get(b'test2', path)
+        self.assertIsNotNone(storage_value)
+        self.assertEqual(stored_value, storage_value)
 
         result = self.run_smart_contract(engine, path, 'Main', b'test2', fake_storage={})
         self.assertIsVoid(result)
-        self.assertTrue(b'test1' not in engine.storage)
-        self.assertTrue(b'test2' in engine.storage)
-        self.assertEqual(stored_value, engine.storage[b'test2'])
+        storage_value = engine.storage_get(b'test1', path)
+        self.assertIsNone(storage_value)
+        storage_value = engine.storage_get(b'test2', path)
+        self.assertIsNotNone(storage_value)
+        self.assertEqual(stored_value, storage_value)
 
     def test_storage_put_bytes_key_int_value(self):
         value = Integer(123).to_byte_array()
@@ -156,21 +161,26 @@ class TestStorageInterop(BoaTest):
         stored_value = Integer(123).to_byte_array()
         result = self.run_smart_contract(engine, path, 'Main', b'test1')
         self.assertIsVoid(result)
-        self.assertTrue(b'test1' in engine.storage)
-        self.assertEqual(stored_value, engine.storage[b'test1'])
+        storage_value = engine.storage_get(b'test1', path)
+        self.assertIsNotNone(storage_value)
+        self.assertEqual(stored_value, storage_value)
 
         result = self.run_smart_contract(engine, path, 'Main', b'test2')
         self.assertIsVoid(result)
-        self.assertTrue(b'test1' in engine.storage)
-        self.assertEqual(stored_value, engine.storage[b'test1'])
-        self.assertTrue(b'test2' in engine.storage)
-        self.assertEqual(stored_value, engine.storage[b'test2'])
+        storage_value = engine.storage_get(b'test1', path)
+        self.assertIsNotNone(storage_value)
+        self.assertEqual(stored_value, storage_value)
+        storage_value = engine.storage_get(b'test2', path)
+        self.assertIsNotNone(storage_value)
+        self.assertEqual(stored_value, storage_value)
 
         result = self.run_smart_contract(engine, path, 'Main', b'test2', fake_storage={})
         self.assertIsVoid(result)
-        self.assertTrue(b'test1' not in engine.storage)
-        self.assertTrue(b'test2' in engine.storage)
-        self.assertEqual(stored_value, engine.storage[b'test2'])
+        storage_value = engine.storage_get(b'test1', path)
+        self.assertIsNone(storage_value)
+        storage_value = engine.storage_get(b'test2', path)
+        self.assertIsNotNone(storage_value)
+        self.assertEqual(stored_value, storage_value)
 
     def test_storage_put_bytes_key_str_value(self):
         value = String('123').to_bytes()
@@ -201,21 +211,26 @@ class TestStorageInterop(BoaTest):
         stored_value = String('123').to_bytes()
         result = self.run_smart_contract(engine, path, 'Main', 'test1')
         self.assertIsVoid(result)
-        self.assertTrue(b'test1' in engine.storage)
-        self.assertEqual(stored_value, engine.storage[b'test1'])
+        storage_value = engine.storage_get(b'test1', path)
+        self.assertIsNotNone(storage_value)
+        self.assertEqual(stored_value, storage_value)
 
         result = self.run_smart_contract(engine, path, 'Main', 'test2')
         self.assertIsVoid(result)
-        self.assertTrue(b'test1' in engine.storage)
-        self.assertEqual(stored_value, engine.storage[b'test1'])
-        self.assertTrue(b'test2' in engine.storage)
-        self.assertEqual(stored_value, engine.storage[b'test2'])
+        storage_value = engine.storage_get(b'test1', path)
+        self.assertIsNotNone(storage_value)
+        self.assertEqual(stored_value, storage_value)
+        storage_value = engine.storage_get(b'test2', path)
+        self.assertIsNotNone(storage_value)
+        self.assertEqual(stored_value, storage_value)
 
         result = self.run_smart_contract(engine, path, 'Main', 'test2', fake_storage={})
         self.assertIsVoid(result)
-        self.assertTrue(b'test1' not in engine.storage)
-        self.assertTrue(b'test2' in engine.storage)
-        self.assertEqual(stored_value, engine.storage[b'test2'])
+        storage_value = engine.storage_get(b'test1', path)
+        self.assertIsNone(storage_value)
+        storage_value = engine.storage_get(b'test2', path)
+        self.assertIsNotNone(storage_value)
+        self.assertEqual(stored_value, storage_value)
 
     def test_storage_put_str_key_bytes_value(self):
         path = self.get_contract_path('StoragePutStrKeyBytesValue.py')
@@ -225,21 +240,26 @@ class TestStorageInterop(BoaTest):
         stored_value = b'\x01\x02\x03'
         result = self.run_smart_contract(engine, path, 'Main', b'test1')
         self.assertIsVoid(result)
-        self.assertTrue(b'test1' in engine.storage)
-        self.assertEqual(stored_value, engine.storage[b'test1'])
+        storage_value = engine.storage_get(b'test1', path)
+        self.assertIsNotNone(storage_value)
+        self.assertEqual(stored_value, storage_value)
 
         result = self.run_smart_contract(engine, path, 'Main', b'test2')
         self.assertIsVoid(result)
-        self.assertTrue(b'test1' in engine.storage)
-        self.assertEqual(stored_value, engine.storage[b'test1'])
-        self.assertTrue(b'test2' in engine.storage)
-        self.assertEqual(stored_value, engine.storage[b'test2'])
+        storage_value = engine.storage_get(b'test1', path)
+        self.assertIsNotNone(storage_value)
+        self.assertEqual(stored_value, storage_value)
+        storage_value = engine.storage_get(b'test2', path)
+        self.assertIsNotNone(storage_value)
+        self.assertEqual(stored_value, storage_value)
 
         result = self.run_smart_contract(engine, path, 'Main', b'test2', fake_storage={})
         self.assertIsVoid(result)
-        self.assertTrue(b'test1' not in engine.storage)
-        self.assertTrue(b'test2' in engine.storage)
-        self.assertEqual(stored_value, engine.storage[b'test2'])
+        storage_value = engine.storage_get(b'test1', path)
+        self.assertIsNone(storage_value)
+        storage_value = engine.storage_get(b'test2', path)
+        self.assertIsNotNone(storage_value)
+        self.assertEqual(stored_value, storage_value)
 
     def test_storage_put_str_key_int_value(self):
         value = Integer(123).to_byte_array()
@@ -272,21 +292,26 @@ class TestStorageInterop(BoaTest):
         stored_value = Integer(123).to_byte_array()
         result = self.run_smart_contract(engine, path, 'Main', 'test1')
         self.assertIsVoid(result)
-        self.assertTrue(b'test1' in engine.storage)
-        self.assertEqual(stored_value, engine.storage[b'test1'])
+        storage_value = engine.storage_get(b'test1', path)
+        self.assertIsNotNone(storage_value)
+        self.assertEqual(stored_value, storage_value)
 
         result = self.run_smart_contract(engine, path, 'Main', 'test2')
         self.assertIsVoid(result)
-        self.assertTrue(b'test1' in engine.storage)
-        self.assertEqual(stored_value, engine.storage[b'test1'])
-        self.assertTrue(b'test2' in engine.storage)
-        self.assertEqual(stored_value, engine.storage[b'test2'])
+        storage_value = engine.storage_get(b'test1', path)
+        self.assertIsNotNone(storage_value)
+        self.assertEqual(stored_value, storage_value)
+        storage_value = engine.storage_get(b'test2', path)
+        self.assertIsNotNone(storage_value)
+        self.assertEqual(stored_value, storage_value)
 
         result = self.run_smart_contract(engine, path, 'Main', 'test2', fake_storage={})
         self.assertIsVoid(result)
-        self.assertTrue(b'test1' not in engine.storage)
-        self.assertTrue(b'test2' in engine.storage)
-        self.assertEqual(stored_value, engine.storage[b'test2'])
+        storage_value = engine.storage_get(b'test1', path)
+        self.assertIsNone(storage_value)
+        storage_value = engine.storage_get(b'test2', path)
+        self.assertIsNotNone(storage_value)
+        self.assertEqual(stored_value, storage_value)
 
     def test_storage_put_str_key_str_value(self):
         value = String('123').to_bytes()
@@ -317,21 +342,26 @@ class TestStorageInterop(BoaTest):
         stored_value = String('123').to_bytes()
         result = self.run_smart_contract(engine, path, 'Main', 'test1')
         self.assertIsVoid(result)
-        self.assertTrue(b'test1' in engine.storage)
-        self.assertEqual(stored_value, engine.storage[b'test1'])
+        storage_value = engine.storage_get(b'test1', path)
+        self.assertIsNotNone(storage_value)
+        self.assertEqual(stored_value, storage_value)
 
         result = self.run_smart_contract(engine, path, 'Main', 'test2')
         self.assertIsVoid(result)
-        self.assertTrue(b'test1' in engine.storage)
-        self.assertEqual(stored_value, engine.storage[b'test1'])
-        self.assertTrue(b'test2' in engine.storage)
-        self.assertEqual(stored_value, engine.storage[b'test2'])
+        storage_value = engine.storage_get(b'test1', path)
+        self.assertIsNotNone(storage_value)
+        self.assertEqual(stored_value, storage_value)
+        storage_value = engine.storage_get(b'test2', path)
+        self.assertIsNotNone(storage_value)
+        self.assertEqual(stored_value, storage_value)
 
         result = self.run_smart_contract(engine, path, 'Main', 'test2', fake_storage={})
         self.assertIsVoid(result)
-        self.assertTrue(b'test1' not in engine.storage)
-        self.assertTrue(b'test2' in engine.storage)
-        self.assertEqual(stored_value, engine.storage[b'test2'])
+        storage_value = engine.storage_get(b'test1', path)
+        self.assertIsNone(storage_value)
+        storage_value = engine.storage_get(b'test2', path)
+        self.assertIsNotNone(storage_value)
+        self.assertEqual(stored_value, storage_value)
 
     def test_storage_put_mismatched_type_key(self):
         path = self.get_contract_path('StoragePutMismatchedTypeKey.py')
@@ -361,13 +391,13 @@ class TestStorageInterop(BoaTest):
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', b'example')
         self.assertIsVoid(result)
-        self.assertFalse(b'example' in engine.storage)
+        self.assertIsNone(engine.storage_get(b'example', path))
 
-        storage = {'example': 23}
+        storage = {('example', path): 23}
         result = self.run_smart_contract(engine, path, 'Main', b'example', fake_storage=storage)
         self.assertIsVoid(result)
-        self.assertTrue('example' in storage)
-        self.assertFalse(b'example' in engine.storage)
+        self.assertIsNone(engine.storage_get('example', path))
+        self.assertIsNone(engine.storage_get(b'example', path))
 
     def test_storage_delete_str_key(self):
         expected_output = (
@@ -389,13 +419,13 @@ class TestStorageInterop(BoaTest):
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', 'example')
         self.assertIsVoid(result)
-        self.assertFalse(b'example' in engine.storage)
+        self.assertIsNone(engine.storage_get(b'example', path))
 
-        storage = {'example': 23}
+        storage = {('example', path): 23}
         result = self.run_smart_contract(engine, path, 'Main', 'example', fake_storage=storage)
         self.assertIsVoid(result)
-        self.assertTrue('example' in storage)
-        self.assertFalse(b'example' in engine.storage)
+        self.assertIsNone(engine.storage_get('example', path))
+        self.assertIsNone(engine.storage_get(b'example', path))
 
     def test_storage_delete_mismatched_type(self):
         path = self.get_contract_path('StorageDeleteMismatchedType.py')
@@ -472,3 +502,24 @@ class TestStorageInterop(BoaTest):
         if isinstance(result, str):
             result = String(result).to_bytes()
         self.assertEqual(b'', result)
+
+    def test_storage_between_contracts(self):
+        path1 = self.get_contract_path('StorageGetAndPut1.py')
+        path2 = self.get_contract_path('StorageGetAndPut2.py')
+        self.compile_and_save(path1)
+        self.compile_and_save(path2)
+        key = 'example_key'
+        value = 42
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path1, 'put_value', key, value)
+        self.assertIsVoid(result)
+        storage_value = engine.storage_get(key, path1)
+        self.assertIsNotNone(storage_value)
+        self.assertEqual(value, Integer.from_bytes(storage_value))
+
+        result = self.run_smart_contract(engine, path2, 'get_value', key)
+        self.assertEqual(0, result)
+
+        result = self.run_smart_contract(engine, path1, 'get_value', key)
+        self.assertEqual(value, result)


### PR DESCRIPTION
**Related issue**
#353

**Summary or solution description**
Fixed a problem in the TestEngine execution, that caused the executing smart contract to have access to other smart contracts' storages.

**How to Reproduce**
```python
path1 = self.get_contract_path('StorageGetAndPut1.py')
path2 = self.get_contract_path('StorageGetAndPut2.py')
key = 'example_key'
value = 42

engine = TestEngine()
result = self.run_smart_contract(engine, path1, 'put_value', key, value)
storage_value = engine.storage_get(key, path1)
assert Integer.from_bytes(storage_value)) == value

result = self.run_smart_contract(engine, path2, 'get_value', key)
assert result == 0
assert engine.storage_get(key, path2) is None
```

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
