### PR TITLE
Change get_time and get_platform

### DIFF
--- a/boa3/builtin/interop/runtime/__init__.py
+++ b/boa3/builtin/interop/runtime/__init__.py
@@ -49,9 +49,9 @@ def get_trigger() -> TriggerType:
 
 executing_script_hash: UInt160 = UInt160()
 calling_script_hash: UInt160 = UInt160()
-get_time: int = 0
+time: int = 0
 gas_left: int = 0
-get_platform: str = ''
+platform: str = ''
 invocation_counter: int = 0
 entry_script_hash: UInt160 = UInt160()
 script_container: Any = None

--- a/boa3/model/builtin/interop/runtime/getblocktimemethod.py
+++ b/boa3/model/builtin/interop/runtime/getblocktimemethod.py
@@ -16,6 +16,6 @@ class GetBlockTimeMethod(InteropMethod):
 
 class BlockTimeProperty(IBuiltinProperty):
     def __init__(self):
-        identifier = 'get_time'
+        identifier = 'time'
         getter = GetBlockTimeMethod()
         super().__init__(identifier, getter)

--- a/boa3/model/builtin/interop/runtime/getplatformmethod.py
+++ b/boa3/model/builtin/interop/runtime/getplatformmethod.py
@@ -16,6 +16,6 @@ class GetPlatformMethod(InteropMethod):
 
 class PlatformProperty(IBuiltinProperty):
     def __init__(self):
-        identifier = 'get_platform'
+        identifier = 'platform'
         getter = GetPlatformMethod()
         super().__init__(identifier, getter)

--- a/boa3_test/examples/HTLC.py
+++ b/boa3_test/examples/HTLC.py
@@ -4,7 +4,7 @@ from boa3.builtin import NeoMetadata, metadata, public
 from boa3.builtin.contract import abort
 from boa3.builtin.interop.contract import GAS, call_contract
 from boa3.builtin.interop.crypto import hash160
-from boa3.builtin.interop.runtime import calling_script_hash, check_witness, executing_script_hash, get_time
+from boa3.builtin.interop.runtime import calling_script_hash, check_witness, executing_script_hash, time
 from boa3.builtin.interop.storage import get, put
 from boa3.builtin.type import UInt160
 
