### PR TITLE
Transactions are not being properly saved in the storage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
 
             git clone https://github.com/simplitech/neo-devpack-dotnet.git -b test-engine-executable --single-branch
             cd ./neo-devpack-dotnet
-            git checkout 82a51ea89595bc07952990e93c4df518ea657fd0
+            git checkout f340a1246f97e8c3705b013208812d06fb8fa1ea
             cd ..
             dotnet build ./neo-devpack-dotnet/src/Neo.TestEngine/Neo.TestEngine.csproj -o ./Neo.TestEngine
             python -m unittest discover boa3_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,10 @@ jobs:
             sudo apt-get update && \
               sudo apt-get install -y dotnet-sdk-5.0
 
-            git clone https://github.com/simplitech/neo-devpack-dotnet.git -b rc2 --single-branch
+            git clone https://github.com/simplitech/neo-devpack-dotnet.git -b test-engine-executable --single-branch
+            cd ./neo-devpack-dotnet
+            git checkout 82a51ea89595bc07952990e93c4df518ea657fd0
+            cd ..
             dotnet build ./neo-devpack-dotnet/src/Neo.TestEngine/Neo.TestEngine.csproj -o ./Neo.TestEngine
             python -m unittest discover boa3_test
 

--- a/boa3/neo/smart_contract/notification.py
+++ b/boa3/neo/smart_contract/notification.py
@@ -7,7 +7,7 @@ from boa3.neo.utils import stack_item_from_json
 
 
 class Notification:
-    _event_name_key = 'eventName'
+    _event_name_key = 'eventname'
     _script_hash_key = 'scripthash'
     _value_key = 'value'
 

--- a/boa3_test/examples/wrapped_neo.py
+++ b/boa3_test/examples/wrapped_neo.py
@@ -3,7 +3,7 @@ from typing import Any, Union
 from boa3.builtin import CreateNewEvent, NeoMetadata, metadata, public
 from boa3.builtin.contract import Nep17TransferEvent, abort
 from boa3.builtin.interop.blockchain import get_contract
-from boa3.builtin.interop.contract import NEO, call_contract
+from boa3.builtin.interop.contract import GAS, NEO, call_contract
 from boa3.builtin.interop.runtime import calling_script_hash, check_witness, executing_script_hash
 from boa3.builtin.interop.storage import delete, get, put
 from boa3.builtin.type import UInt160
@@ -404,5 +404,8 @@ def onNEP17Payment(from_address: UInt160, amount: int, data: Any):
     # Use calling_script_hash to identify if the incoming token is NEO
     if calling_script_hash == NEO:
         mint(from_address, amount)
+    elif calling_script_hash == GAS:
+        # GAS is minted when transferring NEO
+        return
     else:
         abort()

