### PR TITLE
 Implement Contract GetCallFlags Interop #291

### DIFF
--- a/boa3/builtin/interop/contract/__init__.py
+++ b/boa3/builtin/interop/contract/__init__.py
@@ -65,5 +65,12 @@ def destroy_contract():
     pass
 
 
+def get_call_flags() -> CallFlags:
+    """
+    Gets the CallFlags in the current context
+    """
+    pass
+
+
 NEO: UInt160 = UInt160()  # not real value
 GAS: UInt160 = UInt160()  # not real value

--- a/boa3/model/builtin/interop/contract/__init__.py
+++ b/boa3/model/builtin/interop/contract/__init__.py
@@ -4,6 +4,7 @@ __all__ = ['CallFlagsType',
            'CreateMethod',
            'DestroyMethod',
            'GasProperty',
+           'GetCallFlagsMethod',
            'NeoProperty',
            'UpdateMethod'
            ]
@@ -13,6 +14,7 @@ from boa3.model.builtin.interop.contract.callmethod import CallMethod
 from boa3.model.builtin.interop.contract.contracttype import ContractType
 from boa3.model.builtin.interop.contract.createmethod import CreateMethod
 from boa3.model.builtin.interop.contract.destroymethod import DestroyMethod
+from boa3.model.builtin.interop.contract.getcallflagsmethod import GetCallFlagsMethod
 from boa3.model.builtin.interop.contract.getgasscripthashmethod import GasProperty
 from boa3.model.builtin.interop.contract.getneoscripthashmethod import NeoProperty
 from boa3.model.builtin.interop.contract.updatemethod import UpdateMethod

--- a/boa3/model/builtin/interop/contract/getcallflagsmethod.py
+++ b/boa3/model/builtin/interop/contract/getcallflagsmethod.py
@@ -1,0 +1,14 @@
+from typing import Dict
+
+from boa3.model.builtin.interop.contract.callflagstype import CallFlagsType
+from boa3.model.builtin.interop.interopmethod import InteropMethod
+from boa3.model.variable import Variable
+
+
+class GetCallFlagsMethod(InteropMethod):
+
+    def __init__(self, call_flags_type: CallFlagsType):
+        identifier = 'get_call_flags'
+        syscall = 'System.Contract.GetCallFlags'
+        args: Dict[str, Variable] = {}
+        super().__init__(identifier, syscall, args, return_type=call_flags_type)

--- a/boa3/model/builtin/interop/interop.py
+++ b/boa3/model/builtin/interop/interop.py
@@ -67,6 +67,7 @@ class Interop:
     CallContract = CallMethod()
     CreateContract = CreateMethod(ContractType)
     DestroyContract = DestroyMethod()
+    GetCallFlags = GetCallFlagsMethod(CallFlagsType)
     UpdateContract = UpdateMethod()
 
     # Native Contracts
@@ -136,6 +137,7 @@ class Interop:
                                   CreateContract,
                                   DestroyContract,
                                   GasScriptHash,
+                                  GetCallFlags,
                                   NeoScriptHash,
                                   UpdateContract
                                   ],

--- a/boa3_test/test_sc/interop_test/contract/GetCallFlags.py
+++ b/boa3_test/test_sc/interop_test/contract/GetCallFlags.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.interop.contract import CallFlags, get_call_flags
+
+
+@public
+def main() -> CallFlags:
+    return get_call_flags()

--- a/boa3_test/tests/compiler_tests/test_interop/test_contract.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_contract.py
@@ -266,3 +266,36 @@ class TestContractInterop(BoaTest):
         self.assertEqual(0b00000001, result)
         result = self.run_smart_contract(engine, path, 'main', 'NONE')
         self.assertEqual(0, result)
+
+    def test_get_call_flags(self):
+        path = self.get_contract_path('CallScriptHashWithFlags.py')
+        call_contract_path = self.get_contract_path('GetCallFlags.py')
+        Boa3.compile_and_save(call_contract_path)
+
+        contract, manifest = self.get_output(call_contract_path)
+        call_hash = hash160(contract)
+        call_contract_path = call_contract_path.replace('.py', '.nef')
+
+        engine = TestEngine()
+        with self.assertRaises(TestExecutionException, msg=self.CALLED_CONTRACT_DOES_NOT_EXIST_MSG):
+            self.run_smart_contract(engine, path, 'Main', call_hash, 'main')
+        engine.add_contract(call_contract_path)
+
+        from boa3.neo3.contracts import CallFlags
+
+        result = self.run_smart_contract(engine, path, 'Main', call_hash, 'main', [], CallFlags.ALL)
+        self.assertEqual(CallFlags.ALL, result)
+        result = self.run_smart_contract(engine, path, 'Main', call_hash, 'main', [], CallFlags.READ_ONLY)
+        self.assertEqual(CallFlags.READ_ONLY, result)
+        result = self.run_smart_contract(engine, path, 'Main', call_hash, 'main', [], CallFlags.STATES)
+        self.assertEqual(CallFlags.STATES, result)
+        result = self.run_smart_contract(engine, path, 'Main', call_hash, 'main', [], CallFlags.NONE)
+        self.assertEqual(CallFlags.NONE, result)
+        result = self.run_smart_contract(engine, path, 'Main', call_hash, 'main', [], CallFlags.READ_STATES)
+        self.assertEqual(CallFlags.READ_STATES, result)
+        result = self.run_smart_contract(engine, path, 'Main', call_hash, 'main', [], CallFlags.WRITE_STATES)
+        self.assertEqual(CallFlags.WRITE_STATES, result)
+        result = self.run_smart_contract(engine, path, 'Main', call_hash, 'main', [], CallFlags.ALLOW_CALL)
+        self.assertEqual(CallFlags.ALLOW_CALL, result)
+        result = self.run_smart_contract(engine, path, 'Main', call_hash, 'main', [], CallFlags.ALLOW_NOTIFY)
+        self.assertEqual(CallFlags.ALLOW_NOTIFY, result)


### PR DESCRIPTION
**Related issue**
#291 

**How to Reproduce**
Call `get_call_flags()` function.

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/6f26298130d4e2f92749d659956decc16ea29c98/boa3_test/tests/compiler_tests/test_interop/test_contract.py#L270-L301

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8