### PR TITLE
Fix properties access after casting

### DIFF
--- a/boa3_test/test_sc/neo_type_test/CastTransactionGetHash.py
+++ b/boa3_test/test_sc/neo_type_test/CastTransactionGetHash.py
@@ -1,0 +1,10 @@
+from typing import Any, cast
+
+from boa3.builtin import public
+from boa3.builtin.interop.blockchain import Transaction
+
+
+@public
+def get_transaction_hash(value: Any) -> bytes:
+    tx = cast(Transaction, value)
+    return tx.hash

--- a/boa3_test/test_sc/neo_type_test/CastTransactionGetHashToVariable.py
+++ b/boa3_test/test_sc/neo_type_test/CastTransactionGetHashToVariable.py
@@ -1,0 +1,11 @@
+from typing import Any, cast
+
+from boa3.builtin import public
+from boa3.builtin.interop.blockchain import Transaction
+
+
+@public
+def get_transaction_hash(value: Any) -> bytes:
+    tx = cast(Transaction, value)
+    result = tx.hash
+    return result

--- a/boa3_test/test_sc/neo_type_test/ImplicitCastTransactionGetHash.py
+++ b/boa3_test/test_sc/neo_type_test/ImplicitCastTransactionGetHash.py
@@ -1,0 +1,10 @@
+from typing import Any, cast
+
+from boa3.builtin import public
+from boa3.builtin.interop.blockchain import Transaction
+
+
+@public
+def get_transaction_hash(value: Any) -> bytes:
+    tx: Transaction = value
+    return tx.hash

--- a/boa3_test/test_sc/typing_test/CastToTransaction.py
+++ b/boa3_test/test_sc/typing_test/CastToTransaction.py
@@ -1,0 +1,10 @@
+from typing import Any, cast
+
+from boa3.builtin import public
+from boa3.builtin.interop.blockchain import Transaction
+
+
+@public
+def Main(value: Any) -> Transaction:
+    x = cast(Transaction, value)
+    return x

--- a/boa3_test/test_sc/typing_test/CastToUInt160.py
+++ b/boa3_test/test_sc/typing_test/CastToUInt160.py
@@ -1,0 +1,10 @@
+from typing import Any, cast
+
+from boa3.builtin import public
+from boa3.builtin.type import UInt160
+
+
+@public
+def Main(value: Any) -> UInt160:
+    x = cast(UInt160, value)
+    return x

--- a/boa3_test/tests/compiler_tests/test_neo_types.py
+++ b/boa3_test/tests/compiler_tests/test_neo_types.py
@@ -1,4 +1,4 @@
-from boa3.exception.CompilerError import MismatchedTypes
+from boa3.exception import CompilerError, CompilerWarning
 from boa3.neo.vm.type.Integer import Integer
 from boa3_test.tests.boa_test import BoaTest
 from boa3_test.tests.test_classes.TestExecutionException import TestExecutionException
@@ -100,7 +100,7 @@ class TestNeoTypes(BoaTest):
 
     def test_uint160_mismatched_type(self):
         path = self.get_contract_path('UInt160CallMismatchedType.py')
-        self.assertCompilerLogs(MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_uint256_call_bytes(self):
         path = self.get_contract_path('UInt256CallBytes.py')
@@ -193,4 +193,16 @@ class TestNeoTypes(BoaTest):
 
     def test_uint256_mismatched_type(self):
         path = self.get_contract_path('UInt256CallMismatchedType.py')
-        self.assertCompilerLogs(MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+
+    def test_transaction_cast_and_get_hash(self):
+        path = self.get_contract_path('CastTransactionGetHash.py')
+        self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+
+    def test_transaction_implicit_cast_and_get_hash(self):
+        path = self.get_contract_path('ImplicitCastTransactionGetHash.py')
+        self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+
+    def test_transaction_cast_and_assign_hash_to_variable(self):
+        path = self.get_contract_path('CastTransactionGetHashToVariable.py')
+        self.assertCompilerLogs(CompilerWarning.TypeCasting, path)

--- a/boa3_test/tests/compiler_tests/test_typing.py
+++ b/boa3_test/tests/compiler_tests/test_typing.py
@@ -1,4 +1,3 @@
-from boa3.boa3 import Boa3
 from boa3.exception import CompilerError, CompilerWarning
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
@@ -118,3 +117,33 @@ class TestTyping(BoaTest):
     def test_cast_mismatched_type(self):
         path = self.get_contract_path('CastMismatchedType.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+
+    def test_cast_to_uint160(self):
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x01'
+            + b'\x01'
+            + Opcode.LDARG0     # x = cast(UInt160, value)
+            + Opcode.STLOC0
+            + Opcode.LDLOC0     # return x
+            + Opcode.RET
+        )
+
+        path = self.get_contract_path('CastToUInt160.py')
+        output = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+        self.assertEqual(expected_output, output)
+
+    def test_cast_to_transaction(self):
+        expected_output = (
+            Opcode.INITSLOT     # function signature
+            + b'\x01'
+            + b'\x01'
+            + Opcode.LDARG0     # x = cast(Transaction, value)
+            + Opcode.STLOC0
+            + Opcode.LDLOC0     # return x
+            + Opcode.RET
+        )
+
+        path = self.get_contract_path('CastToTransaction.py')
+        output = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+        self.assertEqual(expected_output, output)


### PR DESCRIPTION
**Related issue**
#428

**Summary or solution description**
Fixed casting to Neo types
```python
x = cast(Transaction, script_container)
y: Block = get_block(block_hash)
```

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/9b7453b696e31f647326d34b6a671342f8dc4004/boa3_test/test_sc/neo_type_test/ImplicitCastTransactionGetHash.py#L1-L10

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/9b7453b696e31f647326d34b6a671342f8dc4004/boa3_test/tests/compiler_tests/test_neo_types.py#L198-L208

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