--- a/boa3_test/tests/compiler_tests/test_interop/test_blockchain.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_blockchain.py
@@ -157,7 +157,18 @@ class TestBlockchainInterop(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
+        path_burn_gas = self.get_contract_path('../runtime', 'BurnGas.py')
         engine = TestEngine()
+
+        engine.increase_block()
+        self.run_smart_contract(engine, path_burn_gas, 'main', 1000)
+
+        txs = engine.get_transactions()
+        self.assertGreater(len(txs), 0)
+        hash_ = txs[0]._hash.to_array()
+
+        result = self.run_smart_contract(engine, path, 'main', hash_)
+        self.assertIsNotNone(result)
         # TODO: finish this example when transaction gets added to the storage
 
     def test_get_transaction_from_block_int(self):
@@ -263,6 +274,17 @@ class TestBlockchainInterop(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        path = self.get_contract_path('GetTransactionHeight.py')
+        path_burn_gas = self.get_contract_path('../runtime', 'BurnGas.py')
         engine = TestEngine()
+
+        expected_block_index = 10
+        engine.increase_block(expected_block_index)
+        self.run_smart_contract(engine, path_burn_gas, 'main', 1000)
+
+        txs = engine.get_transactions()
+        self.assertGreater(len(txs), 0)
+        hash_ = txs[0]._hash.to_array()
+
+        result = self.run_smart_contract(engine, path, 'main', hash_)
+        self.assertEqual(expected_block_index, result)
         # TODO: finish this example when transaction gets added to the storage

--- a/boa3_test/tests/compiler_tests/test_interop/test_blockchain.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_blockchain.py
@@ -107,7 +107,7 @@ class TestBlockchainInterop(BoaTest):
         path = self.get_contract_path('GetBlockMismatchedTypes.py')
         self.assertCompilerLogs(MismatchedTypes, path)
 
-    def test_transaction(self):
+    def test_transaction_init(self):
         path = self.get_contract_path('Transaction.py')
         engine = TestEngine()
 
@@ -244,7 +244,21 @@ class TestBlockchainInterop(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
+        path_burn_gas = self.get_contract_path('../runtime', 'BurnGas.py')
         engine = TestEngine()
+
+        engine.increase_block(10)
+        self.run_smart_contract(engine, path_burn_gas, 'main', 100)
+
+        block_10 = engine.current_block
+        block_hash = block_10._hash
+        self.assertIsNotNone(block_hash)
+        block_hash = block_hash.to_array()
+
+        engine.increase_block()
+
+        result = self.run_smart_contract(engine, path, 'main', block_hash, 0)
+        self.assertIsNotNone(result)
         # TODO: finish this example when transaction gets added to the storage
 
     def test_get_transaction_height(self):

--- a/boa3_test/tests/compiler_tests/test_interop/test_blockchain.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_blockchain.py
@@ -165,7 +165,7 @@ class TestBlockchainInterop(BoaTest):
 
         txs = engine.get_transactions()
         self.assertGreater(len(txs), 0)
-        hash_ = txs[0]._hash.to_array()
+        hash_ = txs[0].hash
 
         result = self.run_smart_contract(engine, path, 'main', hash_)
         self.assertIsNotNone(result)
@@ -208,7 +208,7 @@ class TestBlockchainInterop(BoaTest):
 
         block_10 = engine.current_block
         txs = block_10.get_transactions()
-        hash_ = txs[0]._hash.to_array()
+        hash_ = txs[0].hash
 
         engine.increase_block()
 
@@ -251,9 +251,8 @@ class TestBlockchainInterop(BoaTest):
         self.run_smart_contract(engine, path_burn_gas, 'main', 100)
 
         block_10 = engine.current_block
-        block_hash = block_10._hash
+        block_hash = block_10.hash
         self.assertIsNotNone(block_hash)
-        block_hash = block_hash.to_array()
 
         engine.increase_block()
 
@@ -297,7 +296,7 @@ class TestBlockchainInterop(BoaTest):
 
         txs = engine.get_transactions()
         self.assertGreater(len(txs), 0)
-        hash_ = txs[0]._hash.to_array()
+        hash_ = txs[0].hash
 
         result = self.run_smart_contract(engine, path, 'main', hash_)
         self.assertEqual(expected_block_index, result)

--- a/boa3_test/tests/examples_tests/test_HTLC.py
+++ b/boa3_test/tests/examples_tests/test_HTLC.py
@@ -121,11 +121,12 @@ class TestHTLCTemplate(BoaTest):
         self.assertEqual(True, result)
 
         # transfer was accepted so it was registered
-        transfer_events = engine.get_events('Transfer')
+        transfer_events = engine.get_events('Transfer', NEO_SCRIPT)
         self.assertEqual(1, len(transfer_events))
-        self.assertEqual(3, len(transfer_events[0].arguments))
+        neo_transfer_event = transfer_events[0]
+        self.assertEqual(3, len(neo_transfer_event.arguments))
 
-        sender, receiver, amount = transfer_events[0].arguments
+        sender, receiver, amount = neo_transfer_event.arguments
         if isinstance(sender, str):
             sender = String(sender).to_bytes()
         if isinstance(receiver, str):
@@ -148,7 +149,7 @@ class TestHTLCTemplate(BoaTest):
                                     signer_accounts=[aux_address2],
                                     expected_result_type=bool)
 
-        transfer_events = engine.get_events('Transfer')
+        transfer_events = engine.get_events('Transfer', origin=NEO_SCRIPT)
         # the NEO transfer
         self.assertEqual(1, len(transfer_events))
 
@@ -164,11 +165,12 @@ class TestHTLCTemplate(BoaTest):
         self.assertEqual(True, result)
 
         # the transfer was accepted so it was registered
-        transfer_events = engine.get_events('Transfer')
-        self.assertEqual(2, len(transfer_events))
-        self.assertEqual(3, len(transfer_events[1].arguments))
+        transfer_events = engine.get_events('Transfer', origin=GAS_SCRIPT)
+        self.assertGreaterEqual(len(transfer_events), 1)
+        gas_transfer_event = transfer_events[-1]
+        self.assertEqual(3, len(gas_transfer_event.arguments))
 
-        sender, receiver, amount = transfer_events[1].arguments
+        sender, receiver, amount = gas_transfer_event.arguments
         if isinstance(sender, str):
             sender = String(sender).to_bytes()
         if isinstance(receiver, str):
@@ -238,7 +240,7 @@ class TestHTLCTemplate(BoaTest):
                                          signer_accounts=[aux_address],
                                          expected_result_type=bool)
         self.assertEqual(True, result)
-        transfer_events = engine.get_events('Transfer')
+        transfer_events = engine.get_events('Transfer', origin=NEO_SCRIPT)
         self.assertEqual(1, len(transfer_events))
 
         result = self.run_smart_contract(engine, aux_path2, 'calling_transfer',
@@ -246,7 +248,7 @@ class TestHTLCTemplate(BoaTest):
                                          signer_accounts=[aux_address2],
                                          expected_result_type=bool)
         self.assertEqual(True, result)
-        transfer_events = engine.get_events('Transfer')
+        transfer_events = engine.get_events('Transfer', GAS_SCRIPT)
         self.assertEqual(2, len(transfer_events))
 
         # the withdraw will fail, because the secret is wrong
@@ -262,11 +264,17 @@ class TestHTLCTemplate(BoaTest):
         self.assertEqual(True, result)
 
         # the transfer were accepted so they were registered
-        transfer_events = engine.get_events('Transfer')
-        self.assertEqual(4, len(transfer_events))
-        self.assertEqual(3, len(transfer_events[2].arguments))
+        transfer_events = engine.get_events('Transfer', origin=GAS_SCRIPT)
+        self.assertGreaterEqual(len(transfer_events), 1)
+        gas_transfer_event = transfer_events[-1]
+        self.assertEqual(3, len(gas_transfer_event.arguments))
 
-        sender, receiver, amount = transfer_events[2].arguments
+        transfer_events = engine.get_events('Transfer', NEO_SCRIPT)
+        self.assertGreaterEqual(len(transfer_events), 1)
+        neo_transfer_event = transfer_events[-1]
+        self.assertEqual(3, len(neo_transfer_event.arguments))
+
+        sender, receiver, amount = gas_transfer_event.arguments
         if isinstance(sender, str):
             sender = String(sender).to_bytes()
         if isinstance(receiver, str):
@@ -275,8 +283,7 @@ class TestHTLCTemplate(BoaTest):
         self.assertEqual(aux_address, receiver)
         self.assertEqual(transferred_amount_gas, amount)
 
-        self.assertEqual(3, len(transfer_events[3].arguments))
-        sender, receiver, amount = transfer_events[3].arguments
+        sender, receiver, amount = neo_transfer_event.arguments
         if isinstance(sender, str):
             sender = String(sender).to_bytes()
         if isinstance(receiver, str):
@@ -286,6 +293,7 @@ class TestHTLCTemplate(BoaTest):
         self.assertEqual(transferred_amount_neo, amount)
 
         # saving the balance after to compare with the balance before the transfer
+        minted_gas_per_neo_transfer = int(transferred_amount_neo * 0.5)
         balance_neo_person_a_after = self.run_smart_contract(engine, NEO_SCRIPT, 'balanceOf', aux_address)
         balance_neo_person_b_after = self.run_smart_contract(engine, NEO_SCRIPT, 'balanceOf', aux_address2)
         balance_neo_htlc_after = self.run_smart_contract(engine, NEO_SCRIPT, 'balanceOf', htlc_address)
@@ -296,7 +304,8 @@ class TestHTLCTemplate(BoaTest):
         self.assertEqual(balance_neo_person_a_before - transferred_amount_neo, balance_neo_person_a_after)
         self.assertEqual(balance_neo_person_b_before + transferred_amount_neo, balance_neo_person_b_after)
         self.assertEqual(balance_neo_htlc_before, balance_neo_htlc_after)
-        self.assertEqual(balance_gas_person_a_before + transferred_amount_gas, balance_gas_person_a_after)
+        self.assertEqual(balance_gas_person_a_before + transferred_amount_gas + minted_gas_per_neo_transfer,
+                         balance_gas_person_a_after)
         self.assertEqual(balance_gas_person_b_before - transferred_amount_gas, balance_gas_person_b_after)
         self.assertEqual(balance_gas_htlc_before, balance_gas_htlc_after)
 

--- a/boa3_test/tests/examples_tests/test_NEP17.py
+++ b/boa3_test/tests/examples_tests/test_NEP17.py
@@ -223,9 +223,10 @@ class TestNEP17Template(BoaTest):
         # when deploying, the contract will mint tokens to the owner
         transfer_events = engine.get_events('Transfer')
         self.assertEqual(1, len(transfer_events))
-        self.assertEqual(3, len(transfer_events[0].arguments))
+        transfer_event = transfer_events[0]
+        self.assertEqual(3, len(transfer_event.arguments))
 
-        sender, receiver, amount = transfer_events[0].arguments
+        sender, receiver, amount = transfer_event.arguments
         if isinstance(sender, str):
             sender = String(sender).to_bytes()
         if isinstance(receiver, str):
@@ -249,12 +250,14 @@ class TestNEP17Template(BoaTest):
                                          expected_result_type=bool)
         self.assertEqual(True, result)
         transfer_events = engine.get_events('Transfer')
