### PR TITLE
Add FindOptions options parameter to find()

### DIFF
--- a/boa3/builtin/interop/storage/__init__.py
+++ b/boa3/builtin/interop/storage/__init__.py
@@ -3,6 +3,7 @@ from typing import Union
 from boa3.builtin.interop.iterator import Iterator
 from boa3.builtin.interop.storage.storagecontext import StorageContext
 from boa3.builtin.interop.storage.storagemap import StorageMap
+from boa3.builtin.interop.storage.findoptions import FindOptions
 
 
 def get(key: Union[str, bytes], context: StorageContext = None) -> bytes:
@@ -55,7 +56,9 @@ def delete(key: Union[str, bytes], context: StorageContext = None):
     pass
 
 
-def find(prefix: Union[str, bytes], context: StorageContext = None) -> Iterator:
+def find(prefix: Union[str, bytes],
+         context: StorageContext = None,
+         options: FindOptions = FindOptions.NONE) -> Iterator:
     """
     Searches in the storage for keys that start with the given prefix.
 
@@ -63,6 +66,8 @@ def find(prefix: Union[str, bytes], context: StorageContext = None) -> Iterator:
     :type prefix: str or bytes
     :param context: storage context to be used
     :type context: StorageContext
+    :param options: the options of the search
+    :type options: FindOptions
     :return: an iterator with the search results
     :rtype: Iterator
     """

--- a/boa3/builtin/interop/storage/findoptions.py
+++ b/boa3/builtin/interop/storage/findoptions.py
@@ -1,0 +1,3 @@
+from boa3.neo3.contracts import FindOptions
+
+__all__ = ['FindOptions']

--- a/boa3/model/builtin/interop/interop.py
+++ b/boa3/model/builtin/interop/interop.py
@@ -51,6 +51,7 @@ class Interop:
     StorageMapType = StorageMapType.build()
     TransactionType = TransactionType.build()
     TriggerType = TriggerType()
+    FindOptionsType = FindOptionsType()
 
     # Binary Interops
     Atoi = AtoiMethod()
@@ -120,7 +121,7 @@ class Interop:
 
     # Storage Interops
     StorageDelete = StorageDeleteMethod()
-    StorageFind = StorageFindMethod()
+    StorageFind = StorageFindMethod(FindOptionsType)
     StorageGetContext = StorageGetContextMethod(StorageContextType)
     StorageGet = StorageGetMethod()
     StoragePut = StoragePutMethod()
@@ -245,6 +246,9 @@ class Interop:
                                        ]
                              )
 
+    FindOptionsModule = Package(identifier=FindOptionsType.identifier.lower(),
+                                types=[FindOptionsType]
+                                )
     StorageContextModule = Package(identifier=StorageContextType.identifier.lower(),
                                    types=[StorageContextType]
                                    )
