### PR TITLE
Implement square root as a builtin method to neo3-boa #358

### DIFF
--- a/boa3/builtin/__init__.py
+++ b/boa3/builtin/__init__.py
@@ -83,3 +83,10 @@ class NeoMetadata:
         if isinstance(self.description, str):
             extra['Description'] = self.description
         return extra
+
+
+def sqrt(x: int):
+    """
+    Gets the square root of a number
+    """
+    pass

--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -43,14 +43,15 @@ class Builtin:
                 return method
 
     # builtin method
-    Len = LenMethod()
-    IsInstance = IsInstanceMethod()
-    Print = PrintMethod()
-    ScriptHash = ScriptHashMethod()
-    NewEvent = CreateEventMethod()
     Exit = ExitMethod()
+    IsInstance = IsInstanceMethod()
+    Len = LenMethod()
+    NewEvent = CreateEventMethod()
     Max = MaxMethod()
     Min = MinMethod()
+    Print = PrintMethod()
+    ScriptHash = ScriptHashMethod()
+    Sqrt = SqrtMethod()
 
     # python builtin class constructor
     ByteArray = ByteArrayMethod()
@@ -94,7 +95,8 @@ class Builtin:
                                                 SequenceInsert,
                                                 SequencePop,
                                                 SequenceRemove,
-                                                SequenceReverse
+                                                SequenceReverse,
+                                                Sqrt
                                                 ]
 
     @classmethod

--- a/boa3/model/builtin/method/__init__.py
+++ b/boa3/model/builtin/method/__init__.py
@@ -10,7 +10,8 @@ __all__ = ['IBuiltinMethod',
            'MinMethod',
            'PrintMethod',
            'RangeMethod',
-           'ScriptHashMethod'
+           'ScriptHashMethod',
+           'SqrtMethod'
            ]
 
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
@@ -25,3 +26,4 @@ from boa3.model.builtin.method.minmethod import MinMethod
 from boa3.model.builtin.method.printmethod import PrintMethod
 from boa3.model.builtin.method.rangemethod import RangeMethod
 from boa3.model.builtin.method.toscripthashmethod import ScriptHashMethod
+from boa3.model.builtin.method.sqrtmethod import SqrtMethod

--- a/boa3/model/builtin/method/sqrtmethod.py
+++ b/boa3/model/builtin/method/sqrtmethod.py
@@ -1,0 +1,26 @@
+from typing import Dict, List, Optional, Tuple
+
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class SqrtMethod(IBuiltinMethod):
+
+    def __init__(self):
+        from boa3.model.type.type import Type
+        identifier = 'sqrt'
+        args: Dict[str, Variable] = {'val': Variable(Type.int)}
+        super().__init__(identifier, args, return_type=Type.int)
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        return [(Opcode.SQRT, b'')]
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> Optional[str]:
+        return

--- a/boa3_test/test_sc/built_in_methods_test/Sqrt.py
+++ b/boa3_test/test_sc/built_in_methods_test/Sqrt.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public, sqrt
+
+
+@public
+def main(x: int) -> int:
+    return sqrt(x)

--- a/boa3_test/tests/compiler_tests/test_builtin_method.py
+++ b/boa3_test/tests/compiler_tests/test_builtin_method.py
@@ -976,3 +976,40 @@ class TestBuiltinMethod(BoaTest):
         self.assertCompilerLogs(MismatchedTypes, path)
 
     # endregion
+
+    # region sqrt test
+
+    def test_sqrt_method(self):
+        path = self.get_contract_path('Sqrt.py')
+        engine = TestEngine()
+
+        from math import sqrt
+
+        expected_result = int(sqrt(0))
+        result = self.run_smart_contract(engine, path, 'main', 0)
+        self.assertEqual(expected_result, result)
+        expected_result = int(sqrt(1))
+        result = self.run_smart_contract(engine, path, 'main', 1)
+        self.assertEqual(expected_result, result)
+        expected_result = int(sqrt(3))
+        result = self.run_smart_contract(engine, path, 'main', 3)
+        self.assertEqual(expected_result, result)
+        expected_result = int(sqrt(4))
+        result = self.run_smart_contract(engine, path, 'main', 4)
+        self.assertEqual(expected_result, result)
+        expected_result = int(sqrt(8))
+        result = self.run_smart_contract(engine, path, 'main', 8)
+        self.assertEqual(expected_result, result)
+        expected_result = int(sqrt(10))
+        result = self.run_smart_contract(engine, path, 'main', 10)
+        self.assertEqual(expected_result, result)
+
+        with self.assertRaises(TestExecutionException):
+            result = self.run_smart_contract(engine, path, 'main', -1)
+
+        val = 25
+        expected_result = int(sqrt(val))
+        result = self.run_smart_contract(engine, path, 'main', val)
+        self.assertEqual(expected_result, result)
+
+    # endregion


### PR DESCRIPTION
**Related issue**
#358

**Summary or solution description**
Added a square root method

**How to Reproduce**
Call `sqrt()`.

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/6280ef4a1ee23eab6a6cc1d11fc4cfea9bbfbad0/boa3_test/tests/compiler_tests/test_builtin_method.py#L980-L1015

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8