### PR TITLE
Implement StdLib Base58Check Encode and Decode

### DIFF
--- a/boa3/builtin/interop/binary/__init__.py
+++ b/boa3/builtin/interop/binary/__init__.py
@@ -25,6 +25,22 @@ def base58_decode(key: str) -> bytes:
     pass
 
 
+def base58_check_encode(key: bytes) -> str:
+    """
+    Converts a bytes value to its equivalent str representation that is encoded with base-58 digits. The encoded str
+    contains the checksum of the binary data.
+    """
+    pass
+
+
+def base58_check_decode(key: str) -> bytes:
+    """
+    Converts the specified str, which encodes binary data as base-58 digits, to an equivalent bytes value. The encoded
+    str contains the checksum of the binary data.
+    """
+    pass
+
+
 def base64_encode(key: bytes) -> str:
     """
     Encodes a bytes value using base64.

--- a/boa3/model/builtin/interop/binary/__init__.py
+++ b/boa3/model/builtin/interop/binary/__init__.py
@@ -1,4 +1,6 @@
 __all__ = ['AtoiMethod',
+           'Base58CheckDecodeMethod',
+           'Base58CheckEncodeMethod',
            'Base58DecodeMethod',
            'Base58EncodeMethod',
            'Base64DecodeMethod',
@@ -10,6 +12,8 @@ __all__ = ['AtoiMethod',
            ]
 
 from boa3.model.builtin.interop.binary.atoimethod import AtoiMethod
+from boa3.model.builtin.interop.binary.base58checkdecodemethod import Base58CheckDecodeMethod
+from boa3.model.builtin.interop.binary.base58checkencodemethod import Base58CheckEncodeMethod
 from boa3.model.builtin.interop.binary.base58decodemethod import Base58DecodeMethod
 from boa3.model.builtin.interop.binary.base58encodemethod import Base58EncodeMethod
 from boa3.model.builtin.interop.binary.base64decodemethod import Base64DecodeMethod

--- a/boa3/model/builtin/interop/binary/base58checkdecodemethod.py
+++ b/boa3/model/builtin/interop/binary/base58checkdecodemethod.py
@@ -1,0 +1,14 @@
+from typing import Dict
+
+from boa3.model.builtin.interop.nativecontract import StdLibMethod
+from boa3.model.variable import Variable
+
+
+class Base58CheckDecodeMethod(StdLibMethod):
+
+    def __init__(self):
+        from boa3.model.type.type import Type
+        identifier = 'base58_check_decode'
+        native_identifier = 'base58CheckDecode'
+        args: Dict[str, Variable] = {'key': Variable(Type.str)}
+        super().__init__(identifier, native_identifier, args, return_type=Type.bytes)

--- a/boa3/model/builtin/interop/binary/base58checkencodemethod.py
+++ b/boa3/model/builtin/interop/binary/base58checkencodemethod.py
@@ -1,0 +1,14 @@
+from typing import Dict
+
+from boa3.model.builtin.interop.nativecontract import StdLibMethod
+from boa3.model.variable import Variable
+
+
+class Base58CheckEncodeMethod(StdLibMethod):
+
+    def __init__(self):
+        from boa3.model.type.type import Type
+        identifier = 'base58_check_encode'
+        native_identifier = 'base58CheckEncode'
+        args: Dict[str, Variable] = {'key': Variable(Type.bytes)}
+        super().__init__(identifier, native_identifier, args, return_type=Type.str)

--- a/boa3/model/builtin/interop/interop.py
+++ b/boa3/model/builtin/interop/interop.py
@@ -55,6 +55,8 @@ class Interop:
 
     # Binary Interops
     Atoi = AtoiMethod()
+    Base58CheckDecode = Base58CheckDecodeMethod()
+    Base58CheckEncode = Base58CheckEncodeMethod()
     Base58Encode = Base58EncodeMethod()
     Base58Decode = Base58DecodeMethod()
     Base64Encode = Base64EncodeMethod()
@@ -136,6 +138,8 @@ class Interop:
 
     BinaryPackage = Package(identifier=InteropPackage.Binary,
                             methods=[Atoi,
+                                     Base58CheckDecode,
+                                     Base58CheckEncode,
                                      Base58Encode,
                                      Base58Decode,
                                      Base64Encode,

--- a/boa3_test/test_sc/interop_test/binary/Base58CheckDecode.py
+++ b/boa3_test/test_sc/interop_test/binary/Base58CheckDecode.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.interop.binary import base58_check_decode
+
+
+@public
+def main(key: str) -> bytes:
+    return base58_check_decode(key)

--- a/boa3_test/test_sc/interop_test/binary/Base58CheckDecodeMismatchedType.py
+++ b/boa3_test/test_sc/interop_test/binary/Base58CheckDecodeMismatchedType.py
@@ -1,0 +1,5 @@
+from boa3.builtin.interop.binary import base58_check_decode
+
+
+def main(key: int) -> bytes:
+    return base58_check_decode(key)

--- a/boa3_test/test_sc/interop_test/binary/Base58CheckEncode.py
+++ b/boa3_test/test_sc/interop_test/binary/Base58CheckEncode.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.interop.binary import base58_check_encode
+
+
+@public
+def main(key: bytes) -> str:
+    return base58_check_encode(key)

--- a/boa3_test/test_sc/interop_test/binary/Base58CheckEncodeMismatchedType.py
+++ b/boa3_test/test_sc/interop_test/binary/Base58CheckEncodeMismatchedType.py
@@ -1,0 +1,5 @@
+from boa3.builtin.interop.binary import base58_check_encode
+
+
+def main(key: int) -> str:
+    return base58_check_encode(key)

--- a/boa3_test/tests/compiler_tests/test_interop/test_binary.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_binary.py
@@ -131,6 +131,65 @@ class TestBinaryInterop(BoaTest):
         path = self.get_contract_path('Base58DecodeMismatchedType.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
+    def test_base58_check_decode(self):
+        import base58
+        path = self.get_contract_path('Base58CheckDecode.py')
+        engine = TestEngine()
+        arg = base58.b58encode_check('unit test'.encode('utf-8'))
+        result = self.run_smart_contract(engine, path, 'main', arg)
+        self.assertEqual('unit test', result)
+
+        arg = base58.b58encode_check(''.encode('utf-8'))
+        result = self.run_smart_contract(engine, path, 'main', arg)
+        self.assertEqual('', result)
+
+        long_string = ('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam accumsan magna eu massa '
+                       'vulputate bibendum. Aliquam commodo euismod tristique. Sed purus erat, pretium ut interdum '
+                       'et, aliquet sed mauris. Curabitur vitae turpis euismod, hendrerit mi a, rhoncus justo. Mauris '
+                       'sollicitudin, nisl sit amet feugiat pharetra, odio ligula congue tellus, vel pellentesque '
+                       'libero leo id dui. Morbi vel risus vehicula, consectetur mauris eget, gravida ligula. '
+                       'Maecenas aliquam velit sit amet nisi ultricies, ac sollicitudin nisi mollis. Lorem ipsum '
+                       'dolor sit amet, consectetur adipiscing elit. Ut tincidunt, nisi in ullamcorper ornare, '
+                       'est enim dictum massa, id aliquet justo magna in purus.')
+        arg = base58.b58encode_check(long_string.encode('utf-8'))
+        result = self.run_smart_contract(engine, path, 'main', arg)
+        self.assertEqual(long_string, result)
+
+    def test_base58_check_decode_mismatched_type(self):
+        path = self.get_contract_path('Base58CheckDecodeMismatchedType.py')
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+
+    def test_base58_check_encode(self):
+        import base58
+        path = self.get_contract_path('Base58CheckEncode.py')
+        engine = TestEngine()
+        expected_result = base58.b58encode_check('unit test'.encode('utf-8'))
+        result = self.run_smart_contract(engine, path, 'main', 'unit test',
+                                         expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        expected_result = base58.b58encode_check(''.encode('utf-8'))
+        result = self.run_smart_contract(engine, path, 'main', '',
+                                         expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        long_string = ('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam accumsan magna eu massa '
+                       'vulputate bibendum. Aliquam commodo euismod tristique. Sed purus erat, pretium ut interdum '
+                       'et, aliquet sed mauris. Curabitur vitae turpis euismod, hendrerit mi a, rhoncus justo. Mauris '
+                       'sollicitudin, nisl sit amet feugiat pharetra, odio ligula congue tellus, vel pellentesque '
+                       'libero leo id dui. Morbi vel risus vehicula, consectetur mauris eget, gravida ligula. '
+                       'Maecenas aliquam velit sit amet nisi ultricies, ac sollicitudin nisi mollis. Lorem ipsum '
+                       'dolor sit amet, consectetur adipiscing elit. Ut tincidunt, nisi in ullamcorper ornare, '
+                       'est enim dictum massa, id aliquet justo magna in purus.')
+        expected_result = base58.b58encode_check(long_string.encode('utf-8'))
+        result = self.run_smart_contract(engine, path, 'main', long_string,
+                                         expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+    def test_base58_check_encode_mismatched_type(self):
+        path = self.get_contract_path('Base58CheckEncodeMismatchedType.py')
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+
     def test_serialize_int(self):
         path = self.get_contract_path('SerializeInt.py')
         engine = TestEngine()


### PR DESCRIPTION
**Related issue**
#499 

**How to Reproduce**
Call `base58_check_decode` or base58_check_encode`` .

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/9489388338a5a537c15385f2a823071fbb676ed4/boa3_test/tests/compiler_tests/test_interop/test_binary.py#L134-L191

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8