### PR TITLE
Contract Manifest returning null when using Contract related functions

### DIFF
--- a/boa3/neo/utils/__init__.py
+++ b/boa3/neo/utils/__init__.py
@@ -46,7 +46,7 @@ def stack_item_from_json(item: Dict[str, Any]) -> Any:
         except BaseException:
             value = decoded
 
-    elif item_type is StackItemType.Array:
+    elif item_type in (StackItemType.Array, StackItemType.Struct):
         if not isinstance(item_value, Sequence) or isinstance(item_value, (str, bytes)):
             raise ValueError
         value = [stack_item_from_json(x) for x in item_value]

--- a/boa3/neo/vm/type/ContractParameterType.py
+++ b/boa3/neo/vm/type/ContractParameterType.py
@@ -1,0 +1,26 @@
+from enum import IntEnum
+
+
+class ContractParameterType(IntEnum):
+    Any = 0x00
+    Boolean = 0x10
+    Integer = 0x11
+    ByteArray = 0x12
+    String = 0x13
+    Hash160 = 0x14
+    Hash256 = 0x15
+    PublicKey = 0x16
+    Signature = 0x17
+    Array = 0x20
+    Map = 0x22
+    InteropInterface = 0x30
+    Void = 0xff
+
+    @classmethod
+    def get_by_name(cls, name: str) -> int:
+        try:
+            value = cls.__getattr__(name)
+        except BaseException:
+            value = cls.Any
+
+        return int(value)

--- a/boa3_test/tests/test_classes/contract/neoabistruct.py
+++ b/boa3_test/tests/test_classes/contract/neoabistruct.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from boa3_test.tests.test_classes.contract.neoeventstruct import NeoEventStruct
+from boa3_test.tests.test_classes.contract.neomethodstruct import NeoMethodStruct
+from boa3_test.tests.test_classes.contract.neostruct import NeoStruct
+
+
+class NeoAbiStruct(NeoStruct):
+    _methods_field = 'methods'
+    _events_field = 'events'
+
+    @classmethod
+    def from_json(cls, json: Dict[str, Any]) -> NeoAbiStruct:
+        required_fields = [cls._methods_field,
+                           cls._events_field
+                           ]
+        cls._validate_json(json, required_fields)
+
+        struct = cls()
+        struct.append(cls._get_methods(json[cls._methods_field]))
+        struct.append(cls._get_events(json[cls._events_field]))
+
+        return struct
+
+    @classmethod
+    def _get_methods(cls, json_list: List[Dict[str, Any]]) -> List[NeoMethodStruct]:
+        return [NeoMethodStruct.from_json(method_json) for method_json in json_list]
+
+    @classmethod
+    def _get_events(cls, json_list: List[Dict[str, Any]]) -> List[NeoEventStruct]:
+        return [NeoEventStruct.from_json(method_json) for method_json in json_list]

--- a/boa3_test/tests/test_classes/contract/neoeventstruct.py
+++ b/boa3_test/tests/test_classes/contract/neoeventstruct.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from boa3_test.tests.test_classes.contract.neostruct import NeoStruct
+
+
+class NeoEventStruct(NeoStruct):
+
+    _name_field = 'name'
+    _parameters_field = 'parameters'
+
+    @classmethod
+    def from_json(cls, json: Dict[str, Any]) -> NeoEventStruct:
+        required_fields = [cls._name_field,
+                           cls._parameters_field
+                           ]
+        cls._validate_json(json, required_fields)
+
+        struct = cls()
+        struct.append(json[cls._name_field])
+        struct.append([cls._get_param_info(arg) for arg in json[cls._parameters_field]])
+
+        return struct

