### PR TITLE
Implement ContracManifest class and its attributes types

### DIFF
--- a/boa3/builtin/interop/__init__.py
+++ b/boa3/builtin/interop/__init__.py
@@ -22,22 +22,33 @@ class Oracle:
     def request(cls, url: str, request_filter: Union[str, None], callback: str, user_data: Any, gas_for_response: int):
         """
         Requests an information from outside the blockchain.
+
         This method just requests data from the oracle, it won't return the result.
 
-        :param url: external url to retrieve the data
+        :param url: External url to retrieve the data
         :type url: str
-        :param request_filter: filter to the request.
-                               See JSONPath format https://github.com/atifaziz/JSONPath
+        :param request_filter:
+            Filter to the request.
+
+            See JSONPath format https://github.com/atifaziz/JSONPath
+
         :type request_filter: str or None
-        :param callback: Method name that will be as a callback.
-                         This method must be public and implement the following interface:
-                         `(url: str, user_data: Any, code: int, result: bytes) -> None`
+        :param callback:
+            Method name that will be as a callback.
+
+            This method must be public and implement the following interface:
+
+            ``(url: str, user_data: Any, code: int, result: bytes) -> None``
+
         :type callback: str
-        :param user_data: optional data. It'll be returned as the same when the callback is called
+        :param user_data: Optional data. It'll be returned as the same when the callback is called
         :type user_data: Any
-        :param gas_for_response: Amount of GAS needed to run the callback method.
-                                 It MUST NOT be specified as the user representation.
-                                 If it costs 1 gas, this value must be 1_00000000 (with the 8 decimals)
+        :param gas_for_response:
+            Amount of GAS needed to run the callback method.
+
+            It MUST NOT be specified as the user representation.
+
+            If it costs 1 gas, this value must be 1_00000000 (with the 8 decimals)
         :type gas_for_response: int
         """
         pass

--- a/boa3/builtin/interop/contract/contract.py
+++ b/boa3/builtin/interop/contract/contract.py
@@ -1,5 +1,4 @@
-from typing import Any, Dict
-
+from boa3.builtin.interop.contract.contractmanifest import ContractManifest
 from boa3.builtin.type import UInt160
 
 
@@ -17,7 +16,7 @@ class Contract:
         information
     :vartype nef: bytes
     :ivar manifest: the manifest of the contract
