### PR TITLE
Import packages from interop packages

### DIFF
--- a/boa3/analyser/astanalyser.py
+++ b/boa3/analyser/astanalyser.py
@@ -9,6 +9,7 @@ from boa3.exception.CompilerWarning import CompilerWarning
 from boa3.model.attribute import Attribute
 from boa3.model.expression import IExpression
 from boa3.model.operation.operation import IOperation
+from boa3.model.package import Package
 from boa3.model.symbol import ISymbol
 from boa3.model.type.annotation.metatype import MetaType
 from boa3.model.type.classtype import ClassType
@@ -125,6 +126,10 @@ class IAstAnalyser(ABC, ast.NodeVisitor):
             for package in imports:
                 if symbol_id in package.all_symbols:
                     return package.all_symbols[symbol_id]
+                else:
+                    for pkg in package.all_symbols.values():
+                        if isinstance(pkg, Package) and symbol_id in pkg.symbols:
+                            return pkg.symbols[symbol_id]
 
         # the symbol may be a built in. If not, returns None
         from boa3.model.builtin.builtin import Builtin

--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -20,6 +20,7 @@ from boa3.model.operation.operation import IOperation
 from boa3.model.operation.operator import Operator
 from boa3.model.operation.unary.unaryoperation import UnaryOperation
 from boa3.model.operation.unaryop import UnaryOp
+from boa3.model.package import Package
 from boa3.model.symbol import ISymbol
 from boa3.model.type.classtype import ClassType
 from boa3.model.type.collection.icollection import ICollectionType as Collection
@@ -1057,7 +1058,7 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
 
         if (callable_target is not None
                 and (len(call.args) < 1 or call.args[0] != arg0)
-                and not isinstance(self.get_symbol(arg0_identifier), (IType, Import))):
+                and not isinstance(self.get_symbol(arg0_identifier), (IType, Import, Package))):
             call.args.insert(0, arg0)
 
         if len(call.args) > 0 and isinstance(callable_target, IBuiltinMethod) and callable_target.has_self_argument:
@@ -1288,6 +1289,8 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
         if isinstance(value, ISymbol):
             symbol = value
 
+        if isinstance(symbol, Attribute):
+            symbol = symbol.attr_symbol
         if isinstance(symbol, IExpression):
             symbol = symbol.type
         if hasattr(symbol, 'symbols') and attribute.attr in symbol.symbols:

--- a/boa3/compiler/codegenerator/codegenerator.py
+++ b/boa3/compiler/codegenerator/codegenerator.py
@@ -13,6 +13,7 @@ from boa3.model.method import Method
 from boa3.model.operation.binaryop import BinaryOp
 from boa3.model.operation.operation import IOperation
 from boa3.model.operation.unaryop import UnaryOp
+from boa3.model.package import Package
 from boa3.model.property import Property
 from boa3.model.symbol import ISymbol
 from boa3.model.type.classtype import ClassType
@@ -238,6 +239,10 @@ class CodeGenerator:
                 for package in imports:
                     if identifier in package.all_symbols:
                         return package.all_symbols[identifier]
+                    else:
+                        for pkg in package.all_symbols.values():
+                            if isinstance(pkg, Package) and identifier in pkg.symbols:
+                                return pkg.symbols[identifier]
         return Type.none
 
     def initialize_static_fields(self) -> bool:

--- a/boa3/model/builtin/interop/interop.py
+++ b/boa3/model/builtin/interop/interop.py
@@ -12,6 +12,7 @@ from boa3.model.builtin.interop.nativecontract import *
 from boa3.model.builtin.interop.runtime import *
 from boa3.model.builtin.interop.storage import *
 from boa3.model.identifiedsymbol import IdentifiedSymbol
+from boa3.model.package import Package
 
 
 class InteropPackage(str, Enum):
@@ -122,73 +123,121 @@ class Interop:
     StorageGet = StorageGetMethod()
     StoragePut = StoragePutMethod()
 
