### PR TITLE
Support to StorageMap

### DIFF
--- a/boa3/analyser/importanalyser.py
+++ b/boa3/analyser/importanalyser.py
@@ -118,6 +118,7 @@ class ImportAnalyser(IAstAnalyser):
                 return Builtin.package_symbols(packages[0])
 
             if packages[0] == 'interop':
+                # TODO: refactor for getting inner packages
                 return self._get_interop_symbols(packages[1])
 
         return self._get_boa3_builtin_symbols()

--- a/boa3/analyser/moduleanalyser.py
+++ b/boa3/analyser/moduleanalyser.py
@@ -376,6 +376,15 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
         self._global_assigned_variables.clear()
         self._current_module = None
 
+    def visit_ClassDef(self, node: ast.ClassDef):
+        # TODO: refactor when classes defined by the user are implemented
+        self._log_error(
+            CompilerError.NotSupportedOperation(
+                node.lineno, node.col_offset,
+                symbol_id='class'
+            )
+        )
+
     def visit_FunctionDef(self, function: ast.FunctionDef):
         """
         Visitor of the function node

--- a/boa3/builtin/interop/storage/__init__.py
+++ b/boa3/builtin/interop/storage/__init__.py
@@ -2,6 +2,7 @@ from typing import Union
 
 from boa3.builtin.interop.iterator import Iterator
 from boa3.builtin.interop.storage.storagecontext import StorageContext
+from boa3.builtin.interop.storage.storagemap import StorageMap
 
 
 def get(key: Union[str, bytes], context: StorageContext = None) -> bytes:

--- a/boa3/builtin/interop/storage/storagecontext.py
+++ b/boa3/builtin/interop/storage/storagecontext.py
@@ -1,3 +1,20 @@
+from typing import Union
+
+from boa3.builtin.interop.storage.storagemap import StorageMap
+
+
 class StorageContext:
+
     def __init__(self):
+        pass
+
+    def create_map(self, prefix: Union[str, bytes]) -> StorageMap:
+        """
+
+
+        :param prefix:
+        :type prefix:
+        :return:
+        :rtype:
+        """
         pass

--- a/boa3/builtin/interop/storage/storagecontext.py
+++ b/boa3/builtin/interop/storage/storagecontext.py
@@ -10,11 +10,10 @@ class StorageContext:
 
     def create_map(self, prefix: Union[str, bytes]) -> StorageMap:
         """
+        Creates a storage map with the given prefix
 
