### PR TITLE
Add support to storage context in storage functions

### DIFF
--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -77,7 +77,7 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
             symbols.update(module.symbols)
         return symbols
 
-    def get_symbol(self, symbol_id: str) -> Optional[ISymbol]:
+    def get_symbol(self, symbol_id: str, is_internal: bool = False) -> Optional[ISymbol]:
         if not isinstance(symbol_id, str):
             return Variable(self.get_type(symbol_id))
 
@@ -93,7 +93,7 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
             # the symbol exists in the modules scope
             return self.modules[symbol_id]
         else:
-            return super().get_symbol(symbol_id)
+            return super().get_symbol(symbol_id, is_internal)
 
     def new_local_scope(self, symbols: Dict[str, ISymbol] = None):
         if symbols is None:
@@ -961,7 +961,8 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
         """
         if isinstance(call.func, ast.Name):
             callable_id: str = call.func.id
-            callable_target = self.get_symbol(callable_id)
+            is_internal = hasattr(call, 'is_internal_call') and call.is_internal_call
+            callable_target = self.get_symbol(callable_id, is_internal)
         else:
             callable_id, callable_target = self.get_callable_and_update_args(call)  # type: str, ISymbol
 

--- a/boa3/builtin/interop/storage/__init__.py
+++ b/boa3/builtin/interop/storage/__init__.py
@@ -4,12 +4,14 @@ from boa3.builtin.interop.iterator import Iterator
 from boa3.builtin.interop.storage.storagecontext import StorageContext
 
 
-def get(key: Union[str, bytes]) -> bytes:
+def get(key: Union[str, bytes], context: StorageContext = None) -> bytes:
     """
     Gets a value from the persistent store based on the given key.
 
     :param key: value identifier in the store
     :type key: str or bytes
+    :param context: storage context to be used
+    :type context: StorageContext
     :return: the value corresponding to given key for current storage context
     :rtype: bytes
     """
@@ -26,7 +28,7 @@ def get_context() -> StorageContext:
     pass
 
 
-def put(key: Union[str, bytes], value: Union[int, str, bytes]):
+def put(key: Union[str, bytes], value: Union[int, str, bytes], context: StorageContext = None):
     """
     Inserts a given value in the key-value format into the persistent storage.
 
@@ -34,26 +36,32 @@ def put(key: Union[str, bytes], value: Union[int, str, bytes]):
     :type key: str or bytes
     :param value: value to be stored
     :type value: int or str or bytes
+    :param context: storage context to be used
+    :type context: StorageContext
     """
     pass
 
 
-def delete(key: Union[str, bytes]):
+def delete(key: Union[str, bytes], context: StorageContext = None):
     """
     Removes a given key from the persistent storage if exists.
 
     :param key: the identifier in the store for the new value
     :type key: str or bytes
+    :param context: storage context to be used
+    :type context: StorageContext
     """
     pass
 
 
-def find(prefix: Union[str, bytes]) -> Iterator:
+def find(prefix: Union[str, bytes], context: StorageContext = None) -> Iterator:
     """
     Searches in the storage for keys that start with the given prefix
 
     :param prefix: prefix to find the storage keys
     :type prefix: str or bytes
+    :param context: storage context to be used
+    :type context: StorageContext
     :return: an iterator with the search results
     :rtype: Iterator
     """

--- a/boa3/compiler/codegenerator/codegenerator.py
+++ b/boa3/compiler/codegenerator/codegenerator.py
@@ -196,7 +196,7 @@ class CodeGenerator:
         """
         return self.last_code.opcode is Opcode.PUSHNULL
 
