### PR TITLE
 Convert Python builtin abs #254

### DIFF
--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -44,6 +44,7 @@ class Builtin:
                 return method
 
     # builtin method
+    Abs = AbsMethod()
     Exit = ExitMethod()
     IsInstance = IsInstanceMethod()
     Len = LenMethod()
@@ -76,7 +77,8 @@ class Builtin:
     ConvertToStr = ToStrMethod
     ConvertToBool = ToBoolMethod
 
-    _python_builtins: List[IdentifiedSymbol] = [ByteArray,
+    _python_builtins: List[IdentifiedSymbol] = [Abs,
+                                                ByteArray,
                                                 ConvertToBool,
                                                 ConvertToBytes,
                                                 ConvertToInt,

--- a/boa3/model/builtin/method/__init__.py
+++ b/boa3/model/builtin/method/__init__.py
@@ -1,4 +1,5 @@
-__all__ = ['IBuiltinMethod',
+__all__ = ['AbsMethod',
+           'IBuiltinMethod',
            'ByteArrayMethod',
            'CreateEventMethod',
            'EventType',
@@ -14,6 +15,7 @@ __all__ = ['IBuiltinMethod',
            'SqrtMethod'
            ]
 
+from boa3.model.builtin.method.absmethod import AbsMethod
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.builtin.method.bytearraymethod import ByteArrayMethod
 from boa3.model.builtin.method.createeventmethod import CreateEventMethod, EventType

--- a/boa3/model/builtin/method/absmethod.py
+++ b/boa3/model/builtin/method/absmethod.py
@@ -1,0 +1,26 @@
+from typing import Dict, List, Optional, Tuple
+
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class AbsMethod(IBuiltinMethod):
+
+    def __init__(self):
+        from boa3.model.type.type import Type
+        identifier = 'abs'
+        args: Dict[str, Variable] = {'val': Variable(Type.int)}
+        super().__init__(identifier, args, return_type=Type.int)
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        return [(Opcode.ABS, b'')]
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> Optional[str]:
+        return None

--- a/boa3_test/test_sc/built_in_methods_test/Abs.py
+++ b/boa3_test/test_sc/built_in_methods_test/Abs.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main(x: int) -> int:
+    return abs(x)

--- a/boa3_test/test_sc/built_in_methods_test/AbsMismatchedTypesBytes.py
+++ b/boa3_test/test_sc/built_in_methods_test/AbsMismatchedTypesBytes.py
@@ -1,0 +1,2 @@
+def main():
+    abs(b'test')

--- a/boa3_test/test_sc/built_in_methods_test/AbsMismatchedTypesString.py
+++ b/boa3_test/test_sc/built_in_methods_test/AbsMismatchedTypesString.py
@@ -1,0 +1,2 @@
+def main():
+    abs('test')

--- a/boa3_test/test_sc/built_in_methods_test/AbsTooFewParameters.py
+++ b/boa3_test/test_sc/built_in_methods_test/AbsTooFewParameters.py
@@ -1,0 +1,2 @@
+def main() -> int:
+    return abs()

--- a/boa3_test/test_sc/built_in_methods_test/AbsTooManyParameters.py
+++ b/boa3_test/test_sc/built_in_methods_test/AbsTooManyParameters.py
@@ -1,0 +1,2 @@
+def main() -> int:
+    return abs(1, 2)

--- a/boa3_test/tests/compiler_tests/test_builtin_method.py
+++ b/boa3_test/tests/compiler_tests/test_builtin_method.py
@@ -1013,3 +1013,40 @@ class TestBuiltinMethod(BoaTest):
         self.assertEqual(expected_result, result)
 
     # endregion
+
+    # region abs test
+
+    def test_abs(self):
+        path = self.get_contract_path('Abs.py')
+        engine = TestEngine()
+
+        val = 10
+        expected_result = abs(val)
+        result = self.run_smart_contract(engine, path, 'main', val)
+        self.assertEqual(expected_result, result)
+
+        expected_result = abs(-1)
+        result = self.run_smart_contract(engine, path, 'main', -1)
+        self.assertEqual(expected_result, result)
+
+        expected_result = abs(1)
+        result = self.run_smart_contract(engine, path, 'main', 1)
+        self.assertEqual(expected_result, result)
+
+    def test_abs_bytes(self):
+        path = self.get_contract_path('AbsMismatchedTypesBytes.py')
+        self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_abs_string(self):
+        path = self.get_contract_path('AbsMismatchedTypesString.py')
+        self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_abs_too_few_parameters(self):
+        path = self.get_contract_path('AbsTooFewParameters.py')
+        self.assertCompilerLogs(UnfilledArgument, path)
+
+    def test_abs_too_many_parameters(self):
+        path = self.get_contract_path('AbsTooManyParameters.py')
+        self.assertCompilerLogs(UnexpectedArgument, path)
+
+    # endregion


### PR DESCRIPTION
**Related issue**
#254 

**Summary or solution description**
 Added an absolute value method.

**How to Reproduce**
 Call `abs()`.

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/01464dd0a81b7fc952d06d7513bcc4e1cde456e8/boa3_test/tests/compiler_tests/test_builtin_method.py#L1017-L1052

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8