@@ -120,7 +120,7 @@ def atomic_swap(person_a_address: UInt160, person_a_token: bytes, person_a_amoun
         put(AMOUNT_PREFIX + PERSON_B, person_b_amount)
         put(SECRET_HASH, secret_hash)
         put(NOT_INITIALIZED, False)
-        put(START_TIME, get_time)
+        put(START_TIME, time)
         return True
     return False
 
@@ -218,7 +218,7 @@ def refund() -> bool:
     :return: whether enough time has passed and the cryptocurrencies were refunded
     :rtype: bool
     """
-    if get_time > get(START_TIME).to_int() + LOCK_TIME:
+    if time > get(START_TIME).to_int() + LOCK_TIME:
         # Checking if PERSON_A transferred to this smart contract
         funded_crypto = get(FUNDED_PREFIX + PERSON_A).to_int()
         if funded_crypto != 0:

--- a/boa3_test/test_sc/arithmetic_test/ConcatBytesVariablesAndConstants.py
+++ b/boa3_test/test_sc/arithmetic_test/ConcatBytesVariablesAndConstants.py
@@ -1,5 +1,5 @@
 from boa3.builtin import public
-from boa3.builtin.interop.runtime import get_time
+from boa3.builtin.interop.runtime import time
 
 
 VALUE1 = b'value1'
@@ -9,17 +9,17 @@ VALUE3 = b'value3'
 
 @public
 def concat1() -> bytes:
-    current_time = get_time.to_bytes() + b'some_bytes_after'
+    current_time = time.to_bytes() + b'some_bytes_after'
     return VALUE1 + b'  ' + VALUE2 + b'  ' + VALUE3 + b'  ' + current_time
 
 
 @public
 def concat2() -> bytes:
-    current_time = get_time.to_bytes() + b'some_bytes_after'
+    current_time = time.to_bytes() + b'some_bytes_after'
     return VALUE1 + VALUE2 + VALUE3 + current_time
 
 
 @public
 def concat3() -> bytes:
-    current_time = get_time.to_bytes() + b'some_bytes_after'
+    current_time = time.to_bytes() + b'some_bytes_after'
     return VALUE1 + b'__' + VALUE2 + b'__' + VALUE3 + b'__' + current_time

--- a/boa3_test/test_sc/interop_test/runtime/BlockTime.py
+++ b/boa3_test/test_sc/interop_test/runtime/BlockTime.py
@@ -1,7 +1,7 @@
 from boa3.builtin import public
-from boa3.builtin.interop.runtime import get_time
+from boa3.builtin.interop.runtime import time
 
 
 @public
 def Main() -> int:
-    return get_time
+    return time

--- a/boa3_test/test_sc/interop_test/runtime/BlockTimeCantAssign.py
+++ b/boa3_test/test_sc/interop_test/runtime/BlockTimeCantAssign.py
@@ -1,7 +1,7 @@
-from boa3.builtin.interop.runtime import get_time
+from boa3.builtin.interop.runtime import time
 
 
 def Main(example: int) -> int:
-    global get_time
-    get_time = example
-    return get_time
+    global time
+    time = example
+    return time

--- a/boa3_test/test_sc/interop_test/runtime/GetPlatform.py
+++ b/boa3_test/test_sc/interop_test/runtime/GetPlatform.py
@@ -1,7 +1,0 @@
-from boa3.builtin import public
-from boa3.builtin.interop.runtime import get_platform
-
-
-@public
-def main() -> str:
-    return get_platform

--- a/boa3_test/test_sc/interop_test/runtime/GetPlatformCantAssign.py
+++ b/boa3_test/test_sc/interop_test/runtime/GetPlatformCantAssign.py
@@ -1,7 +1,0 @@
-from boa3.builtin.interop.runtime import get_platform
-
-
-def main(example: str) -> str:
-    global get_platform
-    get_platform = example
-    return get_platform

--- a/boa3_test/test_sc/interop_test/runtime/Platform.py
+++ b/boa3_test/test_sc/interop_test/runtime/Platform.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.interop.runtime import platform
+
+
+@public
+def main() -> str:
+    return platform

--- a/boa3_test/test_sc/interop_test/runtime/PlatformCantAssign.py
+++ b/boa3_test/test_sc/interop_test/runtime/PlatformCantAssign.py
@@ -1,0 +1,7 @@
+from boa3.builtin.interop.runtime import platform
+
+
+def main(example: str) -> str:
+    global platform
+    platform = example
+    return platform

--- a/boa3_test/test_sc/interop_test/runtime/RuntimeBoa2Test.py
+++ b/boa3_test/test_sc/interop_test/runtime/RuntimeBoa2Test.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from boa3.builtin import public
-from boa3.builtin.interop.runtime import check_witness, get_time, get_trigger, log, notify
+from boa3.builtin.interop.runtime import check_witness, time, get_trigger, log, notify
 
 
 @public
@@ -13,8 +13,8 @@ def main(operation: str, arg: Any) -> Any:
     elif operation == 'check_witness' and isinstance(arg, bytes):
         return check_witness(arg)
 
-    elif operation == 'get_time':
-        return get_time
+    elif operation == 'time':
+        return time
 
     elif operation == 'log' and isinstance(arg, str):
         log(arg)

--- a/boa3_test/tests/compiler_tests/test_interop/test_runtime.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_runtime.py
@@ -494,14 +494,14 @@ class TestRuntimeInterop(BoaTest):
         output = self.assertCompilerLogs(NameShadowing, path)
         self.assertEqual(expected_output, output)
 
-    def test_get_platform(self):
+    def test_platform(self):
         expected_output = (
             Opcode.SYSCALL
             + Interop.Platform.getter.interop_method_hash
             + Opcode.RET
         )
 
-        path = self.get_contract_path('GetPlatform.py')
+        path = self.get_contract_path('Platform.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -509,7 +509,7 @@ class TestRuntimeInterop(BoaTest):
         result = self.run_smart_contract(engine, path, 'main')
         self.assertEqual('NEO', result)
 
-    def test_get_platform_cant_assign(self):
+    def test_platform_cant_assign(self):
         expected_output = (
             Opcode.INITSLOT
             + b'\x01\x01'
@@ -519,7 +519,7 @@ class TestRuntimeInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('GetPlatformCantAssign.py')
+        path = self.get_contract_path('PlatformCantAssign.py')
         output = self.assertCompilerLogs(NameShadowing, path)
         self.assertEqual(expected_output, output)
 
@@ -554,7 +554,7 @@ class TestRuntimeInterop(BoaTest):
         engine = TestEngine()
 
         new_block = engine.increase_block()
-        result = self.run_smart_contract(engine, path, 'main', 'get_time', 1)
+        result = self.run_smart_contract(engine, path, 'main', 'time', 1)
         self.assertEqual(new_block.timestamp, result)
 
         from boa3.builtin.type import UInt160

--- a/boa3_test/tests/examples_tests/test_HTLC.py
+++ b/boa3_test/tests/examples_tests/test_HTLC.py
@@ -349,7 +349,7 @@ class TestHTLCTemplate(BoaTest):
         self.assertEqual(False, result)
 
         # this simulates a new block in the blockchain
-        # get_time only changes value when a new block enters the blockchain
+        # time only changes value when a new block enters the blockchain
         engine.increase_block()
         # will be able to refund, because enough time has passed
         result = self.run_smart_contract(engine, path, 'refund',

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -317,7 +317,7 @@ All of the examples presented here can be found in the `examples folder of the N
     from boa3.builtin.contract import abort
     from boa3.builtin.interop.contract import call_contract
     from boa3.builtin.interop.crypto import hash160
-    from boa3.builtin.interop.runtime import calling_script_hash, check_witness, executing_script_hash, get_time
+    from boa3.builtin.interop.runtime import calling_script_hash, check_witness, executing_script_hash, time
     from boa3.builtin.interop.storage import get, put
     from boa3.builtin.type import UInt160
 
@@ -427,7 +427,7 @@ All of the examples presented here can be found in the `examples folder of the N
             put(AMOUNT_PREFIX + OTHER_PERSON, other_person_amount)
             put(SECRET_HASH, secret_hash)
             put(NOT_INITIALIZED, False)
-            put(START_TIME, get_time)
+            put(START_TIME, time)
             return True
         return False
 
@@ -515,7 +515,7 @@ All of the examples presented here can be found in the `examples folder of the N
         :return: whether enough time has passed and the cryptocurrencies were refunded
         :rtype: bool
         """
-        if get_time > get(START_TIME).to_int() + LOCK_TIME:
+        if time > get(START_TIME).to_int() + LOCK_TIME:
 
             # Checking if OWNER transferred to this smart contract
             funded_crypto = get(FUNDED_PREFIX + OWNER).to_int()


### PR DESCRIPTION
**Related issue**
#443 

**Summary or solution description**
Changed `get_time` and `get_platform` to `time` and `platform`.

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8