### PR TITLE
Fixed issue with strings in the optimizer

### DIFF
--- a/boa3/analyser/astoptimizer.py
+++ b/boa3/analyser/astoptimizer.py
@@ -56,7 +56,7 @@ class AstOptimizer(IAstAnalyser, ast.NodeTransformer):
         :return: the parsed node
         :rtype: ast.AST or Sequence[ast.AST]
         """
-        if is_origin_str and not expression.startswith(("'", '"')):
+        if is_origin_str:
             expression = "'{0}'".format(expression)
 
         new_node = self.visit(super().parse_to_node(expression, origin))

--- a/boa3_test/test_sc/string_test/StringWithDoubleQuotes.py
+++ b/boa3_test/test_sc/string_test/StringWithDoubleQuotes.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def string_test(str1: str, str2: str) -> str:
+    return '"' + str1[:-1] + '"test_symbol":' + str2 + '}"'

--- a/boa3_test/tests/compiler_tests/test_string.py
+++ b/boa3_test/tests/compiler_tests/test_string.py
@@ -194,3 +194,16 @@ class TestString(BoaTest):
 
         result = self.run_smart_contract(engine, path, 'main', 'concat', ['', 'neo'])
         self.assertEqual('neo', result)
+
+    def test_string_with_double_quotes(self):
+        path = self.get_contract_path('StringWithDoubleQuotes.py')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'string_test', 'hello', 'world')
+        self.assertEqual('"hell"test_symbol":world}"', result)
+
+        result = self.run_smart_contract(engine, path, 'string_test', '1', 'neo')
+        self.assertEqual('""test_symbol":neo}"', result)
+
+        result = self.run_smart_contract(engine, path, 'string_test', 'neo', '')
+        self.assertEqual('"ne"test_symbol":}"', result)


### PR DESCRIPTION
**Related issue**
#447

**Summary or solution description**
The main issue that raised the compiler errors reported in #447 was fixed on #457. 
Changed the validation in `parse_to_node` and included a unit test to ensure that the problem is solved

**How to Reproduce**
```python
from boa3.builtin import public

@public
def string_test(str1: str, str2: str) -> str:
    return '"' + str1 + '"test_symbol":' + str2 + '}"'
```

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/3ab62446235fc6e1d50da3a215c43966e9cbfa4f/boa3_test/tests/compiler_tests/test_string.py#L198-L209

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
