### PR TITLE
Fix version and setup when installing from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ $ git clone https://github.com/CityOfZion/neo3-boa.git
 ```
 ###### Install project dependencies:
 ```shell
+$ pip install wheel
 $ pip install -e .
 ```
 

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ What it currently does...
    ``.manisfest.json`` format for use in the `Neo Virtual
    Machine <https://github.com/neo-project/neo-vm>`__
 
--  Works for Python 3.6+
+-  Works for Python 3.7+
 
 -  Logs compiler errors and warnings
 

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -42,6 +42,7 @@ If neo3-boa is not available via pip, you can build it from source.
 ::
    
     git clone https://github.com/CityOfZion/neo3-boa.git
+    pip install wheel
     pip install -e .
 
 1.2 Creating a New Smart Contract

--- a/setup.py
+++ b/setup.py
@@ -28,11 +28,12 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 # get the requirements from requirements.txt
 install_reqs = parse_requirements('requirements.txt', session=PipSession())
-if pip_version >= parse_version("20"):
-    reqs = [str(ir.requirement) for ir in install_reqs]
-else:
-    reqs = [str(ir.req) for ir in install_reqs]
-
+reqs = []
+for ir in install_reqs:
+    if hasattr(ir, 'requirement'):
+        reqs.append(str(ir.requirement))
+    else:
+        reqs.append(str(ir.req))
 
 setup(
     name='neo3-boa',
@@ -71,8 +72,8 @@ setup(
 
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 
     # What does your project relate to?
@@ -94,7 +95,7 @@ setup(
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=reqs,
 
-    python_requires='>=3.6',
+    python_requires='>=3.7',
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
I think these are important for the RC1 release

**Related issue**
1. Some time ago I pointed out that the required Python version differs from setup.py, documentation and the readme. 
2. current dev fails to install from source due the `parse_requirements` logic failing
3. current dev fails to install from source if the `wheel` package is not installed. `autopep8` and `coverage` fail. 

**Summary or solution description**
1. updated the versions to 3.7 & 3.8 to match with mamba
2. the `parse_requirements()` seems to have changed over time to return different objects. I can't exactly tell when and where or if it is just for a certain platform. The new solution is more generic. On OSX it worked as is, but Ubuntu fails.
3. while the failing packages are development requirements, I think it's easier to just install `wheel` before calling `install -e .`. Note that the two cannot be combined into 1 command or it will still fail to install as the pip session will not have learned about the new `bdist_wheel` command.
