### PR TITLE
Update TestEngine to test updated contracts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,10 @@ jobs:
             sudo apt-get update && \
               sudo apt-get install -y dotnet-sdk-5.0
 
-            git clone https://github.com/simplitech/neo-devpack-dotnet.git -b rc3 --single-branch
+            git clone https://github.com/simplitech/neo-devpack-dotnet.git -b test-engine-executable --single-branch
+            cd ./neo-devpack-dotnet
+            git checkout 1de1ed2740c6bdca98ea8ff4a4d6f2e27daa4414
+            cd ..
             dotnet build ./neo-devpack-dotnet/src/Neo.TestEngine/Neo.TestEngine.csproj -o ./Neo.TestEngine
             python -m unittest discover boa3_test
 

--- a/boa3/analyser/astanalyser.py
+++ b/boa3/analyser/astanalyser.py
@@ -92,7 +92,7 @@ class IAstAnalyser(ABC, ast.NodeVisitor):
         if (isinstance(value, Attribute) and
                 ((isinstance(value.attr_symbol, IExpression) and isinstance(value.attr_symbol.type, ClassType))
                  or (isinstance(value.attr_symbol, IType))
-                )):
+                 )):
             value = value.attr_symbol
 
         if isinstance(value, IType):

--- a/boa3/model/builtin/method/reversedmethod.py
+++ b/boa3/model/builtin/method/reversedmethod.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Tuple, Any, Iterable
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.type.collection.sequence.sequencetype import SequenceType

--- a/boa3_test/test_sc/class_test/NotificationGetVariables.py
+++ b/boa3_test/test_sc/class_test/NotificationGetVariables.py
@@ -1,7 +1,7 @@
 from typing import Any, List
 
 from boa3.builtin import public
-from boa3.builtin.interop.runtime import Notification, get_notifications, notify
+from boa3.builtin.interop.runtime import Notification, executing_script_hash, get_notifications, notify
 
 
 @public
@@ -23,7 +23,7 @@ def notification(args: List[Any]) -> Notification:
     for x in args:
         notify(x)
 
-    n = get_notifications()
+    n = get_notifications(executing_script_hash)
 
     if len(n) > 0:
         return n[0]

--- a/boa3_test/test_sc/interop_test/runtime/GetNotifications.py
+++ b/boa3_test/test_sc/interop_test/runtime/GetNotifications.py
@@ -1,7 +1,7 @@
 from typing import Any, List
 
 from boa3.builtin import public
-from boa3.builtin.interop.runtime import Notification, get_notifications, notify
+from boa3.builtin.interop.runtime import Notification, executing_script_hash, get_notifications, notify
 from boa3.builtin.type import UInt160
 
 
@@ -14,7 +14,7 @@ def with_param(args: List[Any], key: UInt160) -> List[Notification]:
 @public
 def without_param(args: List[Any]) -> List[Notification]:
     notify_args(args)
-    return get_notifications()
+    return get_notifications(executing_script_hash)
 
 
 def notify_args(args: List[Any]):

--- a/boa3_test/tests/compiler_tests/test_class.py
+++ b/boa3_test/tests/compiler_tests/test_class.py
@@ -17,34 +17,41 @@ class TestClass(BoaTest):
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'script_hash', [],
                                          expected_result_type=bytes)
-        self.assertEqual(len(engine.notifications), 0)
+        contract_notifications = engine.get_events(origin=script)
+        self.assertEqual(len(contract_notifications), 0)
         self.assertEqual(bytes(20), result)
 
         result = self.run_smart_contract(engine, path, 'event_name', [])
-        self.assertEqual(len(engine.notifications), 0)
+        contract_notifications = engine.get_events(origin=script)
+        self.assertEqual(len(contract_notifications), 0)
         self.assertEqual('', result)
 
         result = self.run_smart_contract(engine, path, 'state', [])
-        self.assertEqual(len(engine.notifications), 0)
+        contract_notifications = engine.get_events(origin=script)
+        self.assertEqual(len(contract_notifications), 0)
         self.assertEqual([], result)
 
         result = self.run_smart_contract(engine, path, 'script_hash', [1])
-        self.assertEqual(len(engine.notifications), 1)
+        contract_notifications = engine.get_events(origin=script)
+        self.assertEqual(len(contract_notifications), 1)
         self.assertEqual(script, result)
 
         engine.reset_engine()
         result = self.run_smart_contract(engine, path, 'event_name', [1])
-        self.assertEqual(len(engine.notifications), 1)
+        contract_notifications = engine.get_events(origin=script)
+        self.assertEqual(len(contract_notifications), 1)
         self.assertEqual('notify', result)
 
         engine.reset_engine()
         result = self.run_smart_contract(engine, path, 'state', [1])
-        self.assertEqual(len(engine.notifications), 1)
+        contract_notifications = engine.get_events(origin=script)
+        self.assertEqual(len(contract_notifications), 1)
         self.assertEqual([1], result)
 
         engine.reset_engine()
         result = self.run_smart_contract(engine, path, 'state', ['1'])
-        self.assertEqual(len(engine.notifications), 1)
+        contract_notifications = engine.get_events(origin=script)
+        self.assertEqual(len(contract_notifications), 1)
         self.assertEqual(['1'], result)
 
     def test_notification_set_variables(self):