-    def get_symbol(self, identifier: str, scope: Optional[ISymbol] = None) -> ISymbol:
+    def get_symbol(self, identifier: str, scope: Optional[ISymbol] = None, is_internal: bool = False) -> ISymbol:
         """
         Gets a symbol in the symbol table by its id
 
@@ -230,6 +230,13 @@ class CodeGenerator:
                 attr = self.get_symbol(attribute)
                 if hasattr(attr, 'symbols') and symbol_id in attr.symbols:
                     return attr.symbols[symbol_id]
+
+            if is_internal:
+                from boa3.model.importsymbol import Import
+                imports = [symbol for symbol in self.symbol_table.values() if isinstance(symbol, Import)]
+                for package in imports:
+                    if identifier in package.all_symbols:
+                        return package.all_symbols[identifier]
         return Type.none
 
     def initialize_static_fields(self) -> bool:

--- a/boa3/model/builtin/interop/storage/storageputmethod.py
+++ b/boa3/model/builtin/interop/storage/storageputmethod.py
@@ -1,29 +1,38 @@
-from typing import Any, Dict, Iterable, List, Sized, Tuple
+import ast
+from typing import Any, Dict, Iterable, List, Sized
 
 from boa3.model.builtin.interop.interopmethod import InteropMethod
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.expression import IExpression
 from boa3.model.type.itype import IType
 from boa3.model.variable import Variable
-from boa3.neo.vm.opcode.Opcode import Opcode
 
 
 class StoragePutMethod(InteropMethod):
 
     def __init__(self):
         from boa3.model.type.type import Type
+        from boa3.model.builtin.interop.storage.storagecontexttype import StorageContextType
+
         identifier = 'put'
         syscall = 'System.Storage.Put'
-        # TODO: refactor to accept StorageContext as argument
+        context_type = StorageContextType.build()
         args: Dict[str, Variable] = {'key': Variable(Type.union.build([Type.bytes,
                                                                        Type.str
                                                                        ])),
                                      'value': Variable(Type.union.build([Type.bytes,
                                                                          Type.str,
                                                                          Type.int
-                                                                         ]))
-                                     }
-        super().__init__(identifier, syscall, args, return_type=Type.none)
+                                                                         ])),
+                                     'context': Variable(context_type)}
+
+        from boa3.model.builtin.interop.storage.storagegetcontextmethod import StorageGetContextMethod
+        default_id = StorageGetContextMethod(context_type).identifier
+        context_default = ast.parse("{0}()".format(default_id)
+                                    ).body[0].value
+        context_default.is_internal_call = True
+        context_default._fields += ('is_internal_call',)
+        super().__init__(identifier, syscall, args, defaults=[context_default], return_type=Type.none)
 
     def validate_parameters(self, *params: IExpression) -> bool:
         if any(not isinstance(param, IExpression) for param in params):
@@ -38,9 +47,22 @@ class StoragePutMethod(InteropMethod):
                 and self.value_arg.type.is_type_of(params[1].type))
 
     @property
-    def opcode(self) -> List[Tuple[Opcode, bytes]]:
-        from boa3.model.builtin.interop.interop import Interop
-        return Interop.StorageGetContext.opcode + super().opcode
+    def generation_order(self) -> List[int]:
+        """
+        Gets the indexes order that need to be used during code generation.
+        If the order for generation is the same as inputted in code, returns reversed(range(0,len_args))
+
+        :return: Index order for code generation
+        """
+        indexes = super().generation_order
+        context_index = list(self.args).index('context')
+
+        if indexes[-1] != context_index:
+            # context must be the last generated argument
+            indexes.remove(context_index)
+            indexes.append(context_index)
+
+        return indexes
 
     @property
     def key_arg(self) -> Variable:

--- a/boa3/model/builtin/method/builtinmethod.py
+++ b/boa3/model/builtin/method/builtinmethod.py
@@ -113,6 +113,21 @@ class IBuiltinMethod(IBuiltinCallable, Method, ABC):
         """
         pass
 
