### PR TITLE
Implement Storage GetReadOnlyContext Interop

### DIFF
--- a/boa3/builtin/interop/storage/__init__.py
+++ b/boa3/builtin/interop/storage/__init__.py
@@ -30,6 +30,16 @@ def get_context() -> StorageContext:
     pass
 
 
+def get_read_only_context() -> StorageContext:
+    """
+    Gets current read only storage context.
+
+    :return: the current read only storage context
+    :rtype: StorageContext
+    """
+    pass
+
+
 def put(key: Union[str, bytes], value: Union[int, str, bytes], context: StorageContext = None):
     """
     Inserts a given value in the key-value format into the persistent storage.

--- a/boa3/model/builtin/interop/interop.py
+++ b/boa3/model/builtin/interop/interop.py
@@ -123,6 +123,7 @@ class Interop:
     StorageDelete = StorageDeleteMethod()
     StorageFind = StorageFindMethod(FindOptionsType)
     StorageGetContext = StorageGetContextMethod(StorageContextType)
+    StorageGetReadOnlyContext = StorageGetReadOnlyContextMethod(StorageContextType)
     StorageGet = StorageGetMethod()
     StoragePut = StoragePutMethod()
 
@@ -265,6 +266,7 @@ class Interop:
                                       StorageFind,
                                       StorageGet,
                                       StorageGetContext,
+                                      StorageGetReadOnlyContext,
                                       StoragePut
                                       ],
                              packages=[FindOptionsModule,

--- a/boa3/model/builtin/interop/storage/__init__.py
+++ b/boa3/model/builtin/interop/storage/__init__.py
@@ -3,6 +3,7 @@ __all__ = ['FindOptionsType',
            'StorageDeleteMethod',
            'StorageFindMethod',
            'StorageGetContextMethod',
+           'StorageGetReadOnlyContextMethod',
            'StorageGetMethod',
            'StorageMapType',
            'StoragePutMethod'
@@ -14,5 +15,6 @@ from boa3.model.builtin.interop.storage.storagedeletemethod import StorageDelete
 from boa3.model.builtin.interop.storage.storagefindmethod import StorageFindMethod
 from boa3.model.builtin.interop.storage.storagegetcontextmethod import StorageGetContextMethod
 from boa3.model.builtin.interop.storage.storagegetmethod import StorageGetMethod
+from boa3.model.builtin.interop.storage.storagegetreadonlycontextmethod import StorageGetReadOnlyContextMethod
 from boa3.model.builtin.interop.storage.storagemap.storagemaptype import StorageMapType
 from boa3.model.builtin.interop.storage.storageputmethod import StoragePutMethod

--- a/boa3/model/builtin/interop/storage/storagegetreadonlycontextmethod.py
+++ b/boa3/model/builtin/interop/storage/storagegetreadonlycontextmethod.py
@@ -5,10 +5,10 @@ from boa3.model.builtin.interop.storage.storagecontext.storagecontexttype import
 from boa3.model.variable import Variable
 
 
-class StorageGetContextMethod(InteropMethod):
+class StorageGetReadOnlyContextMethod(InteropMethod):
 
     def __init__(self, storage_context_type: StorageContextType):
-        identifier = 'get_context'
+        identifier = 'get_read_only_context'
         native_identifier = 'System.Storage.GetContext'
         args: Dict[str, Variable] = {}
         super().__init__(identifier, native_identifier, args, return_type=storage_context_type)

--- a/boa3_test/test_sc/interop_test/storage/StorageGetReadOnlyContext.py
+++ b/boa3_test/test_sc/interop_test/storage/StorageGetReadOnlyContext.py
@@ -1,0 +1,8 @@
+from boa3.builtin import public
+from boa3.builtin.interop.storage import get_read_only_context
+from boa3.builtin.interop.storage.storagecontext import StorageContext
+
+
+@public
+def main() -> StorageContext:
+    return get_read_only_context()

--- a/boa3_test/tests/compiler_tests/test_interop/test_storage.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_storage.py
@@ -448,6 +448,20 @@ class TestStorageInterop(BoaTest):
         result = self.run_smart_contract(engine, path, 'main')
         self.assertEqual(InteropInterface, result)  # returns an interop interface
 
+    def test_storage_get_read_only_context(self):
+        expected_output = (
+            Opcode.SYSCALL
+            + Interop.StorageGetReadOnlyContext.interop_method_hash
+            + Opcode.RET
+        )
+        path = self.get_contract_path('StorageGetReadOnlyContext.py')
+        output, manifest = self.compile_and_save(path)
+        self.assertEqual(expected_output, output)
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'main')
+        self.assertEqual(InteropInterface, result)  # returns an interop interface
+
     def test_storage_get_with_context(self):
         path = self.get_contract_path('StorageGetWithContext.py')
         engine = TestEngine()


### PR DESCRIPTION
**Related issue**
#280

**Summary or solution description**
Implement Storage GetReadOnlyContext Interop.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/30fab56ed4412ea573aed4b97e184655f4e72f1e/boa3_test/test_sc/interop_test/storage/StorageGetReadOnlyContext.py#L1-L8

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/30fab56ed4412ea573aed4b97e184655f4e72f1e/boa3_test/tests/compiler_tests/test_interop/test_storage.py#L451-L463

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