-        self.assertEqual(3, len(transfer_events))
-        self.assertEqual(3, len(transfer_events[1].arguments))
-        self.assertEqual(3, len(transfer_events[2].arguments))
+        self.assertEqual(4, len(transfer_events))
+        neo_transfer_event = transfer_events[2]
+        transfer_event = transfer_events[3]
+        self.assertEqual(3, len(neo_transfer_event.arguments))
+        self.assertEqual(3, len(transfer_event.arguments))
 
         # this is the event NEO emitted
-        sender, receiver, amount = transfer_events[1].arguments
+        sender, receiver, amount = neo_transfer_event.arguments
         if isinstance(sender, str):
             sender = String(sender).to_bytes()
         if isinstance(receiver, str):
@@ -264,7 +267,7 @@ class TestNEP17Template(BoaTest):
         self.assertEqual(transferred_amount, amount)
 
         # this is the event NEP17 emitted
-        sender, receiver, amount = transfer_events[2].arguments
+        sender, receiver, amount = transfer_event.arguments
         if isinstance(sender, str):
             sender = String(sender).to_bytes()
         if isinstance(receiver, str):
@@ -296,12 +299,14 @@ class TestNEP17Template(BoaTest):
                                          expected_result_type=bool)
         self.assertEqual(True, result)
         transfer_events = engine.get_events('Transfer')
