### PR TITLE
Convert Imported Static Variables

### DIFF
--- a/boa3/analyser/astanalyser.py
+++ b/boa3/analyser/astanalyser.py
@@ -12,7 +12,7 @@ from boa3.model.identifiedsymbol import IdentifiedSymbol
 from boa3.model.operation.operation import IOperation
 from boa3.model.symbol import ISymbol
 from boa3.model.type.annotation.metatype import MetaType
-from boa3.model.type.classtype import ClassType
+from boa3.model.type.classes.classtype import ClassType
 from boa3.model.type.type import IType, Type
 from boa3.model.type.typeutils import TypeUtils
 

--- a/boa3/analyser/moduleanalyser.py
+++ b/boa3/analyser/moduleanalyser.py
@@ -20,7 +20,7 @@ from boa3.model.method import Method
 from boa3.model.module import Module
 from boa3.model.symbol import ISymbol
 from boa3.model.type.annotation.uniontype import UnionType
-from boa3.model.type.classtype import ClassType
+from boa3.model.type.classes.classtype import ClassType
 from boa3.model.type.collection.icollection import ICollectionType as Collection
 from boa3.model.type.collection.sequence.sequencetype import SequenceType
 from boa3.model.type.type import IType, Type

--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -22,7 +22,7 @@ from boa3.model.operation.operator import Operator
 from boa3.model.operation.unary.unaryoperation import UnaryOperation
 from boa3.model.operation.unaryop import UnaryOp
 from boa3.model.symbol import ISymbol
-from boa3.model.type.classtype import ClassType
+from boa3.model.type.classes.classtype import ClassType
 from boa3.model.type.collection.icollection import ICollectionType as Collection
 from boa3.model.type.type import IType, Type
 from boa3.model.type.typeutils import TypeUtils

--- a/boa3/compiler/codegenerator/codegeneratorvisitor.py
+++ b/boa3/compiler/codegenerator/codegeneratorvisitor.py
@@ -106,6 +106,11 @@ class VisitorCodeGenerator(IAstAnalyser):
                 self.visit(stmt)
 
             self.generator.end_initialize()
+        else:
+            for stmt in global_stmts:
+                stmt.origin = module
+
+            self.global_stmts.extend(global_stmts)
 
     def visit_FunctionDef(self, function: ast.FunctionDef):
         """

--- a/boa3/compiler/codegenerator/codegeneratorvisitor.py
+++ b/boa3/compiler/codegenerator/codegeneratorvisitor.py
@@ -2,6 +2,7 @@ import ast
 from inspect import isclass
 from typing import Dict, List, Optional, Tuple
 
+from boa3 import constants
 from boa3.analyser.astanalyser import IAstAnalyser
 from boa3.compiler.codegenerator.codegenerator import CodeGenerator
 from boa3.compiler.codegenerator.vmcodemapping import VMCodeMapping
@@ -13,7 +14,7 @@ from boa3.model.operation.binary.binaryoperation import BinaryOperation
 from boa3.model.operation.binaryop import BinaryOp
 from boa3.model.operation.operation import IOperation
 from boa3.model.operation.unary.unaryoperation import UnaryOperation
-from boa3.model.type.classtype import ClassType
+from boa3.model.type.classes.classtype import ClassType
 from boa3.model.type.type import IType, Type
 from boa3.model.variable import Variable
 
@@ -33,6 +34,8 @@ class VisitorCodeGenerator(IAstAnalyser):
         self.generator = generator
         self.current_method: Optional[Method] = None
         self.symbols = generator.symbol_table
+
+        self.global_stmts: List[ast.AST] = []
 
     def include_instruction(self, node: ast.AST, address: int):
         if self.current_method is not None and address in VMCodeMapping.instance().code_map:
@@ -103,47 +106,6 @@ class VisitorCodeGenerator(IAstAnalyser):
                 self.visit(stmt)
 
             self.generator.end_initialize()
-
-    def visit_ImportFrom(self, import_from: ast.ImportFrom):
-        """
-        Includes methods and variables from other modules into the current scope
-
-        :param import_from:
-        """
-        self._import_static_fields(import_from.names)
-
-    def visit_Import(self, import_node: ast.Import):
-        """
-        Includes methods and variables from other modules into the current scope
-
-        :param import_node:
-        """
-        self._import_static_fields(import_node.names)
-
-    def _import_static_fields(self, names: List[ast.alias]):
-        """
-        Visits the imported nodes that aren't function definitions to initialize static fields
-
-        :param names: list of imported alias
-        """
-        for alias in names:
-            name = alias.asname if alias.asname is not None else alias.name
-            if name in self.symbols:
-                if hasattr(self.symbols[name], 'ast') and self.symbols[name].ast is not None:
-                    ast_root = self.symbols[name].ast
-                elif hasattr(self.symbols[name], 'origin') and self.symbols[name].origin is not None:
-                    ast_root = self.symbols[name].origin
-                else:
-                    continue
-
-                if isinstance(ast_root, ast.Module):
-                    body = ast_root.body
-                else:
-                    body = [ast_root]
-
-                for node in body:
-                    if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                        self.visit(node)
 
     def visit_FunctionDef(self, function: ast.FunctionDef):
         """