-    _interop_symbols: Dict[InteropPackage, List[IdentifiedSymbol]] = {
-        InteropPackage.Binary: [Atoi,
-                                Base58Encode,
-                                Base58Decode,
-                                Base64Encode,
-                                Base64Decode,
-                                Deserialize,
-                                Itoa,
-                                Serialize
-                                ],
-        InteropPackage.Blockchain: [BlockType,
-                                    CurrentHeight,
-                                    GetBlock,
-                                    GetContract,
-                                    GetTransaction,
-                                    GetTransactionFromBlock,
-                                    GetTransactionHeight,
-                                    TransactionType
+    BinaryPackage = Package(identifier=InteropPackage.Binary,
+                            properties=[],
+                            methods=[Atoi,
+                                     Base58Encode,
+                                     Base58Decode,
+                                     Base64Encode,
+                                     Base64Decode,
+                                     Deserialize,
+                                     Itoa,
+                                     Serialize
+                                     ]
+                            )
+
+    BlockchainPackage = Package(identifier=InteropPackage.Blockchain,
+                                types=[BlockType,
+                                       TransactionType
+                                       ],
+                                properties=[],
+                                methods=[CurrentHeight,
+                                         GetBlock,
+                                         GetContract,
+                                         GetTransaction,
+                                         GetTransactionFromBlock,
+                                         GetTransactionHeight
+                                         ]
+                                )
+
+    ContractPackage = Package(identifier=InteropPackage.Contract,
+                              types=[CallFlagsType,
+                                     ContractType
+                                     ],
+                              properties=[GasScriptHash,
+                                          NeoScriptHash
+                                          ],
+                              methods=[CallContract,
+                                       CreateContract,
+                                       DestroyContract,
+                                       GetCallFlags,
+                                       UpdateContract
+                                       ]
+                              )
+
+    CryptoPackage = Package(identifier=InteropPackage.Crypto,
+                            properties=[],
+                            methods=[CheckMultisig,
+                                     Hash160,
+                                     Hash256,
+                                     Ripemd160,
+                                     Sha256,
+                                     VerifyWithECDsaSecp256k1,
+                                     VerifyWithECDsaSecp256r1
+                                     ]
+                            )
+
+    IteratorPackage = Package(identifier=InteropPackage.Iterator,
+                              types=[Iterator],
+                              properties=[],
+                              methods=[]
+                              )
+
+    JsonPackage = Package(identifier=InteropPackage.Json,
+                          types=[],
+                          properties=[],
+                          methods=[JsonDeserialize,
+                                   JsonSerialize
+                                   ]
+                          )
+
+    RuntimePackage = Package(identifier=InteropPackage.Runtime,
+                             types=[NotificationType,
+                                    TriggerType
                                     ],
-        InteropPackage.Contract: [CallContract,
-                                  CallFlagsType,
-                                  ContractType,
-                                  CreateContract,
-                                  DestroyContract,
-                                  GasScriptHash,
-                                  GetCallFlags,
-                                  NeoScriptHash,
-                                  UpdateContract
-                                  ],
-        InteropPackage.Crypto: [CheckMultisig,
-                                Hash160,
-                                Hash256,
-                                Ripemd160,
-                                Sha256,
-                                VerifyWithECDsaSecp256k1,
-                                VerifyWithECDsaSecp256r1
-                                ],
-        InteropPackage.Iterator: [Iterator],
-        InteropPackage.Json: [JsonDeserialize,
-                              JsonSerialize
-                              ],
-        InteropPackage.Runtime: [BlockTime,
-                                 BurnGas,
-                                 CallingScriptHash,
-                                 CheckWitness,
-                                 EntryScriptHash,
-                                 ExecutingScriptHash,
-                                 GasLeft,
-                                 GetNotifications,
-                                 GetTrigger,
-                                 InvocationCounter,
-                                 Log,
-                                 NotificationType,
-                                 Notify,
-                                 Platform,
-                                 ScriptContainer,
-                                 TriggerType
-                                 ],
-        InteropPackage.Storage: [StorageContextType,
-                                 StorageDelete,
-                                 StorageFind,
-                                 StorageGet,
-                                 StorageGetContext,
-                                 StorageMapType,
-                                 StoragePut
-                                 ]
-    }
+                             properties=[BlockTime,
+                                         CallingScriptHash,
+                                         ExecutingScriptHash,
+                                         GasLeft,
+                                         Platform,
+                                         InvocationCounter,
+                                         EntryScriptHash,
+                                         ScriptContainer
+                                         ],
+                             methods=[BurnGas,
+                                      CheckWitness,
+                                      GetNotifications,
+                                      GetTrigger,
+                                      Log,
+                                      Notify
+                                      ]
+                             )
+
+    StoragePackage = Package(identifier=InteropPackage.Storage,
+                             types=[StorageContextType,
+                                    StorageMapType
+                                    ],
+                             properties=[],
+                             methods=[StorageDelete,
+                                      StorageFind,
+                                      StorageGet,
+                                      StorageGetContext,
+                                      StoragePut
+                                      ]
+                             )
+
     package_symbols: List[IdentifiedSymbol] = [
-        OracleType
+        OracleType,
+        BinaryPackage,
+        BlockchainPackage,
+        ContractPackage,
+        CryptoPackage,
+        IteratorPackage,
+        JsonPackage,
+        RuntimePackage,
+        StoragePackage
     ]
+
+    _interop_symbols: Dict[InteropPackage, List[IdentifiedSymbol]] = {
+        package.identifier: list(package.symbols.values()) for package in package_symbols if isinstance(package, Package)
+    }

--- a/boa3/model/package.py
+++ b/boa3/model/package.py
@@ -1,0 +1,49 @@
+from typing import Dict, List
+
+from boa3.model.identifiedsymbol import IdentifiedSymbol
+
+
+class Package(IdentifiedSymbol):
+    """
+    A class used to represent a Python module.
+
+    :ivar properties: a list that stores every property in the package. Empty by default.
+    :ivar methods: a list that stores every method in the package. Empty by default.
+    :ivar types: a list that stores every property in the package. Empty by default.
+    """
+
+    def __init__(self, identifier: str,
+                 properties: List[IdentifiedSymbol] = None,
+                 methods: List[IdentifiedSymbol] = None,
+                 types: List[IdentifiedSymbol] = None,
+                 ):
+        super().__init__(identifier)
+
+        if methods is None:
+            methods = []
+        self.methods = methods
+
+        if properties is None:
+            properties = []
+        self.properties = properties
+
+        if types is None:
+            types = []
+        self.types = types
+
+    @property
+    def shadowing_name(self) -> str:
+        return 'package'
+
+    @property
+    def symbols(self) -> Dict[str, IdentifiedSymbol]:
+        """
+        Gets all the symbols in the package.
+
+        :return: a list that stores every symbol in the package
+        """
+        symbols = {}
+        symbols.update({symbol.raw_identifier: symbol for symbol in self.types})
+        symbols.update({symbol.raw_identifier: symbol for symbol in self.properties})
+        symbols.update({symbol.raw_identifier: symbol for symbol in self.methods})
+        return symbols

--- a/boa3_test/test_sc/interop_test/binary/ImportBinary.py
+++ b/boa3_test/test_sc/interop_test/binary/ImportBinary.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.interop import binary
+
+
+@public
+def main(value: str, base: int) -> int:
+    return binary.atoi(value, base)

--- a/boa3_test/test_sc/interop_test/blockchain/ImportBlockchain.py
+++ b/boa3_test/test_sc/interop_test/blockchain/ImportBlockchain.py
@@ -1,0 +1,9 @@
+from boa3.builtin import public
+from boa3.builtin.interop import blockchain
+from boa3.builtin.interop.contract import Contract
+from boa3.builtin.type import UInt160
+
+
+@public
+def main(hash_: UInt160) -> Contract:
+    return blockchain.get_contract(hash_)

--- a/boa3_test/test_sc/interop_test/contract/ImportContract.py
+++ b/boa3_test/test_sc/interop_test/contract/ImportContract.py
@@ -1,0 +1,15 @@
+from typing import Any
+
+from boa3.builtin import public
+from boa3.builtin.interop import contract
+from boa3.builtin.type import UInt160
+
+
+@public
+def call_flags_all() -> contract.CallFlags:
+    return contract.CallFlags.ALL
+
+
+@public
+def main(scripthash: UInt160, method: str, args: list) -> Any:
+    return contract.call_contract(scripthash, method, args)

--- a/boa3_test/test_sc/interop_test/crypto/ImportCrypto.py
+++ b/boa3_test/test_sc/interop_test/crypto/ImportCrypto.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.interop import crypto
+
+
+@public
+def main(test: str) -> bytes:
+    return crypto.hash160(test)

--- a/boa3_test/test_sc/interop_test/iterator/ImportIterator.py
+++ b/boa3_test/test_sc/interop_test/iterator/ImportIterator.py
@@ -1,0 +1,8 @@
+from boa3.builtin import public
+from boa3.builtin.interop import iterator
+from boa3.builtin.interop.storage import find
+
+
+@public
+def return_iterator() -> iterator.Iterator:
+    return find('random_prefix')

--- a/boa3_test/test_sc/interop_test/json/ImportJson.py
+++ b/boa3_test/test_sc/interop_test/json/ImportJson.py
@@ -1,0 +1,10 @@
+from typing import Any
+
+from boa3.builtin import public
+from boa3.builtin.interop import json
+
+
+@public
+def main(value: Any) -> Any:
+    serialized = json.json_serialize(value)
+    return json.json_deserialize(serialized)

--- a/boa3_test/test_sc/interop_test/runtime/ImportRuntime.py
+++ b/boa3_test/test_sc/interop_test/runtime/ImportRuntime.py
@@ -4,4 +4,4 @@ from boa3.builtin.interop import runtime
 
 @public
 def main() -> int:
-    return runtime.get_time + runtime.gas_left + runtime.invocation_counter
+    return runtime.time + runtime.gas_left + runtime.invocation_counter

--- a/boa3_test/test_sc/interop_test/runtime/ImportRuntime.py
+++ b/boa3_test/test_sc/interop_test/runtime/ImportRuntime.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.interop import runtime
+
+
+@public
+def main() -> int:
+    return runtime.get_time + runtime.gas_left + runtime.invocation_counter

--- a/boa3_test/test_sc/interop_test/storage/ImportStorage.py
+++ b/boa3_test/test_sc/interop_test/storage/ImportStorage.py
@@ -1,0 +1,23 @@
+from boa3.builtin import public
+from boa3.builtin.interop import storage
+from boa3.builtin.interop.iterator import Iterator
+
+
+@public
+def put_value(key: str, value: int):
+    storage.put(key, value)
+
+
+@public
+def get_value(key: str) -> int:
+    return storage.get(key).to_int()
+
+
+@public
+def delete_value(key: str):
+    storage.delete(key)
+
+
+@public
+def find_by_prefix(prefix: str) -> Iterator:
+    return storage.find(prefix)

--- a/boa3_test/tests/compiler_tests/test_interop/test_binary.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_binary.py
@@ -357,3 +357,13 @@ class TestBinaryInterop(BoaTest):
     def test_itoa_mismatched_type(self):
         path = self.get_contract_path('ItoaMismatchedType')
         self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_import_binary(self):
+        path = self.get_contract_path('ImportBinary')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'main', '10', 10)
+        self.assertEqual(10, result)
+
+        result = self.run_smart_contract(engine, path, 'main', '10', 16)
+        self.assertEqual(16, result)

