### PR TITLE
 Implement exponentiation as a builtin method to neo3-boa #359

### DIFF
--- a/boa3/model/operation/binary/arithmetic/power.py
+++ b/boa3/model/operation/binary/arithmetic/power.py
@@ -1,8 +1,9 @@
-from typing import List
+from typing import List, Tuple
 
 from boa3.model.operation.binary.binaryoperation import BinaryOperation
 from boa3.model.operation.operator import Operator
 from boa3.model.type.type import IType, Type
+from boa3.neo.vm.opcode.Opcode import Opcode
 
 
 class Power(BinaryOperation):
@@ -37,6 +38,5 @@ class Power(BinaryOperation):
             return Type.none
 
     @property
-    def is_supported(self) -> bool:
-        # TODO: change when power is supported
-        return False
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        return [(Opcode.POW, b'')]

--- a/boa3/neo/vm/opcode/OpcodeInfo.py
+++ b/boa3/neo/vm/opcode/OpcodeInfo.py
@@ -379,6 +379,10 @@ class OpcodeInfo:
     DIV = OpcodeInformation(Opcode.DIV)
     # Returns the remainder after dividing a by b.
     MOD = OpcodeInformation(Opcode.MOD)
+    # The result of raising value to the exponent power.
+    POW = OpcodeInformation(Opcode.POW)
+    # Returns the square root of a specified number.
+    SQRT = OpcodeInformation(Opcode.SQRT)
     # Shifts a left b bits, preserving sign.
     SHL = OpcodeInformation(Opcode.SHL)
     # Shifts a right b bits, preserving sign.

--- a/boa3_test/test_sc/arithmetic_test/Power.py
+++ b/boa3_test/test_sc/arithmetic_test/Power.py
@@ -1,2 +1,6 @@
-def Main(a: int, b: int) -> int:
-    return a ** b  # not supported yet
+from boa3.builtin import public
+
+
+@public
+def pow(a: int, b: int) -> int:
+    return a ** b

--- a/boa3_test/test_sc/arithmetic_test/PowerAugmentedAssignment.py
+++ b/boa3_test/test_sc/arithmetic_test/PowerAugmentedAssignment.py
@@ -1,2 +1,2 @@
 def Main(a: int, b: int):
-    a **= b  # not supported yet
+    a **= b

--- a/boa3_test/tests/compiler_tests/test_arithmetic.py
+++ b/boa3_test/tests/compiler_tests/test_arithmetic.py
@@ -5,6 +5,7 @@ from boa3.model.type.type import Type
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3_test.tests.boa_test import BoaTest
 from boa3_test.tests.test_classes.testengine import TestEngine
+from boa3_test.tests.test_classes.TestExecutionException import TestExecutionException
 
 
 class TestArithmetic(BoaTest):
@@ -259,8 +260,30 @@ class TestArithmetic(BoaTest):
         self.assertEqual('unittest', result)
 
     def test_power_operation(self):
+        expected_output = (
+                Opcode.INITSLOT
+                + b'\x00'
+                + b'\x02'
+                + Opcode.LDARG0
+                + Opcode.LDARG1
+                + Opcode.POW
+                + Opcode.RET
+        )
         path = self.get_contract_path('Power.py')
-        self.assertCompilerLogs(NotSupportedOperation, path)
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'pow', 10, 3)
+        self.assertEqual(1000, result)
+        result = self.run_smart_contract(engine, path, 'pow', 1, 15)
+        self.assertEqual(1, result)
+        result = self.run_smart_contract(engine, path, 'pow', -2, 2)
+        self.assertEqual(4, result)
+        result = self.run_smart_contract(engine, path, 'pow', 0, 20)
+        self.assertEqual(0, result)
+        with self.assertRaises(TestExecutionException):
+            self.run_smart_contract(engine, path, 'pow', 1, -2)
 
     def test_str_multiplication_operation(self):
         expected_output = (
@@ -513,8 +536,20 @@ class TestArithmetic(BoaTest):
         self.assertEqual(expected_output, output)
 
     def test_power_augmented_assignment(self):
+        expected_output = (
+                Opcode.INITSLOT
+                + b'\x00'
+                + b'\x02'
+                + Opcode.LDARG0
+                + Opcode.LDARG1
+                + Opcode.POW
+                + Opcode.STARG0
+                + Opcode.RET
+        )
         path = self.get_contract_path('PowerAugmentedAssignment.py')
-        self.assertCompilerLogs(NotSupportedOperation, path)
+        output = Boa3.compile(path)
+
+        self.assertEqual(expected_output, output)
 
     def test_str_multiplication_operation_augmented_assignment(self):
         expected_output = (


### PR DESCRIPTION
**Related issue**
#359 

**Summary or solution description**
Implemented exponentiation Opcode in the builtin

**How to Reproduce**
Use `x ** y`.

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/86f4d656238d0981ff8710c9a65fe556273c73dc/boa3_test/tests/compiler_tests/test_arithmetic.py#L262-L286
https://github.com/CityOfZion/neo3-boa/blob/86f4d656238d0981ff8710c9a65fe556273c73dc/boa3_test/tests/compiler_tests/test_arithmetic.py#L538-L552

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8

**(Optional) Additional context**
Also added POW and SQRT Opcodes in OpcodeInfo.
