### PR TITLE
Update debug info file generation

### DIFF
--- a/boa3/compiler/filegenerator.py
+++ b/boa3/compiler/filegenerator.py
@@ -8,6 +8,7 @@ from boa3.model.event import Event
 from boa3.model.importsymbol import Import
 from boa3.model.method import Method
 from boa3.model.symbol import ISymbol
+from boa3.model.variable import Variable
 from boa3.neo import to_hex_str
 from boa3.neo.contracts.neffile import NefFile
 
@@ -33,6 +34,16 @@ class FileGenerator:
         :return: a dictionary that maps each public method with its identifier
         """
         return {name: method for name, method in self._methods.items() if method.is_public}
+
+    @property
+    def _static_variables(self) -> Dict[str, Variable]:
+        """
+        Gets a sublist of the symbols containing all global variables
+
+        :return: a dictionary that maps each global variable with its identifier
+        """
+        return {name: variable for name, variable in self._symbols.items()
+                if isinstance(variable, Variable)}
 
     @property
     def _methods(self) -> Dict[str, Method]:
@@ -190,6 +201,7 @@ class FileGenerator:
         return {
             "hash": self._nef_hash,
             "documents": self._files,
+            "static-variables": self._get_debug_static_variables(),
             "methods": self._get_debug_methods(),
             "events": self._get_debug_events()
         }
@@ -260,6 +272,19 @@ class FileGenerator:
                     '{0},{1}'.format(name, var.type.abi_type) for name, var in event.args.items()
                 ]
             } for event_id, event in self._events.items()
+        ]
+
+    def _get_debug_static_variables(self) -> List[str]:
+        """
+        Gets the static variables' debug information in a dictionary format
+
+        :return: a dictionary with the event's debug information
+        """
+        from boa3.model.type.itype import IType
+        from boa3.neo.vm.type.AbiType import AbiType
+        return [
+            '{0},{1}'.format(name, var.type.abi_type if isinstance(var.type, IType) else AbiType.Any)
+            for name, var in self._static_variables.items()
         ]
 
     # endregion

--- a/boa3_test/test_sc/generation_test/GenerationWithStaticVariables.py
+++ b/boa3_test/test_sc/generation_test/GenerationWithStaticVariables.py
@@ -1,0 +1,15 @@
+from boa3.builtin import public
+
+
+var1 = 42
+var2 = '42'
+
+
+@public
+def Add(a: int, b: int) -> int:
+    return a + b
+
+
+@public
+def Sub(a: int, b: int) -> int:
+    return a - b

--- a/boa3_test/tests/compiler_tests/test_file_generation.py
+++ b/boa3_test/tests/compiler_tests/test_file_generation.py
@@ -8,6 +8,7 @@ from boa3.constants import BYTEORDER, ENCODING
 from boa3.exception.NotLoadedException import NotLoadedException
 from boa3.model.event import Event
 from boa3.model.method import Method
+from boa3.model.variable import Variable
 from boa3.neo.contracts.neffile import NefFile
 from boa3.neo.vm.type.AbiType import AbiType
 from boa3_test.tests.boa_test import BoaTest
@@ -280,6 +281,32 @@ class TestFileGeneration(BoaTest):
                 param_id, param_type = var.split(',')
                 self.assertIn(param_id, actual_event.args)
                 self.assertEqual(param_type, actual_event.args[param_id].type.abi_type)
+
+    def test_generate_nefdbgnfo_file_with_static_variables(self):
+        path = self.get_contract_path('GenerationWithStaticVariables.py')
+
+        expected_nef_output = path.replace('.py', '.nefdbgnfo')
+        compiler = Compiler()
+        compiler.compile_and_save(path, path.replace('.py', '.nef'))
+        variables: Dict[str, Method] = {
+            name: method
+            for name, method in self.get_compiler_analyser(compiler).symbol_table.items()
+            if isinstance(method, Variable)
+        }
+
+        self.assertTrue(os.path.exists(expected_nef_output))
+        debug_info = self.get_debug_info(path)
+
+        self.assertNotIn('entrypoint', debug_info)
+        self.assertIn('static-variables', debug_info)
+        self.assertGreater(len(debug_info['static-variables']), 0)
+
+        for static_variable in debug_info['static-variables']:
+            # validate parameters
+            self.assertEqual(2, len(static_variable.split(',')))
+            param_id, param_type = static_variable.split(',')
+            self.assertIn(param_id, variables)
+            self.assertEqual(param_type, variables[param_id].type.abi_type)
 
     def test_generate_manifest_file_with_notify_event(self):
         path = self.get_contract_path('test_sc/interop_test/runtime', 'NotifySequence.py')


### PR DESCRIPTION
**Related issue**
#433

**Summary or solution description**
Included the field `'static-variables'` in the `.nefdbgnfo` file generation to be compatible with [Neo Debug Info v1.2 format](https://github.com/ngdenterprise/design-notes/blob/master/NDX-DN11%20-%20NEO%20Debug%20Info%20Specification.md#v12-format-draft)

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/32c2ee86adbdc5c00e20bc8ec15bedd65dbc51f9/boa3_test/tests/compiler_tests/test_file_generation.py#L285-L310

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