@@ -253,7 +257,8 @@ class Interop:
                                )
 
     StoragePackage = Package(identifier=InteropPackage.Storage,
-                             types=[StorageContextType,
+                             types=[FindOptionsType,
+                                    StorageContextType,
                                     StorageMapType
                                     ],
                              methods=[StorageDelete,
@@ -262,7 +267,8 @@ class Interop:
                                       StorageGetContext,
                                       StoragePut
                                       ],
-                             packages=[StorageContextModule,
+                             packages=[FindOptionsModule,
+                                       StorageContextModule,
                                        StorageMapModule
                                        ]
                              )

--- a/boa3/model/builtin/interop/storage/__init__.py
+++ b/boa3/model/builtin/interop/storage/__init__.py
@@ -1,4 +1,5 @@
-__all__ = ['StorageContextType',
+__all__ = ['FindOptionsType',
+           'StorageContextType',
            'StorageDeleteMethod',
            'StorageFindMethod',
            'StorageGetContextMethod',
@@ -7,6 +8,7 @@ __all__ = ['StorageContextType',
            'StoragePutMethod'
            ]
 
+from boa3.model.builtin.interop.storage.findoptionstype import FindOptionsType
 from boa3.model.builtin.interop.storage.storagecontext import StorageContextType
 from boa3.model.builtin.interop.storage.storagedeletemethod import StorageDeleteMethod
 from boa3.model.builtin.interop.storage.storagefindmethod import StorageFindMethod

--- a/boa3/model/builtin/interop/storage/findoptionstype.py
+++ b/boa3/model/builtin/interop/storage/findoptionstype.py
@@ -1,0 +1,55 @@
+from typing import Any, Dict
+
+from boa3.model.symbol import ISymbol
+from boa3.model.type.itype import IType
+from boa3.model.type.primitive.inttype import IntType
+
+
+class FindOptionsType(IntType):
+    """
+    A class used to represent Neo interop FindOptions type
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._identifier = 'FindOptions'
+
+    @property
+    def default_value(self) -> Any:
+        from boa3.builtin.interop.storage import FindOptions
+        return FindOptions.NONE
+
+    @classmethod
+    def build(cls, value: Any = None) -> IType:
+        if cls._is_type_of(value) or value is None:
+            from boa3.model.builtin.interop.interop import Interop
+            return Interop.FindOptionsType
+
+    @classmethod
+    def _is_type_of(cls, value: Any):
+        from boa3.builtin.interop.storage import FindOptions
+        return isinstance(value, (FindOptions, FindOptionsType))
+
+    @property
+    def symbols(self) -> Dict[str, ISymbol]:
+        """
+        Gets the class symbols of this type
+
+        :return: a dictionary that maps each symbol in the module with its name
+        """
+        from boa3.builtin.interop.storage import FindOptions
+        from boa3.model.variable import Variable
+
+        return {name: Variable(self) for name in FindOptions.__members__.keys()}
+
+    def get_value(self, symbol_id) -> Any:
+        """
+        Gets the literal value of a symbol
+
+        :return: the value if this type has this symbol. None otherwise.
+        """
+        if symbol_id in self.symbols:
+            from boa3.builtin.interop.storage import FindOptions
+            return FindOptions.__members__[symbol_id]
+
+        return None

--- a/boa3/model/builtin/interop/storage/storagefindmethod.py
+++ b/boa3/model/builtin/interop/storage/storagefindmethod.py
@@ -2,6 +2,7 @@ import ast
 from typing import Any, Dict, Iterable, List, Sized, Tuple
 
 from boa3.model.builtin.interop.interopmethod import InteropMethod
+from boa3.model.builtin.interop.storage import FindOptionsType
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.expression import IExpression
 from boa3.model.type.itype import IType
@@ -11,7 +12,7 @@ from boa3.neo.vm.opcode.Opcode import Opcode
 
 class StorageFindMethod(InteropMethod):
 
-    def __init__(self, prefix_type: IType = None):
+    def __init__(self, find_options_type: FindOptionsType, prefix_type: IType = None):
         from boa3.model.type.type import Type
         from boa3.model.builtin.interop.storage.storagecontext.storagecontexttype import StorageContextType
 
@@ -24,7 +25,8 @@ class StorageFindMethod(InteropMethod):
                                             Type.str
                                             ])
         args: Dict[str, Variable] = {'prefix': Variable(prefix_type),
-                                     'context': Variable(context_type)}
+                                     'context': Variable(context_type),
+                                     'options': Variable(find_options_type)}
 
         from boa3.model.builtin.interop.iterator import IteratorType
         return_type = IteratorType.build(Type.dict.build([prefix_type,  # return an Iterator[prefix, bytes]
@@ -34,10 +36,15 @@ class StorageFindMethod(InteropMethod):
         default_id = StorageGetContextMethod(context_type).identifier
         context_default = ast.parse("{0}()".format(default_id)
                                     ).body[0].value
-        context_default.is_internal_call = True
-        context_default._fields += ('is_internal_call',)
+        options_default = ast.parse("{0}.{1}".format(find_options_type.identifier, find_options_type.default_value.name)
+                                    ).body[0].value
 
-        super().__init__(identifier, syscall, args, defaults=[context_default], return_type=return_type)
+        defaults = [context_default, options_default]
+        for default in defaults:
+            default.is_internal_call = True
+            default._fields += ('is_internal_call',)
+
+        super().__init__(identifier, syscall, args, defaults=defaults, return_type=return_type)
 
     @property
     def identifier(self) -> str:
@@ -55,19 +62,30 @@ class StorageFindMethod(InteropMethod):
         return self.prefix_arg.type.is_type_of(params[0].type)
 
     @property
-    def opcode(self) -> List[Tuple[Opcode, bytes]]:
-        from boa3.neo.vm.type.Integer import Integer
-        from boa3.neo3.contracts import FindOptions
-        find_options = Integer(FindOptions.NONE).to_byte_array(signed=True, min_length=1)
+    def generation_order(self) -> List[int]:
+        """
+        Gets the indexes order that need to be used during code generation.
+        If the order for generation is the same as inputted in code, returns reversed(range(0,len_args))
 
-        return ([(Opcode.PUSHDATA1, Integer(len(find_options)).to_byte_array(min_length=1) + find_options),
-                 (Opcode.REVERSE3, b'')
-                 ]
-                + super().opcode)
+        :return: Index order for code generation
+        """
+        indexes = super().generation_order
+        context_index = list(self.args).index('context')
+
+        if indexes[-1] != context_index:
+            # context must be the last generated argument
+            indexes.remove(context_index)
+            indexes.append(context_index)
+
+        return indexes
 
     @property
     def prefix_arg(self) -> Variable:
         return self.args['prefix']
+
+    @property
+    def options_arg(self) -> Variable:
+        return self.args['options']
 
     def build(self, value: Any) -> IBuiltinMethod:
         exp: List[IExpression] = []
@@ -88,5 +106,5 @@ class StorageFindMethod(InteropMethod):
         method = self
         prefix_type: IType = exp[0].type
         if type(method.prefix_arg.type) != type(prefix_type):
-            method = StorageFindMethod(prefix_type)
+            method = StorageFindMethod(self.options_arg.type, prefix_type)
         return method

--- a/boa3_test/test_sc/interop_test/storage/StorageFindWithOptions.py
+++ b/boa3_test/test_sc/interop_test/storage/StorageFindWithOptions.py
@@ -1,0 +1,17 @@
+from typing import Union
+
+from boa3.builtin import public
+from boa3.builtin.interop.iterator import Iterator
+from boa3.builtin.interop.storage import find, get_context, put
+from boa3.builtin.interop.storage.findoptions import FindOptions
+
+
+@public
+def find_by_prefix(prefix: Union[str, bytes]) -> Iterator:
+    context = get_context()
+    return find(prefix, context, FindOptions.REMOVE_PREFIX)
+
+
+@public
+def put_on_storage(key: Union[str, bytes], value: Union[int, str, bytes]):
+    put(key, value)

--- a/boa3_test/tests/compiler_tests/test_interop/test_iterator.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_iterator.py
@@ -43,7 +43,6 @@ class TestIteratorInterop(BoaTest):
     def test_import_iterator(self):
         path = self.get_contract_path('ImportIterator.py')
         engine = TestEngine()
-        self.compile_and_save(path)
 
         result = self.run_smart_contract(engine, path, 'return_iterator')
         from boa3.neo.core.types.InteropInterface import InteropInterface

--- a/boa3_test/tests/compiler_tests/test_interop/test_storage.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_storage.py
@@ -532,6 +532,13 @@ class TestStorageInterop(BoaTest):
         self.assertEqual(InteropInterface, result)  # returns an interop interface
         # TODO: validate actual result when Enumerator.next() and Enumerator.value() are implemented
 
+    def test_storage_find_with_options(self):
+        path = self.get_contract_path('StorageFindWithOptions.py')
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'find_by_prefix', 'example')
+        self.assertEqual(InteropInterface, result)  # returns an interop interface
+        # TODO: validate actual result when Enumerator.next() and Enumerator.value() are implemented
+
     def test_boa2_storage_test(self):
         path = self.get_contract_path('StorageBoa2Test.py')
         engine = TestEngine()


### PR DESCRIPTION
**Related issue**
#260

**Summary or solution description**
Included an optional arguments `options` to the `storage.find` method

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/0ce7dff16a0e502767ec831dd0c2465ece5b68d2/boa3_test/test_sc/interop_test/storage/StorageFindWithOptions.py#L9-L12

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/0ce7dff16a0e502767ec831dd0c2465ece5b68d2/boa3_test/tests/compiler_tests/test_interop/test_storage.py#L535-L540

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7