### PR TITLE
Fix str and bytes slicing return type

### DIFF
--- a/boa3/analyser/optimizer/Operation.py
+++ b/boa3/analyser/optimizer/Operation.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import ast
 from enum import Enum, auto
-from typing import Any, Optional, Union
+from typing import Optional, Union
 
 from boa3.model.operation.operation import IOperation
 from boa3.model.operation.operator import Operator

--- a/boa3/compiler/codegenerator/codegenerator.py
+++ b/boa3/compiler/codegenerator/codegenerator.py
@@ -17,6 +17,7 @@ from boa3.model.property import Property
 from boa3.model.symbol import ISymbol
 from boa3.model.type.classtype import ClassType
 from boa3.model.type.collection.icollection import ICollectionType
+from boa3.model.type.collection.sequence.buffertype import Buffer as BufferType
 from boa3.model.type.collection.sequence.sequencetype import SequenceType
 from boa3.model.type.primitive.primitivetype import PrimitiveType
 from boa3.model.type.type import IType, Type
@@ -857,12 +858,12 @@ class CodeGenerator:
 
         self._stack_pop()  # length
         self._stack_pop()  # start
-        self._stack_pop()  # original string
+        original = self._stack_pop()  # original string
 
         self.__insert1(OpcodeInfo.SUBSTR)
         self._update_jump(jmp_address, self.last_code_start_address)
-        self._stack_append(Type.bytes)  # substr returns a buffer instead of a bytestring
-        self.convert_cast(Type.str)
+        self._stack_append(BufferType)  # substr returns a buffer instead of a bytestring
+        self.convert_cast(original)
 
     def convert_get_array_slice(self, array: SequenceType):
         """
@@ -939,7 +940,9 @@ class CodeGenerator:
                                               StackItemType.Buffer):
                 self.__insert1(OpcodeInfo.LEFT)
                 self._stack_pop()  # length
-                self._stack_pop()  # original array
+                original_type = self._stack_pop()  # original array
+                self._stack_append(BufferType)  # left returns a buffer instead of a bytestring
+                self.convert_cast(original_type)
             else:
                 array = self._stack[-2]
                 self.convert_literal(0)
@@ -958,7 +961,9 @@ class CodeGenerator:
                 self.convert_operation(BinaryOp.Sub)
                 self.__insert1(OpcodeInfo.RIGHT)
                 self._stack_pop()  # length
-                self._stack_pop()  # original array
+                original_type = self._stack_pop()  # original array
+                self._stack_append(BufferType)     # right returns a buffer instead of a bytestring
+                self.convert_cast(original_type)
             else:
                 array = self._stack[-3]
                 self.swap_reverse_stack_items(2)

--- a/boa3/model/operation/binary/arithmetic/concat.py
+++ b/boa3/model/operation/binary/arithmetic/concat.py
@@ -48,10 +48,6 @@ class Concat(BinaryOperation):
 
     @property
     def opcode(self) -> List[Tuple[Opcode, bytes]]:
-        codes = [(Opcode.CAT, b'')]
-
-        if Type.str.is_type_of(self.left_type) and Type.str.is_type_of(self.right_type):
-            codes.append(
+        return [(Opcode.CAT, b''),
                 (Opcode.CONVERT, Type.str.stack_item)
-            )
-        return codes
+                ]

--- a/boa3/model/type/collection/sequence/buffertype.py
+++ b/boa3/model/type/collection/sequence/buffertype.py
@@ -1,0 +1,19 @@
+from boa3.model.type.primitive.strtype import StrType
+from boa3.neo.vm.type.StackItem import StackItemType
+
+
+class BufferType(StrType):
+    """
+    A class used to represent Neo internal Buffer type
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._identifier = 'buffer'
+
+    @property
+    def stack_item(self) -> StackItemType:
+        return StackItemType.Buffer
+
+
+Buffer = BufferType()

--- a/boa3_test/test_sc/relational_test/CompareString.py
+++ b/boa3_test/test_sc/relational_test/CompareString.py
@@ -1,0 +1,21 @@
+from boa3.builtin import public
+
+
+@public
+def test1(param: str) -> bool:
+    return param[0:1] == '|'
+
+
+@public
+def test2(param: str) -> bool:
+    return param[0:1] == "|"
+
+
+@public
+def test3(param: str) -> bool:
+    return param == "|"
+
+
+@public
+def test4(param: str) -> bool:
+    return param == '|'

