### PR TITLE
Implement Binary Itoa Interop #287

### DIFF
--- a/boa3/builtin/interop/binary/__init__.py
+++ b/boa3/builtin/interop/binary/__init__.py
@@ -91,3 +91,18 @@ def atoi(value: str, base: int = 10) -> int:
     :raise Exception: raised when base isn't 10 or 16.
     """
     pass
+
+
+def itoa(value: int, base: int = 10) -> str:
+    """
+    Converts the specific type of value to a decimal or hexadecimal string. The default is decimal.
+
+    :param value: the int value
+    :type value: int
+    :param base: the value's base
+    :type base: int
+
+    :return: The converted string
+    :rtype: int
+    """
+    pass

--- a/boa3/model/builtin/interop/binary/__init__.py
+++ b/boa3/model/builtin/interop/binary/__init__.py
@@ -1,10 +1,12 @@
-__all__ = ['Base58DecodeMethod',
+__all__ = ['AtoiMethod',
+           'Base58DecodeMethod',
            'Base58EncodeMethod',
            'Base64DecodeMethod',
            'Base64EncodeMethod',
            'DeserializeMethod',
+           'ItoaMethod',
            'SerializeMethod',
-           'AtoiMethod'
+           'SerializeMethod'
            ]
 
 from boa3.model.builtin.interop.binary.atoimethod import AtoiMethod
@@ -13,4 +15,5 @@ from boa3.model.builtin.interop.binary.base58encodemethod import Base58EncodeMet
 from boa3.model.builtin.interop.binary.base64decodemethod import Base64DecodeMethod
 from boa3.model.builtin.interop.binary.base64encodemethod import Base64EncodeMethod
 from boa3.model.builtin.interop.binary.deserializemethod import DeserializeMethod
+from boa3.model.builtin.interop.binary.itoamethod import ItoaMethod
 from boa3.model.builtin.interop.binary.serializemethod import SerializeMethod

--- a/boa3/model/builtin/interop/binary/itoamethod.py
+++ b/boa3/model/builtin/interop/binary/itoamethod.py
@@ -1,0 +1,20 @@
+import ast
+from typing import Dict
+
+from boa3.model.builtin.interop.nativecontract import StdLibMethod
+from boa3.model.variable import Variable
+
+
+class ItoaMethod(StdLibMethod):
+
+    def __init__(self):
+        from boa3.model.type.type import Type
+        identifier = 'itoa'
+        syscall = 'itoa'
+        args: Dict[str, Variable] = {
+            'value': Variable(Type.int),
+            'base': Variable(Type.int)
+        }
+        args_default = ast.parse("{0}".format(10)).body[0].value
+
+        super().__init__(identifier, syscall, args, defaults=[args_default], return_type=Type.str)

--- a/boa3/model/builtin/interop/interop.py
+++ b/boa3/model/builtin/interop/interop.py
@@ -53,6 +53,7 @@ class Interop:
     Base64Encode = Base64EncodeMethod()
     Base64Decode = Base64DecodeMethod()
     Deserialize = DeserializeMethod()
+    Itoa = ItoaMethod()
     Serialize = SerializeMethod()
 
     # Blockchain Interops
@@ -117,6 +118,7 @@ class Interop:
                                 Base64Encode,
                                 Base64Decode,
                                 Deserialize,
+                                Itoa,
                                 Serialize
                                 ],
         InteropPackage.Blockchain: [CurrentHeight,

--- a/boa3_test/test_sc/interop_test/binary/Itoa.py
+++ b/boa3_test/test_sc/interop_test/binary/Itoa.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.interop.binary import itoa
+
+
+@public
+def main(value: int, base: int) -> str:
+    return itoa(value, base)

--- a/boa3_test/test_sc/interop_test/binary/ItoaDefault.py
+++ b/boa3_test/test_sc/interop_test/binary/ItoaDefault.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.interop.binary import itoa
+
+
+@public
+def main(value: int) -> str:
+    return itoa(value)

--- a/boa3_test/test_sc/interop_test/binary/ItoaMismatchedType.py
+++ b/boa3_test/test_sc/interop_test/binary/ItoaMismatchedType.py
@@ -1,0 +1,5 @@
+from boa3.builtin.interop.binary import itoa
+
+
+def main():
+    itoa('123', 10)

--- a/boa3_test/test_sc/interop_test/binary/ItoaTooFewArguments.py
+++ b/boa3_test/test_sc/interop_test/binary/ItoaTooFewArguments.py
@@ -1,0 +1,5 @@
+from boa3.builtin.interop.binary import itoa
+
+
+def main():
+    itoa()

--- a/boa3_test/test_sc/interop_test/binary/ItoaTooManyArguments.py
+++ b/boa3_test/test_sc/interop_test/binary/ItoaTooManyArguments.py
@@ -1,0 +1,5 @@
+from boa3.builtin.interop.binary import itoa
+
+
+def main():
+    itoa(123, 10, 10)

--- a/boa3_test/tests/compiler_tests/test_interop/test_binary.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_binary.py
@@ -2,8 +2,8 @@ from boa3.exception.CompilerError import MismatchedTypes, UnexpectedArgument, Un
 from boa3.neo.vm.type.StackItem import StackItemType, serialize
 from boa3.neo.vm.type.String import String
 from boa3_test.tests.boa_test import BoaTest
-from boa3_test.tests.test_classes.TestExecutionException import TestExecutionException
 from boa3_test.tests.test_classes.testengine import TestEngine
+from boa3_test.tests.test_classes.TestExecutionException import TestExecutionException
 
 
 class TestBinaryInterop(BoaTest):
@@ -317,4 +317,43 @@ class TestBinaryInterop(BoaTest):
 
     def test_atoi_mismatched_type(self):
         path = self.get_contract_path('AtoiMismatchedType.py')
+        self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_itoa(self):
+        path = self.get_contract_path('Itoa')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'main', 10, 10)
+        self.assertEqual('10', result)
+        result = self.run_smart_contract(engine, path, 'main', 16, 16)
+        self.assertEqual('10', result)
+        result = self.run_smart_contract(engine, path, 'main', -1, 10)
+        self.assertEqual('-1', result)
+        result = self.run_smart_contract(engine, path, 'main', -1, 16)
+        self.assertEqual('f', result)
+        result = self.run_smart_contract(engine, path, 'main', 15, 16)
+        self.assertEqual('0f', result)
+
+        with self.assertRaises(TestExecutionException, msg=self.ASSERT_RESULTED_FALSE_MSG):
+            self.run_smart_contract(engine, path, 'main', 10, 2)
+
+    def test_itoa_default(self):
+        path = self.get_contract_path('ItoaDefault')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'main', 10)
+        self.assertEqual('10', result)
+        result = self.run_smart_contract(engine, path, 'main', -1)
+        self.assertEqual('-1', result)
+
+    def test_itoa_too_few_arguments(self):
+        path = self.get_contract_path('ItoaTooFewArguments')
+        self.assertCompilerLogs(UnfilledArgument, path)
+
+    def test_itoa_too_many_arguments(self):
+        path = self.get_contract_path('ItoaTooManyArguments')
+        self.assertCompilerLogs(UnexpectedArgument, path)
+
+    def test_itoa_mismatched_type(self):
+        path = self.get_contract_path('ItoaMismatchedType')
         self.assertCompilerLogs(MismatchedTypes, path)


### PR DESCRIPTION
**Related issue**
#287 

**How to Reproduce**
Use `itoa()`.

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/f95beb09ff6dc7e39663e9a9641003bbc07635c4/boa3_test/tests/compiler_tests/test_interop/test_binary.py#L322-L359

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8