### PR TITLE
Fix error when using empty vararg

### DIFF
--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -1050,11 +1050,12 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
                             origin_type_id = cast_types[0].identifier
                             cast_type_id = cast_types[1].identifier
 
-                        self._log_warning(
-                            CompilerWarning.TypeCasting(call.lineno, call.col_offset,
-                                                        origin_type_id=origin_type_id,
-                                                        cast_type_id=cast_type_id)
-                        )
+                        if not hasattr(call, 'is_internal_call') or not call.is_internal_call:
+                            self._log_warning(
+                                CompilerWarning.TypeCasting(call.lineno, call.col_offset,
+                                                            origin_type_id=origin_type_id,
+                                                            cast_type_id=cast_type_id)
+                            )
 
                 self.validate_passed_arguments(call, args, callable_id, callable_target)
 

--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -1113,11 +1113,11 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
         return callable_target
 
     def validate_callable_arguments(self, call: ast.Call, callable_target: Callable) -> bool:
-        if (callable_target.has_starred_argument
-                and not hasattr(call, 'checked_starred_args')
-                and len(call.args) >= len(callable_target.args)):
+        if callable_target.has_starred_argument and not hasattr(call, 'checked_starred_args'):
 
-            if len(call.args) == 0 or not isinstance(call.args[0], ast.Starred):
+            if (len(call.args) >= len(callable_target.args)
+                    and (len(call.args) == 0 or not isinstance(call.args[0], ast.Starred))):
+
                 # starred argument is always the last argument
                 len_args_without_starred = len(callable_target.args) - 1
                 args = self.parse_to_node(str(Type.tuple.default_value), call)
@@ -1125,6 +1125,7 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
                 # include the arguments into a tuple to be assigned to the starred argument
                 args.elts = call.args[len_args_without_starred:]
                 call.args[len_args_without_starred:] = [args]
+
             call.checked_starred_args = True
 
         len_call_args = len(call.args)

--- a/boa3/model/__init__.py
+++ b/boa3/model/__init__.py
@@ -1,0 +1,7 @@
+import ast
+
+
+def set_intenal_call(node: ast.AST) -> ast.AST:
+    node.is_internal_call = True
+    node._fields += ('is_internal_call',)
+    return node

--- a/boa3/model/__init__.py
+++ b/boa3/model/__init__.py
@@ -1,7 +1,7 @@
 import ast
 
 
-def set_intenal_call(node: ast.AST) -> ast.AST:
+def set_internal_call(node: ast.AST) -> ast.AST:
     node.is_internal_call = True
     node._fields += ('is_internal_call',)
     return node

--- a/boa3/model/builtin/interop/contract/callmethod.py
+++ b/boa3/model/builtin/interop/contract/callmethod.py
@@ -1,7 +1,7 @@
 import ast
 from typing import Dict, List
 
-from boa3.model import set_intenal_call
+from boa3.model import set_internal_call
 from boa3.model.builtin.interop.interopmethod import InteropMethod
 from boa3.model.variable import Variable
 
@@ -24,9 +24,9 @@ class CallMethod(InteropMethod):
         }
         args_default = ast.parse("{0}".format(Type.sequence.default_value)
                                  ).body[0].value
-        call_flags_default = set_intenal_call(ast.parse("{0}.{1}".format(call_flags.identifier,
-                                                                         call_flags.default_value.name)
-                                                        ).body[0].value)
+        call_flags_default = set_internal_call(ast.parse("{0}.{1}".format(call_flags.identifier,
+                                                                          call_flags.default_value.name)
+                                                         ).body[0].value)
 
         super().__init__(identifier, syscall, args, defaults=[args_default, call_flags_default], return_type=Type.any)
 

--- a/boa3/model/builtin/interop/contract/callmethod.py
+++ b/boa3/model/builtin/interop/contract/callmethod.py
@@ -1,6 +1,7 @@
 import ast
 from typing import Dict, List
 
+from boa3.model import set_intenal_call
 from boa3.model.builtin.interop.interopmethod import InteropMethod
 from boa3.model.variable import Variable
 
@@ -23,10 +24,9 @@ class CallMethod(InteropMethod):
         }
         args_default = ast.parse("{0}".format(Type.sequence.default_value)
                                  ).body[0].value
-        call_flags_default = ast.parse("{0}.{1}".format(call_flags.identifier, call_flags.default_value.name)
-                                       ).body[0].value
-        call_flags_default.is_internal_call = True
-        call_flags_default._fields += ('is_internal_call',)
+        call_flags_default = set_intenal_call(ast.parse("{0}.{1}".format(call_flags.identifier,
+                                                                         call_flags.default_value.name)
+                                                        ).body[0].value)
 
         super().__init__(identifier, syscall, args, defaults=[args_default, call_flags_default], return_type=Type.any)
 

