### PR TITLE
Implement Contract CreateStandardAccount Interop

### DIFF
--- a/boa3/builtin/interop/contract/__init__.py
+++ b/boa3/builtin/interop/contract/__init__.py
@@ -2,7 +2,7 @@ from typing import Any, Sequence
 
 from boa3.builtin.interop.contract.callflagstype import CallFlags
 from boa3.builtin.interop.contract.contract import Contract
-from boa3.builtin.type import UInt160
+from boa3.builtin.type import UInt160, ECPoint
 
 
 def call_contract(script_hash: UInt160, method: str, args: Sequence = (), call_flags: CallFlags = CallFlags.ALL) -> Any:
@@ -73,6 +73,13 @@ def destroy_contract():
 def get_call_flags() -> CallFlags:
     """
     Gets the CallFlags in the current context.
+    """
+    pass
+
+
+def create_standard_account(pub_key: ECPoint) -> UInt160:
+    """
+    Calculates the script hash from a public key.
     """
     pass
 

--- a/boa3/builtin/interop/contract/__init__.py
+++ b/boa3/builtin/interop/contract/__init__.py
@@ -80,6 +80,12 @@ def get_call_flags() -> CallFlags:
 def create_standard_account(pub_key: ECPoint) -> UInt160:
     """
     Calculates the script hash from a public key.
+
+    :param pub_key: the given public key
+    :type pub_key: ECPoint
+
+    :return: the corresponding script hash of the public key
+    :rtype: UInt160
     """
     pass
 

--- a/boa3/model/builtin/interop/contract/__init__.py
+++ b/boa3/model/builtin/interop/contract/__init__.py
@@ -2,6 +2,7 @@ __all__ = ['CallFlagsType',
            'CallMethod',
            'ContractType',
            'CreateMethod',
+           'CreateStandardAccountMethod',
            'DestroyMethod',
            'GasProperty',
            'GetCallFlagsMethod',
@@ -13,6 +14,7 @@ from boa3.model.builtin.interop.contract.callflagstype import CallFlagsType
 from boa3.model.builtin.interop.contract.callmethod import CallMethod
 from boa3.model.builtin.interop.contract.contracttype import ContractType
 from boa3.model.builtin.interop.contract.createmethod import CreateMethod
+from boa3.model.builtin.interop.contract.createstandardaccountmethod import CreateStandardAccountMethod
 from boa3.model.builtin.interop.contract.destroymethod import DestroyMethod
 from boa3.model.builtin.interop.contract.getcallflagsmethod import GetCallFlagsMethod
 from boa3.model.builtin.interop.contract.getgasscripthashmethod import GasProperty

--- a/boa3/model/builtin/interop/contract/createstandardaccountmethod.py
+++ b/boa3/model/builtin/interop/contract/createstandardaccountmethod.py
@@ -1,0 +1,18 @@
+from typing import Dict
+
+from boa3.model.builtin.interop.interopmethod import InteropMethod
+from boa3.model.variable import Variable
+
+
+class CreateStandardAccountMethod(InteropMethod):
+
+    def __init__(self):
+        from boa3.model.type.collection.sequence.uint160type import UInt160Type
+        from boa3.model.type.collection.sequence.ecpointtype import ECPointType
+
+        identifier = 'create_standard_account'
+        syscall = 'System.Contract.CreateStandardAccount'
+        args: Dict[str, Variable] = {
+            'pub_key': Variable(ECPointType.build())
+        }
+        super().__init__(identifier, syscall, args, return_type=UInt160Type.build())

--- a/boa3/model/builtin/interop/interop.py
+++ b/boa3/model/builtin/interop/interop.py
@@ -74,6 +74,7 @@ class Interop:
     # Contract Interops
     CallContract = CallMethod()
     CreateContract = CreateMethod(ContractType)
+    CreateStandardAccount = CreateStandardAccountMethod()
     DestroyContract = DestroyMethod()
     GetCallFlags = GetCallFlagsMethod(CallFlagsType)
     UpdateContract = UpdateMethod()
@@ -183,6 +184,7 @@ class Interop:
                                           ],
                               methods=[CallContract,
                                        CreateContract,
+                                       CreateStandardAccount,
                                        DestroyContract,
                                        GetCallFlags,
                                        UpdateContract

--- a/boa3_test/test_sc/interop_test/contract/CreateStandardAccount.py
+++ b/boa3_test/test_sc/interop_test/contract/CreateStandardAccount.py
@@ -1,0 +1,8 @@
+from boa3.builtin import public
+from boa3.builtin.interop.contract import create_standard_account
+from boa3.builtin.type import ECPoint, UInt160
+
+
+@public
+def main(private_key: bytes) -> UInt160:
+    return create_standard_account(ECPoint(private_key))


### PR DESCRIPTION
**Related issue**
#283 

**How to Reproduce**
Call `create_standard_account()`.

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/1ba466c7d3bc9fd16e8d523145376a69fed09dd5/boa3_test/tests/compiler_tests/test_interop/test_contract.py#L403-L428

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8