### PR TITLE
Fixed logic for changing small jumps to large jumps

### DIFF
--- a/boa3/model/builtin/interop/blockchain/__init__.py
+++ b/boa3/model/builtin/interop/blockchain/__init__.py
@@ -12,7 +12,7 @@ from boa3.model.builtin.interop.blockchain.blocktype import BlockType
 from boa3.model.builtin.interop.blockchain.getblockmethod import GetBlockMethod
 from boa3.model.builtin.interop.blockchain.getcontractmethod import GetContractMethod
 from boa3.model.builtin.interop.blockchain.getcurrentheightmethod import CurrentHeightProperty
-from boa3.model.builtin.interop.blockchain.gettransactionmethod import GetTransactionMethod
 from boa3.model.builtin.interop.blockchain.gettransactionfromblockmethod import GetTransactionFromBlockMethod
 from boa3.model.builtin.interop.blockchain.gettransactionheightmethod import GetTransactionHeightMethod
+from boa3.model.builtin.interop.blockchain.gettransactionmethod import GetTransactionMethod
 from boa3.model.builtin.interop.blockchain.transactiontype import TransactionType

--- a/boa3/model/builtin/interop/blockchain/gettransactionheightmethod.py
+++ b/boa3/model/builtin/interop/blockchain/gettransactionheightmethod.py
@@ -1,6 +1,5 @@
 from typing import Dict
 
-from boa3.model.builtin.interop.blockchain.transactiontype import TransactionType
 from boa3.model.builtin.interop.nativecontract import LedgerMethod
 from boa3.model.variable import Variable
 

--- a/boa3/model/builtin/interop/runtime/__init__.py
+++ b/boa3/model/builtin/interop/runtime/__init__.py
@@ -26,9 +26,9 @@ from boa3.model.builtin.interop.runtime.getgasleftmethod import GasLeftProperty
 from boa3.model.builtin.interop.runtime.getinvocationcountermethod import InvocationCounterProperty
 from boa3.model.builtin.interop.runtime.getnotificationsmethod import GetNotificationsMethod
 from boa3.model.builtin.interop.runtime.getplatformmethod import PlatformProperty
-from boa3.model.builtin.interop.runtime.scriptcontainermethod import ScriptContainerProperty
 from boa3.model.builtin.interop.runtime.gettriggermethod import GetTriggerMethod
 from boa3.model.builtin.interop.runtime.logmethod import LogMethod
 from boa3.model.builtin.interop.runtime.notificationtype import NotificationType
 from boa3.model.builtin.interop.runtime.notifymethod import NotifyMethod
+from boa3.model.builtin.interop.runtime.scriptcontainermethod import ScriptContainerProperty
 from boa3.model.builtin.interop.runtime.triggertype import TriggerType

--- a/boa3/model/type/typeutils.py
+++ b/boa3/model/type/typeutils.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Dict
 
 from boa3.model.callable import Callable
 from boa3.model.type.annotation.metatype import metaType

--- a/boa3/neo/vm/VMCode.py
+++ b/boa3/neo/vm/VMCode.py
@@ -66,6 +66,9 @@ class VMCode:
             self_start = code_mapping.get_start_address(self)
             target_start = code_mapping.get_start_address(self.target)
 
+            if self_start == target_start:
+                return self._data
+
             return (Integer(target_start - self_start)
                     .to_byte_array(signed=True, min_length=self._info.data_len))
 

--- a/boa3_test/test_sc/if_test/IfWithInnerFor.py
+++ b/boa3_test/test_sc/if_test/IfWithInnerFor.py
@@ -1,0 +1,28 @@
+from boa3.builtin import public
+
+
+@public
+def Main(condition: bool) -> str:
+    result = "{["
+    if condition:
+        result = result + "]}"
+    else:
+        some_string = "value1|value2|value3"
+        count = 0
+        id_destiny = ""
+
+        for c in some_string:
+            if c.to_bytes().to_str() != "|":
+                id_destiny = id_destiny + c
+            else:
+                if count > 0:
+                    result = result + ","
+                result = result + id_destiny
+                id_destiny = ""
+                count = count + 1
+        if count > 0:
+            result = result + ","
+        result = result + id_destiny
+        result = result + "]}"
+
+    return result

--- a/boa3_test/test_sc/if_test/IfWithInnerWhile.py
+++ b/boa3_test/test_sc/if_test/IfWithInnerWhile.py
@@ -1,0 +1,31 @@
+from boa3.builtin import public
+
+
+@public
+def Main(condition: bool) -> str:
+    result = "{["
+    if condition:
+        result = result + "]}"
+    else:
+        some_string = "value1|value2|value3"
+        index = 0
+        count = 0
+        id_destiny = ""
+
+        while index < len(some_string):
+            c = some_string[index:index + 1]
+            if c.to_bytes().to_str() != "|":
+                id_destiny = id_destiny + c
+            else:
+                if count > 0:
+                    result = result + ","
+                result = result + id_destiny
+                id_destiny = ""
+                count = count + 1
+            index = index + 1
+        if count > 0:
+            result = result + ","
+        result = result + id_destiny
+        result = result + "]}"
+
+    return result

