### PR TITLE
Complement max builtin

### DIFF
--- a/boa3/model/builtin/method/maxmethod.py
+++ b/boa3/model/builtin/method/maxmethod.py
@@ -1,24 +1,89 @@
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Any
 
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.expression import IExpression
+from boa3.model.type.collection.sequence.sequencetype import SequenceType
+from boa3.model.type.collection.sequence.tupletype import TupleType
+from boa3.model.type.itype import IType
 from boa3.model.variable import Variable
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
 class MaxMethod(IBuiltinMethod):
 
-    def __init__(self):     # TODO: make it so that it can accept the same parameters as Python
+    def __init__(self, arg_value: Optional[IType] = None):
         from boa3.model.type.type import Type
         identifier = 'max'
-        args: Dict[str, Variable] = {
-            'val1': Variable(Type.int),
-            'val2': Variable(Type.int),
-        }
-        super().__init__(identifier, args, return_type=Type.int)
+        allowed_types = Type.union.build([Type.int])
+        if not isinstance(arg_value, IType):
+            arg_value = allowed_types
+
+        args: Dict[str, Variable] = {}
+        vararg = ('values', Variable(arg_value))
+        super().__init__(identifier, args, return_type=arg_value, vararg=vararg)
+        self._allowed_types = allowed_types
+
+    @property
+    def _arg_values(self) -> Variable:
+        return self._vararg[1]
+
+    def validate_parameters(self, *params: IExpression) -> bool:
+        if len(params) != 1:
+            return False
+        if not isinstance(params[0], IExpression):
+            return False
+        return isinstance(params[0].type, SequenceType)
 
     @property
     def opcode(self) -> List[Tuple[Opcode, bytes]]:
-        return [(Opcode.MAX, b'')]
+        from boa3.compiler.codegenerator import get_bytes_count
+        from boa3.neo.vm.type.Integer import Integer
+
+        recreate_array = [  # recreates the array to not change the referenced parameter
+            (Opcode.UNPACK, b''),
+            (Opcode.PACK, b'')
+        ]
+
+        if_int_initialize = [   # puts the last array element as the max value
+            (Opcode.DUP, b''),          # index = len(array) - 1
+            (Opcode.SIZE, b''),
+            (Opcode.DEC, b''),
+            (Opcode.OVER, b''),
+            (Opcode.OVER, b''),
+            (Opcode.PICKITEM, b''),     # max = array[index]
+        ]
+
+        if_int_while = [    # this will get the next number in the array and compare it with the current max
+            (Opcode.SWAP, b''),         # index--
+            (Opcode.DEC, b''),
+            (Opcode.SWAP, b''),
+            (Opcode.PUSH2, b''),
+            (Opcode.PICK, b''),
+            (Opcode.PUSH2, b''),
+            (Opcode.PICK, b''),         # max = max if max > array[index] else array[index]
+            (Opcode.PICKITEM, b''),
+            (Opcode.MAX, b''),
+            (Opcode.OVER, b''),
+            (Opcode.SIGN, b'')
+            # if index != 0: go back to index--
+            # else go to the end
+        ]
+
+        jmp_back_to_while_statement = (Opcode.JMPIF, Integer(-get_bytes_count(if_int_while)).to_byte_array(signed=True))
+        if_int_while.append(jmp_back_to_while_statement)
+
+        clean_stack = [    # removes everything but max
+            (Opcode.REVERSE3, b''),
+            (Opcode.DROP, b''),
+            (Opcode.DROP, b''),
+        ]
+
+        return (
+            recreate_array +
+            if_int_initialize +
+            if_int_while +
+            clean_stack
+        )
 
     @property
     def _args_on_stack(self) -> int:
@@ -27,3 +92,12 @@ class MaxMethod(IBuiltinMethod):
     @property
     def _body(self) -> Optional[str]:
         return
+
+    def build(self, value: Any) -> IBuiltinMethod:
+        if isinstance(value, list) and len(value) == 1:
+            value = value[0]
+        if isinstance(value, TupleType):
+            value = value.value_type
+        if type(value) == type(self._arg_values.type):
+            return self
+        return MaxMethod(value)

--- a/boa3/model/builtin/method/maxmethod.py
+++ b/boa3/model/builtin/method/maxmethod.py
@@ -14,11 +14,14 @@ class MaxMethod(IBuiltinMethod):
     def __init__(self, arg_value: Optional[IType] = None):
         from boa3.model.type.type import Type
         identifier = 'max'
-        allowed_types = Type.union.build([Type.int])
+        allowed_types = Type.int
         if not isinstance(arg_value, IType):
             arg_value = allowed_types
 
-        args: Dict[str, Variable] = {}
+        args: Dict[str, Variable] = {
+            'args1': Variable(Type.int),
+            'args2': Variable(Type.int)
+        }
         vararg = ('values', Variable(arg_value))
         super().__init__(identifier, args, return_type=arg_value, vararg=vararg)
         self._allowed_types = allowed_types
@@ -39,12 +42,38 @@ class MaxMethod(IBuiltinMethod):
         from boa3.compiler.codegenerator import get_bytes_count
         from boa3.neo.vm.type.Integer import Integer
 