--- a/boa3/model/builtin/interop/storage/storagedeletemethod.py
+++ b/boa3/model/builtin/interop/storage/storagedeletemethod.py
@@ -1,6 +1,7 @@
 import ast
 from typing import Any, Dict, Iterable, List, Sized
 
+from boa3.model import set_intenal_call
 from boa3.model.builtin.interop.interopmethod import InteropMethod
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.expression import IExpression
@@ -25,10 +26,8 @@ class StorageDeleteMethod(InteropMethod):
 
         from boa3.model.builtin.interop.storage.storagegetcontextmethod import StorageGetContextMethod
         default_id = StorageGetContextMethod(context_type).identifier
-        context_default = ast.parse("{0}()".format(default_id)
-                                    ).body[0].value
-        context_default.is_internal_call = True
-        context_default._fields += ('is_internal_call',)
+        context_default = set_intenal_call(ast.parse("{0}()".format(default_id)
+                                                     ).body[0].value)
         super().__init__(identifier, syscall, args, defaults=[context_default], return_type=Type.none)
 
     def validate_parameters(self, *params: IExpression) -> bool:

--- a/boa3/model/builtin/interop/storage/storagedeletemethod.py
+++ b/boa3/model/builtin/interop/storage/storagedeletemethod.py
@@ -1,7 +1,7 @@
 import ast
 from typing import Any, Dict, Iterable, List, Sized
 
-from boa3.model import set_intenal_call
+from boa3.model import set_internal_call
 from boa3.model.builtin.interop.interopmethod import InteropMethod
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.expression import IExpression
@@ -26,8 +26,8 @@ class StorageDeleteMethod(InteropMethod):
 
         from boa3.model.builtin.interop.storage.storagegetcontextmethod import StorageGetContextMethod
         default_id = StorageGetContextMethod(context_type).identifier
-        context_default = set_intenal_call(ast.parse("{0}()".format(default_id)
-                                                     ).body[0].value)
+        context_default = set_internal_call(ast.parse("{0}()".format(default_id)
+                                                      ).body[0].value)
         super().__init__(identifier, syscall, args, defaults=[context_default], return_type=Type.none)
 
     def validate_parameters(self, *params: IExpression) -> bool:

--- a/boa3/model/builtin/interop/storage/storagefindmethod.py
+++ b/boa3/model/builtin/interop/storage/storagefindmethod.py
@@ -1,6 +1,7 @@
 import ast
 from typing import Any, Dict, Iterable, List, Sized
 
+from boa3.model import set_intenal_call
 from boa3.model.builtin.interop.interopmethod import InteropMethod
 from boa3.model.builtin.interop.storage import FindOptionsType
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
@@ -33,15 +34,13 @@ class StorageFindMethod(InteropMethod):
 
         from boa3.model.builtin.interop.storage.storagegetcontextmethod import StorageGetContextMethod
         default_id = StorageGetContextMethod(context_type).identifier
-        context_default = ast.parse("{0}()".format(default_id)
-                                    ).body[0].value
-        options_default = ast.parse("{0}.{1}".format(find_options_type.identifier, find_options_type.default_value.name)
-                                    ).body[0].value
+        context_default = set_intenal_call(ast.parse("{0}()".format(default_id)
+                                                     ).body[0].value)
+        options_default = set_intenal_call(ast.parse("{0}.{1}".format(find_options_type.identifier,
+                                                                      find_options_type.default_value.name)
+                                                     ).body[0].value)
 
         defaults = [context_default, options_default]
-        for default in defaults:
-            default.is_internal_call = True
-            default._fields += ('is_internal_call',)
 
         super().__init__(identifier, syscall, args, defaults=defaults, return_type=return_type)
 

--- a/boa3/model/builtin/interop/storage/storagefindmethod.py
+++ b/boa3/model/builtin/interop/storage/storagefindmethod.py
@@ -1,7 +1,7 @@
 import ast
 from typing import Any, Dict, Iterable, List, Sized
 
-from boa3.model import set_intenal_call
+from boa3.model import set_internal_call
 from boa3.model.builtin.interop.interopmethod import InteropMethod
 from boa3.model.builtin.interop.storage import FindOptionsType
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
@@ -34,11 +34,11 @@ class StorageFindMethod(InteropMethod):
 
         from boa3.model.builtin.interop.storage.storagegetcontextmethod import StorageGetContextMethod
         default_id = StorageGetContextMethod(context_type).identifier
-        context_default = set_intenal_call(ast.parse("{0}()".format(default_id)
-                                                     ).body[0].value)
-        options_default = set_intenal_call(ast.parse("{0}.{1}".format(find_options_type.identifier,
-                                                                      find_options_type.default_value.name)
-                                                     ).body[0].value)
+        context_default = set_internal_call(ast.parse("{0}()".format(default_id)
+                                                      ).body[0].value)
+        options_default = set_internal_call(ast.parse("{0}.{1}".format(find_options_type.identifier,
+                                                                       find_options_type.default_value.name)
+                                                      ).body[0].value)
 
         defaults = [context_default, options_default]
 

