### PR TITLE
Implement str split method

### DIFF
--- a/boa3/compiler/codegenerator/codegenerator.py
+++ b/boa3/compiler/codegenerator/codegenerator.py
@@ -1107,7 +1107,7 @@ class CodeGenerator:
         store_data: bytes = b''
 
         if function.pack_arguments:
-            self.convert_new_array(len(function.args))
+            self.convert_new_array(len(args_address))
 
         if function.stores_on_slot and 0 < len(function.args) <= len(args_address):
             address = args_address[-len(function.args)]

--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -56,6 +56,7 @@ class Builtin:
     Print = PrintMethod()
     ScriptHash = ScriptHashMethod()
     Sqrt = SqrtMethod()
+    StrSplit = StrSplitMethod()
     Sum = SumMethod()
 
     # python builtin class constructor
@@ -104,6 +105,7 @@ class Builtin:
                                                 SequenceRemove,
                                                 SequenceReverse,
                                                 Sqrt,
+                                                StrSplit,
                                                 Sum
                                                 ]
 

--- a/boa3/model/builtin/method/__init__.py
+++ b/boa3/model/builtin/method/__init__.py
@@ -14,6 +14,7 @@ __all__ = ['AbsMethod',
            'ReversedMethod',
            'ScriptHashMethod',
            'SqrtMethod',
+           'StrSplitMethod',
            'SumMethod'
            ]
 
@@ -31,5 +32,6 @@ from boa3.model.builtin.method.printmethod import PrintMethod
 from boa3.model.builtin.method.rangemethod import RangeMethod
 from boa3.model.builtin.method.reversedmethod import ReversedMethod
 from boa3.model.builtin.method.sqrtmethod import SqrtMethod
+from boa3.model.builtin.method.strsplitmethod import StrSplitMethod
 from boa3.model.builtin.method.summethod import SumMethod
 from boa3.model.builtin.method.toscripthashmethod import ScriptHashMethod

--- a/boa3/model/builtin/method/strsplitmethod.py
+++ b/boa3/model/builtin/method/strsplitmethod.py
@@ -38,4 +38,4 @@ class StrSplitMethod(StdLibMethod):
 
         return indexes
 
-    # TODO: Use maxsplit to verify if the returning array has length less than or equals to maxsplit, and to concatenate if not
+    # TODO: Use maxsplit to verify if the returning array has length less than or equals to maxsplit and to concatenate if not

--- a/boa3/model/builtin/method/strsplitmethod.py
+++ b/boa3/model/builtin/method/strsplitmethod.py
@@ -1,0 +1,41 @@
+import ast
+from typing import Dict, List
+
+from boa3.model.builtin.interop.nativecontract import StdLibMethod
+from boa3.model.variable import Variable
+
+
+class StrSplitMethod(StdLibMethod):
+    def __init__(self):
+        from boa3.model.type.type import Type
+        identifier = 'split'
+        syscall = 'stringSplit'
+        args: Dict[str, Variable] = {
+            'self': Variable(Type.str),
+            'sep': Variable(Type.str),
+            'maxsplit': Variable(Type.int)
+        }
+        # whitespace is the default separator
+        separator_default = ast.parse("' '").body[0].value
+        # maxsplit the default value is -1
+        maxsplit_default = ast.parse("-1").body[0].value
+
+        super().__init__(identifier, syscall, args, defaults=[separator_default, maxsplit_default],
+                         return_type=Type.list.build_collection(Type.str))
+
+    @property
+    def generation_order(self) -> List[int]:
+        """
+        Gets the indexes order that need to be used during code generation.
+        If the order for generation is the same as inputted in code, returns reversed(range(0,len_args))
+
+        :return: Index order for code generation
+        """
+        indexes = super().generation_order
+        maxsplit_index = list(self.args).index('maxsplit')
+
+        indexes.remove(maxsplit_index)
+
+        return indexes
+
+    # TODO: Use maxsplit to verify if the returning array has length less than or equals to maxsplit, and to concatenate if not

--- a/boa3_test/test_sc/built_in_methods_test/StrSplit.py
+++ b/boa3_test/test_sc/built_in_methods_test/StrSplit.py
@@ -1,0 +1,8 @@
+from typing import List
+
+from boa3.builtin import public
+
+
+@public
+def main(string: str, sep: str) -> List[str]:
+    return string.split(sep)

--- a/boa3_test/test_sc/built_in_methods_test/StrSplitSeparatorDefault.py
+++ b/boa3_test/test_sc/built_in_methods_test/StrSplitSeparatorDefault.py
@@ -1,0 +1,8 @@
+from typing import List
+
+from boa3.builtin import public
+
+
+@public
+def main(string: str) -> List[str]:
+    return string.split()

--- a/boa3_test/tests/compiler_tests/test_builtin_method.py
+++ b/boa3_test/tests/compiler_tests/test_builtin_method.py
@@ -958,3 +958,23 @@ class TestBuiltinMethod(BoaTest):
         self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
 
     # endregion
+
+    # region split test
+
+    def test_split_str(self):
+        path = self.get_contract_path('StrSplit.py')
+        engine = TestEngine()
+
+        string = '1#2#3#4'
+        separator = '#'
+        expected_result = string.split(separator)
+        result = self.run_smart_contract(engine, path, 'main', string, separator)
+        self.assertEqual(expected_result, result)
+
+        string = 'unit123test123str123split'
+        separator = '123'
+        expected_result = string.split(separator)
+        result = self.run_smart_contract(engine, path, 'main', string, separator)
+        self.assertEqual(expected_result, result)
+
+    # endregion

--- a/boa3_test/tests/compiler_tests/test_builtin_method.py
+++ b/boa3_test/tests/compiler_tests/test_builtin_method.py
@@ -959,9 +959,9 @@ class TestBuiltinMethod(BoaTest):
 
     # endregion
 
-    # region split test
+    # region str split test
 
-    def test_split_str(self):
+    def test_str_split(self):
         path = self.get_contract_path('StrSplit.py')
         engine = TestEngine()
 
@@ -975,6 +975,15 @@ class TestBuiltinMethod(BoaTest):
         separator = '123'
         expected_result = string.split(separator)
         result = self.run_smart_contract(engine, path, 'main', string, separator)
+        self.assertEqual(expected_result, result)
+
+    def test_str_split_default(self):
+        path = self.get_contract_path('StrSplitSeparatorDefault.py')
+        engine = TestEngine()
+
+        string = '1 2 3 4'
+        expected_result = string.split()
+        result = self.run_smart_contract(engine, path, 'main', string)
         self.assertEqual(expected_result, result)
 
     # endregion


### PR DESCRIPTION
**Related issue**
#502 

**How to Reproduce**
Use `"a string".split()`. 

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/1639d5ed98a7a753fa67d3f55ffe4cdb048bf7c2/boa3_test/tests/compiler_tests/test_builtin_method.py#L964-L987

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8

**(Optional) Additional context**
The maxsplit parameter used on Python3 wasn't implemented in this issue. It will be implemented at #515 