-        recreate_array = [  # recreates the array to not change the referenced parameter
-            (Opcode.UNPACK, b''),
-            (Opcode.PACK, b'')
+        jmp_place_holder = (Opcode.JMP, b'\x01')
+
+        verify_number_of_parameters = [     # verifies if the stack has 2 or 3 items
+            (Opcode.DEPTH, b''),
+            (Opcode.PUSH2, b''),
+            (Opcode.JMPEQ, b''),
+            jmp_place_holder
         ]
 
-        if_int_initialize = [   # puts the last array element as the max value
+        if_n_parameters_gt_2 = [         # if number of items in stack is 3 (2 ints and one tuple)
+            (Opcode.REVERSE3, b''),
+            (Opcode.UNPACK, b''),
+            (Opcode.INC, b''),
+            (Opcode.INC, b''),
+            jmp_place_holder    # skips the next block of instructions
+        ]
+
+        if_n_parameters_eq_2 = [        # if number of items in stack is 2 (2 ints)
+            (Opcode.PUSH2, b'')
+        ]
+
+        jmp_n_parameters_eq_2 = Opcode.get_jump_and_data(Opcode.JMP, get_bytes_count(if_n_parameters_eq_2), True)
+        if_n_parameters_gt_2[-1] = jmp_n_parameters_eq_2
+
+        jmp_n_parameters_gt_2 = Opcode.get_jump_and_data(Opcode.JMPEQ, get_bytes_count(if_n_parameters_gt_2))
+        verify_number_of_parameters[-1] = jmp_n_parameters_gt_2
+
+        repack_array = [        # pack all the arguments in the array
+            (Opcode.PACK, b''),
+        ]
+
+        is_int_initialize = [   # puts the last array element as the max value
             (Opcode.DUP, b''),          # index = len(array) - 1
             (Opcode.SIZE, b''),
             (Opcode.DEC, b''),
@@ -53,7 +82,7 @@ class MaxMethod(IBuiltinMethod):
             (Opcode.PICKITEM, b''),     # max = array[index]
         ]
 
-        if_int_while = [    # this will get the next number in the array and compare it with the current max
+        is_int_while = [    # this will get the next number in the array and compare it with the current max
             (Opcode.SWAP, b''),         # index--
             (Opcode.DEC, b''),
             (Opcode.SWAP, b''),
@@ -69,8 +98,8 @@ class MaxMethod(IBuiltinMethod):
             # else go to the end
         ]
 
-        jmp_back_to_while_statement = (Opcode.JMPIF, Integer(-get_bytes_count(if_int_while)).to_byte_array(signed=True))
-        if_int_while.append(jmp_back_to_while_statement)
+        jmp_back_to_while_statement = (Opcode.JMPIF, Integer(-get_bytes_count(is_int_while)).to_byte_array(signed=True))
+        is_int_while.append(jmp_back_to_while_statement)
 
         clean_stack = [    # removes everything but max
             (Opcode.REVERSE3, b''),
@@ -79,9 +108,12 @@ class MaxMethod(IBuiltinMethod):
         ]
 
         return (
-            recreate_array +
-            if_int_initialize +
-            if_int_while +
+            verify_number_of_parameters +
+            if_n_parameters_gt_2 +
+            if_n_parameters_eq_2 +
+            repack_array +
+            is_int_initialize +
+            is_int_while +
             clean_stack
         )
 
@@ -94,7 +126,7 @@ class MaxMethod(IBuiltinMethod):
         return
 
     def build(self, value: Any) -> IBuiltinMethod:
-        if isinstance(value, list) and len(value) == 1:
+        if isinstance(value, list) and len(value) > 0:
             value = value[0]
         if isinstance(value, TupleType):
             value = value.value_type

--- a/boa3_test/test_sc/built_in_methods_test/MaxIntMoreArguments.py
+++ b/boa3_test/test_sc/built_in_methods_test/MaxIntMoreArguments.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main() -> int:
+    return max(4, 1, 16, 8, 2)

--- a/boa3_test/tests/compiler_tests/test_builtin_method.py
+++ b/boa3_test/tests/compiler_tests/test_builtin_method.py
@@ -812,6 +812,15 @@ class TestBuiltinMethod(BoaTest):
         result = self.run_smart_contract(engine, path, 'main', value1, value2)
         self.assertEqual(expected_result, result)
 
+    def test_max_int_more_arguments(self):
+        path = self.get_contract_path('MaxIntMoreArguments.py')
+        engine = TestEngine()
+
+        numbers = 4, 1, 16, 8, 2
+        expected_result = max(numbers)
+        result = self.run_smart_contract(engine, path, 'main')
+        self.assertEqual(expected_result, result)
+
     def test_max_too_few_parameters(self):
         path = self.get_contract_path('MaxTooFewParameters.py')
         self.assertCompilerLogs(CompilerError.UnfilledArgument, path)


### PR DESCRIPTION
**Related issue**
#266 

**Summary or solution description**
Made it so that it's now possible to use more than 2 ints when using `max`.

**How to Reproduce**
Call `max()`.

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/b10ce14e0c2a3e73798bdb02b480dda8448b8b33/boa3_test/tests/compiler_tests/test_builtin_method.py#L810-L817

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8

**(Optional) Additional context**
Using `max` with `str` and `bytes` was not implemented in this issue.