--- a/boa3/model/builtin/interop/storage/storagegetmethod.py
+++ b/boa3/model/builtin/interop/storage/storagegetmethod.py
@@ -1,6 +1,7 @@
 import ast
 from typing import Any, Dict, Iterable, List, Sized, Tuple
 
+from boa3.model import set_intenal_call
 from boa3.model.builtin.interop.interopmethod import InteropMethod
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.expression import IExpression
@@ -25,10 +26,8 @@ class StorageGetMethod(InteropMethod):
 
         from boa3.model.builtin.interop.storage.storagegetcontextmethod import StorageGetContextMethod
         default_id = StorageGetContextMethod(context_type).identifier
-        context_default = ast.parse("{0}()".format(default_id)
-                                    ).body[0].value
-        context_default.is_internal_call = True
-        context_default._fields += ('is_internal_call',)
+        context_default = set_intenal_call(ast.parse("{0}()".format(default_id)
+                                                     ).body[0].value)
         super().__init__(identifier, syscall, args, defaults=[context_default], return_type=Type.bytes)
 
     def validate_parameters(self, *params: IExpression) -> bool:

--- a/boa3/model/builtin/interop/storage/storagegetmethod.py
+++ b/boa3/model/builtin/interop/storage/storagegetmethod.py
@@ -1,7 +1,7 @@
 import ast
 from typing import Any, Dict, Iterable, List, Sized, Tuple
 
-from boa3.model import set_intenal_call
+from boa3.model import set_internal_call
 from boa3.model.builtin.interop.interopmethod import InteropMethod
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.expression import IExpression
@@ -26,8 +26,8 @@ class StorageGetMethod(InteropMethod):
 
         from boa3.model.builtin.interop.storage.storagegetcontextmethod import StorageGetContextMethod
         default_id = StorageGetContextMethod(context_type).identifier
-        context_default = set_intenal_call(ast.parse("{0}()".format(default_id)
-                                                     ).body[0].value)
+        context_default = set_internal_call(ast.parse("{0}()".format(default_id)
+                                                      ).body[0].value)
         super().__init__(identifier, syscall, args, defaults=[context_default], return_type=Type.bytes)
 
     def validate_parameters(self, *params: IExpression) -> bool:

--- a/boa3/model/builtin/interop/storage/storageputmethod.py
+++ b/boa3/model/builtin/interop/storage/storageputmethod.py
@@ -1,7 +1,7 @@
 import ast
 from typing import Any, Dict, Iterable, List, Sized
 
-from boa3.model import set_intenal_call
+from boa3.model import set_internal_call
 from boa3.model.builtin.interop.interopmethod import InteropMethod
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.expression import IExpression
@@ -29,7 +29,7 @@ class StoragePutMethod(InteropMethod):
 
         from boa3.model.builtin.interop.storage.storagegetcontextmethod import StorageGetContextMethod
         default_id = StorageGetContextMethod(context_type).identifier