-        self.assertEqual(5, len(transfer_events))
-        self.assertEqual(3, len(transfer_events[3].arguments))
-        self.assertEqual(3, len(transfer_events[4].arguments))
+        self.assertEqual(6, len(transfer_events))
+        gas_transfer_event = transfer_events[4]
+        transfer_event = transfer_events[5]
+        self.assertEqual(3, len(gas_transfer_event.arguments))
+        self.assertEqual(3, len(transfer_event.arguments))
 
         # this is the event GAS emitted
-        sender, receiver, amount = transfer_events[3].arguments
+        sender, receiver, amount = gas_transfer_event.arguments
         if isinstance(sender, str):
             sender = String(sender).to_bytes()
         if isinstance(receiver, str):
@@ -311,7 +316,7 @@ class TestNEP17Template(BoaTest):
         self.assertEqual(transferred_amount, amount)
 
         # this is the event NEP17 emitted
-        sender, receiver, amount = transfer_events[4].arguments
+        sender, receiver, amount = transfer_event.arguments
         if isinstance(sender, str):
             sender = String(sender).to_bytes()
         if isinstance(receiver, str):

--- a/boa3_test/tests/test_classes/block.py
+++ b/boa3_test/tests/test_classes/block.py
@@ -37,6 +37,13 @@ class Block:
         if all(block_tx != tx for block_tx in self._transactions):
             self._transactions.append(tx)
 
