### PR TITLE
Add a new signature to update_contract() interop

### DIFF
--- a/boa3/builtin/interop/contract/__init__.py
+++ b/boa3/builtin/interop/contract/__init__.py
@@ -43,7 +43,7 @@ def create_contract(nef_file: bytes, manifest: bytes) -> Contract:
     pass
 
 
-def update_contract(nef_file: bytes, manifest: bytes):
+def update_contract(nef_file: bytes, manifest: bytes, data: Any = None):
     """
     Updates the executing smart contract given the script and the manifest
 
@@ -51,6 +51,8 @@ def update_contract(nef_file: bytes, manifest: bytes):
     :type nef_file: bytes
     :param manifest: the new smart contract's manifest
     :type manifest: bytes
+    :param data: the parameters for the _deploy function
+    :type data: Any
 
     :raise Exception: raised if the nef and the manifest are not a valid smart contract or the new contract is the
         same as the old one.

--- a/boa3/model/builtin/interop/contract/updatemethod.py
+++ b/boa3/model/builtin/interop/contract/updatemethod.py
@@ -1,3 +1,4 @@
+import ast
 from typing import Dict
 
 from boa3.model.builtin.interop.nativecontract import ContractManagementMethod
@@ -12,6 +13,9 @@ class UpdateMethod(ContractManagementMethod):
         syscall = 'update'
         args: Dict[str, Variable] = {
             'nef_file': Variable(Type.bytes),
-            'manifest': Variable(Type.bytes)
+            'manifest': Variable(Type.bytes),
+            'data': Variable(Type.any)
         }
-        super().__init__(identifier, syscall, args, return_type=Type.none)
+        data_default = ast.parse("{0}".format(Type.any.default_value)
+                                 ).body[0].value
+        super().__init__(identifier, syscall, args, defaults=[data_default], return_type=Type.none)

--- a/boa3_test/test_sc/interop_test/UpdateContract.py
+++ b/boa3_test/test_sc/interop_test/UpdateContract.py
@@ -1,12 +1,21 @@
+from typing import Any
+
 from boa3.builtin import public
 from boa3.builtin.interop.contract import update_contract
+from boa3.builtin.interop.runtime import notify
 
 
 @public
-def update(script: bytes, manifest: bytes):
-    update_contract(script, manifest)
+def update(script: bytes, manifest: bytes, data: Any):
+    update_contract(script, manifest, data)
 
 
 @public
 def new_method() -> int:
     return 42
+
+
+@public
+def _deploy(data: Any, update: bool):
+    notify(update)
+    notify(data)

--- a/boa3_test/test_sc/interop_test/contract/UpdateContract.py
+++ b/boa3_test/test_sc/interop_test/contract/UpdateContract.py
@@ -1,7 +1,9 @@
+from typing import Any
+
 from boa3.builtin import public
 from boa3.builtin.interop.contract import update_contract
 
 
 @public
-def update(script: bytes, manifest: bytes):
-    update_contract(script, manifest)
+def update(script: bytes, manifest: bytes, data: Any):
+    update_contract(script, manifest, data)

--- a/boa3_test/test_sc/interop_test/contract/UpdateContractTooManyArguments.py
+++ b/boa3_test/test_sc/interop_test/contract/UpdateContractTooManyArguments.py
@@ -3,5 +3,5 @@ from typing import Any
 from boa3.builtin.interop.contract import update_contract
 
 
-def Main(script: bytes, manifest: str, arg0: Any):
-    update_contract(script, manifest, arg0)
+def Main(script: bytes, manifest: str, data: Any, arg0: Any):
+    update_contract(script, manifest, data, arg0)


### PR DESCRIPTION
**Related issue**
#276 

**Summary or solution description**
Added the `data` parameter in the `update_contract()` function.

**How to Reproduce**
The new signature is `update_contract(nef_file: bytes, manifest: bytes, data: Any = None)`.

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/7082b044a478a65939900e45e98d65a8807082f8/boa3_test/tests/compiler_tests/test_interop/test_contract.py#L162-L179

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8
