### PR TITLE
Fix concat optimization changing order

### DIFF
--- a/boa3/analyser/astoptimizer.py
+++ b/boa3/analyser/astoptimizer.py
@@ -147,19 +147,25 @@ class AstOptimizer(IAstAnalyser, ast.NodeTransformer):
         except ValueError:
             return bin_op
 
-    def is_symmetric_operation(self, first_op: Union[ast.operator, BinaryOperation],
-                               second_op: Union[ast.operator, BinaryOperation]) -> bool:
-        operator = Operation.get_operation(first_op)
-        second_operator = Operation.get_operation(second_op)
-
-        if operator != second_operator:
+    def is_symmetric_operation(self, first_op: BinaryOperation, second_op: BinaryOperation) -> bool:
+        if not isinstance(first_op, BinaryOperation) or not isinstance(second_op, BinaryOperation):
             return False
 
-        return operator.is_symmetric
+        operation = type(first_op)
+        second_operation = type(second_op)
+
+        if operation != second_operation:
+            return False
+
+        return first_op.is_symmetric
 
     def reorder_operations(self, outer_bin_op: ast.BinOp, inner_bin_op: ast.BinOp) -> Tuple[Any, Any]:
         inner_first_value = self.literal_eval(inner_bin_op.left)
         inner_second_value = self.literal_eval(inner_bin_op.right)
+
+        if (not (isinstance(outer_bin_op.op, BinaryOperation) and outer_bin_op.op.is_symmetric)
+                or not (isinstance(outer_bin_op.op, BinaryOperation) and outer_bin_op.op.is_symmetric)):
+            return inner_first_value, inner_second_value
 
         is_left_operand: bool = inner_bin_op is outer_bin_op.left
         other_value = self.literal_eval(outer_bin_op.right if is_left_operand else outer_bin_op.left)

--- a/boa3/analyser/optimizer/Operation.py
+++ b/boa3/analyser/optimizer/Operation.py
@@ -9,13 +9,9 @@ from boa3.model.operation.operator import Operator
 
 
 class Operation(Enum):
-    def __init__(self, value: Any, symmetric: bool = False):
-        self._value_ = value
-        self._symmetric: bool = symmetric
-
-    Add = auto(), True
+    Add = auto()
     Sub = auto()
-    Mult = auto(), True
+    Mult = auto()
     Div = auto()
     FloorDiv = auto()
     Mod = auto()

--- a/boa3/model/operation/binary/arithmetic/addition.py
+++ b/boa3/model/operation/binary/arithmetic/addition.py
@@ -21,6 +21,10 @@ class Addition(BinaryOperation):
         self.operator: Operator = Operator.Plus
         super().__init__(left, right)
 
+    @property
+    def is_symmetric(self) -> bool:
+        return True
+
     def validate_type(self, *types: IType) -> bool:
         if len(types) != self.number_of_operands:
             return False

--- a/boa3/model/operation/binary/arithmetic/multiplication.py
+++ b/boa3/model/operation/binary/arithmetic/multiplication.py
@@ -21,6 +21,10 @@ class Multiplication(BinaryOperation):
         self.operator: Operator = Operator.Mult
         super().__init__(left, right)
 
+    @property
+    def is_symmetric(self) -> bool:
+        return True
+
     def validate_type(self, *types: IType) -> bool:
         if len(types) != self.number_of_operands:
             return False

--- a/boa3/model/operation/binary/binaryoperation.py
+++ b/boa3/model/operation/binary/binaryoperation.py
@@ -31,6 +31,10 @@ class BinaryOperation(IOperation, ABC):
     def number_of_operands(self) -> int:
         return 2
 