+    @property
+    def hash(self) -> Optional[bytes]:
+        if self._hash is None:
+            return None
+        else:
+            return self._hash.to_array()
+
     def to_json(self) -> Dict[str, Any]:
         return {
             'index': self._index,

--- a/boa3_test/tests/test_classes/block.py
+++ b/boa3_test/tests/test_classes/block.py
@@ -34,7 +34,8 @@ class Block:
         return [tx.copy() for tx in self._transactions]
 
     def add_transaction(self, tx: Transaction):
-        self._transactions.append(tx)
+        if all(block_tx != tx for block_tx in self._transactions):
+            self._transactions.append(tx)
 
     def to_json(self) -> Dict[str, Any]:
         return {

--- a/boa3_test/tests/test_classes/testengine.py
+++ b/boa3_test/tests/test_classes/testengine.py
@@ -179,6 +179,9 @@ class TestEngine:
                 new_height = self.height + 1
             self._height = new_height
 
+        if new_height < 1:
+            # don't use height 0 because this is the genesis block index
+            new_height = 1
         new_block = Block(new_height)
         self.add_block(new_block)
         return new_block

--- a/boa3_test/tests/test_classes/testengine.py
+++ b/boa3_test/tests/test_classes/testengine.py
@@ -66,7 +66,7 @@ class TestEngine:
     def notifications(self) -> List[Notification]:
         return self._notifications.copy()
 
-    def get_events(self, event_name: str, origin: UInt160 = None) -> List[Notification]:
+    def get_events(self, event_name: str, origin: Union[UInt160, bytes] = None) -> List[Notification]:
         if origin is None:
             return [n for n in self._notifications if n.name == event_name]
         else:

--- a/boa3_test/tests/test_classes/testengine.py
+++ b/boa3_test/tests/test_classes/testengine.py
@@ -265,11 +265,11 @@ class TestEngine:
             if 'gasconsumed' in result:
                 self._gas_consumed = result['gasconsumed']
 
-            if 'result_stack' in result:
-                if isinstance(result['result_stack'], list):
-                    self._result_stack = [stack_item_from_json(value) for value in result['result_stack']]
+            if 'resultstack' in result:
+                if isinstance(result['resultstack'], list):
+                    self._result_stack = [stack_item_from_json(value) for value in result['resultstack']]
                 else:
-                    self._result_stack = [stack_item_from_json(result['result_stack'])]
+                    self._result_stack = [stack_item_from_json(result['resultstack'])]
 
             if self._vm_state is VMState.HALT or not rollback_on_fault:
                 if 'notifications' in result:

--- a/boa3_test/tests/test_classes/testengine.py
+++ b/boa3_test/tests/test_classes/testengine.py
@@ -293,13 +293,13 @@ class TestEngine:
                     if contract.script_hash is not None and not self._storage.has_contract(contract.script_hash):
                         self.remove_contract(nef_path)
 
-                if 'blocks' in result:
-                    blocks_json = result['blocks']
-                    if not isinstance(blocks_json, list):
-                        blocks_json = [blocks_json]
+                if 'currentblock' in result:
+                    current_block = Block.from_json(result['currentblock'])
 
-                    self._blocks = sorted([Block.from_json(js) for js in blocks_json],
-                                          key=lambda b: b.index)
+                    existing_block = next((block for block in self._blocks if block.index == current_block.index), None)
+                    if existing_block is not None:
+                        self._blocks.remove(existing_block)
+                    self._blocks.append(current_block)
 
                 if 'transaction' in result and self._vm_state is VMState.HALT:
                     block = self.current_block

--- a/boa3_test/tests/test_classes/transaction.py
+++ b/boa3_test/tests/test_classes/transaction.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import base64
 from typing import Any, Dict, List, Optional
 
-from boa3.neo import from_hex_str, to_hex_str
+from boa3.neo import from_hex_str
 from boa3.neo3.core.types import UInt256
 from boa3_test.tests.test_classes import transactionattribute as tx_attribute
 from boa3_test.tests.test_classes.signer import Signer
@@ -79,4 +79,3 @@ class Transaction:
                 and self._attributes == self._attributes
                 and self._signers == other._signers
                 and self._witnesses == other._witnesses)
-

--- a/boa3_test/tests/test_classes/transaction.py
+++ b/boa3_test/tests/test_classes/transaction.py
@@ -23,11 +23,12 @@ class Transaction:
             self._attributes.append(tx_attr)
 
     def to_json(self) -> Dict[str, Any]:
+        from boa3.neo.vm.type.String import String
         return {
             'signers': [signer.to_json() for signer in self._signers],
             'witnesses': [witness.to_json() for witness in self._witnesses],
             'attributes': [attr.to_json() for attr in self._attributes],
-            'script': to_hex_str(self._script)
+            'script': String.from_bytes(base64.b64encode(self._script))
         }
 
     @classmethod

--- a/boa3_test/tests/test_classes/transaction.py
+++ b/boa3_test/tests/test_classes/transaction.py
@@ -61,3 +61,15 @@ class Transaction:
         copied = Transaction(self._script, self._signers, self._witnesses)
         copied._hash = self._hash
         return copied
+
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, Transaction):
+            return False
+        if self._hash == other._hash:
+            return True
+
+        return (self._script == other._script
+                and self._attributes == self._attributes
+                and self._signers == other._signers
+                and self._witnesses == other._witnesses)
+