--- a/boa3_test/test_sc/interop_test/blockchain/GetTransaction.py
+++ b/boa3_test/test_sc/interop_test/blockchain/GetTransaction.py
@@ -1,5 +1,5 @@
 from boa3.builtin import public
-from boa3.builtin.interop.blockchain import get_transaction, Transaction
+from boa3.builtin.interop.blockchain import Transaction, get_transaction
 from boa3.builtin.type import UInt256
 
 

--- a/boa3_test/test_sc/interop_test/blockchain/GetTransactionFromBlockInt.py
+++ b/boa3_test/test_sc/interop_test/blockchain/GetTransactionFromBlockInt.py
@@ -1,5 +1,5 @@
 from boa3.builtin import public
-from boa3.builtin.interop.blockchain import get_transaction_from_block, Transaction
+from boa3.builtin.interop.blockchain import Transaction, get_transaction_from_block
 
 
 @public

--- a/boa3_test/test_sc/interop_test/blockchain/GetTransactionFromBlockUInt256.py
+++ b/boa3_test/test_sc/interop_test/blockchain/GetTransactionFromBlockUInt256.py
@@ -1,5 +1,5 @@
 from boa3.builtin import public
-from boa3.builtin.interop.blockchain import get_transaction_from_block, Transaction
+from boa3.builtin.interop.blockchain import Transaction, get_transaction_from_block
 from boa3.builtin.type import UInt256
 
 

--- a/boa3_test/test_sc/neo_type_test/ImplicitCastTransactionGetHash.py
+++ b/boa3_test/test_sc/neo_type_test/ImplicitCastTransactionGetHash.py
@@ -1,4 +1,4 @@
-from typing import Any, cast
+from typing import Any
 
 from boa3.builtin import public
 from boa3.builtin.interop.blockchain import Transaction

--- a/boa3_test/test_sc/typing_test/CastMismatchedType.py
+++ b/boa3_test/test_sc/typing_test/CastMismatchedType.py
@@ -1,7 +1,5 @@
 from typing import Any, cast
 
-from boa3.builtin import public
-
 
 def Main(value: Any) -> int:
     x = cast(4, value)

--- a/boa3_test/tests/compiler_tests/test_if.py
+++ b/boa3_test/tests/compiler_tests/test_if.py
@@ -583,3 +583,23 @@ class TestIf(BoaTest):
 
         result = self.run_smart_contract(engine, path, 'main', 22)
         self.assertEqual(-1, result)
+
+    def test_if_with_inner_while(self):
+        path = self.get_contract_path('IfWithInnerWhile.py')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'Main', True)
+        self.assertEqual('{[]}', result)
+
+        result = self.run_smart_contract(engine, path, 'Main', False)
+        self.assertEqual('{[value1,value2,value3]}', result)
+
+    def test_if_with_inner_for(self):
+        path = self.get_contract_path('IfWithInnerFor.py')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'Main', True)
+        self.assertEqual('{[]}', result)
+
+        result = self.run_smart_contract(engine, path, 'Main', False)
+        self.assertEqual('{[value1,value2,value3]}', result)

--- a/boa3_test/tests/compiler_tests/test_interop/test_runtime.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_runtime.py
@@ -10,8 +10,8 @@ from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.String import String
 from boa3_test.tests.boa_test import BoaTest
-from boa3_test.tests.test_classes.testengine import TestEngine
 from boa3_test.tests.test_classes.TestExecutionException import TestExecutionException
+from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestRuntimeInterop(BoaTest):

--- a/boa3_test/tests/examples_tests/test_amm.py
+++ b/boa3_test/tests/examples_tests/test_amm.py
@@ -1,5 +1,5 @@
 from boa3.boa3 import Boa3
-from boa3.constants import NEO_SCRIPT, GAS_SCRIPT
+from boa3.constants import GAS_SCRIPT, NEO_SCRIPT
 from boa3.neo import to_script_hash
 from boa3.neo.cryptography import hash160
 from boa3.neo.vm.type.String import String

--- a/boa3_test/tests/examples_tests/test_nep5.py
+++ b/boa3_test/tests/examples_tests/test_nep5.py
@@ -1,5 +1,3 @@
-import unittest
-
 from boa3.boa3 import Boa3
 from boa3.neo import to_script_hash
 from boa3.neo.vm.type.String import String


### PR DESCRIPTION
**Related issue**
#454 

**Summary or solution description**
Fixed the evaluation for changing jump instructions to their larger equivalents.
In #454 the problem was that the compiler was marking the `else` jump to itself.
In the end, the generated .nef didn't have the jump and it was executing the instructions of both `if` and `else` when it should execute `if`'s only

**How to Reproduce**
Use a control flow statement with sufficient instructions to change its JMP assembly instruction to the larger JMP_L equivalent
Fo example: the outer else in this code:
https://github.com/CityOfZion/neo3-boa/blob/adc30a15de93958fc967a0a7eb6a351eb2126ac4/boa3_test/test_sc/if_test/IfWithInnerWhile.py#L5-L31

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/adc30a15de93958fc967a0a7eb6a351eb2126ac4/boa3_test/tests/compiler_tests/test_if.py#L587-L605

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
