### PR TITLE
Implement Block Interop

### DIFF
--- a/boa3/builtin/interop/blockchain/__init__.py
+++ b/boa3/builtin/interop/blockchain/__init__.py
@@ -1,5 +1,8 @@
+from typing import Union
+
+from boa3.builtin.interop.blockchain.block import Block
 from boa3.builtin.interop.contract import Contract
-from boa3.builtin.type import UInt160
+from boa3.builtin.type import UInt160, UInt256
 
 current_height: int = 0
 
@@ -13,5 +16,17 @@ def get_contract(hash: UInt160) -> Contract:
     :return: a contract
     :rtype: Contract
     :raise Exception: raised if hash length isn't 20 bytes
+    """
+    pass
+
+
+def get_block(index_or_hash: Union[int, UInt256]) -> Block:
+    """
+    Gets the block with the given index or hash
+
+    :param index_or_hash: index or hash identifier of the block
+    :type index_or_hash: int or UInt256
+    :return: the desired block, if exists. None otherwise
+    :rtype: Block or None
     """
     pass

--- a/boa3/builtin/interop/blockchain/block.py
+++ b/boa3/builtin/interop/blockchain/block.py
@@ -1,0 +1,14 @@
+from boa3.builtin.type import UInt160, UInt256
+
+
+class Block:
+    def __init__(self):
+        self.hash: UInt256 = UInt256()
+        self.version: int = 0
+        self.previous_hash: UInt256 = UInt256()
+        self.merkle_root: UInt256 = UInt256()
+        self.timestamp: int = 0
+        self.index: int = 0
+        self.primary_index: int = 0
+        self.next_consensus: UInt160 = UInt160()
+        self.transaction_count: int = 0

--- a/boa3/builtin/interop/contract/__init__.py
+++ b/boa3/builtin/interop/contract/__init__.py
@@ -1,7 +1,7 @@
 from typing import Any, Sequence
 
-from boa3.builtin.interop.contract.contract import Contract
 from boa3.builtin.interop.contract.callflagstype import CallFlags
+from boa3.builtin.interop.contract.contract import Contract
 from boa3.builtin.type import UInt160
 
 

--- a/boa3/constants.py
+++ b/boa3/constants.py
@@ -20,7 +20,8 @@ DEPLOY_METHOD_ID = '_deploy'
 
 NEO_SCRIPT = from_hex_str('0xef4073a0f2b305a38ec4050e4d3d28bc40ea63f5')
 GAS_SCRIPT = from_hex_str('0xd2a4cff31913016155e38e474a2c06d08be276cf')
-MANAGEMENT_SCRIPT = from_hex_str('0xfffdc93764dbaddd97c48f252a53ea4643faa3fd')
 CRYPTO_SCRIPT = from_hex_str('0x726cb6e0cd8628a1350a611384688911ab75f51b')
-STD_LIB_SCRIPT = from_hex_str('0xacce6fd80d44e1796aa0c2c625e9e4e0ce39efc0')
+LEDGER_SCRIPT = from_hex_str('0xda65b600f7124ce6c79950c1772a36403104f2be')
+MANAGEMENT_SCRIPT = from_hex_str('0xfffdc93764dbaddd97c48f252a53ea4643faa3fd')
 ORACLE_SCRIPT = from_hex_str('0xfe924b7cfe89ddd271abaf7210a80a7e11178758')
+STD_LIB_SCRIPT = from_hex_str('0xacce6fd80d44e1796aa0c2c625e9e4e0ce39efc0')

--- a/boa3/model/builtin/interop/blockchain/__init__.py
+++ b/boa3/model/builtin/interop/blockchain/__init__.py
@@ -1,6 +1,10 @@
-__all__ = ['CurrentHeightProperty',
+__all__ = ['BlockType',
+           'CurrentHeightProperty',
+           'GetBlockMethod',
            'GetContractMethod'
            ]
 
+from boa3.model.builtin.interop.blockchain.blocktype import BlockType
+from boa3.model.builtin.interop.blockchain.getblockmethod import GetBlockMethod
 from boa3.model.builtin.interop.blockchain.getcontractmethod import GetContractMethod
 from boa3.model.builtin.interop.blockchain.getcurrentheightmethod import CurrentHeightProperty

--- a/boa3/model/builtin/interop/blockchain/blocktype.py
+++ b/boa3/model/builtin/interop/blockchain/blocktype.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.expression import IExpression
+from boa3.model.method import Method
+from boa3.model.property import Property
+from boa3.model.type.classtype import ClassType
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class BlockType(ClassType):
+    """
+    A class used to represent Neo Block class
+    """
+
+    def __init__(self):
+        super().__init__('Block')
+        from boa3.model.type.type import Type
+        from boa3.model.type.collection.sequence.uint160type import UInt160Type
+        from boa3.model.type.collection.sequence.uint256type import UInt256Type
+
+        uint256 = UInt256Type.build()
+
+        self._variables: Dict[str, Variable] = {
+            'hash': Variable(uint256),
+            'version': Variable(Type.int),
+            'previous_hash': Variable(uint256),
+            'merkle_root': Variable(uint256),
+            'timestamp': Variable(Type.int),
+            'index': Variable(Type.int),
+            'primary_index': Variable(Type.int),
+            'next_consensus': Variable(UInt160Type.build()),
+            'transaction_count': Variable(Type.int)
+        }
+        self._constructor: Method = None
+
+    @property
+    def variables(self) -> Dict[str, Variable]:
+        return self._variables.copy()
+
+    @property
+    def properties(self) -> Dict[str, Property]:
+        return {}
+
+    @property
+    def class_methods(self) -> Dict[str, Method]:
+        return {}
+
+    @property
+    def instance_methods(self) -> Dict[str, Method]:
+        return {}
+
+    def constructor_method(self) -> Method:
+        # was having a problem with recursive import
+        if self._constructor is None:
+            self._constructor: Method = BlockMethod(self)
+        return self._constructor
+
+    @classmethod
+    def build(cls, value: Any = None) -> BlockType:
+        if value is None or cls._is_type_of(value):
+            return _Block
+
+    @classmethod
+    def _is_type_of(cls, value: Any):
+        return isinstance(value, BlockType)
+
+
+_Block = BlockType()
+
+
+class BlockMethod(IBuiltinMethod):
+
+    def __init__(self, return_type: BlockType):
+        identifier = '-Block__init__'
+        args: Dict[str, Variable] = {}
+        super().__init__(identifier, args, return_type=return_type)
+
+    def validate_parameters(self, *params: IExpression) -> bool:
+        return len(params) == 0
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        from boa3.neo.vm.type.Integer import Integer
+
+        uint160_default = Integer(20).to_byte_array() + bytes(20)
+        uint256_default = Integer(32).to_byte_array() + bytes(32)
+
+        return [
+            (Opcode.PUSH0, b''),  # transaction_count
+            (Opcode.PUSHDATA1, uint160_default),  # next_consensus
+            (Opcode.PUSH0, b''),  # primary_index
+            (Opcode.PUSH0, b''),  # index
+            (Opcode.PUSH0, b''),  # timestamp
+            (Opcode.PUSHDATA1, uint256_default),  # merkle_root
+            (Opcode.PUSHDATA1, uint256_default),  # previous_hash
+            (Opcode.PUSH0, b''),  # version
+            (Opcode.PUSHDATA1, uint256_default),  # hash
+            (Opcode.PUSH9, b''),
+            (Opcode.PACK, b'')
+        ]
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> Optional[str]:
+        return

--- a/boa3/model/builtin/interop/blockchain/getblockmethod.py
+++ b/boa3/model/builtin/interop/blockchain/getblockmethod.py
@@ -1,0 +1,18 @@
+from typing import Dict
+
+from boa3.model.builtin.interop.blockchain.blocktype import BlockType
+from boa3.model.builtin.interop.nativecontract import LedgerMethod
+from boa3.model.variable import Variable
+
+
+class GetBlockMethod(LedgerMethod):
+
+    def __init__(self, block_type: BlockType):
+        from boa3.model.type.collection.sequence.uint256type import UInt256Type
+        from boa3.model.type.type import Type
+
+        identifier = 'get_block'
+        syscall = 'getBlock'
+        args: Dict[str, Variable] = {'index': Variable(Type.union.build([Type.int,
+                                                                         UInt256Type.build()]))}
+        super().__init__(identifier, syscall, args, return_type=block_type)

--- a/boa3/model/builtin/interop/blockchain/getcontractmethod.py
+++ b/boa3/model/builtin/interop/blockchain/getcontractmethod.py
@@ -1,7 +1,8 @@
 from typing import Dict
 
-from boa3.model.builtin.interop.nativecontract.ContractManagement.contractmanagementmethod import ContractManagementMethod
 from boa3.model.builtin.interop.contract.contracttype import ContractType
+from boa3.model.builtin.interop.nativecontract.ContractManagement.contractmanagementmethod import \
+    ContractManagementMethod
 from boa3.model.variable import Variable
 
 

--- a/boa3/model/builtin/interop/contract/createmethod.py
+++ b/boa3/model/builtin/interop/contract/createmethod.py
@@ -1,7 +1,7 @@
 from typing import Dict, List, Tuple
 
-from boa3.model.builtin.interop.nativecontract import ContractManagementMethod
 from boa3.model.builtin.interop.contract.contracttype import ContractType
+from boa3.model.builtin.interop.nativecontract import ContractManagementMethod
 from boa3.model.variable import Variable
 from boa3.neo.vm.opcode.Opcode import Opcode
 

--- a/boa3/model/builtin/interop/interop.py
+++ b/boa3/model/builtin/interop/interop.py
@@ -38,6 +38,7 @@ class Interop:
         return lst
 
     # Interop Types
+    BlockType = BlockType.build()
     CallFlagsType = CallFlagsType()
     ContractType = ContractType.build()
     Iterator = IteratorType.build()
@@ -60,6 +61,7 @@ class Interop:
     # Blockchain Interops
     CurrentHeight = CurrentHeightProperty()
     GetContract = GetContractMethod(ContractType)
+    GetBlock = GetBlockMethod(BlockType)
 
     # Contract Interops
     CallContract = CallMethod()
@@ -72,6 +74,7 @@ class Interop:
     NeoScriptHash = NeoProperty()
     ContractManagementScriptHash = ContractManagement
     CryptoLibScriptHash = CryptoLibContract
+    LedgerScriptHash = LedgerContract
     OracleScriptHash = OracleContract
     StdLibScriptHash = StdLibContract
 
@@ -122,7 +125,9 @@ class Interop:
                                 Itoa,
                                 Serialize
                                 ],
-        InteropPackage.Blockchain: [CurrentHeight,
+        InteropPackage.Blockchain: [BlockType,
+                                    CurrentHeight,
+                                    GetBlock,
                                     GetContract
                                     ],
         InteropPackage.Contract: [CallContract,

--- a/boa3/model/builtin/interop/nativecontract/ContractManagement/contractmanagementmethod.py
+++ b/boa3/model/builtin/interop/nativecontract/ContractManagement/contractmanagementmethod.py
@@ -1,7 +1,8 @@
 import ast
 from typing import Dict, List
 
-from boa3.model.builtin.interop.nativecontract.ContractManagement.getcontractmanagementscripthashmethod import ContractManagement
+from boa3.model.builtin.interop.nativecontract.ContractManagement.getcontractmanagementscripthashmethod import \
+    ContractManagement
 from boa3.model.builtin.interop.nativecontract.nativecontractmethod import NativeContractMethod
 from boa3.model.type.itype import IType
 from boa3.model.variable import Variable

--- a/boa3/model/builtin/interop/nativecontract/Ledger/__init__.py
+++ b/boa3/model/builtin/interop/nativecontract/Ledger/__init__.py
@@ -1,0 +1,2 @@
+from .getledgerscripthashmethod import LedgerContract
+from .ledgermethod import LedgerMethod

--- a/boa3/model/builtin/interop/nativecontract/Ledger/getledgerscripthashmethod.py
+++ b/boa3/model/builtin/interop/nativecontract/Ledger/getledgerscripthashmethod.py
@@ -1,0 +1,42 @@
+from typing import Dict, List, Optional, Tuple
+
+from boa3.constants import LEDGER_SCRIPT
+from boa3.model.builtin.builtinproperty import IBuiltinProperty
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class GetLedgerScriptHashMethod(IBuiltinMethod):
+    def __init__(self):
+        from boa3.model.type.collection.sequence.uint160type import UInt160Type
+        identifier = '-get_ledger_contract'
+        args: Dict[str, Variable] = {}
+        super().__init__(identifier, args, return_type=UInt160Type.build())
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> Optional[str]:
+        return None
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        from boa3.neo.vm.type.Integer import Integer
+
+        value = LEDGER_SCRIPT
+        return [
+            (Opcode.PUSHDATA1, Integer(len(value)).to_byte_array() + value)
+        ]
+
+
+class LedgerContractProperty(IBuiltinProperty):
+    def __init__(self):
+        identifier = 'LedgerContract'
+        getter = GetLedgerScriptHashMethod()
+        super().__init__(identifier, getter)
+
+
+LedgerContract = LedgerContractProperty()

--- a/boa3/model/builtin/interop/nativecontract/Ledger/ledgermethod.py
+++ b/boa3/model/builtin/interop/nativecontract/Ledger/ledgermethod.py
@@ -1,0 +1,14 @@
+import ast
+from typing import Dict, List
+
+from boa3.model.builtin.interop.nativecontract.Ledger.getledgerscripthashmethod import LedgerContract
+from boa3.model.builtin.interop.nativecontract.nativecontractmethod import NativeContractMethod
+from boa3.model.type.itype import IType
+from boa3.model.variable import Variable
+
+
+class LedgerMethod(NativeContractMethod):
+
+    def __init__(self, identifier: str, native_identifier: str, args: Dict[str, Variable] = None,
+                 defaults: List[ast.AST] = None, return_type: IType = None):
+        super().__init__(LedgerContract.getter, identifier, native_identifier, args, defaults, return_type)

--- a/boa3/model/builtin/interop/nativecontract/__init__.py
+++ b/boa3/model/builtin/interop/nativecontract/__init__.py
@@ -1,4 +1,5 @@
 from .ContractManagement import ContractManagement, ContractManagementMethod
 from .CryptoLib import CryptoLibContract, CryptoLibMethod
+from .Ledger import LedgerContract, LedgerMethod
 from .Oracle import OracleContract, OracleMethod
 from .StdLib import StdLibContract, StdLibMethod

--- a/boa3/neo3/contracts/__init__.py
+++ b/boa3/neo3/contracts/__init__.py
@@ -1,5 +1,4 @@
-from boa3.neo3.contracts.contracttypes import CallFlags
-from boa3.neo3.contracts.contracttypes import TriggerType
+from boa3.neo3.contracts.contracttypes import CallFlags, TriggerType
 from boa3.neo3.contracts.findoptions import FindOptions
 
 __all__ = ['CallFlags',

--- a/boa3_test/test_sc/built_in_methods_test/SumMismatchedTypes.py
+++ b/boa3_test/test_sc/built_in_methods_test/SumMismatchedTypes.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from boa3.builtin import public
 
 

--- a/boa3_test/test_sc/interop_test/blockchain/GetBlockByHash.py
+++ b/boa3_test/test_sc/interop_test/blockchain/GetBlockByHash.py
@@ -1,0 +1,8 @@
+from boa3.builtin import public
+from boa3.builtin.interop.blockchain import Block, get_block
+from boa3.builtin.type import UInt256
+
+
+@public
+def Main(block_hash: UInt256) -> Block:
+    return get_block(block_hash)

--- a/boa3_test/test_sc/interop_test/blockchain/GetBlockByIndex.py
+++ b/boa3_test/test_sc/interop_test/blockchain/GetBlockByIndex.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.interop.blockchain import Block, get_block
+
+
+@public
+def Main(index: int) -> Block:
+    return get_block(index)

--- a/boa3_test/test_sc/interop_test/blockchain/GetBlockMismatchedTypes.py
+++ b/boa3_test/test_sc/interop_test/blockchain/GetBlockMismatchedTypes.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.interop.blockchain import Block, get_block
+
+
+@public
+def Main(index: str) -> Block:
+    return get_block(index)

--- a/boa3_test/test_sc/interop_test/contract/CallFlagsUsage.py
+++ b/boa3_test/test_sc/interop_test/contract/CallFlagsUsage.py
@@ -1,8 +1,8 @@
 from typing import Any
 
 from boa3.builtin import public
-from boa3.builtin.interop.contract import call_contract, NEO
-from boa3.builtin.interop.runtime import notify, executing_script_hash
+from boa3.builtin.interop.contract import NEO, call_contract
+from boa3.builtin.interop.runtime import executing_script_hash, notify
 from boa3.builtin.interop.storage import get, put
 
 

--- a/boa3_test/test_sc/interop_test/contract/CallScriptHashTooManyArguments.py
+++ b/boa3_test/test_sc/interop_test/contract/CallScriptHashTooManyArguments.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from boa3.builtin.interop.contract import call_contract, CallFlags
+from boa3.builtin.interop.contract import CallFlags, call_contract
 
 
 def Main(scripthash: bytes, method: str, arg0: Any, arg1: Any, flags: CallFlags):

--- a/boa3_test/test_sc/interop_test/contract/CallScriptHashWithFlags.py
+++ b/boa3_test/test_sc/interop_test/contract/CallScriptHashWithFlags.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from boa3.builtin import public
-from boa3.builtin.interop.contract import call_contract, CallFlags
+from boa3.builtin.interop.contract import CallFlags, call_contract
 from boa3.builtin.type import UInt160
 
 

--- a/boa3_test/tests/compiler_tests/test_interop/test_binary.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_binary.py
@@ -2,8 +2,8 @@ from boa3.exception.CompilerError import MismatchedTypes, UnexpectedArgument, Un
 from boa3.neo.vm.type.StackItem import StackItemType, serialize
 from boa3.neo.vm.type.String import String
 from boa3_test.tests.boa_test import BoaTest
-from boa3_test.tests.test_classes.testengine import TestEngine
 from boa3_test.tests.test_classes.TestExecutionException import TestExecutionException
+from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestBinaryInterop(BoaTest):

--- a/boa3_test/tests/test_classes/testengine.py
+++ b/boa3_test/tests/test_classes/testengine.py
@@ -234,7 +234,7 @@ class TestEngine:
                                        stdout=subprocess.PIPE,
                                        stderr=subprocess.STDOUT,
                                        text=True)
-        except:
+        except BaseException:
             json_path = '{0}/test-engine-test.json'.format(path.curdir)
             with open(json_path, 'wb+') as json_file:
                 json_file.write(String(param_json).to_bytes())


### PR DESCRIPTION
**Related issue**
#285

**Summary or solution description**
Implemented ``get_block`` function

**How to Reproduce**
```python
from boa3.builtin import public
from boa3.builtin.interop.blockchain import Block, get_block


@public
def example():
    block_from_index: Block = get_block(10)
    if isinstance(block_from_index, Block):
        block_from_hash = get_block(block_from_index.hash)

```

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/74bc7ca9b081b781d13f9924354ac12e0a33a0c1/boa3_test/tests/compiler_tests/test_interop/test_blockchain.py#L63-L104

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