+    @property
+    def generation_order(self) -> List[int]:
+        """
+        Gets the indexes order that need to be used during code generation.
+        If the order for generation is the same as inputted in code, returns reversed(range(0,len_args))
+
+        :return: Index order for code generation
+        """
+        indexes = list(reversed(range(0, len(self.args))))
+        if self.push_self_first():
+            indexes.remove(0)     # remove the first index from whatever position it is
+            indexes.insert(0, 0)  # and move to the first position
+
+        return indexes
+
     def validate_negative_arguments(self) -> List[int]:
         """
         Returns a list of the arguments that have to be positive values and need validation.

--- a/boa3_test/test_sc/interop_test/storage/StorageBoa2Test.py
+++ b/boa3_test/test_sc/interop_test/storage/StorageBoa2Test.py
@@ -1,26 +1,27 @@
 from typing import Any
 
 from boa3.builtin import public
-from boa3.builtin.interop.storage import delete, get, put
+from boa3.builtin.interop.storage import delete, get, get_context, put
 
 
 @public
 def main(operation: str, arg: str, val: str) -> Any:
 
+    storage_context = get_context()
     print("context")
 
     if operation == 'sget':
 
-        return get(arg)
+        return get(arg, storage_context)
 
     elif operation == 'sput':
 
-        put(arg, val)
+        put(arg, val, storage_context)
         return True
 
     elif operation == 'sdel':
 
-        delete(arg)
+        delete(arg, storage_context)
         return True
 
     return 'unknown operation'

--- a/boa3_test/test_sc/interop_test/storage/StorageDeleteWithContext.py
+++ b/boa3_test/test_sc/interop_test/storage/StorageDeleteWithContext.py
@@ -1,0 +1,10 @@
+from typing import Union
+
+from boa3.builtin import public
+from boa3.builtin.interop.storage import delete, get_context
+
+
+@public
+def Main(key: Union[bytes, str]):
+    context = get_context()
+    delete(key, context)

--- a/boa3_test/test_sc/interop_test/storage/StorageFindWithContext.py
+++ b/boa3_test/test_sc/interop_test/storage/StorageFindWithContext.py
@@ -1,0 +1,16 @@
+from typing import Union
+
+from boa3.builtin import public
+from boa3.builtin.interop.iterator import Iterator
+from boa3.builtin.interop.storage import find, get_context, put
+
+
+@public
+def find_by_prefix(prefix: Union[str, bytes]) -> Iterator:
+    context = get_context()
+    return find(prefix, context)
+
+
+@public
+def put_on_storage(key: Union[str, bytes], value: Union[int, str, bytes]):
+    put(key, value)

--- a/boa3_test/test_sc/interop_test/storage/StorageGetWithContext.py
+++ b/boa3_test/test_sc/interop_test/storage/StorageGetWithContext.py
@@ -1,0 +1,10 @@
+from typing import Union
+
+from boa3.builtin import public
+from boa3.builtin.interop.storage import get, get_context
+
+
+@public
+def Main(key: Union[bytes, str]) -> bytes:
+    context = get_context()
+    return get(key, context)

--- a/boa3_test/test_sc/interop_test/storage/StoragePutWithContext.py
+++ b/boa3_test/test_sc/interop_test/storage/StoragePutWithContext.py
@@ -1,0 +1,9 @@
+from boa3.builtin import public
+from boa3.builtin.interop.storage import get_context, put
+
+
+@public
+def Main(key: bytes):
+    context = get_context()
+    value: bytes = b'\x01\x02\x03'
+    put(key, value, context)

--- a/boa3_test/tests/test_classes/testengine.py
+++ b/boa3_test/tests/test_classes/testengine.py
@@ -191,6 +191,7 @@ class TestEngine:
 
         test_engine_args = self.to_json(nef_path, method, *arguments)
         param_json = json.dumps(test_engine_args, separators=(',', ':'))
+
         process = subprocess.Popen(['dotnet', self._test_engine_path, param_json],
                                    stdout=subprocess.PIPE,
                                    stderr=subprocess.STDOUT,


### PR DESCRIPTION
**Related issue**
#354

**Summary or solution description**
Included an argument to each storage function to use a specific storage context.

**How to Reproduce**
```python
from typing import Any

from boa3.builtin import public
from boa3.builtin.interop.storage import delete, get, get_context, put


@public
def main(operation: str, arg: str, val: str) -> Any:
    storage_context = get_context()

    if operation == 'get':
        return get(arg, storage_context)

    elif operation == 'put':
        put(arg, val, storage_context)
        return True

    elif operation == 'del':
        delete(arg, storage_context)
        return True
        
    elif operation == 'find':
        return find(arg, storage_context)

    return 'unknown operation'
```

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7