@@ -259,6 +221,9 @@ class VisitorCodeGenerator(IAstAnalyser):
         :param ann_assign: the python ast variable assignment node
         """
         var_id = self.visit(ann_assign.target)
+        # filter to find the imported variables
+        if var_id not in self.symbols and hasattr(ann_assign, 'origin') and isinstance(ann_assign.origin, ast.AST):
+            var_id = '{0}{2}{1}'.format(ann_assign.origin.__hash__(), var_id, constants.VARIABLE_NAME_SEPARATOR)
         self.store_variable((var_id, None), value=ann_assign.value)
 
     def visit_Assign(self, assign: ast.Assign):
@@ -277,6 +242,9 @@ class VisitorCodeGenerator(IAstAnalyser):
                 var_index = var_id[1]
                 var_id: str = var_id[0]
 
+            # filter to find the imported variables
+            if var_id not in self.symbols and hasattr(assign, 'origin') and isinstance(assign.origin, ast.AST):
+                var_id = '{0}{2}{1}'.format(assign.origin.__hash__(), var_id, constants.VARIABLE_NAME_SEPARATOR)
             vars_ids.append((var_id, var_index))
 
         self.store_variable(*vars_ids, value=assign.value)
@@ -288,6 +256,10 @@ class VisitorCodeGenerator(IAstAnalyser):
         :param aug_assign: the python ast augmented assignment node
         """
         var_id = self.visit(aug_assign.target)
+        # filter to find the imported variables
+        if var_id not in self.symbols and hasattr(aug_assign, 'origin') and isinstance(aug_assign.origin, ast.AST):
+            var_id = '{0}{2}{1}'.format(aug_assign.origin.__hash__(), var_id, constants.VARIABLE_NAME_SEPARATOR)
+
         self.generator.convert_load_symbol(var_id)
         self.visit_to_generate(aug_assign.value)
         self.generator.convert_operation(aug_assign.op)

--- a/boa3/constants.py
+++ b/boa3/constants.py
@@ -15,6 +15,8 @@ DEFAULT_UINT32 = 0
 ENCODING = 'utf-8'
 BYTEORDER = 'little'
 
+VARIABLE_NAME_SEPARATOR = ','
+
 INITIALIZE_METHOD_ID = '_initialize'
 DEPLOY_METHOD_ID = '_deploy'
 

--- a/boa3/model/attribute.py
+++ b/boa3/model/attribute.py
@@ -4,7 +4,7 @@ from typing import Optional, Tuple, Union
 from boa3.model.expression import IExpression
 from boa3.model.imports.package import Package
 from boa3.model.symbol import ISymbol
-from boa3.model.type.classtype import ClassType
+from boa3.model.type.classes.classtype import ClassType
 from boa3.model.type.itype import IType
 
 

--- a/boa3/model/builtin/interop/blockchain/blocktype.py
+++ b/boa3/model/builtin/interop/blockchain/blocktype.py
@@ -6,12 +6,12 @@ from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.expression import IExpression
 from boa3.model.method import Method
 from boa3.model.property import Property
