### PR TITLE
Fix return when using update_contract and destroy_contract

### DIFF
--- a/boa3/model/builtin/interop/contract/contractmanagementmethod.py
+++ b/boa3/model/builtin/interop/contract/contractmanagementmethod.py
@@ -16,16 +16,22 @@ class ContractManagementMethod(InteropMethod):
     @property
     def opcode(self) -> List[Tuple[Opcode, bytes]]:
         from boa3.model.builtin.interop.interop import Interop
+        from boa3.model.type.type import Type
         from boa3.neo.vm.type.Integer import Integer
         from boa3.neo.vm.type.String import String
 
         method = String(self._sys_call).to_bytes()
-        opcode = [
+        method_opcode = [
             (Opcode.PUSHDATA1, Integer(len(method)).to_byte_array(min_length=1) + method)
         ]
-        return (opcode
+        drop_if_void_opcode = [
+            (Opcode.DROP, b'')
+        ] if self.return_type is Type.none else []
+
+        return (method_opcode
                 + Interop.ManagementContractScriptHash.getter.opcode
                 + Interop.CallContract.opcode
+                + drop_if_void_opcode
                 )
 
     @property

--- a/boa3_test/test_sc/interop_test/UpdateContract.py
+++ b/boa3_test/test_sc/interop_test/UpdateContract.py
@@ -5,3 +5,8 @@ from boa3.builtin.interop.contract import update_contract
 @public
 def update(script: bytes, manifest: bytes):
     update_contract(script, manifest)
+
+
+@public
+def new_method() -> int:
+    return 42

--- a/boa3_test/tests/test_interop/test_contract.py
+++ b/boa3_test/tests/test_interop/test_contract.py
@@ -186,12 +186,22 @@ class TestContractInterop(BoaTest):
             + Opcode.ROT
             + Opcode.SYSCALL
             + Interop.CallContract.interop_method_hash
+            + Opcode.DROP
             + Opcode.RET
         )
 
         path = self.get_contract_path('UpdateContract.py')
-        output = Boa3.compile(path)
+        output, manifest = self.compile_and_save(path)
         self.assertEqual(expected_output, output)
+
+        new_path = self.get_contract_path('test_sc/interop_test', 'UpdateContract.py')
+        self.compile_and_save(new_path)
+        new_nef, new_manifest = self.get_bytes_output(new_path)
+        arg_manifest = String(json.dumps(new_manifest, separators=(',', ':'))).to_bytes()
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'update', new_nef, arg_manifest)
+        self.assertIsVoid(result)
 
     def test_update_contract_too_many_parameters(self):
         path = self.get_contract_path('UpdateContractTooManyArguments.py')
@@ -218,6 +228,7 @@ class TestContractInterop(BoaTest):
             + Opcode.ROT
             + Opcode.SYSCALL
             + Interop.CallContract.interop_method_hash
+            + Opcode.DROP
             + Opcode.RET
         )
 


### PR DESCRIPTION
**Related issue**
#362 

**Summary or solution description**
When using `update_contract` or `destroy_contract` boa built-in methods, instead of returning no value it was returning null. This resulted in the execution failing due to the unexpected value.

**How to Reproduce**
Update or destroy a smart contract compiled with neo3-boa

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
