### PR TITLE
 Implement Binary Atoi Interop #289

### DIFF
--- a/boa3/builtin/interop/binary/__init__.py
+++ b/boa3/builtin/interop/binary/__init__.py
@@ -75,3 +75,19 @@ def deserialize(data: bytes) -> Any:
     :raise Exception: raised when the date doesn't represent a serialized value.
     """
     pass
+
+
+def atoi(value: str, base: int = 10) -> int:
+    """
+    Converts a character string to a specific base value, decimal or hexadecimal. The default is decimal.
+
+    :param value: the int value as a string
+    :type value: str
+    :param base: the value base
+    :type base: int
+    :return: the equivalent value
+    :rtype: int
+
+    :raise Exception: raised when base isn't 10 or 16.
+    """
+    pass

--- a/boa3/model/builtin/interop/binary/__init__.py
+++ b/boa3/model/builtin/interop/binary/__init__.py
@@ -3,9 +3,11 @@ __all__ = ['Base58DecodeMethod',
            'Base64DecodeMethod',
            'Base64EncodeMethod',
            'DeserializeMethod',
-           'SerializeMethod'
+           'SerializeMethod',
+           'AtoiMethod'
            ]
 
+from boa3.model.builtin.interop.binary.atoimethod import AtoiMethod
 from boa3.model.builtin.interop.binary.base58decodemethod import Base58DecodeMethod
 from boa3.model.builtin.interop.binary.base58encodemethod import Base58EncodeMethod
 from boa3.model.builtin.interop.binary.base64decodemethod import Base64DecodeMethod

--- a/boa3/model/builtin/interop/binary/atoimethod.py
+++ b/boa3/model/builtin/interop/binary/atoimethod.py
@@ -1,0 +1,22 @@
+import ast
+from typing import Dict
+
+from boa3.model.builtin.interop.nativecontract import StdLibMethod
+from boa3.model.variable import Variable
+
+
+class AtoiMethod(StdLibMethod):
+
+    def __init__(self):
+        from boa3.model.type.type import Type
+        identifier = 'atoi'
+        syscall = 'atoi'
+        args: Dict[str, Variable] = {
+            'value': Variable(Type.str),
+            'base': Variable(Type.int)
+        }
+
+        args_default = ast.parse("{0}".format(10)
+                                 ).body[0].value
+
+        super().__init__(identifier, syscall, args, defaults=[args_default], return_type=Type.int)

--- a/boa3/model/builtin/interop/interop.py
+++ b/boa3/model/builtin/interop/interop.py
@@ -47,6 +47,7 @@ class Interop:
     TriggerType = TriggerType()
 
     # Binary Interops
+    Atoi = AtoiMethod()
     Base58Encode = Base58EncodeMethod()
     Base58Decode = Base58DecodeMethod()
     Base64Encode = Base64EncodeMethod()
@@ -110,7 +111,8 @@ class Interop:
     StoragePut = StoragePutMethod()
 
     _interop_symbols: Dict[InteropPackage, List[IdentifiedSymbol]] = {
-        InteropPackage.Binary: [Base58Encode,
+        InteropPackage.Binary: [Atoi,
+                                Base58Encode,
                                 Base58Decode,
                                 Base64Encode,
                                 Base64Decode,

--- a/boa3_test/test_sc/interop_test/binary/Atoi.py
+++ b/boa3_test/test_sc/interop_test/binary/Atoi.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.interop.binary import atoi
+
+
+@public
+def main(value: str, base: int) -> int:
+    return atoi(value, base)

--- a/boa3_test/test_sc/interop_test/binary/AtoiDefault.py
+++ b/boa3_test/test_sc/interop_test/binary/AtoiDefault.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.interop.binary import atoi
+
+
+@public
+def main(value: str) -> int:
+    return atoi(value)

--- a/boa3_test/test_sc/interop_test/binary/AtoiMismatchedType.py
+++ b/boa3_test/test_sc/interop_test/binary/AtoiMismatchedType.py
@@ -1,0 +1,5 @@
+from boa3.builtin.interop.binary import atoi
+
+
+def main():
+    atoi(10, 10)

--- a/boa3_test/test_sc/interop_test/binary/AtoiTooFewArguments.py
+++ b/boa3_test/test_sc/interop_test/binary/AtoiTooFewArguments.py
@@ -1,0 +1,5 @@
+from boa3.builtin.interop.binary import atoi
+
+
+def main() -> int:
+    return atoi()

--- a/boa3_test/test_sc/interop_test/binary/AtoiTooManyArguments.py
+++ b/boa3_test/test_sc/interop_test/binary/AtoiTooManyArguments.py
@@ -1,0 +1,5 @@
+from boa3.builtin.interop.binary import atoi
+
+
+def main() -> int:
+    return atoi('100', 10, 'extra')


### PR DESCRIPTION
**Related issue**
#289 

**How to Reproduce**
Import the atoi function from boa3.builtin.interop.binary and use it in the smart contract. For example:
```python
from boa3.builtin.interop.binary import atoi

def test():
    atoi('123', 10)
```

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/d2922b361d47528f758bfc03aff8bed55f439df0/boa3_test/tests/compiler_tests/test_interop/test_binary.py#L263-L320

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8