### PR TITLE
env is not included in pip installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ For an extensive collection of examples:
 
 Install [`neo3-boa`](#installation) and the [`TestEngine`](#testengine) and run the following command
 
-> Note: If you didn't install TestEngine in neo3-boa's root folder, you need to change the value of `TEST_ENGINE_DIRECTORY` in [this file](/env.py)
+> Note: If you didn't install TestEngine in neo3-boa's root folder, you need to change the value of `TEST_ENGINE_DIRECTORY` in [this file](/boa3/env.py)
 
 ```
 python -m unittest discover boa3_test

--- a/boa3/env.py
+++ b/boa3/env.py
@@ -1,6 +1,6 @@
 import os
 
-PROJECT_ROOT_DIRECTORY = '/'.join(os.path.dirname(__file__).split(os.sep))
+PROJECT_ROOT_DIRECTORY = '/'.join(os.path.dirname(__file__).split(os.sep)[:-1])
 
 # If you didn't install TestEngine in this project's root folder, change this to the path of your .dll folder
 TEST_ENGINE_DIRECTORY = '{0}/Neo.TestEngine'.format(PROJECT_ROOT_DIRECTORY)

--- a/boa3_test/tests/boa_test.py
+++ b/boa3_test/tests/boa_test.py
@@ -2,7 +2,7 @@ import os
 from typing import Any, Dict, Iterable, Optional, Tuple, Type, Union
 from unittest import TestCase
 
-import env
+from boa3 import env
 from boa3.analyser.analyser import Analyser
 from boa3.compiler.compiler import Compiler
 from boa3.neo.smart_contract.VoidType import VoidType

--- a/boa3_test/tests/compiler_tests/test_test_engine.py
+++ b/boa3_test/tests/compiler_tests/test_test_engine.py
@@ -357,7 +357,7 @@ class TestTestEngine(BoaTest):
 
     def test_test_engine_not_found_error(self):
         # if the TestEngine is correctly installed a error should not occur
-        import env
+        from boa3 import env
         engine_path = env.TEST_ENGINE_DIRECTORY
         engine = TestEngine(engine_path)
 

--- a/boa3_test/tests/test_classes/testengine.py
+++ b/boa3_test/tests/test_classes/testengine.py
@@ -17,7 +17,7 @@ from boa3_test.tests.test_classes.transaction import Transaction
 class TestEngine:
     def __init__(self, root_path: Optional[str] = None):
         if root_path is None:
-            import env
+            from boa3 import env
             root_path = env.TEST_ENGINE_DIRECTORY
 
         engine_path = '{0}/Neo.TestEngine.dll'.format(root_path)

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -137,7 +137,7 @@ Testing
 *******
 
 .. note::
-   If you didn't install TestEngine in neo3-boa's root folder, you need to change the value of `TEST_ENGINE_DIRECTORY` in the file ``/env.py``
+   If you didn't install TestEngine in neo3-boa's root folder, you need to change the value of `TEST_ENGINE_DIRECTORY` in the file ``boa3/env.py``
 
 Create a Python Script, import the TestEngine class, and define a function to test your smart contract. In this function you'll need to call the method run(). Its parameters are the path of the compiled smart contract, the smart contract's method, and the arguments if necessary. Then assert your result to see if it's correct.
 


### PR DESCRIPTION
**Related issue**
#375

**Summary or solution description**
[env.py](https://github.com/CityOfZion/neo3-boa/blob/8b66f12cfad881050e202e31cc474e39d83014c3/env.py) was not included when installing neo3-boa using pip. Because of that, users that installed using pip couldn't run the unit tests as specified in the [README file](https://github.com/CityOfZion/neo3-boa/tree/8b66f12cfad881050e202e31cc474e39d83014c3#tests)

**How to Reproduce**
Install neo3-boa's developer branch using pip. `env` should be inside boa3 package path.

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
