### PR TITLE
Fix unexpected double DROPs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
 
             git clone https://github.com/simplitech/neo-devpack-dotnet.git -b test-engine-executable --single-branch
             cd ./neo-devpack-dotnet
-            git checkout f340a1246f97e8c3705b013208812d06fb8fa1ea
+            git checkout 1aec9f704bcf0ad76de00ac4467ecdbad7ed35bc
             cd ..
             dotnet build ./neo-devpack-dotnet/src/Neo.TestEngine/Neo.TestEngine.csproj -o ./Neo.TestEngine
             python -m unittest discover boa3_test

--- a/boa3/analyser/astanalyser.py
+++ b/boa3/analyser/astanalyser.py
@@ -102,8 +102,6 @@ class IAstAnalyser(ABC, ast.NodeVisitor):
         else:
             final_type = Type.get_type(value)
 
-        if isinstance(final_type, MetaType):
-            print()
         if isinstance(final_type, MetaType) and not use_metatype:
             return final_type.meta_type
         else:

--- a/boa3/model/type/typingmethod/casttypemethod.py
+++ b/boa3/model/type/typingmethod/casttypemethod.py
@@ -82,6 +82,10 @@ class CastTypeMethod(IBuiltinMethod):
         return 1  # the implementation is the same as x = arg
 
     @property
+    def args_on_stack(self) -> int:
+        return 1  # the implementation is the same as x = arg
+
+    @property
     def generation_order(self) -> List[int]:
         # type should not be converted
         indexes = super().generation_order

--- a/boa3_test/test_sc/interop_test/contract/CallScriptHashWithCast.py
+++ b/boa3_test/test_sc/interop_test/contract/CallScriptHashWithCast.py
@@ -1,0 +1,11 @@
+from typing import Any, cast
+
+from boa3.builtin import public
+from boa3.builtin.interop.contract import call_contract
+from boa3.builtin.type import UInt160
+
+
+@public
+def Main(scripthash: bytes, method: str, args: list) -> bool:
+    call_contract(cast(UInt160, scripthash), method, args)
+    return True

--- a/boa3_test/tests/compiler_tests/test_interop/test_contract.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_contract.py
@@ -39,6 +39,23 @@ class TestContractInterop(BoaTest):
         result = self.run_smart_contract(engine, path, 'Main', call_hash, 'add', [-42, 24])
         self.assertEqual(-18, result)
 
+    def test_call_contract_with_cast(self):
+        path = self.get_contract_path('CallScriptHashWithCast.py')
+        call_contract_path = self.get_contract_path('test_sc/arithmetic_test', 'Addition.py')
+        Boa3.compile_and_save(call_contract_path)
+
+        contract, manifest = self.get_output(call_contract_path)
+        call_hash = hash160(contract)
+        call_contract_path = call_contract_path.replace('.py', '.nef')
+
+        engine = TestEngine()
+        with self.assertRaises(TestExecutionException, msg=self.CALLED_CONTRACT_DOES_NOT_EXIST_MSG):
+            self.run_smart_contract(engine, path, 'Main', call_hash, 'add', [1, 2])
+        engine.add_contract(call_contract_path)
+
+        result = self.run_smart_contract(engine, path, 'Main', call_hash, 'add', [1, 2])
+        self.assertEqual(True, result)
+
     def test_call_contract_without_args(self):
         path = self.get_contract_path('CallScriptHashWithoutArgs.py')
         call_contract_path = self.get_contract_path('test_sc/list_test', 'IntList.py')

--- a/boa3_test/tests/compiler_tests/test_typing.py
+++ b/boa3_test/tests/compiler_tests/test_typing.py
@@ -1,8 +1,10 @@
 from boa3.exception import CompilerError, CompilerWarning
+from boa3.neo.cryptography import hash160
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.String import String
 from boa3_test.tests.boa_test import BoaTest
+from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestTyping(BoaTest):
@@ -119,19 +121,14 @@ class TestTyping(BoaTest):
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_cast_to_uint160(self):
-        expected_output = (
-            Opcode.INITSLOT     # function signature
-            + b'\x01'
-            + b'\x01'
-            + Opcode.LDARG0     # x = cast(UInt160, value)
-            + Opcode.STLOC0
-            + Opcode.LDLOC0     # return x
-            + Opcode.RET
-        )
-
         path = self.get_contract_path('CastToUInt160.py')
-        output = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
-        self.assertEqual(expected_output, output)
+        self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+
+        engine = TestEngine()
+        value = bytes(range(20))
+        result = self.run_smart_contract(engine, path, 'Main', value,
+                                         expected_result_type=bytes)
+        self.assertEqual(value, result)
 
     def test_cast_to_transaction(self):
         expected_output = (

--- a/boa3_test/tests/test_classes/testengine.py
+++ b/boa3_test/tests/test_classes/testengine.py
@@ -262,8 +262,8 @@ class TestEngine:
 
             self._error_message = result['error'] if 'error' in result else None
 
-            if 'vm_state' in result:
-                self._vm_state = VMState.get_vm_state(result['vm_state'])
+            if 'vmstate' in result:
+                self._vm_state = VMState.get_vm_state(result['vmstate'])
 
             if 'gasconsumed' in result:
                 self._gas_consumed = result['gasconsumed']
@@ -339,10 +339,10 @@ class TestEngine:
             'arguments': [contract_parameter_to_json(x) for x in args],
             'storage': self._storage.to_json(),
             'contracts': [{'nef': contract_path} for contract_path in self.contracts],
-            'signerAccounts': [to_hex_str(address) for address in self._accounts],
+            'signeraccounts': [to_hex_str(address) for address in self._accounts],
             'height': self.height,
             'blocks': [block.to_json() for block in self.blocks]
         }
         if isinstance(self._current_tx, Transaction):
-            json['currentTx'] = self._current_tx.to_json()
+            json['currenttx'] = self._current_tx.to_json()
         return json


### PR DESCRIPTION
**Related issue**
#469

**Summary or solution description**
Fixed the problem of including more DROP instructions than it should. This was causing runtime errors.
The issue was with the implementation of `CastTypeMethod`, which didn't overwrite the method `args_on_stack` from `Method`, causing an error in the simulation of the evaluation stack during the code generation.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/843f313643633095e47346036ed67002e628c76a/boa3_test/test_sc/interop_test/contract/CallScriptHashWithCast.py#L9-L11

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/843f313643633095e47346036ed67002e628c76a/boa3_test/tests/compiler_tests/test_interop/test_contract.py#L42-L57

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7