### PR TITLE
Fixed jump targets and slicing after cast

### DIFF
--- a/boa3/analyser/moduleanalyser.py
+++ b/boa3/analyser/moduleanalyser.py
@@ -639,7 +639,8 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
         symbol = self.get_symbol(value) if isinstance(value, str) else value
 
         if isinstance(subscript.ctx, ast.Load):
-            if isinstance(symbol, Collection):
+            if isinstance(symbol, Collection) and isinstance(subscript.value, (ast.Name, ast.NameConstant)):
+                # for evaluating names like List[str], Dict[int, bool], etc
                 value = subscript.slice.value if isinstance(subscript.slice, ast.Index) else subscript.slice
                 values_type: Iterable[IType] = self.get_values_type(value)
                 return symbol.build_collection(*values_type)
@@ -880,6 +881,15 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
         :return: the value of the string
         """
         return str.s
+
+    def visit_Bytes(self, btes: ast.Bytes) -> bytes:
+        """
+        Visitor of literal string node
+
+        :param btes:
+        :return: the value of the string
+        """
+        return btes.s
 
     def visit_Tuple(self, tup_node: ast.Tuple) -> Optional[Tuple[Any, ...]]:
         """

--- a/boa3/builtin/interop/blockchain/block.py
+++ b/boa3/builtin/interop/blockchain/block.py
@@ -24,6 +24,7 @@ class Block:
     :ivar transaction_count: the number of transactions on this block
     :vartype transaction_count: int
     """
+
     def __init__(self):
         self.hash: UInt256 = UInt256()
         self.version: int = 0

--- a/boa3/builtin/interop/blockchain/transaction.py
+++ b/boa3/builtin/interop/blockchain/transaction.py
@@ -22,6 +22,7 @@ class Transaction:
     :ivar script: the array of instructions to be executed on the transaction chain by the virtual machine
     :vartype script: bytes
     """
+
     def __init__(self):
         self.hash: UInt256 = UInt256()
         self.version: int = 0

--- a/boa3/builtin/interop/contract/contract.py
+++ b/boa3/builtin/interop/contract/contract.py
@@ -19,6 +19,7 @@ class Contract:
     :ivar manifest: the manifest of the contract
     :vartype manifest: Dict[str, Any]
     """
+
     def __init__(self):
         self.id: int = 0
         self.update_counter: int = 0

--- a/boa3/builtin/interop/runtime/notification.py
+++ b/boa3/builtin/interop/runtime/notification.py
@@ -14,6 +14,7 @@ class Notification:
     :ivar state: a tuple value storing all the notification contents.
     :vartype state: tuple
     """
+
     def __init__(self):
         self.script_hash: UInt160 = UInt160()
         self.event_name: str = ''

--- a/boa3/builtin/type/__init__.py
+++ b/boa3/builtin/type/__init__.py
@@ -5,6 +5,7 @@ class UInt160(bytes):
     """
     Represents a 160-bit unsigned integer.
     """
+
     def __init__(self, arg: Union[bytes, int] = 0):
         super().__init__()
         pass
@@ -14,6 +15,7 @@ class UInt256(bytes):
     """
     Represents a 256-bit unsigned integer.
     """
+
     def __init__(self, arg: Union[bytes, int] = 0):
         super().__init__()
         pass

--- a/boa3/compiler/codegenerator/codegenerator.py
+++ b/boa3/compiler/codegenerator/codegenerator.py
@@ -1278,7 +1278,7 @@ class CodeGenerator:
         vm_code = VMCode(op_info, data)
 
         if op_info.opcode.has_target():
