### PR TITLE
Convert Python builtin sum

### DIFF
--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -54,6 +54,7 @@ class Builtin:
     Print = PrintMethod()
     ScriptHash = ScriptHashMethod()
     Sqrt = SqrtMethod()
+    Sum = SumMethod()
 
     # python builtin class constructor
     ByteArray = ByteArrayMethod()
@@ -99,7 +100,8 @@ class Builtin:
                                                 SequencePop,
                                                 SequenceRemove,
                                                 SequenceReverse,
-                                                Sqrt
+                                                Sqrt,
+                                                Sum
                                                 ]
 
     @classmethod

--- a/boa3/model/builtin/method/__init__.py
+++ b/boa3/model/builtin/method/__init__.py
@@ -12,7 +12,8 @@ __all__ = ['AbsMethod',
            'PrintMethod',
            'RangeMethod',
            'ScriptHashMethod',
-           'SqrtMethod'
+           'SqrtMethod',
+           'SumMethod'
            ]
 
 from boa3.model.builtin.method.absmethod import AbsMethod
@@ -28,4 +29,5 @@ from boa3.model.builtin.method.minmethod import MinMethod
 from boa3.model.builtin.method.printmethod import PrintMethod
 from boa3.model.builtin.method.rangemethod import RangeMethod
 from boa3.model.builtin.method.sqrtmethod import SqrtMethod
+from boa3.model.builtin.method.summethod import SumMethod
 from boa3.model.builtin.method.toscripthashmethod import ScriptHashMethod

--- a/boa3/model/builtin/method/summethod.py
+++ b/boa3/model/builtin/method/summethod.py
@@ -1,0 +1,51 @@
+import ast
+from typing import Dict, List, Optional, Tuple
+
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class SumMethod(IBuiltinMethod):
+
+    def __init__(self):
+        from boa3.model.type.type import Type
+        identifier = 'sum'
+        args: Dict[str, Variable] = {'__iterable': Variable(Type.sequence.build_collection(Type.int)),
+                                     '__start': Variable(Type.int)}
+
+        start_default = ast.parse("{0}".format(Type.int.default_value)
+                                  ).body[0].value
+        super().__init__(identifier, args, defaults=[start_default], return_type=Type.int)
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        from boa3.neo.vm.type.Integer import Integer
+        return [
+            (Opcode.PUSH0, b''),    # index = 0
+            (Opcode.DUP, b''),
+            (Opcode.PUSH2, b''),    # len(iterable)
+            (Opcode.PICK, b''),
+            (Opcode.SIZE, b''),
+            (Opcode.GE, b''),       # index > len(iterable)
+            (Opcode.JMPIF, Integer(12).to_byte_array(signed=True, min_length=1)),
+            (Opcode.REVERSE3, b''),
+            (Opcode.OVER, b''),
+            (Opcode.PUSH3, b''),    # x = iterable[index]
+            (Opcode.PICK, b''),
+            (Opcode.PICKITEM, b''),
+            (Opcode.ADD, b''),      # result += x
+            (Opcode.REVERSE3, b''),
+            (Opcode.INC, b''),      # index += 1
+            (Opcode.JMP, Integer(-15).to_byte_array(signed=True, min_length=1)),
+            (Opcode.DROP, b''),
+            (Opcode.DROP, b''),
+        ]
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> Optional[str]:
+        return None

--- a/boa3_test/test_sc/built_in_methods_test/Sum.py
+++ b/boa3_test/test_sc/built_in_methods_test/Sum.py
@@ -1,0 +1,8 @@
+from typing import List
+
+from boa3.builtin import public
+
+
+@public
+def main(x: List[int]) -> int:
+    return sum(x)

--- a/boa3_test/test_sc/built_in_methods_test/SumMismatchedTypes.py
+++ b/boa3_test/test_sc/built_in_methods_test/SumMismatchedTypes.py
@@ -1,0 +1,8 @@
+from typing import List
+
+from boa3.builtin import public
+
+
+@public
+def main(x: str) -> int:
+    return sum(x)

--- a/boa3_test/test_sc/built_in_methods_test/SumTooFewParameters.py
+++ b/boa3_test/test_sc/built_in_methods_test/SumTooFewParameters.py
@@ -1,0 +1,8 @@
+from typing import List
+
+from boa3.builtin import public
+
+
+@public
+def main(x: List[int], start: int) -> int:
+    return sum()

--- a/boa3_test/test_sc/built_in_methods_test/SumTooManyParameters.py
+++ b/boa3_test/test_sc/built_in_methods_test/SumTooManyParameters.py
@@ -1,0 +1,8 @@
+from typing import List
+
+from boa3.builtin import public
+
+
+@public
+def main(x: List[int], start: int) -> int:
+    return sum(x, start, 10)

--- a/boa3_test/test_sc/built_in_methods_test/SumWithStart.py
+++ b/boa3_test/test_sc/built_in_methods_test/SumWithStart.py
@@ -1,0 +1,8 @@
+from typing import List
+
+from boa3.builtin import public
+
+
+@public
+def main(x: List[int], start: int) -> int:
+    return sum(x, start)

--- a/boa3_test/tests/compiler_tests/test_builtin_method.py
+++ b/boa3_test/tests/compiler_tests/test_builtin_method.py
@@ -1050,3 +1050,49 @@ class TestBuiltinMethod(BoaTest):
         self.assertCompilerLogs(UnexpectedArgument, path)
 
     # endregion
+
+    # region sum test
+
+    def test_sum(self):
+        path = self.get_contract_path('Sum.py')
+        self.compile_and_save(path)
+        engine = TestEngine()
+
+        val = [1, 2, 3, 4]
+        expected_result = sum(val)
+        result = self.run_smart_contract(engine, path, 'main', val)
+        self.assertEqual(expected_result, result)
+
+        val = list(range(10, 20, 2))
+        expected_result = sum(val)
+        result = self.run_smart_contract(engine, path, 'main', val)
+        self.assertEqual(expected_result, result)
+
+    def test_sum_with_start(self):
+        path = self.get_contract_path('SumWithStart.py')
+        self.compile_and_save(path)
+        engine = TestEngine()
+
+        val = [1, 2, 3, 4]
+        expected_result = sum(val, 10)
+        result = self.run_smart_contract(engine, path, 'main', val, 10)
+        self.assertEqual(expected_result, result)
+
+        val = list(range(10, 20, 2))
+        expected_result = sum(val, 20)
+        result = self.run_smart_contract(engine, path, 'main', val, 20)
+        self.assertEqual(expected_result, result)
+
+    def test_sum_mismatched_type(self):
+        path = self.get_contract_path('SumMismatchedTypes.py')
+        self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_sum_too_few_parameters(self):
+        path = self.get_contract_path('SumTooFewParameters.py')
+        self.assertCompilerLogs(UnfilledArgument, path)
+
+    def test_sum_too_many_parameters(self):
+        path = self.get_contract_path('SumTooManyParameters.py')
+        self.assertCompilerLogs(UnexpectedArgument, path)
+
+    # endregion


### PR DESCRIPTION
**Related issue**
#255

**Summary or solution description**
Implemented Python's built-in `sum` function 

**How to Reproduce**
```python
@public
def main() -> int:
    return sum([1, 2, 3, 4], 10)  # expected 1+2+3+4+10 = 20
```

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/72b213e0b332826f718ed690d29f9ed55696e5ac/boa3_test/tests/compiler_tests/test_builtin_method.py#L1054-L1098

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