--- a/boa3_test/tests/compiler_tests/test_interop/test_contract.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_contract.py
@@ -359,3 +359,23 @@ class TestContractInterop(BoaTest):
         self.assertEqual(CallFlags.ALLOW_CALL, result)
         result = self.run_smart_contract(engine, path, 'Main', call_hash, 'main', [], CallFlags.ALLOW_NOTIFY)
         self.assertEqual(CallFlags.ALLOW_NOTIFY, result)
+
+    def test_import_contract(self):
+        path = self.get_contract_path('ImportContract.py')
+        call_contract_path = self.get_contract_path('test_sc/arithmetic_test', 'Addition.py')
+        Boa3.compile_and_save(path)
+        Boa3.compile_and_save(call_contract_path)
+
+        contract, manifest = self.get_output(call_contract_path)
+        call_hash = hash160(contract)
+        call_contract_path = call_contract_path.replace('.py', '.nef')
+
+        engine = TestEngine()
+        engine.add_contract(call_contract_path)
+
+        result = self.run_smart_contract(engine, path, 'main', call_hash, 'add', [1, 2])
+        self.assertEqual(3, result)
+
+        result = self.run_smart_contract(engine, path, 'call_flags_all')
+        from boa3.neo3.contracts import CallFlags
+        self.assertEqual(CallFlags.ALL, result)