-        context_default = set_intenal_call(ast.parse("{0}()".format(default_id)
+        context_default = set_internal_call(ast.parse("{0}()".format(default_id)
                                                       ).body[0].value)
         super().__init__(identifier, syscall, args, defaults=[context_default], return_type=Type.none)
 

--- a/boa3/model/builtin/interop/storage/storageputmethod.py
+++ b/boa3/model/builtin/interop/storage/storageputmethod.py
@@ -1,6 +1,7 @@
 import ast
 from typing import Any, Dict, Iterable, List, Sized
 
+from boa3.model import set_intenal_call
 from boa3.model.builtin.interop.interopmethod import InteropMethod
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.expression import IExpression
@@ -28,10 +29,8 @@ class StoragePutMethod(InteropMethod):
 
         from boa3.model.builtin.interop.storage.storagegetcontextmethod import StorageGetContextMethod
         default_id = StorageGetContextMethod(context_type).identifier
-        context_default = ast.parse("{0}()".format(default_id)
-                                    ).body[0].value
-        context_default.is_internal_call = True
-        context_default._fields += ('is_internal_call',)
+        context_default = set_intenal_call(ast.parse("{0}()".format(default_id)
+                                                      ).body[0].value)
         super().__init__(identifier, syscall, args, defaults=[context_default], return_type=Type.none)
 
     def validate_parameters(self, *params: IExpression) -> bool:

--- a/boa3/model/callable.py
+++ b/boa3/model/callable.py
@@ -2,7 +2,7 @@ import ast
 from abc import ABC
 from typing import Dict, List, Optional, Tuple
 
-from boa3.model import set_intenal_call
+from boa3.model import set_internal_call
 from boa3.model.expression import IExpression
 from boa3.model.type.type import IType, Type
 from boa3.model.variable import Variable
@@ -41,7 +41,7 @@ class Callable(IExpression, ABC):
             default_code = "{0}({1}, {2})".format(TypeUtils.cast.raw_identifier,
                                                   Type.tuple.build_collection(vararg_var.type),
                                                   Type.tuple.default_value)
-            default_value = set_intenal_call(ast.parse(default_code).body[0].value)
+            default_value = set_internal_call(ast.parse(default_code).body[0].value)
 
             self.args[vararg_id] = Variable(Type.tuple.build_collection([vararg_var.type]))
             self.defaults.append(default_value)

--- a/boa3/model/callable.py
+++ b/boa3/model/callable.py
@@ -38,9 +38,13 @@ class Callable(IExpression, ABC):
             from boa3.model.type.typeutils import TypeUtils
 
             vararg_id, vararg_var = vararg
-            default_code = "{0}({1}, {2})".format(TypeUtils.cast.raw_identifier,
-                                                  Type.tuple.build_collection(vararg_var.type),
-                                                  Type.tuple.default_value)
+            if vararg_var.type is not Type.any:
+                default_code = "{0}({1}, {2})".format(TypeUtils.cast.raw_identifier,
+                                                      Type.tuple.build_collection(vararg_var.type),
+                                                      Type.tuple.default_value)
+            else:
+                default_code = "{0}".format(Type.tuple.default_value)
+            
             default_value = set_internal_call(ast.parse(default_code).body[0].value)
 
             self.args[vararg_id] = Variable(Type.tuple.build_collection([vararg_var.type]))

--- a/boa3/model/callable.py
+++ b/boa3/model/callable.py
@@ -2,6 +2,7 @@ import ast
 from abc import ABC
 from typing import Dict, List, Optional, Tuple
 
+from boa3.model import set_intenal_call
 from boa3.model.expression import IExpression
 from boa3.model.type.type import IType, Type
 from boa3.model.variable import Variable
@@ -33,8 +34,14 @@ class Callable(IExpression, ABC):
         self._vararg: Optional[Tuple[str, Variable]] = None
         if (isinstance(vararg, tuple) and len(vararg) == 2
                 and isinstance(vararg[0], str) and isinstance(vararg[1], Variable)):
+
+            from boa3.model.type.typeutils import TypeUtils
+
             vararg_id, vararg_var = vararg
-            default_value = ast.parse(f"{Type.tuple.default_value}").body[0].value
+            default_code = "{0}({1}, {2})".format(TypeUtils.cast.raw_identifier,
+                                                  Type.tuple.build_collection(vararg_var.type),
+                                                  Type.tuple.default_value)
+            default_value = set_intenal_call(ast.parse(default_code).body[0].value)
 
             self.args[vararg_id] = Variable(Type.tuple.build_collection([vararg_var.type]))
             self.defaults.append(default_value)

--- a/boa3_test/test_sc/built_in_methods_test/PrintNoArgs.py
+++ b/boa3_test/test_sc/built_in_methods_test/PrintNoArgs.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def Main():
+    print()

--- a/boa3_test/tests/compiler_tests/test_builtin_method.py
+++ b/boa3_test/tests/compiler_tests/test_builtin_method.py
@@ -594,17 +594,15 @@ class TestBuiltinMethod(BoaTest):
 
     def test_print_int(self):
         path = self.get_contract_path('PrintInt.py')
-        output = Boa3.compile(path)
-
         engine = TestEngine()
+
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertIsVoid(result)
 
     def test_print_str(self):
         path = self.get_contract_path('PrintStr.py')
-        output = Boa3.compile(path)
-
         engine = TestEngine()
+
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertIsVoid(result)
 
@@ -614,6 +612,13 @@ class TestBuiltinMethod(BoaTest):
 
     def test_print_many_values(self):
         path = self.get_contract_path('PrintManyValues.py')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'Main')
+        self.assertIsVoid(result)
+
+    def test_print_no_args(self):
+        path = self.get_contract_path('PrintNoArgs.py')
         engine = TestEngine()
 
         result = self.run_smart_contract(engine, path, 'Main')


### PR DESCRIPTION
**Related issue**
#523

**Summary or solution description**
Fixed the issue with varargs defaults values that was raising a mismatched types error

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/a7c133f50e80d9ee59ecb00e7c6bf181900497b3/boa3_test/test_sc/built_in_methods_test/PrintNoArgs.py#L1-L6

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/a7c133f50e80d9ee59ecb00e7c6bf181900497b3/boa3_test/tests/compiler_tests/test_builtin_method.py#L620-L625

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7