-    :vartype manifest: Dict[str, Any]
+    :vartype manifest: ContractManifest
     """
 
     def __init__(self):
@@ -25,4 +24,4 @@ class Contract:
         self.update_counter: int = 0
         self.hash: UInt160 = UInt160()
         self.nef: bytes = bytes()
-        self.manifest: Dict[str, Any] = {}
+        self.manifest: ContractManifest = ContractManifest()

--- a/boa3/builtin/interop/contract/contractmanifest.py
+++ b/boa3/builtin/interop/contract/contractmanifest.py
@@ -1,0 +1,187 @@
+from typing import List, Optional
+
+from boa3.builtin.type import ECPoint, UInt160
+from boa3.neo.vm.type.ContractParameterType import ContractParameterType
+
+
+class ContractManifest:
+    """
+    Represents the manifest of a smart contract [#]_.
+
+    When a smart contract is deployed, it must explicitly declare the features and permissions it will use.
+
+    When it is running, it will be limited by its declared list of features and permissions, and cannot make any
+    behavior beyond the scope of the list.
+
+    .. [#] For more details, see NEP-15.
+
+    :ivar name: The name of the contract.
+    :vartype name: str
+    :ivar groups: The groups of the contract.
+    :vartype groups: List[ContractGroup]
+    :ivar supported_standards: Indicates which standards the contract supports. It can be a list of NEPs.
+    :vartype supported_standards: List[str]
+    :ivar abi: The ABI of the contract.
+    :vartype abi: ContractAbi
+    :ivar permissions: The permissions of the contract.
+    :vartype permissions: List[ContractPermission]
+    :ivar trusts:
+        The trusted contracts and groups of the contract.
+
+        If a contract is trusted, the user interface will not give any warnings when called by the contract.
+
+    :vartype trusts: List[ContractPermissionDescriptor] or None
+    :ivar extras: Custom user data as a json string.
+    :vartype extras: str
+    """
+
+    def __init__(self):
+        self.name: str = ''
+        self.groups: List[ContractGroup] = []
+        self.supported_standards: List[str] = []
+        self.abi: ContractAbi = None
+        self.permissions: List[ContractPermission] = []
+        self.trusts: Optional[List[ContractPermissionDescriptor]] = None
+        self.extras: str = ''
+
+
+class ContractPermission:
+    """
+    Represents a permission of a contract. It describes which contracts may be invoked and which methods are called.
+
+    If a contract invokes a contract or method that is not declared in the manifest at runtime, the invocation will
+    fail.
+
+    :ivar contract:
+        Indicates which contract to be invoked.
+
+        It can be a hash of a contract, a public key of a group, or a wildcard *.
+
+        If it specifies a hash of a contract, then the contract will be invoked; If it specifies a public key of a
+        group, then any contract in this group may be invoked; If it specifies a wildcard *, then any contract may be
+        invoked.
+
+    :vartype contract: ContractPermissionDescriptor or None
+    :ivar methods:
+        Indicates which methods to be called.
+
+        It can also be assigned with a wildcard *. If it is a wildcard *, then it means that any method can be called.
+
+    :vartype methods: List[str] or None
+    """
+
+    def __init__(self):
+        self.contract: Optional[ContractPermissionDescriptor] = None
+        self.methods: Optional[List[str]] = None
+
+
+class ContractPermissionDescriptor:
+    """
+    Indicates which contracts are authorized to be called.
+
+    :ivar hash: The hash of the contract.
+    :vartype hash: UInt160 or None
+    :ivar group: The group of the contracts.
+    :vartype group: ECPoint or None
+    """
+
+    def __init__(self):
+        self.hash: Optional[UInt160] = None
+        self.group: Optional[ECPoint] = None
+
+
+class ContractGroup:
+    """
+    Represents a set of mutually trusted contracts.
+
+    A contract will trust and allow any contract in the same group to invoke it, and the user interface will not give
+    any warnings.
+
+    A group is identified by a public key and must be accompanied by a signature for the contract hash to prove that
+    the contract is indeed included in the group.
+
+    :ivar pubkey: The public key of the group.
+    :vartype pubkey: ECPoint
+    :ivar signature: The signature of the contract hash which can be verified by `pubkey`.
+    :vartype signature: bytes
+    """
+
+    def __init__(self):
+        self.pubkey: ECPoint = ECPoint(b'')
+        self.signature: bytes = b''
+
+
+class ContractAbi:
+    """
+    Represents the ABI of a smart contract [#]_.
+
+    .. [#] For more details, see NEP-14.
+
+    :ivar methods: Gets the methods in the ABI.
+    :vartype methods: List[ContractMethodDescriptor]
+    :ivar events: Gets the events in the ABI.
+    :vartype events: List[ContractEventDescriptor]
+    """
+
+    def __init__(self):
+        self.methods: List[ContractMethodDescriptor] = []
+        self.events: List[ContractEventDescriptor] = []
+
+
+class ContractMethodDescriptor:
+    """
+    Represents a method in a smart contract ABI.
+
+    :ivar name: The name of the method.
+    :vartype name: str
+    :ivar parameters: The parameters of the method.
+    :vartype parameters: List[ContractParameterDefinition]
+    :ivar return_type: Indicates the return type of the method.
+    :vartype return_type: ContractParameterType
+    :ivar offset: The position of the method in the contract script.
+    :vartype offset: int
+    :ivar safe:
+        Indicates whether the method is a safe method.
+
+        If a method is marked as safe, the user interface will not give any warnings when it is called by other
+        contracts.
+
+    :vartype safe: bool
+    """
+
+    def __init__(self):
+        self.name: str = ''
+        self.parameters: List[ContractParameterDefinition] = []
+        self.return_type: ContractParameterType = ContractParameterType.Any
+        self.offset: int = 0
+        self.safe: bool = False
+
+
+class ContractEventDescriptor:
+    """
+    Represents an event in a smart contract ABI.
+
+    :ivar name: The name of the event.
+    :vartype name: str
+    :ivar parameters: The parameters of the event.
+    :vartype parameters: List[ContractParameterDefinition]
+    """
+
+    def __init__(self):
+        self.name: str = ''
+        self.parameters: List[ContractParameterDefinition] = []
+
+
+class ContractParameterDefinition:
+    """
+    Represents a parameter of an event or method in ABI.
+
+    :ivar name: The name of the parameter.
+    :vartype name: str
+    :ivar type: The type of the parameter.
+    :vartype type: ContractParameterType
+    """
+
+    def __init__(self):
+        self.name: str = ''
+        self.type: ContractParameterType = ContractParameterType.Any

--- a/boa3/builtin/interop/runtime/notification.py
+++ b/boa3/builtin/interop/runtime/notification.py
@@ -1,5 +1,3 @@
-from typing import Any, Tuple
-
 from boa3.builtin.type import UInt160
 
 
@@ -18,4 +16,4 @@ class Notification:
     def __init__(self):
         self.script_hash: UInt160 = UInt160()
         self.event_name: str = ''
-        self.state: Tuple[Any] = ()
+        self.state: tuple = ()

--- a/boa3/model/builtin/interop/contract/contractmanifest/__init__.py
+++ b/boa3/model/builtin/interop/contract/contractmanifest/__init__.py
@@ -1,0 +1,24 @@
+__all__ = ['ContractAbiType',
+           'ContractEventDescriptorType',
+           'ContractGroupType',
+           'ContractGroupType',
+           'ContractManifestType',
+           'ContractMethodDescriptorType',
+           'ContractParameterDefinitionType',
+           'ContractParameterType',
+           'ContractPermissionDescriptorType',
+           'ContractPermissionType'
+           ]
+
+from boa3.model.builtin.interop.contract.contractmanifest.contractabitype import ContractAbiType
+from boa3.model.builtin.interop.contract.contractmanifest.contracteventdescriptortype import ContractEventDescriptorType
+from boa3.model.builtin.interop.contract.contractmanifest.contractgrouptype import ContractGroupType
+from boa3.model.builtin.interop.contract.contractmanifest.contractmanifesttype import ContractManifestType
+from boa3.model.builtin.interop.contract.contractmanifest.contractmethoddescriptortype import \
+    ContractMethodDescriptorType
+from boa3.model.builtin.interop.contract.contractmanifest.contractparameterdefinitiontype import \
+    ContractParameterDefinitionType
+from boa3.model.builtin.interop.contract.contractmanifest.contractparametertype import ContractParameterType
+from boa3.model.builtin.interop.contract.contractmanifest.contractpermissiondescriptortype import \
+    ContractPermissionDescriptorType
+from boa3.model.builtin.interop.contract.contractmanifest.contractpermissiontype import ContractPermissionType

--- a/boa3/model/builtin/interop/contract/contractmanifest/contractabitype.py
+++ b/boa3/model/builtin/interop/contract/contractmanifest/contractabitype.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from boa3.model.method import Method
+from boa3.model.property import Property
+from boa3.model.type.classtype import ClassType
+from boa3.model.variable import Variable
+from boa3.neo.vm.type.StackItem import StackItemType
+
+
+class ContractAbiType(ClassType):
+    """
+    A class used to represent Neo ContractAbi class
+    """
+
+    def __init__(self):
+        super().__init__('ContractAbi')
+        from boa3.model.builtin.interop.contract.contractmanifest.contractmethoddescriptortype import \
+            ContractMethodDescriptorType
+        from boa3.model.builtin.interop.contract.contractmanifest.contracteventdescriptortype import \
+            ContractEventDescriptorType
+        from boa3.model.type.type import Type
+
+        self._variables: Dict[str, Variable] = {
+            'methods': Variable(Type.list.build_collection(ContractMethodDescriptorType.build())),
+            'events': Variable(Type.list.build_collection(ContractEventDescriptorType.build()))
+        }
+        self._constructor: Method = None
+
+    @property
+    def variables(self) -> Dict[str, Variable]:
+        return self._variables.copy()
+
+    @property
+    def properties(self) -> Dict[str, Property]:
+        return {}
+
+    @property
+    def class_methods(self) -> Dict[str, Method]:
+        return {}
+
+    @property
+    def instance_methods(self) -> Dict[str, Method]:
+        return {}
+
+    def constructor_method(self) -> Optional[Method]:
+        return self._constructor
+
+    @property
+    def stack_item(self) -> StackItemType:
+        return StackItemType.Struct
+
+    @classmethod
+    def build(cls, value: Any = None) -> ContractAbiType:
+        if value is None or cls._is_type_of(value):
+            return _ContractAbi
+
+    @classmethod
+    def _is_type_of(cls, value: Any):
+        return isinstance(value, ContractAbiType)
+
+
+_ContractAbi = ContractAbiType()

--- a/boa3/model/builtin/interop/contract/contractmanifest/contracteventdescriptortype.py
+++ b/boa3/model/builtin/interop/contract/contractmanifest/contracteventdescriptortype.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from boa3.model.method import Method
+from boa3.model.property import Property
+from boa3.model.type.classtype import ClassType
+from boa3.model.variable import Variable
+from boa3.neo.vm.type.StackItem import StackItemType
+
+
+class ContractEventDescriptorType(ClassType):
+    """
+    A class used to represent Neo ContractEventDescriptor class
+    """
+
+    def __init__(self):
+        super().__init__('ContractEventDescriptor')
+        from boa3.model.builtin.interop.contract.contractmanifest.contractparameterdefinitiontype import \
+            ContractParameterDefinitionType
+        from boa3.model.type.type import Type
+
+        self._variables: Dict[str, Variable] = {
+            'name': Variable(Type.str),
+            'parameters': Variable(Type.list.build_collection(ContractParameterDefinitionType.build()))
+        }
+        self._constructor: Method = None
+
+    @property
+    def variables(self) -> Dict[str, Variable]:
+        return self._variables.copy()
+
+    @property
+    def properties(self) -> Dict[str, Property]:
+        return {}
+
+    @property
+    def class_methods(self) -> Dict[str, Method]:
+        return {}
+
+    @property
+    def instance_methods(self) -> Dict[str, Method]:
+        return {}
+
+    def constructor_method(self) -> Optional[Method]:
+        return self._constructor
+
+    @property
+    def stack_item(self) -> StackItemType:
+        return StackItemType.Struct
+
+    @classmethod
+    def build(cls, value: Any = None) -> ContractEventDescriptorType:
+        if value is None or cls._is_type_of(value):
+            return _ContractEventDescriptor
+
+    @classmethod
+    def _is_type_of(cls, value: Any):
+        return isinstance(value, ContractEventDescriptorType)
+
+
+_ContractEventDescriptor = ContractEventDescriptorType()

--- a/boa3/model/builtin/interop/contract/contractmanifest/contractgrouptype.py
+++ b/boa3/model/builtin/interop/contract/contractmanifest/contractgrouptype.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from boa3.model.method import Method
+from boa3.model.property import Property
+from boa3.model.type.classtype import ClassType
+from boa3.model.variable import Variable
+from boa3.neo.vm.type.StackItem import StackItemType
+
+
+class ContractGroupType(ClassType):
+    """
+    A class used to represent Neo ContractGroup class
+    """
+
+    def __init__(self):
+        super().__init__('ContractGroup')
+        from boa3.model.type.collection.sequence.ecpointtype import ECPointType
+        from boa3.model.type.type import Type
+
+        self._variables: Dict[str, Variable] = {
+            'pubkey': Variable(ECPointType.build()),
+            'signature': Variable(Type.bytes)
+        }
+        self._constructor: Method = None
+
+    @property
+    def variables(self) -> Dict[str, Variable]:
+        return self._variables.copy()
+
+    @property
+    def properties(self) -> Dict[str, Property]:
+        return {}
+
+    @property
+    def class_methods(self) -> Dict[str, Method]:
+        return {}
+
+    @property
+    def instance_methods(self) -> Dict[str, Method]:
+        return {}
+
+    def constructor_method(self) -> Optional[Method]:
+        return self._constructor
+
+    @property
+    def stack_item(self) -> StackItemType:
+        return StackItemType.Struct
+
+    @classmethod
+    def build(cls, value: Any = None) -> ContractGroupType:
+        if value is None or cls._is_type_of(value):
+            return _ContractGroup
+
+    @classmethod
+    def _is_type_of(cls, value: Any):
+        return isinstance(value, ContractGroupType)
+
+
+_ContractGroup = ContractGroupType()

--- a/boa3/model/builtin/interop/contract/contractmanifest/contractmanifesttype.py
+++ b/boa3/model/builtin/interop/contract/contractmanifest/contractmanifesttype.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from boa3.model.method import Method
+from boa3.model.property import Property
+from boa3.model.type.classtype import ClassType
+from boa3.model.variable import Variable
+from boa3.neo.vm.type.StackItem import StackItemType
+
+
+class ContractManifestType(ClassType):
+    """
+    A class used to represent Neo ContractManifest class
+    """
+
+    def __init__(self):
+        super().__init__('ContractManifest')
+        from boa3.model.type.type import Type
+
+        self._variables: Dict[str, Variable] = {
+            'name': Variable(Type.str),
+            'groups': Variable(Type.list),
+            '-features': Variable(Type.dict),  # TODO: rename this variable when features are implemented in neo3-boa
+            'supported_standards': Variable(Type.list.build_collection([Type.str])),
+            'abi': Variable(Type.any),
+            'permissions': Variable(Type.list),
+            'trusts': Variable(Type.optional.build(Type.list)),
+            'extras': Variable(Type.str)
+        }
+        self._constructor: Method = None
+
+    @property
+    def variables(self) -> Dict[str, Variable]:
+        return self._variables.copy()
+
+    @property
+    def properties(self) -> Dict[str, Property]:
+        return {}
+
+    @property
+    def class_methods(self) -> Dict[str, Method]:
+        return {}
+
+    @property
+    def instance_methods(self) -> Dict[str, Method]:
+        return {}
+
+    def constructor_method(self) -> Optional[Method]:
+        return self._constructor
+
+    @property
+    def stack_item(self) -> StackItemType:
+        return StackItemType.Struct
+
+    @classmethod
+    def build(cls, value: Any = None) -> ContractManifestType:
+        if value is None or cls._is_type_of(value):
+            return _ContractManifest
+
+    @classmethod
+    def _is_type_of(cls, value: Any):
+        return isinstance(value, ContractManifestType)
+
+
+_ContractManifest = ContractManifestType()

--- a/boa3/model/builtin/interop/contract/contractmanifest/contractmethoddescriptortype.py
+++ b/boa3/model/builtin/interop/contract/contractmanifest/contractmethoddescriptortype.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from boa3.model.method import Method
+from boa3.model.property import Property
+from boa3.model.type.classtype import ClassType
+from boa3.model.variable import Variable
+from boa3.neo.vm.type.StackItem import StackItemType
+
+
+class ContractMethodDescriptorType(ClassType):
+    """
+    A class used to represent Neo ContractMethodDescriptor class
+    """
+
+    def __init__(self):
+        super().__init__('ContractMethodDescriptor')
+        from boa3.model.builtin.interop.contract.contractmanifest.contractparameterdefinitiontype import \
+            ContractParameterDefinitionType
+        from boa3.model.builtin.interop.contract.contractmanifest.contractparametertype import ContractParameterType
+        from boa3.model.type.type import Type
+
+        self._variables: Dict[str, Variable] = {
+            'name': Variable(Type.str),
+            'parameters': Variable(Type.list.build_collection(ContractParameterDefinitionType.build())),
+            'return_type': Variable(ContractParameterType.build()),
+            'offset': Variable(Type.int),
+            'safe': Variable(Type.bool)
+        }
+        self._constructor: Method = None
+
+    @property
+    def variables(self) -> Dict[str, Variable]:
+        return self._variables.copy()
+
+    @property
+    def properties(self) -> Dict[str, Property]:
+        return {}
+
+    @property
+    def class_methods(self) -> Dict[str, Method]:
+        return {}
+
+    @property
+    def instance_methods(self) -> Dict[str, Method]:
+        return {}
+
+    def constructor_method(self) -> Optional[Method]:
+        return self._constructor
+
+    @property
+    def stack_item(self) -> StackItemType:
+        return StackItemType.Struct
+
+    @classmethod
+    def build(cls, value: Any = None) -> ContractMethodDescriptorType:
+        if value is None or cls._is_type_of(value):
+            return _ContractMethodDescriptor
+
+    @classmethod
+    def _is_type_of(cls, value: Any):
+        return isinstance(value, ContractMethodDescriptorType)
+
+
+_ContractMethodDescriptor = ContractMethodDescriptorType()

--- a/boa3/model/builtin/interop/contract/contractmanifest/contractparameterdefinitiontype.py
+++ b/boa3/model/builtin/interop/contract/contractmanifest/contractparameterdefinitiontype.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from boa3.model.method import Method
+from boa3.model.property import Property
+from boa3.model.type.classtype import ClassType
+from boa3.model.variable import Variable
+from boa3.neo.vm.type.StackItem import StackItemType
+
+
+class ContractParameterDefinitionType(ClassType):
+    """
+    A class used to represent Neo ContractParameterDefinition class
+    """
+
+    def __init__(self):
+        super().__init__('ContractParameterDefinition')
+        from boa3.model.builtin.interop.contract.contractmanifest.contractparametertype import ContractParameterType
+        from boa3.model.type.type import Type
+
+        self._variables: Dict[str, Variable] = {
+            'name': Variable(Type.str),
+            'type': Variable(ContractParameterType.build())
+        }
+        self._constructor: Method = None
+
+    @property
+    def variables(self) -> Dict[str, Variable]:
+        return self._variables.copy()
+
+    @property
+    def properties(self) -> Dict[str, Property]:
+        return {}
+
+    @property
+    def class_methods(self) -> Dict[str, Method]:
+        return {}
+
+    @property
+    def instance_methods(self) -> Dict[str, Method]:
+        return {}
+
+    def constructor_method(self) -> Optional[Method]:
+        return self._constructor
+
+    @property
+    def stack_item(self) -> StackItemType:
+        return StackItemType.Struct
+
+    @classmethod
+    def build(cls, value: Any = None) -> ContractParameterDefinitionType:
+        if value is None or cls._is_type_of(value):
+            return _ContractParameterDefinition
+
+    @classmethod
+    def _is_type_of(cls, value: Any):
+        return isinstance(value, ContractParameterDefinitionType)
+
+
+_ContractParameterDefinition = ContractParameterDefinitionType()

--- a/boa3/model/builtin/interop/contract/contractmanifest/contractparametertype.py
+++ b/boa3/model/builtin/interop/contract/contractmanifest/contractparametertype.py
@@ -1,0 +1,57 @@
+from typing import Any, Dict
+
+from boa3.model.symbol import ISymbol
+from boa3.model.type.itype import IType
+from boa3.model.type.primitive.inttype import IntType
+
+
+class ContractParameterType(IntType):
+    """
+    A class used to represent Neo interop ContractParameterType type
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._identifier = 'ContractParameterType'
+
+    @property
+    def default_value(self) -> Any:
+        from boa3.neo.vm.type.ContractParameterType import ContractParameterType as ContractParameter
+        return ContractParameter.ALL
+
+    @classmethod
+    def build(cls, value: Any = None) -> IType:
+        if value is None or cls._is_type_of(value):
+            return _ContractParameterType
+
+    @classmethod
+    def _is_type_of(cls, value: Any):
+        from boa3.neo.vm.type.ContractParameterType import ContractParameterType as ContractParameter
+        return isinstance(value, (ContractParameter, ContractParameterType))
+
+    @property
+    def symbols(self) -> Dict[str, ISymbol]:
+        """
+        Gets the class symbols of this type
+
+        :return: a dictionary that maps each symbol in the module with its name
+        """
+        from boa3.neo.vm.type.ContractParameterType import ContractParameterType as ContractParameter
+        from boa3.model.variable import Variable
+
+        return {name: Variable(self) for name in ContractParameter.__members__.keys()}
+
+    def get_value(self, symbol_id) -> Any:
+        """
+        Gets the literal value of a symbol
+
+        :return: the value if this type has this symbol. None otherwise.
+        """
+        if symbol_id in self.symbols:
+            from boa3.neo.vm.type.ContractParameterType import ContractParameterType as ContractParameter
+            return ContractParameter.__members__[symbol_id]
+
+        return None
+
+
+_ContractParameterType = ContractParameterType()

--- a/boa3/model/builtin/interop/contract/contractmanifest/contractpermissiondescriptortype.py
+++ b/boa3/model/builtin/interop/contract/contractmanifest/contractpermissiondescriptortype.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from boa3.model.method import Method
+from boa3.model.property import Property
+from boa3.model.type.classtype import ClassType
+from boa3.model.variable import Variable
+from boa3.neo.vm.type.StackItem import StackItemType
+
+
+class ContractPermissionDescriptorType(ClassType):
+    """
+    A class used to represent Neo ContractPermissionDescriptor class
+    """
+
+    def __init__(self):
+        super().__init__('ContractPermissionDescriptor')
+        from boa3.model.type.collection.sequence.uint160type import UInt160Type
+        from boa3.model.type.collection.sequence.ecpointtype import ECPointType
+        from boa3.model.type.type import Type
+
+        self._variables: Dict[str, Variable] = {
+            'hash': Variable(Type.optional.build(UInt160Type.build())),
+            'group': Variable(Type.optional.build(ECPointType.build()))
+        }
+        self._constructor: Method = None
+
+    @property
+    def variables(self) -> Dict[str, Variable]:
+        return self._variables.copy()
+
+    @property
+    def properties(self) -> Dict[str, Property]:
+        return {}
+
+    @property
+    def class_methods(self) -> Dict[str, Method]:
+        return {}
+
+    @property
+    def instance_methods(self) -> Dict[str, Method]:
+        return {}
+
+    def constructor_method(self) -> Optional[Method]:
+        return self._constructor
+
+    @property
+    def stack_item(self) -> StackItemType:
+        return StackItemType.Struct
+
+    @classmethod
+    def build(cls, value: Any = None) -> ContractPermissionDescriptorType:
+        if value is None or cls._is_type_of(value):
+            return _ContractPermissionDescriptor
+
+    @classmethod
+    def _is_type_of(cls, value: Any):
+        return isinstance(value, ContractPermissionDescriptorType)
+
+
+_ContractPermissionDescriptor = ContractPermissionDescriptorType()

--- a/boa3/model/builtin/interop/contract/contractmanifest/contractpermissiontype.py
+++ b/boa3/model/builtin/interop/contract/contractmanifest/contractpermissiontype.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from boa3.model.method import Method
+from boa3.model.property import Property
+from boa3.model.type.classtype import ClassType
+from boa3.model.variable import Variable
+from boa3.neo.vm.type.StackItem import StackItemType
+
+
+class ContractPermissionType(ClassType):
+    """
+    A class used to represent Neo ContractPermission class
+    """
+
+    def __init__(self):
+        super().__init__('ContractPermission')
+        from boa3.model.type.type import Type
+
+        self._variables: Dict[str, Variable] = {
+            'contract': Variable(Type.str),
+            'methods': Variable(Type.optional.build(Type.list.build_collection([Type.str])))
+        }
+        self._constructor: Method = None
+
+    @property
+    def variables(self) -> Dict[str, Variable]:
+        return self._variables.copy()
+
+    @property
+    def properties(self) -> Dict[str, Property]:
+        return {}
+
+    @property
+    def class_methods(self) -> Dict[str, Method]:
+        return {}
+
+    @property
+    def instance_methods(self) -> Dict[str, Method]:
+        return {}
+
+    def constructor_method(self) -> Optional[Method]:
+        return self._constructor
+
+    @property
+    def stack_item(self) -> StackItemType:
+        return StackItemType.Array
+
+    @classmethod
+    def build(cls, value: Any = None) -> ContractPermissionType:
+        if value is None or cls._is_type_of(value):
+            return _ContractPermission
+
+    @classmethod
+    def _is_type_of(cls, value: Any):
+        return isinstance(value, ContractPermissionType)
+
+
+_ContractPermission = ContractPermissionType()

--- a/boa3/model/builtin/interop/contract/contracttype.py
+++ b/boa3/model/builtin/interop/contract/contracttype.py
@@ -18,6 +18,7 @@ class ContractType(ClassType):
 
     def __init__(self):
         super().__init__('Contract')
+        from boa3.model.builtin.interop.contract.contractmanifest import ContractManifestType
         from boa3.model.type.type import Type
         from boa3.model.type.collection.sequence.uint160type import UInt160Type
 
@@ -26,7 +27,7 @@ class ContractType(ClassType):
             'update_counter': Variable(Type.int),
             'hash': Variable(UInt160Type.build()),
             'nef': Variable(Type.bytes),
-            'manifest': Variable(Type.dict)
+            'manifest': Variable(ContractManifestType.build())
         }
         self._constructor: Method = None
 
@@ -60,12 +61,6 @@ class ContractType(ClassType):
     @classmethod
     def _is_type_of(cls, value: Any):
         return isinstance(value, ContractType)
-
-    def is_instance_opcodes(self) -> List[Tuple[Opcode, bytes]]:
-        # TODO: remove this overwrite when the classes related to the manifest are implemented
-        # ContractManifest, ContractAbi, ContractPermission,
-        # ContractMethodDescriptor, ContractEventDescriptor, ContractParameterDefinition
-        return []
 
 
 _Contract = ContractType()

--- a/boa3/model/builtin/interop/interop.py
+++ b/boa3/model/builtin/interop/interop.py
@@ -5,6 +5,7 @@ from boa3.model.builtin.interop import *
 from boa3.model.builtin.interop.binary import *
 from boa3.model.builtin.interop.blockchain import *
 from boa3.model.builtin.interop.contract import *
+from boa3.model.builtin.interop.contract.contractmanifest import *
 from boa3.model.builtin.interop.crypto import *
 from boa3.model.builtin.interop.iterator import *
 from boa3.model.builtin.interop.json import *
@@ -43,7 +44,9 @@ class Interop:
     # Interop Types
     BlockType = BlockType.build()
     CallFlagsType = CallFlagsType()
+    ContractManifestType = ContractManifestType.build()
     ContractType = ContractType.build()
+    FindOptionsType = FindOptionsType()
     Iterator = IteratorType.build()
     NotificationType = NotificationType.build()
     OracleType = OracleType.build()
@@ -51,7 +54,6 @@ class Interop:
     StorageMapType = StorageMapType.build()
     TransactionType = TransactionType.build()
     TriggerType = TriggerType()
-    FindOptionsType = FindOptionsType()
 
     # Binary Interops
     Atoi = AtoiMethod()
@@ -184,8 +186,22 @@ class Interop:
                              types=[ContractType]
                              )
 
+    ContractManifestModule = Package(identifier=ContractManifestType.identifier.lower(),
+                                     types=[ContractAbiType.build(),
+                                            ContractEventDescriptorType.build(),
+                                            ContractGroupType.build(),
+                                            ContractManifestType,
+                                            ContractMethodDescriptorType.build(),
+                                            ContractParameterDefinitionType.build(),
+                                            ContractParameterType.build(),
+                                            ContractPermissionDescriptorType.build(),
+                                            ContractPermissionType.build()
+                                            ]
+                                     )
+
     ContractPackage = Package(identifier=InteropPackage.Contract,
                               types=[CallFlagsType,
+                                     ContractManifestType,
                                      ContractType
                                      ],
                               properties=[GasScriptHash,
@@ -199,6 +215,7 @@ class Interop:
                                        UpdateContract
                                        ],
                               packages=[CallFlagsTypeModule,
+                                        ContractManifestModule,
                                         ContractModule
                                         ]
                               )

--- a/boa3/neo/vm/type/ContractParameterType.py
+++ b/boa3/neo/vm/type/ContractParameterType.py
@@ -17,7 +17,7 @@ class ContractParameterType(IntEnum):
     Void = 0xff
 
     @classmethod
-    def get_by_name(cls, name: str) -> int:
+    def _get_by_name(cls, name: str) -> int:
         try:
             value = cls.__getattr__(name)
         except BaseException:

--- a/boa3_test/tests/compiler_tests/test_neo_types.py
+++ b/boa3_test/tests/compiler_tests/test_neo_types.py
@@ -269,7 +269,23 @@ class TestNeoTypes(BoaTest):
 
     def test_isinstance_contract(self):
         path = self.get_contract_path('IsInstanceContract.py')
-        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'is_contract', bytes(10),
+                                         expected_result_type=bool)
+        self.assertEqual(False, result)
+        result = self.run_smart_contract(engine, path, 'is_contract', [1, 2, 3],
+                                         expected_result_type=bool)
+        self.assertEqual(False, result)
+        result = self.run_smart_contract(engine, path, 'is_contract', "test_with_string",
+                                         expected_result_type=bool)
+        self.assertEqual(False, result)
+        result = self.run_smart_contract(engine, path, 'is_contract', 42,
+                                         expected_result_type=bool)
+        self.assertEqual(False, result)
+
+        result = self.run_smart_contract(engine, path, 'is_get_contract_a_contract',
+                                         expected_result_type=bool)
+        self.assertEqual(True, result)
 
     def test_isinstance_block(self):
         path = self.get_contract_path('IsInstanceBlock.py')

--- a/boa3_test/tests/test_classes/contract/neomethodstruct.py
+++ b/boa3_test/tests/test_classes/contract/neomethodstruct.py
@@ -27,7 +27,7 @@ class NeoMethodStruct(NeoStruct):
         struct = cls()
         struct.append(json[cls._name_field])
         struct.append([cls._get_param_info(arg) for arg in json[cls._parameters_field]])
-        struct.append(ContractParameterType.get_by_name(json[cls._return_type_field]))
+        struct.append(ContractParameterType._get_by_name(json[cls._return_type_field]))
         struct.append(json[cls._offset_field])
         struct.append(json[cls._is_safe_field])
 

--- a/boa3_test/tests/test_classes/contract/neostruct.py
+++ b/boa3_test/tests/test_classes/contract/neostruct.py
@@ -28,7 +28,7 @@ class NeoStruct(list, ABC):
         name = json[_name]
         from boa3.neo.vm.type.ContractParameterType import ContractParameterType
         try:
-            param_type = ContractParameterType.get_by_name(json[_type])
+            param_type = ContractParameterType._get_by_name(json[_type])
         except BaseException:
             param_type = None
 

--- a/docs/source/boa3/builtin/interop/contract/boa3-builtin-interop-contract-callflags.rst
+++ b/docs/source/boa3/builtin/interop/contract/boa3-builtin-interop-contract-callflags.rst
@@ -1,0 +1,4 @@
+callflagstype
+-------------
+
+.. automodule:: boa3.builtin.interop.contract.callflagstype

--- a/docs/source/boa3/builtin/interop/contract/boa3-builtin-interop-contract-contract.rst
+++ b/docs/source/boa3/builtin/interop/contract/boa3-builtin-interop-contract-contract.rst
@@ -1,0 +1,4 @@
+contract
+--------
+
+.. automodule:: boa3.builtin.interop.contract.contract

--- a/docs/source/boa3/builtin/interop/contract/boa3-builtin-interop-contract-contractmanifest.rst
+++ b/docs/source/boa3/builtin/interop/contract/boa3-builtin-interop-contract-contractmanifest.rst
@@ -1,0 +1,4 @@
+contractmanifest
+----------------
+
+.. automodule:: boa3.builtin.interop.contract.contractmanifest

--- a/docs/source/boa3/builtin/interop/contract/boa3-builtin-interop-contract.rst
+++ b/docs/source/boa3/builtin/interop/contract/boa3-builtin-interop-contract.rst
@@ -3,12 +3,11 @@ contract
 
 .. automodule:: boa3.builtin.interop.contract
 
-CallFlags
----------
+Subpackages
+-----------
 
-.. automodule:: boa3.builtin.interop.contract.callflagstype
+.. toctree::
 
-Contract
---------
-
-.. automodule:: boa3.builtin.interop.contract.contract
+    boa3-builtin-interop-contract-callflags
+    boa3-builtin-interop-contract-contract
+    boa3-builtin-interop-contract-contractmanifest


### PR DESCRIPTION
**Related issue**
#467

**Summary or solution description**
Implemented the ContractManifest classes:
- ContractManifest
- ContractAbi
- ContractPermission
- ContractPermissionDescriptor
- ContractMethodDescriptor
- ContractEventDescriptor
- ContractParameterDefinition
- ContractParameterType
- ContractGroup

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/bfa846c572f13833ffba11094dc4a4419852f2c4/boa3/builtin/interop/contract/contractmanifest.py#L7-L187

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/bfa846c572f13833ffba11094dc4a4419852f2c4/boa3_test/tests/compiler_tests/test_neo_types.py#L270-L288

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7