-            data = vm_code.data
+            data = vm_code.raw_data
             relative_address: int = Integer.from_bytes(data, signed=True)
             actual_address = VMCodeMapping.instance().bytecode_size + relative_address
             if (self._can_append_target

--- a/boa3/compiler/codegenerator/vmcodemapping.py
+++ b/boa3/compiler/codegenerator/vmcodemapping.py
@@ -235,9 +235,10 @@ class VMCodeMapping:
 
         if address in targeted_addresses:
             next_address = self.get_end_address(code) + 1
-            next_code = self._codes[next_address]
-            for source in targeted_addresses[address]:
-                self._codes[source].set_target(next_code)
+            if next_address < self.bytecode_size:
+                next_code = self._codes[next_address]
+                for source in targeted_addresses[address]:
+                    self._codes[source].set_target(next_code)
 
     def move_to_end(self, first_code_address: int, last_code_address: int):
         """

--- a/boa3/neo3/contracts/contracttypes.py
+++ b/boa3/neo3/contracts/contracttypes.py
@@ -12,28 +12,28 @@ class TriggerType(IntFlag):
     SYSTEM = 0x01
     """
     The combination of all system triggers.
-    
+
     :meta hide-value:
     """
 
     VERIFICATION = 0x20
     """
     Indicates that the contract is triggered by the verification of a IVerifiable.
-    
+
     :meta hide-value:
     """
 
     APPLICATION = 0x40
     """
     Indicates that the contract is triggered by the execution of transactions.
-    
+
     :meta hide-value:
     """
 
     ALL = SYSTEM | VERIFICATION | APPLICATION
     """
     The combination of all triggers.
-    
+
     :meta hide-value:
     """
 
@@ -48,7 +48,7 @@ class CallFlags(IntFlag):
     """
     Special behaviors of the invoked contract are not allowed, such as chain calls, sending notifications, modifying 
     state, etc.
-    
+
     :meta hide-value:
     """
 
@@ -90,7 +90,7 @@ class CallFlags(IntFlag):
     READ_ONLY = READ_STATES | ALLOW_CALL
     """
     Indicates that the called contract is allowed to read states or call another contract.
-    
+
     :meta hide-value:
     """
 

--- a/boa3_test/test_sc/bytes_test/SliceWithCast.py
+++ b/boa3_test/test_sc/bytes_test/SliceWithCast.py
@@ -1,0 +1,11 @@
+from typing import Any, cast
+
+from boa3.builtin import public
+
+
+@public
+def main(a: Any) -> bytes:
+
+    m = cast(bytes, a)[1:2]
+
+    return m

--- a/boa3_test/test_sc/interop_test/contract/CallScriptHashWithCast.py
+++ b/boa3_test/test_sc/interop_test/contract/CallScriptHashWithCast.py
@@ -1,4 +1,4 @@
-from typing import Any, cast
+from typing import cast
 
 from boa3.builtin import public
 from boa3.builtin.interop.contract import call_contract

--- a/boa3_test/test_sc/interop_test/runtime/RuntimeBoa2Test.py
+++ b/boa3_test/test_sc/interop_test/runtime/RuntimeBoa2Test.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from boa3.builtin import public
-from boa3.builtin.interop.runtime import check_witness, time, get_trigger, log, notify
+from boa3.builtin.interop.runtime import check_witness, get_trigger, log, notify, time
 
 
 @public

--- a/boa3_test/test_sc/while_test/WhileWithInteropCondition.py
+++ b/boa3_test/test_sc/while_test/WhileWithInteropCondition.py
@@ -1,0 +1,35 @@
+from typing import cast
+
+from boa3.builtin import public
+from boa3.builtin.interop.contract import GAS, NEO
+from boa3.builtin.interop.runtime import executing_script_hash, notify
+from boa3.builtin.interop.storage import find, get, get_context, put
+from boa3.builtin.type import UInt160
+
+FEE_RECEIVER_KEY = b'FEE_RECEIVER'
+
+feesMap = get_context().create_map('feesMap')
+
+
+@public
+def test_end_while_jump() -> bool:
+    iterator = find(b'feesMap')
+    fee_receiver = get(FEE_RECEIVER_KEY)
+    while iterator.next():
+        token_bytes = cast(bytes, iterator.value[0])
+        token_bytes = token_bytes[7:]  # cut 'feesMap' at the beginning of the bytes
+        token = cast(UInt160, token_bytes)
+        fee_amount = cast(int, iterator.value[1])
+        if fee_amount > 0:
+            notify([token, executing_script_hash, fee_receiver, fee_amount])
+    return True
+
+
+@public
+def deploy() -> bool:
+    # placeholders for testing
+    put(FEE_RECEIVER_KEY, UInt160())
+
+    feesMap.put(GAS, 10)
+    feesMap.put(NEO, 20)
+    return True

--- a/boa3_test/tests/compiler_tests/test_bytes.py
+++ b/boa3_test/tests/compiler_tests/test_bytes.py
@@ -227,6 +227,25 @@ class TestBytes(BoaTest):
         with self.assertRaises(TestExecutionException):
             self.run_smart_contract(engine, path, 'main', bytearray())
 
+    def test_slice_with_cast(self):
+        path = self.get_contract_path('SliceWithCast.py')
+        self.compile_and_save(path)
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'main', b'unittest',
+                                         expected_result_type=bytes)
+        self.assertEqual(b'unittest'[1:2], result)
+
+        result = self.run_smart_contract(engine, path, 'main', '123',
+                                         expected_result_type=bytes)
+        self.assertEqual(b'123'[1:2], result)
+
+        with self.assertRaises(TestExecutionException):
+            self.run_smart_contract(engine, path, 'main', bytearray())
+
+        result = self.run_smart_contract(engine, path, 'main', 12345,
+                                         expected_result_type=bytes)
+        self.assertEqual(Integer(12345).to_byte_array()[1:2], result)
+
     def test_byte_array_get_value(self):
         expected_output = (
             Opcode.INITSLOT     # function signature

--- a/boa3_test/tests/compiler_tests/test_interop/test_blockchain.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_blockchain.py
@@ -7,7 +7,7 @@ from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.String import String
 from boa3.neo3.contracts import CallFlags
-from boa3.neo3.core.types import UInt256, UInt160
+from boa3.neo3.core.types import UInt160, UInt256
 from boa3_test.tests.boa_test import BoaTest
 from boa3_test.tests.test_classes.contract.neomanifeststruct import NeoManifestStruct
 from boa3_test.tests.test_classes.testengine import TestEngine

--- a/boa3_test/tests/compiler_tests/test_typing.py
+++ b/boa3_test/tests/compiler_tests/test_typing.py
@@ -1,5 +1,4 @@
 from boa3.exception import CompilerError, CompilerWarning
-from boa3.neo.cryptography import hash160
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.String import String


### PR DESCRIPTION
**Related issue**
#472

**Summary or solution description**
The target of JUMP and CALL instructions wasn't correct when the argument address size of these operations was greater than one and it was generated by control flow statements (`while`, `for`, `if`).
Fixed by always using the `raw_data` to find the target instead of the formatted `data`.

**How to Reproduce**
Use control flow with sufficient instructions to use large jumps instructions
```python
while iterator.next():
    token_bytes = cast(bytes, iterator.value[0])[7:]  # cut 'feesMap' at the beginning of the bytes
    token = cast(UInt160, token_bytes)
    fee_amount = cast(int, iterator.value[1])
    if fee_amount > 0:
        notify([token, executing_script_hash, fee_receiver, fee_amount])
```

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/d5ef03dba718ffb70996515747b168263cd28c0c/boa3_test/tests/compiler_tests/test_while.py#L436-L449

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