-from boa3.model.type.classtype import ClassType
+from boa3.model.type.classes.classarraytype import ClassArrayType
 from boa3.model.variable import Variable
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
-class BlockType(ClassType):
+class BlockType(ClassArrayType):
     """
     A class used to represent Neo Block class
     """

--- a/boa3/model/builtin/interop/blockchain/transactiontype.py
+++ b/boa3/model/builtin/interop/blockchain/transactiontype.py
@@ -6,12 +6,12 @@ from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.expression import IExpression
 from boa3.model.method import Method
 from boa3.model.property import Property
-from boa3.model.type.classtype import ClassType
+from boa3.model.type.classes.classarraytype import ClassArrayType
 from boa3.model.variable import Variable
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
-class TransactionType(ClassType):
+class TransactionType(ClassArrayType):
     """
     A class used to represent Neo Transaction class
     """

--- a/boa3/model/builtin/interop/contract/contractmanifest/contractabitype.py
+++ b/boa3/model/builtin/interop/contract/contractmanifest/contractabitype.py
@@ -4,12 +4,11 @@ from typing import Any, Dict, Optional
 
 from boa3.model.method import Method
 from boa3.model.property import Property
-from boa3.model.type.classtype import ClassType
+from boa3.model.type.classes.classstructtype import ClassStructType
 from boa3.model.variable import Variable
-from boa3.neo.vm.type.StackItem import StackItemType
 
 
-class ContractAbiType(ClassType):
+class ContractAbiType(ClassStructType):
     """
     A class used to represent Neo ContractAbi class
     """
@@ -46,10 +45,6 @@ class ContractAbiType(ClassType):
 
     def constructor_method(self) -> Optional[Method]:
         return self._constructor
-
-    @property
-    def stack_item(self) -> StackItemType:
-        return StackItemType.Struct
 
     @classmethod
     def build(cls, value: Any = None) -> ContractAbiType:

--- a/boa3/model/builtin/interop/contract/contractmanifest/contracteventdescriptortype.py
+++ b/boa3/model/builtin/interop/contract/contractmanifest/contracteventdescriptortype.py
@@ -4,12 +4,11 @@ from typing import Any, Dict, Optional
 
 from boa3.model.method import Method
 from boa3.model.property import Property
-from boa3.model.type.classtype import ClassType
+from boa3.model.type.classes.classstructtype import ClassStructType
 from boa3.model.variable import Variable
-from boa3.neo.vm.type.StackItem import StackItemType
 
 
-class ContractEventDescriptorType(ClassType):
+class ContractEventDescriptorType(ClassStructType):
     """
     A class used to represent Neo ContractEventDescriptor class
     """
@@ -44,10 +43,6 @@ class ContractEventDescriptorType(ClassType):
 
     def constructor_method(self) -> Optional[Method]:
         return self._constructor
-
-    @property
-    def stack_item(self) -> StackItemType:
-        return StackItemType.Struct
 
     @classmethod
     def build(cls, value: Any = None) -> ContractEventDescriptorType:

--- a/boa3/model/builtin/interop/contract/contractmanifest/contractgrouptype.py
+++ b/boa3/model/builtin/interop/contract/contractmanifest/contractgrouptype.py
@@ -4,12 +4,11 @@ from typing import Any, Dict, Optional
 
 from boa3.model.method import Method
 from boa3.model.property import Property
-from boa3.model.type.classtype import ClassType
+from boa3.model.type.classes.classstructtype import ClassStructType
 from boa3.model.variable import Variable
-from boa3.neo.vm.type.StackItem import StackItemType
 
 
-class ContractGroupType(ClassType):
+class ContractGroupType(ClassStructType):
     """
     A class used to represent Neo ContractGroup class
     """
@@ -43,10 +42,6 @@ class ContractGroupType(ClassType):
 
     def constructor_method(self) -> Optional[Method]:
         return self._constructor
-
-    @property
-    def stack_item(self) -> StackItemType:
-        return StackItemType.Struct
 
     @classmethod
     def build(cls, value: Any = None) -> ContractGroupType:

--- a/boa3/model/builtin/interop/contract/contractmanifest/contractmanifesttype.py
+++ b/boa3/model/builtin/interop/contract/contractmanifest/contractmanifesttype.py
@@ -4,12 +4,11 @@ from typing import Any, Dict, Optional
 
 from boa3.model.method import Method
 from boa3.model.property import Property
