### PR TITLE
Add a new signature to create_contract() interop

### DIFF
--- a/boa3/builtin/interop/contract/__init__.py
+++ b/boa3/builtin/interop/contract/__init__.py
@@ -27,14 +27,16 @@ def call_contract(script_hash: UInt160, method: str, args: Sequence = (), call_f
     pass
 
 
-def create_contract(nef_file: bytes, manifest: bytes) -> Contract:
+def create_contract(nef_file: bytes, manifest: bytes, data: Any = None) -> Contract:
     """
     Creates a smart contract given the script and the manifest
 
     :param nef_file: the target smart contract's compiled nef
     :type nef_file: bytes
     :param manifest: the manifest.json that describes how the script should behave
-    type manifest: bytes
+    :type manifest: bytes
+    :param data: the parameters for the _deploy function
+    :type data: Any
     :return: the contract that was created.
     :rtype: Any
 

--- a/boa3/model/builtin/interop/contract/createmethod.py
+++ b/boa3/model/builtin/interop/contract/createmethod.py
@@ -17,7 +17,7 @@ class CreateMethod(ContractManagementMethod):
             'manifest': Variable(Type.bytes),
             'data': Variable(Type.any)
         }
-        data_default = ast.parse("{0}".format(Type.sequence.default_value)
+        data_default = ast.parse("{0}".format(Type.any.default_value)
                                  ).body[0].value
 
         super().__init__(identifier, syscall, args, defaults=[data_default], return_type=contract_type)

--- a/boa3/model/builtin/interop/contract/createmethod.py
+++ b/boa3/model/builtin/interop/contract/createmethod.py
@@ -1,9 +1,9 @@
-from typing import Dict, List, Tuple
+import ast
+from typing import Dict
 
 from boa3.model.builtin.interop.contract.contracttype import ContractType
 from boa3.model.builtin.interop.nativecontract import ContractManagementMethod
 from boa3.model.variable import Variable
-from boa3.neo.vm.opcode.Opcode import Opcode
 
 
 class CreateMethod(ContractManagementMethod):
@@ -14,16 +14,10 @@ class CreateMethod(ContractManagementMethod):
         syscall = 'deploy'
         args: Dict[str, Variable] = {
             'nef_file': Variable(Type.bytes),
-            'manifest': Variable(Type.bytes)
+            'manifest': Variable(Type.bytes),
+            'data': Variable(Type.any)
         }
+        data_default = ast.parse("{0}".format(Type.sequence.default_value)
+                                 ).body[0].value
 
-        super().__init__(identifier, syscall, args, return_type=contract_type)
-
-    @property
-    def opcode(self) -> List[Tuple[Opcode, bytes]]:
-        opcodes = [
-            (Opcode.DUP, b''),
-            (Opcode.PUSHNULL, b''),
-            (Opcode.APPEND, b'')
-        ]
-        return opcodes + super().opcode
+        super().__init__(identifier, syscall, args, defaults=[data_default], return_type=contract_type)

--- a/boa3_test/test_sc/interop_test/contract/CreateContract.py
+++ b/boa3_test/test_sc/interop_test/contract/CreateContract.py
@@ -1,7 +1,9 @@
+from typing import Any
+
 from boa3.builtin import public
 from boa3.builtin.interop.contract import Contract, create_contract
 
 
 @public
-def Main(script: bytes, manifest: bytes) -> Contract:
-    return create_contract(script, manifest)
+def Main(script: bytes, manifest: bytes, data: Any) -> Contract:
+    return create_contract(script, manifest, data)

--- a/boa3_test/test_sc/interop_test/contract/CreateContractTooManyArguments.py
+++ b/boa3_test/test_sc/interop_test/contract/CreateContractTooManyArguments.py
@@ -3,5 +3,5 @@ from typing import Any
 from boa3.builtin.interop.contract import create_contract
 
 
-def Main(script: bytes, manifest: bytes, arg0: Any):
-    create_contract(script, manifest, arg0)
+def Main(script: bytes, manifest: bytes, data: Any, arg0: Any):
+    create_contract(script, manifest, data, arg0)

--- a/boa3_test/test_sc/interop_test/contract/NewContract.py
+++ b/boa3_test/test_sc/interop_test/contract/NewContract.py
@@ -1,0 +1,18 @@
+from typing import Any
+
+from boa3.builtin import public
+from boa3.builtin.interop.runtime import notify
+from boa3.builtin.interop.storage import get, put
+
+
+@public
+def main() -> str:
+    return get('storage').to_str()
+
+
+@public
+def _deploy(data: Any, update: bool):
+    notify(update)
+    notify(data)
+    if isinstance(data, str):
+        put('storage', data)


### PR DESCRIPTION
**Related issue**
#277 

**Summary or solution description**
Added the `data` parameter in the `create_contract()` function.

**How to Reproduce**
The new signature is `create_contract(nef_file: bytes, manifest: bytes, data: Any = None)`.

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/39dff843aa71df2a8f4f185e3a6d9849d8b873f5/boa3_test/tests/compiler_tests/test_interop/test_contract.py#L137-L159

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8