+    @property
+    def is_symmetric(self) -> bool:
+        return False
+
     @abstractmethod
     def _get_result(self, left: IType, right: IType) -> IType:
         """

--- a/boa3_test/test_sc/arithmetic_test/ConcatBytesVariablesAndConstants.py
+++ b/boa3_test/test_sc/arithmetic_test/ConcatBytesVariablesAndConstants.py
@@ -8,6 +8,18 @@ VALUE3 = b'value3'
 
 
 @public
-def concat() -> bytes:
-    current_time = get_time.to_bytes()
+def concat1() -> bytes:
+    current_time = get_time.to_bytes() + b'some_bytes_after'
     return VALUE1 + b'  ' + VALUE2 + b'  ' + VALUE3 + b'  ' + current_time
+
+
+@public
+def concat2() -> bytes:
+    current_time = get_time.to_bytes() + b'some_bytes_after'
+    return VALUE1 + VALUE2 + VALUE3 + current_time
+
+
+@public
+def concat3() -> bytes:
+    current_time = get_time.to_bytes() + b'some_bytes_after'
+    return VALUE1 + b'__' + VALUE2 + b'__' + VALUE3 + b'__' + current_time

--- a/boa3_test/test_sc/arithmetic_test/ConcatBytesVariablesAndConstants.py
+++ b/boa3_test/test_sc/arithmetic_test/ConcatBytesVariablesAndConstants.py
@@ -1,0 +1,13 @@
+from boa3.builtin import public
+from boa3.builtin.interop.runtime import get_time
+
+
+VALUE1 = b'value1'
+VALUE2 = b'value2'
+VALUE3 = b'value3'
+
+
+@public
+def concat() -> bytes:
+    current_time = get_time.to_bytes()
+    return VALUE1 + b'  ' + VALUE2 + b'  ' + VALUE3 + b'  ' + current_time

--- a/boa3_test/test_sc/arithmetic_test/ConcatStringVariablesAndConstants.py
+++ b/boa3_test/test_sc/arithmetic_test/ConcatStringVariablesAndConstants.py
@@ -1,0 +1,9 @@
+from boa3.builtin import public
+
+
+@public
+def concat() -> str:
+    a = '1,2,3'
+    b = a[:-2]
+    c = '[' + b + ']'
+    return c

--- a/boa3_test/tests/compiler_tests/test_arithmetic.py
+++ b/boa3_test/tests/compiler_tests/test_arithmetic.py
@@ -265,9 +265,17 @@ class TestArithmetic(BoaTest):
 
         engine = TestEngine()
         engine.increase_block()  # increase to get consistent block_time between execution and engine
-        result = self.run_smart_contract(engine, path, 'concat')
+        result = self.run_smart_contract(engine, path, 'concat1')
         current_time = Integer(engine.current_block.timestamp).to_byte_array()
-        self.assertEqual(b'value1  value2  value3  ' + current_time, result)
+        self.assertEqual(b'value1  value2  value3  ' + current_time + b'some_bytes_after', result)
+
+        result = self.run_smart_contract(engine, path, 'concat2')
+        current_time = Integer(engine.current_block.timestamp).to_byte_array()
+        self.assertEqual(b'value1value2value3' + current_time + b'some_bytes_after', result)
+
+        result = self.run_smart_contract(engine, path, 'concat3')
+        current_time = Integer(engine.current_block.timestamp).to_byte_array()
+        self.assertEqual(b'value1__value2__value3__' + current_time + b'some_bytes_after', result)
 
     def test_concat_string_variables_and_constants(self):
         path = self.get_contract_path('ConcatStringVariablesAndConstants.py')

--- a/boa3_test/tests/compiler_tests/test_arithmetic.py
+++ b/boa3_test/tests/compiler_tests/test_arithmetic.py
@@ -3,6 +3,7 @@ from boa3.exception.CompilerError import MismatchedTypes, NotSupportedOperation
 from boa3.model.operation.binaryop import BinaryOp
 from boa3.model.type.type import Type
 from boa3.neo.vm.opcode.Opcode import Opcode
+from boa3.neo.vm.type.Integer import Integer
 from boa3_test.tests.boa_test import BoaTest
 from boa3_test.tests.test_classes.TestExecutionException import TestExecutionException
 from boa3_test.tests.test_classes.testengine import TestEngine
@@ -258,6 +259,22 @@ class TestArithmetic(BoaTest):
         self.assertEqual('ab', result)
         result = self.run_smart_contract(engine, path, 'concat', 'unit', 'test')
         self.assertEqual('unittest', result)
+
+    def test_concat_bytes_variables_and_constants(self):
+        path = self.get_contract_path('ConcatBytesVariablesAndConstants.py')
+
+        engine = TestEngine()
+        engine.increase_block()  # increase to get consistent block_time between execution and engine
+        result = self.run_smart_contract(engine, path, 'concat')
+        current_time = Integer(engine.current_block.timestamp).to_byte_array()
+        self.assertEqual(b'value1  value2  value3  ' + current_time, result)
+
+    def test_concat_string_variables_and_constants(self):
+        path = self.get_contract_path('ConcatStringVariablesAndConstants.py')
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'concat')
+        self.assertEqual('[1,2]', result)
 
     def test_power_operation(self):
         expected_output = (


### PR DESCRIPTION
**Summary or solution description**
Fixed the problem in code optimization that was changing the order of the operands in `str` and `bytes` concatenation

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/1484602d45a8f1391a750ff28cdeb38e82ed751c/boa3_test/test_sc/arithmetic_test/ConcatBytesVariablesAndConstants.py#L10-L25
https://github.com/CityOfZion/neo3-boa/blob/1484602d45a8f1391a750ff28cdeb38e82ed751c/boa3_test/test_sc/arithmetic_test/ConcatStringVariablesAndConstants.py#L5-L9

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/1484602d45a8f1391a750ff28cdeb38e82ed751c/boa3_test/tests/compiler_tests/test_arithmetic.py#L263-L285

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
