### PR TITLE
Implement Transaction Interops

### DIFF
--- a/boa3/builtin/interop/blockchain/__init__.py
+++ b/boa3/builtin/interop/blockchain/__init__.py
@@ -31,3 +31,38 @@ def get_block(index_or_hash: Union[int, UInt256]) -> Block:
     :rtype: Block or None
     """
     pass
+
+
+def get_transaction(hash_: UInt256) -> Transaction:
+    """
+    Gets a transaction with the given hash
+
+    :param hash_: hash identifier of the transaction
+    :type hash_: UInt256
+    :return: the Transaction, if exists. None otherwise
+    """
+    pass
+
+
+def get_transaction_from_block(block_hash_or_height: Union[UInt256, int], tx_index: int) -> Transaction:
+    """
+    Gets a transaction from a block
+
+    :param block_hash_or_height: a block identifier
+    :type block_hash_or_height: UInt256 or int
+    :param tx_index: the transaction identifier in the block
+    :type tx_index: int
+    :return: the Transaction, if exists. None otherwise
+    """
+    pass
+
+
+def get_transaction_height(hash_: UInt256) -> int:
+    """
+    Gets the height of a transaction
+
+    :param hash_: hash identifier of the transaction
+    :type hash_: UInt256
+    :return: height of the transaction
+    """
+    pass

--- a/boa3/model/builtin/interop/blockchain/__init__.py
+++ b/boa3/model/builtin/interop/blockchain/__init__.py
@@ -2,6 +2,9 @@ __all__ = ['BlockType',
            'CurrentHeightProperty',
            'GetBlockMethod',
            'GetContractMethod',
+           'GetTransactionMethod',
+           'GetTransactionFromBlockMethod',
+           'GetTransactionHeightMethod',
            'TransactionType'
            ]
 
@@ -9,4 +12,7 @@ from boa3.model.builtin.interop.blockchain.blocktype import BlockType
 from boa3.model.builtin.interop.blockchain.getblockmethod import GetBlockMethod
 from boa3.model.builtin.interop.blockchain.getcontractmethod import GetContractMethod
 from boa3.model.builtin.interop.blockchain.getcurrentheightmethod import CurrentHeightProperty
+from boa3.model.builtin.interop.blockchain.gettransactionmethod import GetTransactionMethod
+from boa3.model.builtin.interop.blockchain.gettransactionfromblockmethod import GetTransactionFromBlockMethod
+from boa3.model.builtin.interop.blockchain.gettransactionheightmethod import GetTransactionHeightMethod
 from boa3.model.builtin.interop.blockchain.transactiontype import TransactionType

--- a/boa3/model/builtin/interop/blockchain/gettransactionfromblockmethod.py
+++ b/boa3/model/builtin/interop/blockchain/gettransactionfromblockmethod.py
@@ -1,0 +1,19 @@
+from typing import Dict
+
+from boa3.model.builtin.interop.blockchain.transactiontype import TransactionType
+from boa3.model.builtin.interop.nativecontract import LedgerMethod
+from boa3.model.variable import Variable
+
+
+class GetTransactionFromBlockMethod(LedgerMethod):
+
+    def __init__(self, transaction_type: TransactionType):
+        from boa3.model.type.collection.sequence.uint256type import UInt256Type
+        from boa3.model.type.type import Type
+
+        identifier = 'get_transaction_from_block'
+        syscall = 'getTransactionFromBlock'
+        args: Dict[str, Variable] = {'block_hash_or_height': Variable(Type.union.build([UInt256Type.build(),
+                                                                                        Type.int])),
+                                     'tx_index': Variable(Type.int)}
+        super().__init__(identifier, syscall, args, return_type=transaction_type)

--- a/boa3/model/builtin/interop/blockchain/gettransactionheightmethod.py
+++ b/boa3/model/builtin/interop/blockchain/gettransactionheightmethod.py
@@ -1,0 +1,17 @@
+from typing import Dict
+
+from boa3.model.builtin.interop.blockchain.transactiontype import TransactionType
+from boa3.model.builtin.interop.nativecontract import LedgerMethod
+from boa3.model.variable import Variable
+
+
+class GetTransactionHeightMethod(LedgerMethod):
+
+    def __init__(self):
+        from boa3.model.type.collection.sequence.uint256type import UInt256Type
+        from boa3.model.type.type import Type
+
+        identifier = 'get_transaction_height'
+        syscall = 'getTransactionHeight'
+        args: Dict[str, Variable] = {'hash_': Variable(UInt256Type.build())}
+        super().__init__(identifier, syscall, args, return_type=Type.int)

--- a/boa3/model/builtin/interop/blockchain/gettransactionmethod.py
+++ b/boa3/model/builtin/interop/blockchain/gettransactionmethod.py
@@ -1,0 +1,16 @@
+from typing import Dict
+
+from boa3.model.builtin.interop.blockchain.transactiontype import TransactionType
+from boa3.model.builtin.interop.nativecontract import LedgerMethod
+from boa3.model.variable import Variable
+
+
+class GetTransactionMethod(LedgerMethod):
+
+    def __init__(self, transaction_type: TransactionType):
+        from boa3.model.type.collection.sequence.uint256type import UInt256Type
+
+        identifier = 'get_transaction'
+        syscall = 'getTransaction'
+        args: Dict[str, Variable] = {'hash_': Variable(UInt256Type.build())}
+        super().__init__(identifier, syscall, args, return_type=transaction_type)

--- a/boa3/model/builtin/interop/interop.py
+++ b/boa3/model/builtin/interop/interop.py
@@ -63,6 +63,9 @@ class Interop:
     CurrentHeight = CurrentHeightProperty()
     GetContract = GetContractMethod(ContractType)
     GetBlock = GetBlockMethod(BlockType)
+    GetTransaction = GetTransactionMethod(TransactionType)
+    GetTransactionFromBlock = GetTransactionFromBlockMethod(TransactionType)
+    GetTransactionHeight = GetTransactionHeightMethod()
 
     # Contract Interops
     CallContract = CallMethod()
@@ -133,6 +136,9 @@ class Interop:
                                     CurrentHeight,
                                     GetBlock,
                                     GetContract,
+                                    GetTransaction,
+                                    GetTransactionFromBlock,
+                                    GetTransactionHeight,
                                     TransactionType
                                     ],
         InteropPackage.Contract: [CallContract,

--- a/boa3_test/test_sc/interop_test/blockchain/GetTransaction.py
+++ b/boa3_test/test_sc/interop_test/blockchain/GetTransaction.py
@@ -1,0 +1,8 @@
+from boa3.builtin import public
+from boa3.builtin.interop.blockchain import get_transaction, Transaction
+from boa3.builtin.type import UInt256
+
+
+@public
+def main(hash_: UInt256) -> Transaction:
+    return get_transaction(hash_)

--- a/boa3_test/test_sc/interop_test/blockchain/GetTransactionFromBlockInt.py
+++ b/boa3_test/test_sc/interop_test/blockchain/GetTransactionFromBlockInt.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.interop.blockchain import get_transaction_from_block, Transaction
+
+
+@public
+def main(height: int, tx_index: int) -> Transaction:
+    return get_transaction_from_block(height, tx_index)

--- a/boa3_test/test_sc/interop_test/blockchain/GetTransactionFromBlockUInt256.py
+++ b/boa3_test/test_sc/interop_test/blockchain/GetTransactionFromBlockUInt256.py
@@ -1,0 +1,8 @@
+from boa3.builtin import public
+from boa3.builtin.interop.blockchain import get_transaction_from_block, Transaction
+from boa3.builtin.type import UInt256
+
+
+@public
+def main(hash_: UInt256, tx_index: int) -> Transaction:
+    return get_transaction_from_block(hash_, tx_index)

--- a/boa3_test/test_sc/interop_test/blockchain/GetTransactionHeight.py
+++ b/boa3_test/test_sc/interop_test/blockchain/GetTransactionHeight.py
@@ -1,0 +1,8 @@
+from boa3.builtin import public
+from boa3.builtin.interop.blockchain import get_transaction_height
+from boa3.builtin.type import UInt256
+
+
+@public
+def main(hash_: UInt256) -> int:
+    return get_transaction_height(hash_)

--- a/boa3_test/tests/compiler_tests/test_interop/test_blockchain.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_blockchain.py
@@ -1,8 +1,12 @@
 from boa3.boa3 import Boa3
+from boa3.constants import LEDGER_SCRIPT
 from boa3.exception.CompilerError import MismatchedTypes
 from boa3.model.builtin.interop.interop import Interop
 from boa3.neo.cryptography import hash160
 from boa3.neo.vm.opcode.Opcode import Opcode
+from boa3.neo.vm.type.Integer import Integer
+from boa3.neo.vm.type.String import String
+from boa3.neo3.contracts import CallFlags
 from boa3_test.tests.boa_test import BoaTest
 from boa3_test.tests.test_classes.contract.neomanifeststruct import NeoManifestStruct
 from boa3_test.tests.test_classes.testengine import TestEngine
@@ -125,3 +129,140 @@ class TestBlockchainInterop(BoaTest):
         if isinstance(result[7], str):
             result[7] = String(result[7]).to_bytes()
         self.assertEqual(b'', result[7])   # script
+
+    def test_get_transaction(self):
+        call_flags = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
+        method = String('getTransaction').to_bytes()
+
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x00\x01'
+            + Opcode.LDARG0
+            + Opcode.PUSH1
+            + Opcode.PACK
+            + Opcode.PUSHDATA1
+            + Integer(len(call_flags)).to_byte_array()
+            + call_flags
+            + Opcode.PUSHDATA1
+            + Integer(len(method)).to_byte_array()
+            + method
+            + Opcode.PUSHDATA1
+            + Integer(len(LEDGER_SCRIPT)).to_byte_array()
+            + LEDGER_SCRIPT
+            + Opcode.SYSCALL
+            + Interop.CallContract.interop_method_hash
+            + Opcode.RET
+        )
+        path = self.get_contract_path('GetTransaction.py')
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+        engine = TestEngine()
+        # TODO: finish this example when transaction gets added to the storage
+
+    def test_get_transaction_from_block_int(self):
+        call_flags = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
+        method = String('getTransactionFromBlock').to_bytes()
+
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x00\x02'
+            + Opcode.LDARG1
+            + Opcode.LDARG0
+            + Opcode.PUSH2
+            + Opcode.PACK
+            + Opcode.PUSHDATA1
+            + Integer(len(call_flags)).to_byte_array()
+            + call_flags
+            + Opcode.PUSHDATA1
+            + Integer(len(method)).to_byte_array()
+            + method
+            + Opcode.PUSHDATA1
+            + Integer(len(LEDGER_SCRIPT)).to_byte_array()
+            + LEDGER_SCRIPT
+            + Opcode.SYSCALL
+            + Interop.CallContract.interop_method_hash
+            + Opcode.RET
+        )
+        path = self.get_contract_path('GetTransactionFromBlockInt.py')
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+        path_burn_gas = self.get_contract_path('../runtime', 'BurnGas.py')
+        engine = TestEngine()
+
+        engine.increase_block(10)
+
+        self.run_smart_contract(engine, path_burn_gas, 'main', 100)
+
+        block_10 = engine.current_block
+        txs = block_10.get_transactions()
+        hash_ = txs[0]._hash.to_array()
+
+        engine.increase_block()
+
+        result = self.run_smart_contract(engine, path, 'main', 10, 0)
+        self.assertIsNotNone(result)
+        # TODO: finish this example when transaction gets added to the storage
+
+    def test_get_transaction_from_block_uint256(self):
+        call_flags = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
+        method = String('getTransactionFromBlock').to_bytes()
+
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x00\x02'
+            + Opcode.LDARG1
+            + Opcode.LDARG0
+            + Opcode.PUSH2
+            + Opcode.PACK
+            + Opcode.PUSHDATA1
+            + Integer(len(call_flags)).to_byte_array()
+            + call_flags
+            + Opcode.PUSHDATA1
+            + Integer(len(method)).to_byte_array()
+            + method
+            + Opcode.PUSHDATA1
+            + Integer(len(LEDGER_SCRIPT)).to_byte_array()
+            + LEDGER_SCRIPT
+            + Opcode.SYSCALL
+            + Interop.CallContract.interop_method_hash
+            + Opcode.RET
+        )
+        path = self.get_contract_path('GetTransactionFromBlockUInt256.py')
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+        engine = TestEngine()
+        # TODO: finish this example when transaction gets added to the storage
+
+    def test_get_transaction_height(self):
+        call_flags = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
+        method = String('getTransactionHeight').to_bytes()
+
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x00\x01'
+            + Opcode.LDARG0
+            + Opcode.PUSH1
+            + Opcode.PACK
+            + Opcode.PUSHDATA1
+            + Integer(len(call_flags)).to_byte_array()
+            + call_flags
+            + Opcode.PUSHDATA1
+            + Integer(len(method)).to_byte_array()
+            + method
+            + Opcode.PUSHDATA1
+            + Integer(len(LEDGER_SCRIPT)).to_byte_array()
+            + LEDGER_SCRIPT
+            + Opcode.SYSCALL
+            + Interop.CallContract.interop_method_hash
+            + Opcode.RET
+        )
+        path = self.get_contract_path('GetTransactionHeight.py')
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+        path = self.get_contract_path('GetTransactionHeight.py')
+        engine = TestEngine()
+        # TODO: finish this example when transaction gets added to the storage


### PR DESCRIPTION
**Related issue**
#288 

**Summary or solution description**
Implemented `get_transaction()`, `get_transaction_from_block()` and `get_transaction_height()`.

**Tests**
Tested it verifying the Opcodes.

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8

**(Optional) Additional context**
The tests aren't finished right now, because there was a problem with the transactions and storage.