--- a/boa3_test/tests/compiler_tests/test_arithmetic.py
+++ b/boa3_test/tests/compiler_tests/test_arithmetic.py
@@ -265,15 +265,18 @@ class TestArithmetic(BoaTest):
 
         engine = TestEngine()
         engine.increase_block()  # increase to get consistent block_time between execution and engine
-        result = self.run_smart_contract(engine, path, 'concat1')
+        result = self.run_smart_contract(engine, path, 'concat1',
+                                         expected_result_type=bytes)
         current_time = Integer(engine.current_block.timestamp).to_byte_array()
         self.assertEqual(b'value1  value2  value3  ' + current_time + b'some_bytes_after', result)
 
-        result = self.run_smart_contract(engine, path, 'concat2')
+        result = self.run_smart_contract(engine, path, 'concat2',
+                                         expected_result_type=bytes)
         current_time = Integer(engine.current_block.timestamp).to_byte_array()
         self.assertEqual(b'value1value2value3' + current_time + b'some_bytes_after', result)
 
-        result = self.run_smart_contract(engine, path, 'concat3')
+        result = self.run_smart_contract(engine, path, 'concat3',
+                                         expected_result_type=bytes)
         current_time = Integer(engine.current_block.timestamp).to_byte_array()
         self.assertEqual(b'value1__value2__value3__' + current_time + b'some_bytes_after', result)
 

--- a/boa3_test/tests/compiler_tests/test_relational.py
+++ b/boa3_test/tests/compiler_tests/test_relational.py
@@ -455,6 +455,27 @@ class TestRelational(BoaTest):
                                          expected_result_type=bool)
         self.assertEqual(True, result)
 
+    def test_compare_string(self):
+        path = self.get_contract_path('CompareString.py')
+        Boa3.compile_and_save(path)
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'test1', '|',
+                                         expected_result_type=bool)
+        self.assertEqual(True, result)
+
+        result = self.run_smart_contract(engine, path, 'test2', '|',
+                                         expected_result_type=bool)
+        self.assertEqual(True, result)
+
+        result = self.run_smart_contract(engine, path, 'test3', '|',
+                                         expected_result_type=bool)
+        self.assertEqual(True, result)
+
+        result = self.run_smart_contract(engine, path, 'test4', '|',
+                                         expected_result_type=bool)
+        self.assertEqual(True, result)
+
     def test_boa2_equality_test2(self):
         path = self.get_contract_path('Equality2Boa2Test.py')
         engine = TestEngine()

--- a/boa3_test/tests/compiler_tests/test_string.py
+++ b/boa3_test/tests/compiler_tests/test_string.py
@@ -1,5 +1,6 @@
 from boa3.boa3 import Boa3
 from boa3.exception.CompilerError import InternalError, UnresolvedOperation
+from boa3.model.type.type import Type
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.String import String
@@ -91,6 +92,7 @@ class TestString(BoaTest):
             + Opcode.SIZE
             + Opcode.ADD
             + Opcode.LEFT
+            + Opcode.CONVERT + Type.str.stack_item
             + Opcode.RET        # return
         )
         path = self.get_contract_path('StringSlicingNegativeStart.py')


### PR DESCRIPTION
**Related issue**
#453

**Summary or solution description**
Fixed the instructions for slicing `str` and `bytes` types. It was missing the conversion from the Neo `Buffer` type to `ByteString`.
Comparing `Buffer` and `ByteString` in Neo always returns False because of the typings, but this was behaving differently from what is expected of the equivalent Python code.

**How to Reproduce**
In the following code, all methods should return True with the input `'|'`, but the first two methods returned False.
https://github.com/CityOfZion/neo3-boa/blob/9c30f692d6ee246d48cbc42cd02d4981d37fef7c/boa3_test/test_sc/relational_test/CompareString.py#L4-L21

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/9c30f692d6ee246d48cbc42cd02d4981d37fef7c/boa3_test/tests/compiler_tests/test_relational.py#L458-L477

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