--- a/boa3_test/tests/compiler_tests/test_interop/test_contract.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_contract.py
@@ -76,9 +76,8 @@ class TestContractInterop(BoaTest):
     def test_call_contract_with_flags(self):
         path = self.get_contract_path('CallScriptHashWithFlags.py')
         call_contract_path = self.get_contract_path('CallFlagsUsage.py')
-        Boa3.compile_and_save(call_contract_path)
 
-        contract, manifest = self.get_output(call_contract_path)
+        contract, manifest = self.compile_and_save(call_contract_path)
         call_hash = hash160(contract)
         call_contract_path = call_contract_path.replace('.py', '.nef')
 
@@ -114,7 +113,7 @@ class TestContractInterop(BoaTest):
             self.run_smart_contract(engine, path, 'Main', call_hash, 'notify_user', [], CallFlags.NONE)
         result = self.run_smart_contract(engine, path, 'Main', call_hash, 'notify_user', [], CallFlags.ALL)
         self.assertEqual(None, result)
-        notify = engine.notifications
+        notify = engine.get_events(origin=call_hash)
         self.assertEqual(1, len(notify))
         self.assertEqual('Notify was called', notify[0].arguments[0])
 

--- a/boa3_test/tests/compiler_tests/test_interop/test_runtime.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_runtime.py
@@ -532,22 +532,22 @@ class TestRuntimeInterop(BoaTest):
         # can not burn negative GAS
         with self.assertRaises(TestExecutionException):
             self.run_smart_contract(engine, path, 'main', -10**8)
-        self.assertEqual(int(engine.gas_consumed) - burn_gas_cost, 0)
+        self.assertEqual(engine.gas_consumed - burn_gas_cost, 0)
 
         # can not burn no GAS
         with self.assertRaises(TestExecutionException):
             self.run_smart_contract(engine, path, 'main', 0)
-        self.assertEqual(int(engine.gas_consumed) - burn_gas_cost, 0)
+        self.assertEqual(engine.gas_consumed - burn_gas_cost, 0)
 
         burned_gas = 1 * 10**8  # 1 GAS
         result = self.run_smart_contract(engine, path, 'main', burned_gas)
         self.assertIsVoid(result)
-        self.assertEqual(int(engine.gas_consumed) - burn_gas_cost, burned_gas)
+        self.assertEqual(engine.gas_consumed - burn_gas_cost, burned_gas)
 
         burned_gas = 123 * 10**5   # 0.123 GAS
         result = self.run_smart_contract(engine, path, 'main', burned_gas)
         self.assertIsVoid(result)
-        self.assertEqual(int(engine.gas_consumed) - burn_gas_cost, burned_gas)
+        self.assertEqual(engine.gas_consumed - burn_gas_cost, burned_gas)
 
     def test_boa2_runtime_test(self):
         path = self.get_contract_path('RuntimeBoa2Test.py')

--- a/boa3_test/tests/test_classes/binaryserializer/__init__.py
+++ b/boa3_test/tests/test_classes/binaryserializer/__init__.py
@@ -1,0 +1,53 @@
+from typing import Any
+
+from boa3.neo.vm.type.Integer import Integer
+from boa3.neo.vm.type.StackItem import StackItemType
+from boa3.neo3.core.serialization import BinaryReader
+
+
+def deserialize_binary(reader: BinaryReader) -> Any:
+    deserialized_items = []
+    underserialized = 1
+
+    while underserialized > 0:
+        stack_type = reader.read_byte()
+        if stack_type == StackItemType.Any:
+            deserialized_items.append(None)
+        elif stack_type == StackItemType.Boolean:
+            deserialized_items.append(reader.read_bool())
+        elif stack_type == StackItemType.Integer:
+            value_in_bytes = reader.read_var_bytes()
+            deserialized_items.append(Integer.from_bytes(value_in_bytes))
+        elif stack_type in (StackItemType.ByteString, StackItemType.Buffer):
+            deserialized_items.append(reader.read_var_bytes())
+        elif stack_type in (StackItemType.Array, StackItemType.Struct):
+            count = reader.read_var_int()
+            deserialized_items.append(list(range(count)))
+            underserialized += count
+        elif stack_type == StackItemType.Map:
+            count = reader.read_var_int()
+            deserialized_items.append({key: None for key in range(count)})
+            underserialized += count * 2
+        else:
+            raise ValueError
+
+        underserialized -= 1
+
+    stack_temp = []
+    while len(deserialized_items) > 0:
+        item = deserialized_items.pop()
+        if isinstance(item, list):
+            new_item = []
+            for _ in range(len(item)):
+                new_item.append(stack_temp.pop())
+            item = new_item
+        elif isinstance(item, dict):
+            new_item = {}
+            for _ in range(0, len(item), 2):
+                key = stack_temp.pop()
+                value = stack_temp.pop()
+                new_item[key] = value
+            item = new_item
+        stack_temp.append(item)
+
+    return stack_temp.pop()


### PR DESCRIPTION
**Summary or solution description**
Updated the TestEngine version used for testing to be able to properly test smart contracts that were updated with `update_contract`
Fixed the contract id used by boa's TestEngine interface

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