--- a/boa3_test/tests/compiler_tests/test_interop/test_crypto.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_crypto.py
@@ -503,3 +503,11 @@ class TestCryptoInterop(BoaTest):
     def test_verify_with_ecdsa_secp256k1_mismatched_type(self):
         path = self.get_contract_path('VerifyWithECDsaSecp256k1MismatchedType.py')
         self.assertCompilerLogs(MismatchedTypes, path)
+
+    def test_import_crypto(self):
+        import hashlib
+        path = self.get_contract_path('ImportCrypto.py')
+        engine = TestEngine()
+        expected_result = hashlib.new('ripemd160', (hashlib.sha256(b'unit test').digest())).digest()
+        result = self.run_smart_contract(engine, path, 'main', 'unit test')
+        self.assertEqual(expected_result, result)

--- a/boa3_test/tests/compiler_tests/test_interop/test_iterator.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_iterator.py
@@ -43,3 +43,12 @@ class TestIteratorInterop(BoaTest):
     def test_iterator_value_dict_mismatched_type(self):
         path = self.get_contract_path('IteratorValueMismatchedType.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+
+    def test_import_iterator(self):
+        path = self.get_contract_path('ImportIterator.py')
+        engine = TestEngine()
+        self.compile_and_save(path)
+
+        result = self.run_smart_contract(engine, path, 'return_iterator')
+        from boa3.neo.core.types.InteropInterface import InteropInterface
+        self.assertEqual(InteropInterface, result)  # returns an interop interface

--- a/boa3_test/tests/compiler_tests/test_interop/test_json.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_json.py
@@ -73,3 +73,15 @@ class TestJsonInterop(BoaTest):
         expected_result = json.loads(test_input)
         result = self.run_smart_contract(engine, path, 'main', test_input)
         self.assertEqual(expected_result, result)
+
+    def test_import_json(self):
+        path = self.get_contract_path('ImportJson.py')
+        engine = TestEngine()
+
+        value = 123
+        result = self.run_smart_contract(engine, path, 'main', value)
+        self.assertEqual(value, result)
+
+        value = 'string'
+        result = self.run_smart_contract(engine, path, 'main', value)
+        self.assertEqual(value, result)

--- a/boa3_test/tests/compiler_tests/test_interop/test_runtime.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_runtime.py
@@ -1,5 +1,5 @@
 from boa3.boa3 import Boa3
-from boa3.builtin.interop.runtime import TriggerType
+from boa3.neo3.contracts import TriggerType
 from boa3.exception.CompilerError import MismatchedTypes
 from boa3.exception.CompilerWarning import NameShadowing
 from boa3.model.builtin.interop.interop import Interop
@@ -618,3 +618,10 @@ class TestRuntimeInterop(BoaTest):
         if isinstance(result[6], str):
             result[6] = String(result[6]).to_bytes()
         self.assertIsInstance(result[7], bytes)
+
+    def test_import_runtime(self):
+        path = self.get_contract_path('ImportRuntime.py')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'main')
+        self.assertIsInstance(result, int)