-from boa3.model.type.classtype import ClassType
+from boa3.model.type.classes.classstructtype import ClassStructType
 from boa3.model.variable import Variable
-from boa3.neo.vm.type.StackItem import StackItemType
 
 
-class ContractManifestType(ClassType):
+class ContractManifestType(ClassStructType):
     """
     A class used to represent Neo ContractManifest class
     """
@@ -48,10 +47,6 @@ class ContractManifestType(ClassType):
 
     def constructor_method(self) -> Optional[Method]:
         return self._constructor
-
-    @property
-    def stack_item(self) -> StackItemType:
-        return StackItemType.Struct
 
     @classmethod
     def build(cls, value: Any = None) -> ContractManifestType:

--- a/boa3/model/builtin/interop/contract/contractmanifest/contractmethoddescriptortype.py
+++ b/boa3/model/builtin/interop/contract/contractmanifest/contractmethoddescriptortype.py
@@ -4,12 +4,11 @@ from typing import Any, Dict, Optional
 
 from boa3.model.method import Method
 from boa3.model.property import Property
-from boa3.model.type.classtype import ClassType
+from boa3.model.type.classes.classstructtype import ClassStructType
 from boa3.model.variable import Variable
-from boa3.neo.vm.type.StackItem import StackItemType
 
 
-class ContractMethodDescriptorType(ClassType):
+class ContractMethodDescriptorType(ClassStructType):
     """
     A class used to represent Neo ContractMethodDescriptor class
     """
@@ -48,10 +47,6 @@ class ContractMethodDescriptorType(ClassType):
 
     def constructor_method(self) -> Optional[Method]:
         return self._constructor
-
-    @property
-    def stack_item(self) -> StackItemType:
-        return StackItemType.Struct
 
     @classmethod
     def build(cls, value: Any = None) -> ContractMethodDescriptorType:

--- a/boa3/model/builtin/interop/contract/contractmanifest/contractparameterdefinitiontype.py
+++ b/boa3/model/builtin/interop/contract/contractmanifest/contractparameterdefinitiontype.py
@@ -4,12 +4,11 @@ from typing import Any, Dict, Optional
 
 from boa3.model.method import Method
 from boa3.model.property import Property
-from boa3.model.type.classtype import ClassType
+from boa3.model.type.classes.classstructtype import ClassStructType
 from boa3.model.variable import Variable
-from boa3.neo.vm.type.StackItem import StackItemType
 
 
-class ContractParameterDefinitionType(ClassType):
+class ContractParameterDefinitionType(ClassStructType):
     """
     A class used to represent Neo ContractParameterDefinition class
     """
@@ -43,10 +42,6 @@ class ContractParameterDefinitionType(ClassType):
 
     def constructor_method(self) -> Optional[Method]:
         return self._constructor
-
-    @property
-    def stack_item(self) -> StackItemType:
-        return StackItemType.Struct
 
     @classmethod
     def build(cls, value: Any = None) -> ContractParameterDefinitionType:

--- a/boa3/model/builtin/interop/contract/contractmanifest/contractpermissiondescriptortype.py
+++ b/boa3/model/builtin/interop/contract/contractmanifest/contractpermissiondescriptortype.py
@@ -4,12 +4,11 @@ from typing import Any, Dict, Optional
 
 from boa3.model.method import Method
 from boa3.model.property import Property
-from boa3.model.type.classtype import ClassType
+from boa3.model.type.classes.classstructtype import ClassStructType
 from boa3.model.variable import Variable
-from boa3.neo.vm.type.StackItem import StackItemType
 
 
-class ContractPermissionDescriptorType(ClassType):
+class ContractPermissionDescriptorType(ClassStructType):
     """
     A class used to represent Neo ContractPermissionDescriptor class
     """
@@ -44,10 +43,6 @@ class ContractPermissionDescriptorType(ClassType):
 
     def constructor_method(self) -> Optional[Method]:
         return self._constructor
-
-    @property
-    def stack_item(self) -> StackItemType:
-        return StackItemType.Struct
 
     @classmethod
     def build(cls, value: Any = None) -> ContractPermissionDescriptorType:

--- a/boa3/model/builtin/interop/contract/contractmanifest/contractpermissiontype.py
+++ b/boa3/model/builtin/interop/contract/contractmanifest/contractpermissiontype.py
@@ -4,12 +4,11 @@ from typing import Any, Dict, Optional
 
 from boa3.model.method import Method
 from boa3.model.property import Property
-from boa3.model.type.classtype import ClassType
+from boa3.model.type.classes.classarraytype import ClassArrayType
 from boa3.model.variable import Variable
-from boa3.neo.vm.type.StackItem import StackItemType
 
 
-class ContractPermissionType(ClassType):
+class ContractPermissionType(ClassArrayType):
     """
     A class used to represent Neo ContractPermission class
     """
@@ -42,10 +41,6 @@ class ContractPermissionType(ClassType):
 
     def constructor_method(self) -> Optional[Method]:
         return self._constructor
-
-    @property
-    def stack_item(self) -> StackItemType:
-        return StackItemType.Array
 
     @classmethod
     def build(cls, value: Any = None) -> ContractPermissionType:

--- a/boa3/model/builtin/interop/contract/contracttype.py
+++ b/boa3/model/builtin/interop/contract/contracttype.py
@@ -6,12 +6,12 @@ from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.expression import IExpression
 from boa3.model.method import Method
 from boa3.model.property import Property
-from boa3.model.type.classtype import ClassType
+from boa3.model.type.classes.classarraytype import ClassArrayType
 from boa3.model.variable import Variable
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
-class ContractType(ClassType):
+class ContractType(ClassArrayType):
     """
     A class used to represent Neo Contract class
     """

--- a/boa3/model/builtin/interop/interopinterfacetype.py
+++ b/boa3/model/builtin/interop/interopinterfacetype.py
@@ -1,11 +1,14 @@
 from abc import ABC
 
-from boa3.model.type.classtype import ClassType
+from boa3.model.type.classes.classtype import ClassType
 from boa3.neo.vm.type.AbiType import AbiType
 from boa3.neo.vm.type.StackItem import StackItemType
 
 
 class InteropInterfaceType(ClassType, ABC):
+    """
+    An abstract class used to represent a Python class that is implemented internally as a Neo Interop Interface
+    """
 
     @property
     def stack_item(self) -> StackItemType:

--- a/boa3/model/builtin/interop/oracle/oracletype.py
+++ b/boa3/model/builtin/interop/oracle/oracletype.py
@@ -4,11 +4,11 @@ from typing import Any, Dict, Optional
 
 from boa3.model.method import Method
 from boa3.model.property import Property
-from boa3.model.type.classtype import ClassType
+from boa3.model.type.classes.classarraytype import ClassArrayType
 from boa3.model.variable import Variable
 
 
-class OracleType(ClassType):
+class OracleType(ClassArrayType):
     """
     A class used to represent Oracle class
     """

--- a/boa3/model/builtin/interop/runtime/notificationtype.py
+++ b/boa3/model/builtin/interop/runtime/notificationtype.py
@@ -6,13 +6,13 @@ from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.expression import IExpression
 from boa3.model.method import Method
 from boa3.model.property import Property
-from boa3.model.type.classtype import ClassType
+from boa3.model.type.classes.classarraytype import ClassArrayType
 from boa3.model.type.collection.sequence.uint160type import UInt160Type
 from boa3.model.variable import Variable
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
-class NotificationType(ClassType):
+class NotificationType(ClassArrayType):
     """
     A class used to represent Neo Notification class
     """

--- a/boa3/model/builtin/interop/storage/storagemap/storagemaptype.py
+++ b/boa3/model/builtin/interop/storage/storagemap/storagemaptype.py
@@ -6,12 +6,12 @@ from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.expression import IExpression
 from boa3.model.method import Method
 from boa3.model.property import Property
-from boa3.model.type.classtype import ClassType
+from boa3.model.type.classes.classarraytype import ClassArrayType
 from boa3.model.variable import Variable
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
-class StorageMapType(ClassType):
+class StorageMapType(ClassArrayType):
     """
     A class used to represent Neo StorageMap class
     """

