### PR TITLE
UInt256 not working in runtime

### DIFF
--- a/boa3_test/test_sc/bytes_test/UInt160Bytes.py
+++ b/boa3_test/test_sc/bytes_test/UInt160Bytes.py
@@ -1,0 +1,9 @@
+from boa3.builtin import public
+from boa3.builtin.type import UInt160
+
+
+@public
+def main() -> UInt160:
+    bytes_value = b'0123456789abcdefghijklmnopqrstuvwxyz'
+    len20 = bytes_value[:20]
+    return UInt160(len20)

--- a/boa3_test/test_sc/bytes_test/UInt160Int.py
+++ b/boa3_test/test_sc/bytes_test/UInt160Int.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.type import UInt160
+
+
+@public
+def main() -> UInt160:
+    return UInt160(160)

--- a/boa3_test/test_sc/bytes_test/UInt256Bytes.py
+++ b/boa3_test/test_sc/bytes_test/UInt256Bytes.py
@@ -1,0 +1,9 @@
+from boa3.builtin import public
+from boa3.builtin.type import UInt256
+
+
+@public
+def main() -> UInt256:
+    bytes_value = b'0123456789abcdefghijklmnopqrstuvwxyz'
+    len32 = bytes_value[:32]
+    return UInt256(len32)

--- a/boa3_test/test_sc/bytes_test/UInt256Int.py
+++ b/boa3_test/test_sc/bytes_test/UInt256Int.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.type import UInt256
+
+
+@public
+def main() -> UInt256:
+    return UInt256(256)

--- a/boa3_test/tests/compiler_tests/test_bytes.py
+++ b/boa3_test/tests/compiler_tests/test_bytes.py
@@ -526,3 +526,39 @@ class TestBytes(BoaTest):
         result = self.run_smart_contract(engine, path, 'main',
                                          expected_result_type=bytes)
         self.assertEqual(b'\x02\x03\x04\x02\x03\x04\x05\x06\x01\x02\x03\x04\x03\x04', result)
+
+    def test_uint160_bytes(self):
+        path = self.get_contract_path('UInt160Bytes.py')
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'main')
+        if isinstance(result, str):
+            from boa3.neo.vm.type.String import String
+            result = String(result).to_bytes()
+        self.assertEqual(b'0123456789abcdefghij', result)
+
+    def test_uint160_int(self):
+        path = self.get_contract_path('UInt160Int.py')
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'main')
+        if isinstance(result, str):
+            from boa3.neo.vm.type.String import String
+            result = String(result).to_bytes()
+        self.assertEqual((160).to_bytes(2, 'little') + bytes(18), result)
+
+    def test_uint256_bytes(self):
+        path = self.get_contract_path('UInt256Bytes.py')
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'main')
+        if isinstance(result, str):
+            from boa3.neo.vm.type.String import String
+            result = String(result).to_bytes()
+        self.assertEqual(b'0123456789abcdefghijklmnopqrstuv', result)
+
+    def test_uint256_int(self):
+        path = self.get_contract_path('UInt256Int.py')
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'main')
+        if isinstance(result, str):
+            from boa3.neo.vm.type.String import String
+            result = String(result).to_bytes()
+        self.assertEqual((256).to_bytes(2, 'little') + bytes(30), result)

--- a/boa3_test/tests/compiler_tests/test_bytes.py
+++ b/boa3_test/tests/compiler_tests/test_bytes.py
@@ -4,6 +4,7 @@ from boa3.boa3 import Boa3
 from boa3.exception import CompilerError, CompilerWarning
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
+from boa3.neo.vm.type.String import String
 from boa3_test.tests.boa_test import BoaTest
 from boa3_test.tests.test_classes.TestExecutionException import TestExecutionException
 from boa3_test.tests.test_classes.testengine import TestEngine
@@ -550,7 +551,6 @@ class TestBytes(BoaTest):
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'main')
         if isinstance(result, str):
-            from boa3.neo.vm.type.String import String
             result = String(result).to_bytes()
         self.assertEqual(b'0123456789abcdefghijklmnopqrstuv', result)
 
@@ -559,6 +559,5 @@ class TestBytes(BoaTest):
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'main')
         if isinstance(result, str):
-            from boa3.neo.vm.type.String import String
             result = String(result).to_bytes()
         self.assertEqual((256).to_bytes(2, 'little') + bytes(30), result)


### PR DESCRIPTION
**Related issue**
#446 

**Summary or solution description**
The issue was already fixed when I tried it. Just added some tests for UInt160 and UInt256.

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/e89ac3d16483a8296dc08fc0fc722f0ee1296437/boa3_test/tests/compiler_tests/test_bytes.py#L530-L564

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8