--- a/boa3_test/tests/test_classes/transaction.py
+++ b/boa3_test/tests/test_classes/transaction.py
@@ -22,6 +22,13 @@ class Transaction:
         if tx_attr not in self._attributes:
             self._attributes.append(tx_attr)
 
+    @property
+    def hash(self) -> Optional[bytes]:
+        if self._hash is None:
+            return None
+        else:
+            return self._hash.to_array()
+
     def to_json(self) -> Dict[str, Any]:
         from boa3.neo.vm.type.String import String
         return {


### PR DESCRIPTION
**Related issue**
#451

**Summary or solution description**
There were an inconsistency between TestEngine transactions output and the conversion of those transactions to the blocks in the TestEngine input. Updated in [simplitech/neo-devpack-dotnet](https://github.com/simplitech/neo-devpack-dotnet/tree/test-engine-executable) and fixed the issues in the boa side.

**How to Reproduce**
```
path = 'path/to/a/smart/contract.py'
engine = TestEngine()

engine.increase_block()
self.run_smart_contract(engine, path, 'some_method', 1000)

txs = engine.get_transactions()
self.assertGreater(len(txs), 0)
tx_hash = txs[0].hash

result = self.run_smart_contract(engine, path, 'get_transaction', tx_hash)
```
The last instruction resulted in `None` even though the transaction existed. It was a problem with both the TestEngine return and boa's conversions.

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/1fcb0a0eab3408d716473c29cdf797cf38176590/boa3_test/tests/compiler_tests/test_interop/test_blockchain.py#L133-L303

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