--- a/boa3/model/builtin/method/isinstancemethod.py
+++ b/boa3/model/builtin/method/isinstancemethod.py
@@ -61,7 +61,7 @@ class IsInstanceMethod(IBuiltinMethod):
 
     @property
     def is_supported(self) -> bool:
-        from boa3.model.type.classtype import ClassType
+        from boa3.model.type.classes.classtype import ClassType
         return not any(isinstance(param, ClassType) and len(param.is_instance_opcodes()) == 0
                        for param in self._instances_type)
 

--- a/boa3/model/type/classes/classarraytype.py
+++ b/boa3/model/type/classes/classarraytype.py
@@ -1,0 +1,19 @@
+from abc import ABC
+
+from boa3.model.type.classes.classtype import ClassType
+from boa3.neo.vm.type.AbiType import AbiType
+from boa3.neo.vm.type.StackItem import StackItemType
+
+
+class ClassArrayType(ClassType, ABC):
+    """
+    An abstract class used to represent a Python class that is implemented internally using Neo Array type
+    """
+
+    @property
+    def abi_type(self) -> AbiType:
+        return AbiType.Array
+
+    @property
+    def stack_item(self) -> StackItemType:
+        return StackItemType.Array

--- a/boa3/model/type/classes/classstructtype.py
+++ b/boa3/model/type/classes/classstructtype.py
@@ -1,0 +1,19 @@
+from abc import ABC
+
+from boa3.model.type.classes.classtype import ClassType
+from boa3.neo.vm.type.AbiType import AbiType
+from boa3.neo.vm.type.StackItem import StackItemType
+
+
+class ClassStructType(ClassType, ABC):
+    """
+    An abstract class used to represent a Python class that is implemented internally using Neo Struct type
+    """
+
+    @property
+    def abi_type(self) -> AbiType:
+        return AbiType.Any
+
+    @property
+    def stack_item(self) -> StackItemType:
+        return StackItemType.Struct

--- a/boa3/model/type/classes/classtype.py
+++ b/boa3/model/type/classes/classtype.py
@@ -8,6 +8,7 @@ from boa3.model.symbol import ISymbol
 from boa3.model.type.itype import IType
 from boa3.model.variable import Variable
 from boa3.neo.vm.opcode.Opcode import Opcode
+from boa3.neo.vm.type.AbiType import AbiType
 from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.StackItem import StackItemType
 
@@ -62,8 +63,16 @@ class ClassType(IType, ABC):
         pass
 
     @property
+    @abstractmethod
+    def abi_type(self) -> AbiType:
+        # must be overwritten, classes cannot be mapped to Any
+        return super().abi_type
+
+    @property
+    @abstractmethod
     def stack_item(self) -> StackItemType:
-        return StackItemType.Array
+        # must be overwritten, classes cannot be mapped to Any
+        return super().stack_item
 
     def is_instance_opcodes(self) -> List[Tuple[Opcode, bytes]]:
         is_type_opcodes = [

--- a/boa3/model/type/collection/sequence/ecpointtype.py
+++ b/boa3/model/type/collection/sequence/ecpointtype.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from boa3.model.method import Method
 from boa3.model.property import Property
-from boa3.model.type.classtype import ClassType
+from boa3.model.type.classes.classtype import ClassType
 from boa3.model.type.itype import IType
 from boa3.model.type.primitive.bytestype import BytesType
 from boa3.model.variable import Variable

--- a/boa3/model/type/collection/sequence/uint160type.py
+++ b/boa3/model/type/collection/sequence/uint160type.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from boa3.model.method import Method
 from boa3.model.property import Property
-from boa3.model.type.classtype import ClassType
+from boa3.model.type.classes.classtype import ClassType
 from boa3.model.type.itype import IType
 from boa3.model.type.primitive.bytestype import BytesType
 from boa3.model.variable import Variable

--- a/boa3/model/type/collection/sequence/uint256type.py
+++ b/boa3/model/type/collection/sequence/uint256type.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from boa3.model.method import Method
 from boa3.model.property import Property
-from boa3.model.type.classtype import ClassType
+from boa3.model.type.classes.classtype import ClassType
 from boa3.model.type.itype import IType
 from boa3.model.type.primitive.bytestype import BytesType
 from boa3.model.variable import Variable

--- a/boa3_test/test_sc/import_test/ImportUserModuleWithNotImportedVariables.py
+++ b/boa3_test/test_sc/import_test/ImportUserModuleWithNotImportedVariables.py
@@ -1,0 +1,10 @@
+from boa3.builtin import public
+from boa3_test.test_sc.variable_test.GlobalAssignmentBetweenFunctions import example
+
+
+a = 15
+
+
+@public
+def main() -> int:
+    return example()

--- a/boa3_test/tests/compiler_tests/test_file_generation.py
+++ b/boa3_test/tests/compiler_tests/test_file_generation.py
@@ -302,10 +302,19 @@ class TestFileGeneration(BoaTest):
 
         for static_variable in debug_info['static-variables']:
             # validate parameters
-            self.assertEqual(2, len(static_variable.split(',')))
-            param_id, param_type = static_variable.split(',')
-            self.assertIn(param_id, variables)
-            self.assertEqual(param_type, variables[param_id].type.abi_type)
+            self.assertEqual(3, len(static_variable.split(',')))
+            var_id, var_type, var_slot = static_variable.split(',')
+            if var_id not in variables:
+                self.assertIn(var_id, [var_full_id.split(constants.VARIABLE_NAME_SEPARATOR)[-1]
+                                       for var_full_id in variables])
+                var_inner_id = next((var for var in variables
+                                     if var.split(constants.VARIABLE_NAME_SEPARATOR)[-1] == var_id),
+                                    var_id)
+            else:
+                var_inner_id = var_id
+
+            self.assertIn(var_inner_id, variables)
+            self.assertEqual(var_type, variables[var_inner_id].type.abi_type)
 
     def test_generate_nefdbgnfo_file_with_user_module_import(self):
         from boa3.model.type.itype import IType

--- a/boa3_test/tests/compiler_tests/test_interop/test_native_contract.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_native_contract.py
@@ -113,19 +113,19 @@ class TestNativeContracts(BoaTest):
         method = String(OracleGetPriceMethod().method_name).to_bytes()
 
         expected_output = (
-                Opcode.NEWARRAY0
-                + Opcode.PUSHDATA1
-                + Integer(len(call_flags)).to_byte_array(min_length=1, signed=True)
-                + call_flags
-                + Opcode.PUSHDATA1
-                + Integer(len(method)).to_byte_array(min_length=1, signed=True)
-                + method
-                + Opcode.PUSHDATA1
-                + Integer(len(ORACLE_SCRIPT)).to_byte_array(min_length=1, signed=True)
-                + ORACLE_SCRIPT
-                + Opcode.SYSCALL
-                + Interop.CallContract.interop_method_hash
-                + Opcode.RET
+            Opcode.NEWARRAY0
+            + Opcode.PUSHDATA1
+            + Integer(len(call_flags)).to_byte_array(min_length=1, signed=True)
+            + call_flags
+            + Opcode.PUSHDATA1
+            + Integer(len(method)).to_byte_array(min_length=1, signed=True)
+            + method
+            + Opcode.PUSHDATA1
+            + Integer(len(ORACLE_SCRIPT)).to_byte_array(min_length=1, signed=True)
+            + ORACLE_SCRIPT
+            + Opcode.SYSCALL
+            + Interop.CallContract.interop_method_hash
+            + Opcode.RET
         )
 
         path = self.get_contract_path('OracleGetPrice.py')


### PR DESCRIPTION
**Related issue**
#245

**Summary or solution description**
Include the static variables from imported modules in the bytecode, even if these variables aren't imported by the entry file.
It was implemented this way to guarantee the correct behavior of imported functions that use those internal static variables.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/daa24d50787e281e12b23b285219afea57f60afd/boa3_test/test_sc/import_test/ImportUserModuleWithNotImportedVariables.py#L1-L10
https://github.com/CityOfZion/neo3-boa/blob/daa24d50787e281e12b23b285219afea57f60afd/boa3_test/test_sc/variable_test/GlobalAssignmentBetweenFunctions.py#L1-L16

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/daa24d50787e281e12b23b285219afea57f60afd/boa3_test/tests/compiler_tests/test_import.py#L251-L276

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7