### PR TITLE
 Implement Runtime BurnGas Interop

### DIFF
--- a/boa3/builtin/interop/runtime/__init__.py
+++ b/boa3/builtin/interop/runtime/__init__.py
@@ -67,3 +67,14 @@ def get_notifications(script_hash: UInt160 = UInt160()) -> List[Notification]:
     :rtype: List[Notification]
     """
     pass
+
+
+def burn_gas(gas: int):
+    """
+    Burns GAS to benefit the NEO ecosystem.
+
+    :param gas: the amount of GAS that will be burned
+
+    :raise Exception: raised if gas value is negative.
+    """
+    pass

--- a/boa3/model/builtin/interop/interop.py
+++ b/boa3/model/builtin/interop/interop.py
@@ -97,6 +97,7 @@ class Interop:
 
     # Runtime Interops
     BlockTime = BlockTimeProperty()
+    BurnGas = BurnGasMethod()
     CallingScriptHash = CallingScriptHashProperty()
     CheckWitness = CheckWitnessMethod()
     EntryScriptHash = EntryScriptHashProperty()
@@ -154,6 +155,7 @@ class Interop:
                               JsonSerialize
                               ],
         InteropPackage.Runtime: [BlockTime,
+                                 BurnGas,
                                  CallingScriptHash,
                                  CheckWitness,
                                  EntryScriptHash,

--- a/boa3/model/builtin/interop/runtime/__init__.py
+++ b/boa3/model/builtin/interop/runtime/__init__.py
@@ -1,4 +1,5 @@
 __all__ = ['BlockTimeProperty',
+           'BurnGasMethod',
            'CallingScriptHashProperty',
            'CheckWitnessMethod',
            'EntryScriptHashProperty',
@@ -14,6 +15,7 @@ __all__ = ['BlockTimeProperty',
            'TriggerType',
            ]
 
+from boa3.model.builtin.interop.runtime.burngasmethod import BurnGasMethod
 from boa3.model.builtin.interop.runtime.checkwitnessmethod import CheckWitnessMethod
 from boa3.model.builtin.interop.runtime.getblocktimemethod import BlockTimeProperty
 from boa3.model.builtin.interop.runtime.getcallingscripthashmethod import CallingScriptHashProperty

--- a/boa3/model/builtin/interop/runtime/burngasmethod.py
+++ b/boa3/model/builtin/interop/runtime/burngasmethod.py
@@ -1,0 +1,14 @@
+from typing import Dict
+
+from boa3.model.builtin.interop.interopmethod import InteropMethod
+from boa3.model.variable import Variable
+
+
+class BurnGasMethod(InteropMethod):
+
+    def __init__(self):
+        from boa3.model.type.type import Type
+        identifier = 'burn_gas'
+        syscall = 'System.Runtime.BurnGas'
+        args: Dict[str, Variable] = {'gas': Variable(Type.int)}
+        super().__init__(identifier, syscall, args, return_type=Type.none)

--- a/boa3_test/test_sc/interop_test/runtime/BurnGas.py
+++ b/boa3_test/test_sc/interop_test/runtime/BurnGas.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.interop.runtime import burn_gas
+
+
+@public
+def main(gas: int):
+    burn_gas(gas)

--- a/boa3_test/tests/compiler_tests/test_interop/test_runtime.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_runtime.py
@@ -11,6 +11,7 @@ from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.String import String
 from boa3_test.tests.boa_test import BoaTest
 from boa3_test.tests.test_classes.testengine import TestEngine
+from boa3_test.tests.test_classes.TestExecutionException import TestExecutionException
 
 
 class TestRuntimeInterop(BoaTest):
@@ -521,6 +522,32 @@ class TestRuntimeInterop(BoaTest):
         path = self.get_contract_path('GetPlatformCantAssign.py')
         output = self.assertCompilerLogs(NameShadowing, path)
         self.assertEqual(expected_output, output)
+
+    def test_burn_gas(self):
+        path = self.get_contract_path('BurnGas.py')
+        engine = TestEngine()
+
+        burn_gas_cost = 2460    # 2460 * 10^-8 GAS
+
+        # can not burn negative GAS
+        with self.assertRaises(TestExecutionException):
+            self.run_smart_contract(engine, path, 'main', -10**8)
+        self.assertEqual(int(engine.gas_consumed) - burn_gas_cost, 0)
+
+        # can not burn no GAS
+        with self.assertRaises(TestExecutionException):
+            self.run_smart_contract(engine, path, 'main', 0)
+        self.assertEqual(int(engine.gas_consumed) - burn_gas_cost, 0)
+
+        burned_gas = 1 * 10**8  # 1 GAS
+        result = self.run_smart_contract(engine, path, 'main', burned_gas)
+        self.assertIsVoid(result)
+        self.assertEqual(int(engine.gas_consumed) - burn_gas_cost, burned_gas)
+
+        burned_gas = 123 * 10**5   # 0.123 GAS
+        result = self.run_smart_contract(engine, path, 'main', burned_gas)
+        self.assertIsVoid(result)
+        self.assertEqual(int(engine.gas_consumed) - burn_gas_cost, burned_gas)
 
     def test_boa2_runtime_test(self):
         path = self.get_contract_path('RuntimeBoa2Test.py')


### PR DESCRIPTION
**Related issue**
#438 

**How to Reproduce**
Call `burn_gas(gas: int)`.

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/4040286be71d61e1e4ddcf7415854362a82fa56c/boa3_test/tests/compiler_tests/test_interop/test_runtime.py#L526-L550

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8