--- a/boa3_test/tests/test_classes/contract/neomanifeststruct.py
+++ b/boa3_test/tests/test_classes/contract/neomanifeststruct.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from boa3_test.tests.test_classes.contract.neoabistruct import NeoAbiStruct
+from boa3_test.tests.test_classes.contract.neopermissionsstruct import NeoPermissionsStruct
+from boa3_test.tests.test_classes.contract.neostruct import NeoStruct
+
+
+class NeoManifestStruct(NeoStruct):
+    _name_field = 'name'
+    _groups_field = 'groups'
+    _supported_standards_field = 'supportedstandards'
+    _abi_field = 'abi'
+    _permissions_field = 'permissions'
+    _trusts_field = 'trusts'
+    _extra_field = 'extra'
+
+    @classmethod
+    def from_json(cls, json: Dict[str, Any]) -> NeoManifestStruct:
+        required_fields = [cls._name_field,
+                           cls._groups_field,
+                           cls._supported_standards_field,
+                           cls._abi_field,
+                           cls._permissions_field,
+                           cls._trusts_field,
+                           cls._extra_field
+                           ]
+        cls._validate_json(json, required_fields)
+
+        struct = cls()
+        struct.append(json[cls._name_field])
+        struct.append(json[cls._groups_field])  # TODO: groups aren't implemented yet
+        struct.append(json[cls._supported_standards_field])  # TODO: supported standards aren't implemented
+        struct.append(NeoAbiStruct.from_json(json[cls._abi_field]))
+        struct.append([NeoPermissionsStruct.from_json(permission) for permission in json[cls._permissions_field]])
+        struct.append(json[cls._trusts_field])  # TODO: trusts aren't implemented
+        extras = json[cls._extra_field]
+        struct.append(extras if extras is not None else "null")
+
+        return struct

--- a/boa3_test/tests/test_classes/contract/neomethodstruct.py
+++ b/boa3_test/tests/test_classes/contract/neomethodstruct.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from boa3.neo.vm.type.ContractParameterType import ContractParameterType
+from boa3_test.tests.test_classes.contract.neostruct import NeoStruct
+
+
+class NeoMethodStruct(NeoStruct):
+
+    _name_field = 'name'
+    _parameters_field = 'parameters'
+    _return_type_field = 'returntype'
+    _offset_field = 'offset'
+    _is_safe_field = 'safe'
+
+    @classmethod
+    def from_json(cls, json: Dict[str, Any]) -> NeoMethodStruct:
+        required_fields = [cls._name_field,
+                           cls._parameters_field,
+                           cls._return_type_field,
+                           cls._offset_field,
+                           cls._is_safe_field
+                           ]
+        cls._validate_json(json, required_fields)
+
+        struct = cls()
+        struct.append(json[cls._name_field])
+        struct.append([cls._get_param_info(arg) for arg in json[cls._parameters_field]])
+        struct.append(ContractParameterType.get_by_name(json[cls._return_type_field]))
+        struct.append(json[cls._offset_field])
+        struct.append(json[cls._is_safe_field])
+
+        return struct

--- a/boa3_test/tests/test_classes/contract/neopermissionsstruct.py
+++ b/boa3_test/tests/test_classes/contract/neopermissionsstruct.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from boa3.neo3.core.types import UInt160
+from boa3_test.tests.test_classes.contract.neostruct import NeoStruct
+
+
+class NeoPermissionsStruct(NeoStruct):
+
+    _contract_fields = 'contract'
+    _methods_fields = 'methods'
+
+    @classmethod
+    def from_json(cls, json: Dict[str, Any]) -> NeoPermissionsStruct:
+        required_fields = [cls._contract_fields,
+                           cls._methods_fields
+                           ]
+        cls._validate_json(json, required_fields)
+
+        struct = cls()
+        struct.append(cls.get_contract(json[cls._contract_fields]))
+        struct.append(cls.get_methods(json[cls._methods_fields]))
+        return struct
+
+    @classmethod
+    def _is_wildcard(cls, value: Any) -> bool:
+        if value is None:
+            return True
+        return value is '*'
+
+    @classmethod
+    def get_contract(cls, value: Any) -> Optional[UInt160]:
+        if cls._is_wildcard(value):
+            return None
+
+        # TODO: Permissions are not implemented yet
+        return UInt160()
+
+    @classmethod
+    def get_methods(cls, value: Any) -> Optional[list]:
+        if cls._is_wildcard(value):
+            return None
+
+        # TODO: Permissions are not implemented yet
+        return []

