### PR TITLE
Implement Storage AsReadOnly Interop

### DIFF
--- a/boa3/builtin/interop/storage/storagecontext.py
+++ b/boa3/builtin/interop/storage/storagecontext.py
@@ -1,5 +1,6 @@
-from typing import Union
+from __future__ import annotations
 
+from typing import Union
 from boa3.builtin.interop.storage.storagemap import StorageMap
 
 
@@ -19,5 +20,14 @@ class StorageContext:
         :type prefix: str or bytes
         :return: a map with the key-values in the storage that match with the given prefix
         :rtype: StorageMap
+        """
+        pass
+
+    def as_read_only(self) -> StorageContext:
+        """
+        Converts the specified storage context to a new readonly storage context.
+
+        :return: current StorageContext as ReadOnly
+        :rtype: StorageContext
         """
         pass

--- a/boa3/model/builtin/interop/storage/storagecontext/storagecontextasreadonlymethod.py
+++ b/boa3/model/builtin/interop/storage/storagecontext/storagecontextasreadonlymethod.py
@@ -1,0 +1,15 @@
+from typing import Dict
+
+from boa3.model.builtin.interop.interopmethod import InteropMethod
+from boa3.model.variable import Variable
+
+
+class StorageContextAsReadOnlyMethod(InteropMethod):
+
+    def __init__(self):
+        from boa3.model.builtin.interop.storage.storagecontext.storagecontexttype import _StorageContext
+
+        identifier = 'as_read_only'
+        syscall = 'System.Storage.AsReadOnly'
+        args: Dict[str, Variable] = {'self': Variable(_StorageContext)}
+        super().__init__(identifier, syscall, args, return_type=_StorageContext)

--- a/boa3/model/builtin/interop/storage/storagecontext/storagecontexttype.py
+++ b/boa3/model/builtin/interop/storage/storagecontext/storagecontexttype.py
@@ -38,9 +38,11 @@ class StorageContextType(InteropInterfaceType):
         if len(self._instance_methods) == 0:
             from boa3.model.builtin.interop.storage.storagecontext.storagecontextcreatemapmethod import \
                 StorageContextCreateMapMethod
+            from boa3.model.builtin.interop.storage.storagecontext.storagecontextasreadonlymethod import StorageContextAsReadOnlyMethod
 
             self._instance_methods = {
-                'create_map': StorageContextCreateMapMethod()
+                'create_map': StorageContextCreateMapMethod(),
+                'as_read_only': StorageContextAsReadOnlyMethod()
             }
         return self._instance_methods
 

--- a/boa3_test/test_sc/interop_test/storage/StorageAsReadOnly.py
+++ b/boa3_test/test_sc/interop_test/storage/StorageAsReadOnly.py
@@ -1,0 +1,22 @@
+from boa3.builtin import public
+from boa3.builtin.interop.storage import get_context, put, get
+
+
+@public
+def put_value_in_storage(key: str, value: str):
+    put(key, value)
+
+
+@public
+def get_value_in_storage(key: str) -> str:
+    return get(key).to_str()
+
+
+@public
+def put_value_in_storage_read_only(key: str, value: str):
+    put(key, value, get_context().as_read_only())
+
+
+@public
+def get_value_in_storage_read_only(key: str) -> str:
+    return get(key, get_context().as_read_only()).to_str()


### PR DESCRIPTION
**Related issue**
#279 

**How to Reproduce**
Use the instance method on a Storage Context, e.g., `get_context().as_read_only`.

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/8fb49365680d9e46f9e1d1d600219805499f3182/boa3_test/tests/compiler_tests/test_interop/test_storage.py#L649-L676

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8