--- a/boa3_test/tests/compiler_tests/test_interop/test_storage.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_storage.py
@@ -644,3 +644,29 @@ class TestStorageInterop(BoaTest):
         result = self.run_smart_contract(engine, path, 'get_from_map', 'test1',
                                          expected_result_type=bytes)
         self.assertEqual(b'', result)
+
+    def test_import_storage(self):
+        path = self.get_contract_path('ImportStorage.py')
+        engine = TestEngine()
+
+        key = 'unit_test'
+        value = 1234
+
+        result = self.run_smart_contract(engine, path, 'get_value', key)
+        self.assertEqual(0, result)
+
+        result = self.run_smart_contract(engine, path, 'put_value', key, value)
+        self.assertIsVoid(result)
+
+        result = self.run_smart_contract(engine, path, 'get_value', key)
+        self.assertEqual(value, result)
+
+        result = self.run_smart_contract(engine, path, 'delete_value', key)
+        self.assertIsVoid(result)
+
+        result = self.run_smart_contract(engine, path, 'get_value', key)
+        self.assertEqual(0, result)
+
+        result = self.run_smart_contract(engine, path, 'find_by_prefix', 'prefix')
+        self.assertEqual(InteropInterface, result)  # returns an interop interface
+        # TODO: validate actual result when Enumerator.next() and Enumerator.value() are implemented


### PR DESCRIPTION
**Related issue**
#261 

**Summary or solution description**
Added a Package class and some extra requirements to make it work on the compiler.

**How to Reproduce**
It's now possible to use ` from boa3.builtin.interop import {subpackage}`.

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/308c606bdd53e883b5fff40230315a8475641f88/boa3_test/tests/compiler_tests/test_interop/test_binary.py#L361-L369
https://github.com/CityOfZion/neo3-boa/blob/308c606bdd53e883b5fff40230315a8475641f88/boa3_test/tests/compiler_tests/test_interop/test_blockchain.py#L305-L326
https://github.com/CityOfZion/neo3-boa/blob/308c606bdd53e883b5fff40230315a8475641f88/boa3_test/tests/compiler_tests/test_interop/test_contract.py#L363-L381
https://github.com/CityOfZion/neo3-boa/blob/308c606bdd53e883b5fff40230315a8475641f88/boa3_test/tests/compiler_tests/test_interop/test_crypto.py#L507-L513
https://github.com/CityOfZion/neo3-boa/blob/308c606bdd53e883b5fff40230315a8475641f88/boa3_test/tests/compiler_tests/test_interop/test_iterator.py#L47-L54
https://github.com/CityOfZion/neo3-boa/blob/308c606bdd53e883b5fff40230315a8475641f88/boa3_test/tests/compiler_tests/test_interop/test_json.py#L77-L87
https://github.com/CityOfZion/neo3-boa/blob/308c606bdd53e883b5fff40230315a8475641f88/boa3_test/tests/compiler_tests/test_interop/test_runtime.py#L622-L627
https://github.com/CityOfZion/neo3-boa/blob/308c606bdd53e883b5fff40230315a8475641f88/boa3_test/tests/compiler_tests/test_interop/test_storage.py#L648-L672

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8