--- a/boa3_test/tests/test_classes/contract/neostruct.py
+++ b/boa3_test/tests/test_classes/contract/neostruct.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List
+
+
+class NeoStruct(list, ABC):
+
+    @classmethod
+    @abstractmethod
+    def from_json(cls, json: Dict[str, Any]) -> NeoStruct:
+        pass
+
+    @classmethod
+    def _validate_json(cls, json: Dict[str, Any], required_fields: List[str]):
+        keys = set(json.keys())
+        if not keys.issubset(required_fields):
+            raise ValueError
+
+    @classmethod
+    def _get_param_info(cls, json: Dict[str, Any]) -> list:
+        _name = 'name'
+        _type = 'type'
+
+        required_fields = [_name, _type]
+        cls._validate_json(json, required_fields)
+
+        name = json[_name]
+        from boa3.neo.vm.type.ContractParameterType import ContractParameterType
+        try:
+            param_type = ContractParameterType.get_by_name(json[_type])
+        except BaseException:
+            param_type = None
+
+        return [name, param_type]

--- a/boa3_test/tests/test_interop/test_blockchain.py
+++ b/boa3_test/tests/test_interop/test_blockchain.py
@@ -1,5 +1,3 @@
-import json
-
 from boa3 import constants
 from boa3.boa3 import Boa3
 from boa3.model.builtin.interop.interop import Interop
@@ -8,6 +6,7 @@ from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.String import String
 from boa3_test.tests.boa_test import BoaTest
+from boa3_test.tests.test_classes.contract.neomanifeststruct import NeoManifestStruct
 from boa3_test.tests.test_classes.testengine import TestEngine
 
 
@@ -81,11 +80,10 @@ class TestBlockchainInterop(BoaTest):
         call_contract_path = call_contract_path.replace('.py', '.nef')
 
         engine.add_contract(call_contract_path)
-        arg_manifest = json.dumps(manifest, separators=(',', ':'))
 
         result = self.run_smart_contract(engine, path, 'main', call_hash)
         self.assertEqual(5, len(result))
         self.assertEqual(call_hash, result[2])
         self.assertEqual(nef, result[3])
-        # TODO: manifest is None, check why
-        # self.assertEqual(json.loads(arg_manifest), json.loads(result[4]))
+        manifest_struct = NeoManifestStruct.from_json(manifest)
+        self.assertEqual(manifest_struct, result[4])

--- a/boa3_test/tests/test_interop/test_contract.py
+++ b/boa3_test/tests/test_interop/test_contract.py
@@ -13,6 +13,7 @@ from boa3.neo.vm.type.String import String
 from boa3.neo3.contracts import CallFlags
 from boa3_test.tests.boa_test import BoaTest
 from boa3_test.tests.test_classes.TestExecutionException import TestExecutionException
+from boa3_test.tests.test_classes.contract.neomanifeststruct import NeoManifestStruct
 from boa3_test.tests.test_classes.testengine import TestEngine
 
 
@@ -152,8 +153,8 @@ class TestContractInterop(BoaTest):
 
         self.assertEqual(5, len(result))
         self.assertEqual(nef_file, result[3])
-        # TODO: manifest is None, check why
-        # self.assertEqual(manifest, json.loads(result[4]))
+        manifest_struct = NeoManifestStruct.from_json(manifest)
+        self.assertEqual(manifest_struct, result[4])
 
     def test_create_contract_too_many_parameters(self):
         path = self.get_contract_path('CreateContractTooManyArguments.py')


### PR DESCRIPTION
**Related issue**
#318 

**Summary or solution description**
The result of ``create_contract`` was returning with `null` manifest. The problem was in neo3-boa's unit tests, where it couldn't convert Neo's `Struct` type, which is the manifest's type in this case.
Implemented Struct conversion from TestEngine's output and a way to convert json to Struct for testing

**How to Reproduce**
Create a smart contract that calls `create_contract`
```python
from boa3.builtin import public
from boa3.builtin.interop.contract import Contract, create_contract


@public
def Main(script: bytes, manifest: bytes) -> Contract:
    return create_contract(script, manifest)
```

and deploy another smart contract invoking it.
```python
call_contract_path = 'path/to/other/contract.py'
nef_file, manifest = self.compile_and_save(call_contract_path)
arg_manifest = String(json.dumps(manifest, separators=(',', ':'))).to_bytes()

engine = TestEngine()
result = self.run_smart_contract(engine, path, 'Main', nef_file, arg_manifest)
```
**Tests**
Unit tests

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7