### PR TITLE
Binary logic Augmented assignment operators

### DIFF
--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -294,10 +294,6 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
         """
         operation = self.validate_binary_operation(aug_assign, aug_assign.target, aug_assign.value)
         if operation is not None:
-            # TODO: remove when other augmented assignment operations are implemented
-            if operation.result not in [Type.int, Type.str]:
-                raise NotImplementedError
-
             self.validate_type_variable_assign(aug_assign.target, operation)
             aug_assign.op = operation
 

--- a/boa3_test/test_sc/logical_test/AugmentedAssignmentOperators.py
+++ b/boa3_test/test_sc/logical_test/AugmentedAssignmentOperators.py
@@ -1,0 +1,31 @@
+from boa3.builtin import public
+
+
+@public
+def left_shift(a: int, b: int) -> int:
+    a <<= b
+    return a
+
+
+@public
+def right_shift(a: int, b: int) -> int:
+    a >>= b
+    return a
+
+
+@public
+def l_and(a: int, b: int) -> int:
+    a &= b
+    return a
+
+
+@public
+def l_or(a: int, b: int) -> int:
+    a |= b
+    return a
+
+
+@public
+def xor(a: int, b: int) -> int:
+    a ^= b
+    return a

--- a/boa3_test/tests/compiler_tests/test_logical.py
+++ b/boa3_test/tests/compiler_tests/test_logical.py
@@ -433,3 +433,42 @@ class TestLogical(BoaTest):
 
         result = self.run_smart_contract(engine, path, 'main', '~', -3, 0)
         self.assertEqual(2, result)
+
+    def test_logic_augmented_assignment(self):
+        path = self.get_contract_path('AugmentedAssignmentOperators.py')
+        engine = TestEngine()
+
+        a = 1
+        b = 4
+        result = self.run_smart_contract(engine, path, 'right_shift', a, b)
+        a >>= b
+        expected_result = a
+        self.assertEqual(expected_result, result)
+
+        a = 4
+        b = 1
+        result = self.run_smart_contract(engine, path, 'left_shift', a, b)
+        a <<= b
+        expected_result = a
+        self.assertEqual(expected_result, result)
+
+        a = 255
+        b = 123
+        result = self.run_smart_contract(engine, path, 'l_and', a, b)
+        a &= b
+        expected_result = a
+        self.assertEqual(expected_result, result)
+
+        a = 255
+        b = 123
+        result = self.run_smart_contract(engine, path, 'l_or', a, b)
+        a |= b
+        expected_result = a
+        self.assertEqual(expected_result, result)
+
+        a = 255
+        b = 123
+        result = self.run_smart_contract(engine, path, 'xor', a, b)
+        a ^= b
+        expected_result = a
+        self.assertEqual(expected_result, result)


### PR DESCRIPTION
**Related issue**
#244

**Summary or solution description**
The logic that accepts augmented assignment operators was already working, just removed an `if` at the typeanalyser and added a test.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/8211b41374a7bd97cafd1db6de57e8658d524aa2/boa3_test/test_sc/logical_test/AugmentedAssignmentOperators.py#L1-L31

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/8211b41374a7bd97cafd1db6de57e8658d524aa2/boa3_test/tests/compiler_tests/test_logical.py#L437-L474

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8
