### PR TITLE
Implement Oracle getPrice

### DIFF
--- a/boa3/builtin/interop/__init__.py
+++ b/boa3/builtin/interop/__init__.py
@@ -43,7 +43,7 @@ class Oracle:
         pass
 
     @classmethod
-    def get_price(cls):
+    def get_price(cls) -> int:
         """
         Gets the price for an Oracle request.
 

--- a/boa3/builtin/interop/__init__.py
+++ b/boa3/builtin/interop/__init__.py
@@ -41,3 +41,12 @@ class Oracle:
         :type gas_for_response: int
         """
         pass
+
+    @classmethod
+    def get_price(cls):
+        """
+        Gets the price for an Oracle request.
+
+        :return: the price for an Oracle request
+        """
+        pass

--- a/boa3/model/builtin/interop/oracle/oraclegetpricemethod.py
+++ b/boa3/model/builtin/interop/oracle/oraclegetpricemethod.py
@@ -1,0 +1,24 @@
+from typing import Dict, Optional
+
+from boa3.model.builtin.interop.nativecontract import OracleMethod
+from boa3.model.variable import Variable
+
+
+class OracleGetPriceMethod(OracleMethod):
+
+    def __init__(self):
+        from boa3.model.type.type import Type
+
+        identifier = 'get_price'
+        syscall = 'getPrice'
+        args: Dict[str, Variable] = {}
+
+        super().__init__(identifier, syscall, args, return_type=Type.int)
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> Optional[str]:
+        return None

--- a/boa3/model/builtin/interop/oracle/oracletype.py
+++ b/boa3/model/builtin/interop/oracle/oracletype.py
@@ -31,10 +31,12 @@ class OracleType(ClassType):
     @property
     def class_methods(self) -> Dict[str, Method]:
         # avoid recursive import
+        from boa3.model.builtin.interop.oracle.oraclegetpricemethod import OracleGetPriceMethod
         from boa3.model.builtin.interop.oracle.oraclerequesmethod import OracleRequesMethod
 
         if len(self._class_methods) == 0:
             self._class_methods = {
+                'get_price': OracleGetPriceMethod(),
                 'request': OracleRequesMethod()
             }
         return self._class_methods

--- a/boa3_test/test_sc/interop_test/native_contracts/OracleGetPrice.py
+++ b/boa3_test/test_sc/interop_test/native_contracts/OracleGetPrice.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.interop import Oracle
+
+
+@public
+def main() -> int:
+    return Oracle.get_price()

--- a/boa3_test/tests/compiler_tests/test_interop/test_native_contract.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_native_contract.py
@@ -1,6 +1,9 @@
 from boa3 import constants
 from boa3.exception import CompilerError
 from boa3.neo.cryptography import hash160
+from boa3.neo.vm.opcode.Opcode import Opcode
+from boa3.neo.vm.type.Integer import Integer
+from boa3.neo.vm.type.String import String
 from boa3_test.tests.boa_test import BoaTest
 from boa3_test.tests.test_classes.TestExecutionException import TestExecutionException
 from boa3_test.tests.test_classes.testengine import TestEngine
@@ -98,3 +101,37 @@ class TestNativeContracts(BoaTest):
         with self.assertRaises(TestExecutionException):
             # callback function doesn't exist
             self.run_oracle_response(engine, request_id, OracleResponseCode.Success, b'12345')
+
+    def test_oracle_get_price(self):
+
+        from boa3.model.builtin.interop.interop import Interop
+        from boa3.neo3.contracts import CallFlags
+        from boa3.model.builtin.interop.oracle.oraclegetpricemethod import OracleGetPriceMethod
+        from boa3.constants import ORACLE_SCRIPT
+
+        call_flags = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
+        method = String(OracleGetPriceMethod().method_name).to_bytes()
+
+        expected_output = (
+                Opcode.NEWARRAY0
+                + Opcode.PUSHDATA1
+                + Integer(len(call_flags)).to_byte_array(min_length=1, signed=True)
+                + call_flags
+                + Opcode.PUSHDATA1
+                + Integer(len(method)).to_byte_array(min_length=1, signed=True)
+                + method
+                + Opcode.PUSHDATA1
+                + Integer(len(ORACLE_SCRIPT)).to_byte_array(min_length=1, signed=True)
+                + ORACLE_SCRIPT
+                + Opcode.SYSCALL
+                + Interop.CallContract.interop_method_hash
+                + Opcode.RET
+        )
+
+        path = self.get_contract_path('OracleGetPrice.py')
+        output, manifest = self.compile_and_save(path)
+        self.assertEqual(expected_output, output)
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'main')
+        self.assertIsInstance(result, int)


### PR DESCRIPTION
**Related issue**
#496 

**How to Reproduce**
Call `Oracle.get_price()`.

**Tests**
A clear and concise description of how you tested it.

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8