-
-        :param prefix:
-        :type prefix:
-        :return:
-        :rtype:
+        :param prefix: the identifier of the storage map
+        :type prefix: str or bytes
+        :return: a map with the key-values in the storage that match with the given prefix
         """
         pass

--- a/boa3/builtin/interop/storage/storagemap.py
+++ b/boa3/builtin/interop/storage/storagemap.py
@@ -1,0 +1,41 @@
+from typing import Union
+
+
+class StorageMap:
+
+    def __init__(self, context, prefix: Union[bytes, str]):
+        from boa3.builtin.interop.storage.storagecontext import StorageContext
+
+        self._context: StorageContext
+        self._prefix: Union[bytes, str]
+
+    def get(self, key: Union[str, bytes]) -> bytes:
+        """
+        Gets a value from the map based on the given key.
+
+        :param key: value identifier in the store
+        :type key: str or bytes
+        :return: the value corresponding to given key for current storage context
+        :rtype: bytes
+        """
+        pass
+
+    def put(self, key: Union[str, bytes], value: Union[int, str, bytes]):
+        """
+        Inserts a given value in the key-value format into the map.
+
+        :param key: the identifier in the store for the new value
+        :type key: str or bytes
+        :param value: value to be stored
+        :type value: int or str or bytes
+        """
+        pass
+
+    def delete(self, key: Union[str, bytes]):
+        """
+        Removes a given key from the map if exists.
+
+        :param key: the identifier in the store for the new value
+        :type key: str or bytes
+        """
+        pass

--- a/boa3/model/builtin/interop/interop.py
+++ b/boa3/model/builtin/interop/interop.py
@@ -40,6 +40,7 @@ class Interop:
     Iterator = IteratorType.build()
     NotificationType = NotificationType.build()
     StorageContextType = StorageContextType.build()
+    StorageMapType = StorageMapType.build()
     TriggerType = TriggerType()
 
     # Binary Interops
@@ -155,6 +156,7 @@ class Interop:
                                  StorageFind,
                                  StorageGet,
                                  StorageGetContext,
+                                 StorageMapType,
                                  StoragePut
                                  ]
     }

--- a/boa3/model/builtin/interop/storage/__init__.py
+++ b/boa3/model/builtin/interop/storage/__init__.py
@@ -3,12 +3,14 @@ __all__ = ['StorageContextType',
            'StorageFindMethod',
            'StorageGetContextMethod',
            'StorageGetMethod',
+           'StorageMapType',
            'StoragePutMethod'
            ]
 
-from boa3.model.builtin.interop.storage.storagecontexttype import StorageContextType
+from boa3.model.builtin.interop.storage.storagecontext import StorageContextType
 from boa3.model.builtin.interop.storage.storagedeletemethod import StorageDeleteMethod
 from boa3.model.builtin.interop.storage.storagefindmethod import StorageFindMethod
 from boa3.model.builtin.interop.storage.storagegetcontextmethod import StorageGetContextMethod
 from boa3.model.builtin.interop.storage.storagegetmethod import StorageGetMethod
+from boa3.model.builtin.interop.storage.storagemap.storagemaptype import StorageMapType
 from boa3.model.builtin.interop.storage.storageputmethod import StoragePutMethod

--- a/boa3/model/builtin/interop/storage/storagecontext/__init__.py
+++ b/boa3/model/builtin/interop/storage/storagecontext/__init__.py
@@ -1,0 +1,4 @@
+__all__ = ['StorageContextType']
+
+
+from boa3.model.builtin.interop.storage.storagecontext.storagecontexttype import StorageContextType

--- a/boa3/model/builtin/interop/storage/storagecontext/storagecontextcreatemapmethod.py
+++ b/boa3/model/builtin/interop/storage/storagecontext/storagecontextcreatemapmethod.py
@@ -1,0 +1,34 @@
+from typing import Dict, List, Optional, Tuple
+
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class StorageContextCreateMapMethod(IBuiltinMethod):
+
+    def __init__(self):
+        from boa3.model.builtin.interop.storage.storagecontext.storagecontexttype import _StorageContext
+        from boa3.model.builtin.interop.storage.storagemap.storagemaptype import _StorageMap
+        from boa3.model.type.type import Type
+
+        identifier = 'put'
+        args: Dict[str, Variable] = {'self': Variable(_StorageContext),
+                                     'prefix': Variable(Type.union.build([Type.bytes,
+                                                                          Type.str
+                                                                          ]))}
+
+        super().__init__(identifier, args, return_type=_StorageMap)
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> Optional[str]:
+        return None
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        from boa3.model.builtin.interop.storage.storagemap.storagemaptype import _StorageMap as StorageMapType
+        return StorageMapType.constructor_method().opcode

--- a/boa3/model/builtin/interop/storage/storagecontext/storagecontexttype.py
+++ b/boa3/model/builtin/interop/storage/storagecontext/storagecontexttype.py
@@ -20,6 +20,7 @@ class StorageContextType(ClassType):
         super().__init__('StorageContext')
 
         self._variables: Dict[str, Variable] = {}
+        self._instance_methods: Dict[str, Method] = {}
         self._constructor: Method = None
 
     @property
@@ -36,7 +37,15 @@ class StorageContextType(ClassType):
 
     @property
     def instance_methods(self) -> Dict[str, Method]:
-        return {}
+        # avoid recursive import
+        if len(self._instance_methods) == 0:
+            from boa3.model.builtin.interop.storage.storagecontext.storagecontextcreatemapmethod import \
+                StorageContextCreateMapMethod
+
+            self._instance_methods = {
+                'create_map': StorageContextCreateMapMethod()
+            }
+        return self._instance_methods
 
     def constructor_method(self) -> Method:
         # was having a problem with recursive import

--- a/boa3/model/builtin/interop/storage/storagedeletemethod.py
+++ b/boa3/model/builtin/interop/storage/storagedeletemethod.py
@@ -12,7 +12,7 @@ class StorageDeleteMethod(InteropMethod):
 
     def __init__(self):
         from boa3.model.type.type import Type
-        from boa3.model.builtin.interop.storage.storagecontexttype import StorageContextType
+        from boa3.model.builtin.interop.storage.storagecontext.storagecontexttype import StorageContextType
 
         identifier = 'delete'
         syscall = 'System.Storage.Delete'

--- a/boa3/model/builtin/interop/storage/storagefindmethod.py
+++ b/boa3/model/builtin/interop/storage/storagefindmethod.py
@@ -13,7 +13,7 @@ class StorageFindMethod(InteropMethod):
 
     def __init__(self, prefix_type: IType = None):
         from boa3.model.type.type import Type
-        from boa3.model.builtin.interop.storage.storagecontexttype import StorageContextType
+        from boa3.model.builtin.interop.storage.storagecontext.storagecontexttype import StorageContextType
 
         identifier = 'find'
         syscall = 'System.Storage.Find'

--- a/boa3/model/builtin/interop/storage/storagegetcontextmethod.py
+++ b/boa3/model/builtin/interop/storage/storagegetcontextmethod.py
@@ -1,7 +1,7 @@
 from typing import Dict
 
 from boa3.model.builtin.interop.interopmethod import InteropMethod
-from boa3.model.builtin.interop.storage.storagecontexttype import StorageContextType
+from boa3.model.builtin.interop.storage.storagecontext.storagecontexttype import StorageContextType
 from boa3.model.variable import Variable
 
 

--- a/boa3/model/builtin/interop/storage/storagegetmethod.py
+++ b/boa3/model/builtin/interop/storage/storagegetmethod.py
@@ -13,7 +13,7 @@ class StorageGetMethod(InteropMethod):
 
     def __init__(self):
         from boa3.model.type.type import Type
-        from boa3.model.builtin.interop.storage.storagecontexttype import StorageContextType
+        from boa3.model.builtin.interop.storage.storagecontext.storagecontexttype import StorageContextType
 
         identifier = 'get'
         syscall = 'System.Storage.Get'

--- a/boa3/model/builtin/interop/storage/storagemap/__init__.py
+++ b/boa3/model/builtin/interop/storage/storagemap/__init__.py
@@ -1,0 +1,4 @@
+__all__ = ['StorageMapType']
+
+from boa3.model.builtin.interop.storage.storagemap.storagemaptype import StorageMapType
+

--- a/boa3/model/builtin/interop/storage/storagemap/storagemapdeletemethod.py
+++ b/boa3/model/builtin/interop/storage/storagemap/storagemapdeletemethod.py
@@ -1,0 +1,43 @@
+from typing import Dict, List, Optional, Tuple
+
+from boa3.model.builtin.method import IBuiltinMethod
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class StorageMapDeleteMethod(IBuiltinMethod):
+
+    def __init__(self):
+        from boa3.model.builtin.interop.storage.storagemap.storagemaptype import _StorageMap
+        from boa3.model.type.type import Type
+
+        identifier = 'delete'
+        args: Dict[str, Variable] = {'self': Variable(_StorageMap),
+                                     'key': Variable(Type.union.build([Type.bytes,
+                                                                       Type.str
+                                                                       ]))}
+
+        super().__init__(identifier, args, return_type=Type.none)
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> Optional[str]:
+        return None
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        from boa3.model.builtin.interop.interop import Interop
+        return [
+            (Opcode.SWAP, b''),
+            (Opcode.OVER, b''),
+            (Opcode.PUSH1, b''),
+            (Opcode.PICKITEM, b''),
+            (Opcode.SWAP, b''),
+            (Opcode.CAT, b''),
+            (Opcode.SWAP, b''),
+            (Opcode.PUSH0, b''),
+            (Opcode.PICKITEM, b''),
+        ] + Interop.StorageDelete.opcode

--- a/boa3/model/builtin/interop/storage/storagemap/storagemapgetmethod.py
+++ b/boa3/model/builtin/interop/storage/storagemap/storagemapgetmethod.py
@@ -1,0 +1,43 @@
+from typing import Dict, List, Optional, Tuple
+
+from boa3.model.builtin.method import IBuiltinMethod
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class StorageMapGetMethod(IBuiltinMethod):
+
+    def __init__(self):
+        from boa3.model.builtin.interop.storage.storagemap.storagemaptype import _StorageMap
+        from boa3.model.type.type import Type
+
+        identifier = 'get'
+        args: Dict[str, Variable] = {'self': Variable(_StorageMap),
+                                     'key': Variable(Type.union.build([Type.bytes,
+                                                                       Type.str
+                                                                       ]))}
+
+        super().__init__(identifier, args, return_type=Type.bytes)
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> Optional[str]:
+        return None
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        from boa3.model.builtin.interop.interop import Interop
+        return [
+            (Opcode.SWAP, b''),
+            (Opcode.OVER, b''),
+            (Opcode.PUSH1, b''),
+            (Opcode.PICKITEM, b''),
+            (Opcode.SWAP, b''),
+            (Opcode.CAT, b''),
+            (Opcode.SWAP, b''),
+            (Opcode.PUSH0, b''),
+            (Opcode.PICKITEM, b''),
+        ] + Interop.StorageGet.opcode

--- a/boa3/model/builtin/interop/storage/storagemap/storagemapputmethod.py
+++ b/boa3/model/builtin/interop/storage/storagemap/storagemapputmethod.py
@@ -1,0 +1,47 @@
+from typing import Dict, List, Optional, Tuple
+
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class StorageMapPutMethod(IBuiltinMethod):
+
+    def __init__(self):
+        from boa3.model.builtin.interop.storage.storagemap.storagemaptype import _StorageMap
+        from boa3.model.type.type import Type
+
+        identifier = 'put'
+        args: Dict[str, Variable] = {'self': Variable(_StorageMap),
+                                     'key': Variable(Type.union.build([Type.bytes,
+                                                                       Type.str
+                                                                       ])),
+                                     'value': Variable(Type.union.build([Type.bytes,
+                                                                         Type.str,
+                                                                         Type.int
+                                                                         ]))}
+
+        super().__init__(identifier, args, return_type=Type.none)
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> Optional[str]:
+        return None
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        from boa3.model.builtin.interop.interop import Interop
+        return [
+            (Opcode.SWAP, b''),
+            (Opcode.OVER, b''),
+            (Opcode.PUSH1, b''),
+            (Opcode.PICKITEM, b''),
+            (Opcode.SWAP, b''),
+            (Opcode.CAT, b''),
+            (Opcode.SWAP, b''),
+            (Opcode.PUSH0, b''),
+            (Opcode.PICKITEM, b''),
+        ] + Interop.StoragePut.opcode

--- a/boa3/model/builtin/interop/storage/storagemap/storagemaptype.py
+++ b/boa3/model/builtin/interop/storage/storagemap/storagemaptype.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.expression import IExpression
+from boa3.model.method import Method
+from boa3.model.property import Property
+from boa3.model.type.classtype import ClassType
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class StorageMapType(ClassType):
+    """
+    A class used to represent Neo StorageMap class
+    """
+
+    def __init__(self):
+        super().__init__('StorageMap')
+
+        self._variables: Dict[str, Variable] = {}
+        self._constructor: Method = None
+        self._instance_methods: Dict[str, Method] = {}
+
+    @property
+    def variables(self) -> Dict[str, Variable]:
+        return self._variables.copy()
+
+    @property
+    def properties(self) -> Dict[str, Property]:
+        return {}
+
+    @property
+    def class_methods(self) -> Dict[str, Method]:
+        return {}
+
+    @property
+    def instance_methods(self) -> Dict[str, Method]:
+        # avoid recursive import
+        if len(self._instance_methods) == 0:
+            from boa3.model.builtin.interop.storage.storagemap.storagemapdeletemethod import StorageMapDeleteMethod
+            from boa3.model.builtin.interop.storage.storagemap.storagemapgetmethod import StorageMapGetMethod
+            from boa3.model.builtin.interop.storage.storagemap.storagemapputmethod import StorageMapPutMethod
+
+            self._instance_methods = {
+                'get': StorageMapGetMethod(),
+                'put': StorageMapPutMethod(),
+                'delete': StorageMapDeleteMethod()
+            }
+        return self._instance_methods
+
+    def constructor_method(self) -> Method:
+        # was having a problem with recursive import
+        if self._constructor is None:
+            self._constructor: Method = StorageMapMethod(self)
+        return self._constructor
+
+    @classmethod
+    def build(cls, value: Any = None) -> StorageMapType:
+        if value is None or cls._is_type_of(value):
+            return _StorageMap
+
+    @classmethod
+    def _is_type_of(cls, value: Any):
+        return isinstance(value, StorageMapType)
+
+
+_StorageMap = StorageMapType()
+
+
+class StorageMapMethod(IBuiltinMethod):
+
+    def __init__(self, return_type: StorageMapType):
+        from boa3.model.type.type import Type
+        from boa3.model.builtin.interop.storage.storagecontext.storagecontexttype import _StorageContext as StorageContextType
+
+        identifier = '-StorageMap__init__'
+        args: Dict[str, Variable] = {
+            'context': Variable(StorageContextType),
+            'prefix': Variable(Type.union.build([Type.bytes,
+                                                 Type.str
+                                                 ]))
+        }
+        super().__init__(identifier, args, return_type=return_type)
+
+    def validate_parameters(self, *params: IExpression) -> bool:
+        return len(params) == 0
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        return [
+            (Opcode.PUSH2, b''),
+            (Opcode.PACK, b'')
+        ]
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> Optional[str]:
+        return

--- a/boa3/model/builtin/interop/storage/storageputmethod.py
+++ b/boa3/model/builtin/interop/storage/storageputmethod.py
@@ -12,7 +12,7 @@ class StoragePutMethod(InteropMethod):
 
     def __init__(self):
         from boa3.model.type.type import Type
-        from boa3.model.builtin.interop.storage.storagecontexttype import StorageContextType
+        from boa3.model.builtin.interop.storage.storagecontext.storagecontexttype import StorageContextType
 
         identifier = 'put'
         syscall = 'System.Storage.Put'

--- a/boa3_test/test_sc/interop_test/storage/StorageCreateMap.py
+++ b/boa3_test/test_sc/interop_test/storage/StorageCreateMap.py
@@ -1,0 +1,24 @@
+from boa3.builtin import public
+from boa3.builtin.interop.storage import StorageMap, get_context
+
+
+@public
+def get_from_map(key: str) -> bytes:
+    context = create_map()
+    return context.get(key)
+
+
+@public
+def insert_to_map(key: str, value: str):
+    context = create_map()
+    context.put(key, value)
+
+
+@public
+def delete_from_map(key: str):
+    context = create_map()
+    context.delete(key)
+
+
+def create_map() -> StorageMap:
+    return get_context().create_map('example_')

--- a/boa3_test/tests/compiler_tests/test_interop/test_storage.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_storage.py
@@ -612,3 +612,35 @@ class TestStorageInterop(BoaTest):
 
         result = self.run_smart_contract(engine, path1, 'get_value', key)
         self.assertEqual(value, result)
+
+    def test_create_map(self):
+        path = self.get_contract_path('StorageCreateMap.py')
+        self.compile_and_save(path)
+        map_key = b'example_'
+
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'get_from_map', 'test1',
+                                         expected_result_type=bytes)
+        self.assertEqual(b'', result)
+
+        stored_value = b'123'
+        result = self.run_smart_contract(engine, path, 'insert_to_map', 'test1', stored_value)
+        self.assertIsVoid(result)
+
+        storage_value = engine.storage_get(b'test1', path)
+        self.assertIsNone(storage_value)
+        storage_value = engine.storage_get(map_key + b'test1', path)
+        self.assertIsNotNone(storage_value)
+        self.assertEqual(stored_value, storage_value)
+
+        result = self.run_smart_contract(engine, path, 'get_from_map', 'test1',
+                                         expected_result_type=bytes)
+        self.assertEqual(stored_value, result)
+
+        result = self.run_smart_contract(engine, path, 'delete_from_map', 'test1')
+        self.assertIsVoid(result)
+
+        result = self.run_smart_contract(engine, path, 'get_from_map', 'test1',
+                                         expected_result_type=bytes)
+        self.assertEqual(b'', result)


### PR DESCRIPTION
**Related issue**
#393 

**Summary or solution description**
Implemented the class StorageMap for simplifying the access to the storage.

**How to Reproduce**
```python
from boa3.builtin import public
from boa3.builtin.interop.storage import get_context


@public
def Main(key: str) -> bytes:
    storage_map = get_context().create_map('example')
    return storage_map.get(key)
```

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/a95c8fbca7e3f3c45f61fa4f2f63b96b77d9cfae/boa3_test/test_sc/interop_test/storage/StorageCreateMap.py#L1-L24
https://github.com/CityOfZion/neo3-boa/blob/a95c8fbca7e3f3c45f61fa4f2f63b96b77d9cfae/boa3_test/tests/compiler_tests/test_interop/test_storage.py#L616-L646

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
