### PR TITLE
Cast types

### DIFF
--- a/boa3/analyser/builtinfunctioncallanalyser.py
+++ b/boa3/analyser/builtinfunctioncallanalyser.py
@@ -31,11 +31,11 @@ class BuiltinFunctionCallAnalyser(IAstAnalyser):
     def call(self) -> ast.Call:
         return self._tree
 
-    def get_symbol(self, symbol_id: str) -> Optional[ISymbol]:
-        return self._origin.get_symbol(symbol_id)
+    def get_symbol(self, symbol_id: str, is_internal: bool = False) -> Optional[ISymbol]:
+        return self._origin.get_symbol(symbol_id, is_internal)
 
-    def get_type(self, value: Any) -> IType:
-        return self._origin.get_type(value)
+    def get_type(self, value: Any, use_metadata: bool = False) -> IType:
+        return self._origin.get_type(value, use_metadata)
 
     def validate(self) -> bool:
         """
@@ -72,12 +72,15 @@ class BuiltinFunctionCallAnalyser(IAstAnalyser):
                 self.call.args[-1] = last_arg.elts[-1]
                 return
 
+        from boa3.model.type.annotation.metatype import MetaType
         from boa3.model.type.type import Type
         is_ast_valid = (isinstance(last_arg, ast.Name)
                         or (isinstance(last_arg, ast.NameConstant) and args_types[-1] is Type.none))
+
         is_id_valid = (hasattr(last_arg, 'id')
                        and last_arg.id != args_types[-1].identifier
-                       and last_arg.id != args_types[-1].raw_identifier)
+                       and last_arg.id != args_types[-1].raw_identifier
+                       and isinstance(self.get_type(last_arg, use_metadata=True), MetaType))
 
         if not is_ast_valid or is_id_valid:
             # if the value is not the identifier of a type

--- a/boa3/analyser/importanalyser.py
+++ b/boa3/analyser/importanalyser.py
@@ -7,6 +7,7 @@ from boa3.analyser.astanalyser import IAstAnalyser
 from boa3.model.builtin.builtin import Builtin
 from boa3.model.symbol import ISymbol
 from boa3.model.type.type import Type
+from boa3.model.type.typeutils import TypeUtils
 
 
 class ImportAnalyser(IAstAnalyser):
@@ -103,6 +104,10 @@ class ImportAnalyser(IAstAnalyser):
                 type_id: str = t_id if t_id in Type.all_types() else t_id.lower()
                 if type_id in Type.all_types():
                     type_symbols[t_id] = Type.all_types()[type_id]
+            else:
+                function_id: str = t_id if t_id in TypeUtils.all_functions() else t_id.lower()
+                if function_id in TypeUtils.all_functions():
+                    type_symbols[t_id] = TypeUtils.all_functions()[function_id]
 
         return type_symbols
 

--- a/boa3/model/builtin/method/builtinmethod.py
+++ b/boa3/model/builtin/method/builtinmethod.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import ast
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from boa3.model.builtin.builtincallable import IBuiltinCallable
 from boa3.model.method import Method
@@ -23,6 +23,25 @@ class IBuiltinMethod(IBuiltinCallable, Method, ABC):
         :return: True if it is supported. False otherwise.
         """
         return True
+
+    def not_supported_str(self, callable_id: str) -> str:
+        return '{0}({1})'.format(callable_id,
+                                 ','.join([arg.type.identifier for arg in self.args.values()]))
+
+    @property
+    def is_cast(self) -> bool:
+        """
+        Returns whether this method is for casting types
+        """
+        return False
+
+    @property
+    def cast_types(self) -> Optional[Tuple[IType, IType]]:
+        """
+        If `is_cast` is True, must return the original type and the target type of the cast.
+        Otherwise, must return None
+        """
+        return None
 
     @property
     def args_on_stack(self) -> int:
@@ -174,7 +193,3 @@ class IBuiltinMethod(IBuiltinCallable, Method, ABC):
         :rtype: IBuiltinMethod
         """
         return self
-
-    def not_supported_str(self, callable_id: str) -> str:
-        return '{0}({1})'.format(callable_id,
-                                 ','.join([arg.type.identifier for arg in self.args.values()]))

--- a/boa3/model/builtin/method/isinstancemethod.py
+++ b/boa3/model/builtin/method/isinstancemethod.py
@@ -21,13 +21,16 @@ class IsInstanceMethod(IBuiltinMethod):
         super().__init__(identifier, args, return_type=Type.bool)
 
         from boa3.model.type.collection.sequence.tupletype import TupleType
+        from boa3.model.type.annotation.metatype import MetaType
         from boa3.model.type.annotation.uniontype import UnionType
+
         if not isinstance(target_type, IType):
             instances = [Type.none]
         elif isinstance(target_type, TupleType) and isinstance(target_type.item_type, UnionType):
-            instances = target_type.item_type.union_types
+            instances = [typ.meta_type if isinstance(typ, MetaType) else typ
+                         for typ in target_type.item_type.union_types]
         else:
-            instances = [target_type]
+            instances = [target_type.meta_type if isinstance(target_type, MetaType) else target_type]
 
         self._instances_type: List[IType] = instances
 

--- a/boa3/model/type/annotation/metatype.py
+++ b/boa3/model/type/annotation/metatype.py
@@ -1,0 +1,48 @@
+from typing import Any, Optional
+
+from boa3.model.type.itype import IType
+from boa3.neo.vm.type.AbiType import AbiType
+
+
+class MetaType(IType):
+    """
+    A class used to represent internal Boa and Python types
+    """
+
+    def __init__(self, type_of: IType = None):
+        identifier = 'type'
+        super().__init__(identifier)
+        self._internal_type: Optional[IType] = type_of
+
+    @property
+    def abi_type(self) -> AbiType:
+        return AbiType.Any
+
+    @classmethod
+    def build(cls, value: Any) -> IType:
+        if isinstance(value, IType):
+            return cls(value)
+        else:
+            return metaType
+
+    @classmethod
+    def _is_type_of(cls, value: Any) -> bool:
+        return isinstance(value, MetaType)
+
+    def is_type_of(self, value: Any) -> bool:
+        return isinstance(value, MetaType) and self._internal_type.is_type_of(value._internal_type)
+
+    @property
+    def has_meta_type(self) -> bool:
+        return self._internal_type is not None
+
+    @property
+    def meta_type(self) -> Optional[IType]:
+        return self._internal_type
+
+    @property
+    def meta_id(self) -> Optional[None]:
+        return self._internal_type.identifier if self._internal_type is not None else None
+
+
+metaType: IType = MetaType()

--- a/boa3/model/type/type.py
+++ b/boa3/model/type/type.py
@@ -92,6 +92,8 @@ class Type:
 
                 if generic is Type.any:
                     break
+        if generic is Type.any and Type.any not in types:
+            generic = Type.union.build(types)
         return generic
 
     # Builtin Types

--- a/boa3/model/type/typeutils.py
+++ b/boa3/model/type/typeutils.py
@@ -1,0 +1,18 @@
+from typing import Any, Dict
+
+from boa3.model.callable import Callable
+from boa3.model.type.annotation.metatype import metaType
+from boa3.model.type.typingmethod.casttypemethod import CastTypeMethod
+
+
+class TypeUtils:
+    @classmethod
+    def all_functions(cls) -> Dict[str, Callable]:
+        from boa3.model.builtin.builtincallable import IBuiltinCallable
+        return {tpe._identifier: tpe for tpe in vars(cls).values() if isinstance(tpe, IBuiltinCallable)}
+
+    # type for internal validation
+    type = metaType
+
+    # Annotation function utils
+    cast = CastTypeMethod()

--- a/boa3/model/type/typingmethod/casttypemethod.py
+++ b/boa3/model/type/typingmethod/casttypemethod.py
@@ -1,0 +1,117 @@
+from typing import Any, Dict, List, Optional, Sized, Tuple
+
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.expression import IExpression
+from boa3.model.type.annotation.metatype import MetaType, metaType
+from boa3.model.type.anytype import anyType
+from boa3.model.type.collection.sequence.sequencetype import SequenceType
+from boa3.model.type.itype import IType
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class CastTypeMethod(IBuiltinMethod):
+
+    def __init__(self, cast_to_type: IType = None, origin_type: IType = None):
+        # if the type to be casted is not value, there's an error in the signature
+        if cast_to_type is None:
+            type_value = metaType
+        elif isinstance(cast_to_type, MetaType):
+            type_value = cast_to_type if cast_to_type.has_meta_type else metaType
+        else:
+            type_value = MetaType.build(cast_to_type)
+
+        if origin_type is None:
+            origin_type = anyType
+        elif isinstance(origin_type, MetaType):
+            origin_type = origin_type.meta_type if origin_type.has_meta_type else anyType
+
+        identifier = 'cast'
+        args: Dict[str, Variable] = {'typ': Variable(type_value),
+                                     'val': Variable(anyType)}
+        super().__init__(identifier, args,
+                         return_type=cast_to_type.meta_type if isinstance(cast_to_type, MetaType) else anyType)
+        self._origin_type: IType = origin_type
+
+    @property
+    def identifier(self) -> str:
+        if self.is_supported:
+            identifier = (self.typ_arg.type.meta_id
+                          if hasattr(self.typ_arg.type, 'meta_id')
+                          else self.typ_arg.type.identifier)
+            return '-{0}_{1}'.format(self._identifier, identifier)
+        else:
+            return self._identifier
+
+    def validate_parameters(self, *params: IExpression) -> bool:
+        if len(params) != 1:
+            return False
+        if not isinstance(params[0], IExpression):
+            return False
+        return isinstance(params[0].type, SequenceType)
+
+    @property
+    def is_supported(self) -> bool:
+        return (isinstance(self.typ_arg, Variable)
+                and isinstance(self.typ_arg.type, MetaType)
+                and self.typ_arg.type.has_meta_type)
+
+    def not_supported_str(self, callable_id: str) -> str:
+        return '{0}({1})'.format(callable_id,
+                                 ','.join([arg.type.identifier if isinstance(arg, Variable) else 'unknown'
+                                           for arg in self.args.values()]))
+
+    @property
+    def is_cast(self) -> bool:
+        return True
+
+    @property
+    def cast_types(self) -> Optional[Tuple[IType, IType]]:
+        origin_type = self._origin_type
+        target_type = (self.typ_arg.type.meta_type
+                       if hasattr(self.typ_arg.type, 'meta_type')
+                       else self.typ_arg.type)
+        return origin_type, target_type
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        return []
+
+    @property
+    def _args_on_stack(self) -> int:
+        return 1  # the implementation is the same as x = arg
+
+    @property
+    def generation_order(self) -> List[int]:
+        # type should not be converted
+        indexes = super().generation_order
+        typ_index = list(self.args).index('typ')
+
+        if typ_index in indexes:
+            indexes.remove(typ_index)
+
+        return indexes
+
+    @property
+    def _body(self) -> Optional[str]:
+        return None
+
+    @property
+    def typ_arg(self) -> Variable:
+        return self.args['typ'] if isinstance(self.args['typ'], Variable) else Variable(anyType)
+
+    @property
+    def val_arg(self) -> Variable:
+        return self.args['val']
+
+    def build(self, value: Any) -> IBuiltinMethod:
+        if isinstance(value, Sized) and len(value) == len(self.args):
+            cast_to = value[0]
+            cast_from = value[1]
+
+            if isinstance(cast_to, IType):
+                if isinstance(cast_from, IType):
+                    return CastTypeMethod(cast_to, cast_from)
+                else:
+                    return CastTypeMethod(cast_to)
+        return super().build(value)

--- a/boa3_test/test_sc/dict_test/DictAnyKeyAndValue.py
+++ b/boa3_test/test_sc/dict_test/DictAnyKeyAndValue.py
@@ -1,3 +1,5 @@
+from typing import List, cast
+
 from boa3.builtin import public
 
 
@@ -14,18 +16,9 @@ def main() -> int:
         'fcall': mymethod(10, 4)
     }
 
-    value1 = d['fcall']
+    value1: int = d['fcall']
 
-    if isinstance(value1, int):
-        value2 = d['c']
-
-        if isinstance(value2, list):
-            value3 = value2[3]
-
-            if isinstance(value3, int):
-                return value1 + value3
-
-    return -1
+    return value1 + cast(List[int], d['c'])[3]
 
 
 def mymethod(a: int, b: int) -> int:

--- a/boa3_test/test_sc/dict_test/DictBoa2Test4.py
+++ b/boa3_test/test_sc/dict_test/DictBoa2Test4.py
@@ -1,3 +1,5 @@
+from typing import List, cast
+
 from boa3.builtin import public
 
 
@@ -15,17 +17,8 @@ def main() -> int:
         'mcalll': mymethod(1, 4)
     }
 
-    j4 = d['mcalll']
-
-    if isinstance(j4, int):
-        j5 = d['z']
-
-        if isinstance(j5, list):
-            j6 = j5[3]
-
-            if isinstance(j6, int):
-                return j4 + j6
-    return -1
+    j4: int = d['mcalll']
+    return j4 + cast(List[int], d['z'])[3]
 
 
 def mymethod(a: int, b: int) -> int:

--- a/boa3_test/test_sc/dict_test/MismatchedTypeKeysDict.py
+++ b/boa3_test/test_sc/dict_test/MismatchedTypeKeysDict.py
@@ -1,6 +1,9 @@
 from typing import Dict, Sequence, Tuple
 
+from boa3.builtin import public
 
+
+@public
 def Main() -> Sequence[str]:
     a: Dict[str, int] = {'one': 1, 'two': 2, 'three': 3}
     b: Tuple[str] = a.keys()

--- a/boa3_test/test_sc/dict_test/MismatchedTypeValuesDict.py
+++ b/boa3_test/test_sc/dict_test/MismatchedTypeValuesDict.py
@@ -1,6 +1,9 @@
 from typing import Dict, Sequence, Tuple
 
+from boa3.builtin import public
 
+
+@public
 def Main() -> Sequence[int]:
     a: Dict[str, int] = {'one': 1, 'two': 2, 'three': 3}
     b: Tuple[int] = a.values()

--- a/boa3_test/test_sc/if_test/MismatchedIfExp.py
+++ b/boa3_test/test_sc/if_test/MismatchedIfExp.py
@@ -1,3 +1,7 @@
+from boa3.builtin import public
+
+
+@public
 def Main(condition: bool) -> int:
     a: int = 2 if condition else None
 

--- a/boa3_test/test_sc/interop_test/binary/SerializationBoa2Test.py
+++ b/boa3_test/test_sc/interop_test/binary/SerializationBoa2Test.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, cast
 
 from boa3.builtin import public
 from boa3.builtin.interop.binary import deserialize, serialize
@@ -32,7 +32,6 @@ def main(operation: int) -> Any:
 
         to_retrieve = get('serialized')
         deserialized = deserialize(to_retrieve)
-        if isinstance(deserialized, list):
-            return deserialized[2]
+        return cast(list, deserialized)[2]
 
     return False

--- a/boa3_test/test_sc/list_test/PopListMismatchedTypeResult.py
+++ b/boa3_test/test_sc/list_test/PopListMismatchedTypeResult.py
@@ -1,3 +1,7 @@
+from boa3.builtin import public
+
+
+@public
 def pop_test() -> str:
     a = [1, 2, 3, 4, 5]
     b: str = a.pop(2)

--- a/boa3_test/test_sc/typing_test/CastMismatchedType.py
+++ b/boa3_test/test_sc/typing_test/CastMismatchedType.py
@@ -1,0 +1,8 @@
+from typing import Any, cast
+
+from boa3.builtin import public
+
+
+def Main(value: Any) -> int:
+    x = cast(4, value)
+    return x

--- a/boa3_test/test_sc/typing_test/CastToDict.py
+++ b/boa3_test/test_sc/typing_test/CastToDict.py
@@ -1,0 +1,9 @@
+from typing import Any, Dict, cast
+
+from boa3.builtin import public
+
+
+@public
+def Main(value: Any) -> Dict[Any, Any]:
+    x = cast(dict, value)
+    return x

--- a/boa3_test/test_sc/typing_test/CastToInt.py
+++ b/boa3_test/test_sc/typing_test/CastToInt.py
@@ -1,0 +1,9 @@
+from typing import Any, cast
+
+from boa3.builtin import public
+
+
+@public
+def Main(value: Any) -> int:
+    x = cast(int, value)
+    return x

--- a/boa3_test/test_sc/typing_test/CastToList.py
+++ b/boa3_test/test_sc/typing_test/CastToList.py
@@ -1,0 +1,9 @@
+from typing import Any, List, cast
+
+from boa3.builtin import public
+
+
+@public
+def Main(value: Any) -> List[Any]:
+    x = cast(list, value)
+    return x

--- a/boa3_test/test_sc/typing_test/CastToStr.py
+++ b/boa3_test/test_sc/typing_test/CastToStr.py
@@ -1,0 +1,9 @@
+from typing import Any, cast
+
+from boa3.builtin import public
+
+
+@public
+def Main(value: Any) -> str:
+    x = cast(str, value)
+    return x

--- a/boa3_test/test_sc/typing_test/CastToTypedDict.py
+++ b/boa3_test/test_sc/typing_test/CastToTypedDict.py
@@ -1,0 +1,9 @@
+from typing import Any, Dict, cast
+
+from boa3.builtin import public
+
+
+@public
+def Main(value: Any) -> int:
+    x = cast(Dict[str, int], value)
+    return x['example']

--- a/boa3_test/test_sc/typing_test/CastToTypedList.py
+++ b/boa3_test/test_sc/typing_test/CastToTypedList.py
@@ -1,0 +1,9 @@
+from typing import Any, List, cast
+
+from boa3.builtin import public
+
+
+@public
+def Main(value: Any) -> int:
+    x = cast(List[int], value)
+    return x[0]

--- a/boa3_test/tests/compiler_tests/test_bytes.py
+++ b/boa3_test/tests/compiler_tests/test_bytes.py
@@ -1,7 +1,7 @@
 import unittest
 
 from boa3.boa3 import Boa3
-from boa3.exception.CompilerError import MismatchedTypes, NotSupportedOperation, UnresolvedOperation
+from boa3.exception import CompilerError, CompilerWarning
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3_test.tests.boa_test import BoaTest
@@ -90,15 +90,15 @@ class TestBytes(BoaTest):
 
     def test_bytes_set_value(self):
         path = self.get_contract_path('BytesSetValue.py')
-        self.assertCompilerLogs(UnresolvedOperation, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedOperation, path)
 
     def test_bytes_clear(self):
         path = self.get_contract_path('BytesClear.py')
-        self.assertCompilerLogs(MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_bytes_reverse(self):
         path = self.get_contract_path('BytesReverse.py')
-        self.assertCompilerLogs(MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_bytes_to_int(self):
         path = self.get_contract_path('BytesToInt.py')
@@ -118,11 +118,11 @@ class TestBytes(BoaTest):
 
     def test_bytes_to_int_mismatched_types(self):
         path = self.get_contract_path('BytesToIntWithBuiltinMismatchedTypes.py')
-        self.assertCompilerLogs(MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_bytes_to_int_with_byte_array_builtin(self):
         path = self.get_contract_path('BytesToIntWithBytearrayBuiltin.py')
-        self.assertCompilerLogs(MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_bytes_to_bool(self):
         path = self.get_contract_path('BytesToBool.py')
@@ -170,7 +170,7 @@ class TestBytes(BoaTest):
 
     def test_bytes_to_bool_mismatched_types(self):
         path = self.get_contract_path('BytesToBoolWithBuiltinMismatchedTypes.py')
-        self.assertCompilerLogs(MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_bytes_to_str(self):
         path = self.get_contract_path('BytesToStr.py')
@@ -190,7 +190,7 @@ class TestBytes(BoaTest):
 
     def test_bytes_to_str_mismatched_types(self):
         path = self.get_contract_path('BytesToStrWithBuiltinMismatchedTypes.py')
-        self.assertCompilerLogs(MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_bytes_from_byte_array(self):
         data = b'\x01\x02\x03'
@@ -349,8 +349,21 @@ class TestBytes(BoaTest):
         self.assertEqual(b'\x01', result)
 
     def test_byte_array_literal_value(self):
+        data = b'\x01\x02\x03'
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x01'
+            + b'\x00'
+            + Opcode.PUSHDATA1  # a = bytearray(b'\x01\x02\x03')
+            + Integer(len(data)).to_byte_array(min_length=1)
+            + data
+            + Opcode.STLOC0
+            + Opcode.RET        # return
+        )
+
         path = self.get_contract_path('BytearrayLiteral.py')
-        self.assertCompilerLogs(MismatchedTypes, path)
+        output = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+        self.assertEqual(expected_output, output)
 
     def test_byte_array_from_literal_bytes(self):
         data = b'\x01\x02\x03'
@@ -392,7 +405,7 @@ class TestBytes(BoaTest):
 
     def test_byte_array_string(self):
         path = self.get_contract_path('BytearrayFromString.py')
-        self.assertCompilerLogs(NotSupportedOperation, path)
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
 
     def test_byte_array_append(self):
         path = self.get_contract_path('BytearrayAppend.py')
@@ -491,7 +504,7 @@ class TestBytes(BoaTest):
 
     def test_boa2_byte_array_test2(self):
         path = self.get_contract_path('BytearrayBoa2Test2.py')
-        self.assertCompilerLogs(MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_boa2_byte_array_test3(self):
         path = self.get_contract_path('BytearrayBoa2Test3.py')

--- a/boa3_test/tests/compiler_tests/test_typing.py
+++ b/boa3_test/tests/compiler_tests/test_typing.py
@@ -1,0 +1,120 @@
+from boa3.boa3 import Boa3
+from boa3.exception import CompilerError, CompilerWarning
+from boa3.neo.vm.opcode.Opcode import Opcode
+from boa3.neo.vm.type.Integer import Integer
+from boa3.neo.vm.type.String import String
+from boa3_test.tests.boa_test import BoaTest
+
+
+class TestTyping(BoaTest):
+
+    default_folder: str = 'test_sc/typing_test'
+
+    def test_cast_to_int(self):
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x01'
+            + b'\x01'
+            + Opcode.LDARG0     # x = cast(int, value)
+            + Opcode.STLOC0
+            + Opcode.LDLOC0     # return x
+            + Opcode.RET
+        )
+
+        path = self.get_contract_path('CastToInt.py')
+        output = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+        self.assertEqual(expected_output, output)
+
+    def test_cast_to_str(self):
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x01'
+            + b'\x01'
+            + Opcode.LDARG0     # x = cast(str, value)
+            + Opcode.STLOC0
+            + Opcode.LDLOC0     # return x
+            + Opcode.RET
+        )
+
+        path = self.get_contract_path('CastToStr.py')
+        output = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+        self.assertEqual(expected_output, output)
+
+    def test_cast_to_list(self):
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x01'
+            + b'\x01'
+            + Opcode.LDARG0     # x = cast(list, value)
+            + Opcode.STLOC0
+            + Opcode.LDLOC0     # return x
+            + Opcode.RET
+        )
+
+        path = self.get_contract_path('CastToList.py')
+        output = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+        self.assertEqual(expected_output, output)
+
+    def test_cast_to_typed_list(self):
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x01'
+            + b'\x01'
+            + Opcode.LDARG0     # x = cast(List[int], value)
+            + Opcode.STLOC0
+            + Opcode.LDLOC0     # return x[0]
+            + Opcode.PUSH0
+            + Opcode.DUP
+            + Opcode.SIGN
+            + Opcode.PUSHM1
+            + Opcode.JMPNE
+            + Integer(5).to_byte_array(min_length=1, signed=True)
+            + Opcode.OVER
+            + Opcode.SIZE
+            + Opcode.ADD
+            + Opcode.PICKITEM
+            + Opcode.RET
+        )
+
+        path = self.get_contract_path('CastToTypedList.py')
+        output = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+        self.assertEqual(expected_output, output)
+
+    def test_cast_to_dict(self):
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x01'
+            + b'\x01'
+            + Opcode.LDARG0     # x = cast(dict, value)
+            + Opcode.STLOC0
+            + Opcode.LDLOC0     # return x
+            + Opcode.RET
+        )
+
+        path = self.get_contract_path('CastToDict.py')
+        output = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+        self.assertEqual(expected_output, output)
+
+    def test_cast_to_typed_dict(self):
+        string = String('example').to_bytes()
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x01'
+            + b'\x01'
+            + Opcode.LDARG0     # x = cast(Dict[str, int], value)
+            + Opcode.STLOC0
+            + Opcode.LDLOC0     # return x['example']
+            + Opcode.PUSHDATA1
+            + Integer(len(string)).to_byte_array(min_length=1)
+            + string
+            + Opcode.PICKITEM
+            + Opcode.RET
+        )
+
+        path = self.get_contract_path('CastToTypedDict.py')
+        output = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+        self.assertEqual(expected_output, output)
+
+    def test_cast_mismatched_type(self):
+        path = self.get_contract_path('CastMismatchedType.py')
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)


### PR DESCRIPTION
**Related issue**
#428

**Summary or solution description**
Implemented two different ways of casting typings:
1. Cast implicitly when the target type is specified in the assignment:
```python
y: Dict[str, Any] = json_deserialize(json_serialized)  # returns Any, implicitly cast because the type is specified
```
2. Explicitly casting values using `typing.cast` method to work in other cases
```python
a = json_deserialize(json_serialized) # type: Any
y = cast(Dict[str, Any], a)  # y type is Dict[str, Any], but the value is the same from a
```

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/cbf94e295ab7a1eadd2426ca722e771bec20be5a/boa3_test/test_sc/dict_test/DictBoa2Test4.py#L20-L21
https://github.com/CityOfZion/neo3-boa/blob/cbf94e295ab7a1eadd2426ca722e771bec20be5a/boa3_test/test_sc/interop_test/binary/SerializationBoa2Test.py#L31-L35
https://github.com/CityOfZion/neo3-boa/blob/cbf94e295ab7a1eadd2426ca722e771bec20be5a/boa3_test/test_sc/typing_test/CastToStr.py#L6-L9

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/cbf94e295ab7a1eadd2426ca722e771bec20be5a/boa3_test/tests/compiler_tests/test_typing.py#L13-L120

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
