### PR TITLE
Bind storage to module variables

### DIFF
--- a/boa3/compiler/codegenerator/__init__.py
+++ b/boa3/compiler/codegenerator/__init__.py
@@ -1,7 +1,21 @@
 from typing import List, Tuple
 
+from boa3.model.expression import IExpression
+from boa3.model.symbol import ISymbol
 from boa3.neo.vm.opcode.Opcode import Opcode
+from boa3.neo.vm.type.Integer import Integer
 
 
 def get_bytes_count(instructions: List[Tuple[Opcode, bytes]]) -> int:
     return sum([len(opcode) + len(arg) for opcode, arg in instructions])
+
+
+def get_storage_key_for_variable(symbol: ISymbol) -> bytes:
+    if isinstance(symbol, IExpression):
+        symbol_obj = symbol.origin
+    else:
+        symbol_obj = symbol
+
+    origin_hash = Integer(hash(symbol_obj)).to_byte_array()
+    symbol_hash = Integer(hash(symbol)).to_byte_array()
+    return Integer(hash(origin_hash + symbol_hash)).to_byte_array()

--- a/boa3/compiler/codegenerator/codegenerator.py
+++ b/boa3/compiler/codegenerator/codegenerator.py
@@ -49,6 +49,7 @@ class CodeGenerator:
         :return: the Neo VM bytecode
         """
         VMCodeMapping.reset()
+        import ast
         from boa3.compiler.codegenerator.codegeneratorvisitor import VisitorCodeGenerator
 
         generator = CodeGenerator(analyser.symbol_table)
@@ -79,7 +80,6 @@ class CodeGenerator:
             generator.symbol_table.update(analyser.symbol_table.copy())
 
         if len(generator._globals) > 0:
-            import ast
             from boa3.compiler.codegenerator.initstatementsvisitor import InitStatementsVisitor
             deploy_stmts, static_stmts = InitStatementsVisitor.separate_global_statements(analyser.symbol_table,
                                                                                           visitor.global_stmts)
@@ -92,6 +92,9 @@ class CodeGenerator:
                 if_update_body.test.op = UnaryOp.Not
                 deploy_method.origin.body.insert(0, if_update_body)
 
+            visitor.global_stmts = static_stmts
+
+        if hasattr(deploy_method, 'origin'):
             deploy_ast = ast.parse("")
             deploy_ast.body = [deploy_method.origin]
 
@@ -102,11 +105,8 @@ class CodeGenerator:
             generator.symbol_table.clear()
             generator.symbol_table.update(analyser.symbol_table.copy())
 
-            visitor.global_stmts = static_stmts
-
         generator.can_init_static_fields = True
         if len(visitor.global_stmts) > 0:
-            import ast
             global_ast = ast.parse("")
             global_ast.body = visitor.global_stmts
             visitor.visit(global_ast)

--- a/boa3/compiler/codegenerator/codegenerator.py
+++ b/boa3/compiler/codegenerator/codegenerator.py
@@ -56,6 +56,7 @@ class CodeGenerator:
         deploy_method = (analyser.symbol_table[constants.DEPLOY_METHOD_ID]
                          if constants.DEPLOY_METHOD_ID in analyser.symbol_table
                          else None)
+        deploy_origin_module = analyser.ast_tree
 
         if hasattr(deploy_method, 'origin') and deploy_method.origin in analyser.ast_tree.body:
             analyser.ast_tree.body.remove(deploy_method.origin)
@@ -72,6 +73,7 @@ class CodeGenerator:
 
             if hasattr(deploy_method, 'origin') and deploy_method.origin in symbol.ast.body:
                 symbol.ast.body.remove(deploy_method.origin)
+                deploy_origin_module = symbol.ast
 
             visitor.visit(symbol.ast)
 
@@ -100,6 +102,7 @@ class CodeGenerator:
 
             generator.symbol_table[constants.DEPLOY_METHOD_ID] = deploy_method
             analyser.symbol_table[constants.DEPLOY_METHOD_ID] = deploy_method
+            visitor._tree = deploy_origin_module
             visitor.visit(deploy_ast)
 
             generator.symbol_table.clear()

--- a/boa3/compiler/codegenerator/codegenerator.py
+++ b/boa3/compiler/codegenerator/codegenerator.py
@@ -1,11 +1,14 @@
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+from boa3 import constants
 from boa3.analyser.analyser import Analyser
 from boa3.analyser.model.symbolscope import SymbolScope
+from boa3.compiler import codegenerator
 from boa3.compiler.codegenerator.stackmemento import NeoStack, StackMemento
 from boa3.compiler.codegenerator.vmcodemapping import VMCodeMapping
-from boa3.constants import ENCODING
 from boa3.model.builtin.builtin import Builtin
+from boa3.model.builtin.internal.innerdeploymethod import InnerDeployMethod
+from boa3.model.builtin.interop.interop import Interop
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.event import Event
 from boa3.model.imports.importsymbol import Import
@@ -49,6 +52,13 @@ class CodeGenerator:
         from boa3.compiler.codegenerator.codegeneratorvisitor import VisitorCodeGenerator
 
         generator = CodeGenerator(analyser.symbol_table)
+        deploy_method = (analyser.symbol_table[constants.DEPLOY_METHOD_ID]
+                         if constants.DEPLOY_METHOD_ID in analyser.symbol_table
+                         else None)
+
+        if hasattr(deploy_method, 'origin') and deploy_method.origin in analyser.ast_tree.body:
+            analyser.ast_tree.body.remove(deploy_method.origin)
+
         visitor = VisitorCodeGenerator(generator)
         visitor.visit(analyser.ast_tree)
 
@@ -58,11 +68,41 @@ class CodeGenerator:
 
         for symbol in [symbol for symbol in analyser.symbol_table.values() if isinstance(symbol, Import)]:
             generator.symbol_table.update(symbol.all_symbols)
+
+            if hasattr(deploy_method, 'origin') and deploy_method.origin in symbol.ast.body:
+                symbol.ast.body.remove(deploy_method.origin)
+
             visitor.visit(symbol.ast)
 
             analyser.update_symbol_table(symbol.all_symbols)
             generator.symbol_table.clear()
             generator.symbol_table.update(analyser.symbol_table.copy())
+
+        if len(generator._globals) > 0:
+            import ast
+            from boa3.compiler.codegenerator.initstatementsvisitor import InitStatementsVisitor
+            deploy_stmts, static_stmts = InitStatementsVisitor.separate_global_statements(analyser.symbol_table,
+                                                                                          visitor.global_stmts)
+
+            deploy_method = deploy_method if deploy_method is not None else InnerDeployMethod.instance().copy()
+
+            if len(deploy_stmts) > 0:
+                if_update_body = ast.parse(f"if not {list(deploy_method.args)[1]}: pass").body[0]
+                if_update_body.body = deploy_stmts
+                if_update_body.test.op = UnaryOp.Not
+                deploy_method.origin.body.insert(0, if_update_body)
+
+            deploy_ast = ast.parse("")
+            deploy_ast.body = [deploy_method.origin]
+
+            generator.symbol_table[constants.DEPLOY_METHOD_ID] = deploy_method
+            analyser.symbol_table[constants.DEPLOY_METHOD_ID] = deploy_method
+            visitor.visit(deploy_ast)
+
+            generator.symbol_table.clear()
+            generator.symbol_table.update(analyser.symbol_table.copy())
+
+            visitor.global_stmts = static_stmts
 
         generator.can_init_static_fields = True
         if len(visitor.global_stmts) > 0:
@@ -188,19 +228,29 @@ class CodeGenerator:
 
     @property
     def _globals(self) -> List[str]:
+        return self._module_variables(True)
+
+    @property
+    def _statics(self) -> List[str]:
+        return self._module_variables(False)
+
+    def _module_variables(self, modified_variable: bool) -> List[str]:
         """
         Gets a list with the variables name in the global scope
 
         :return: A list with the variables names
         """
-        module_globals = [var_id for var_id, var in self.symbol_table.items() if isinstance(var, Variable)]
+        module_globals = [var_id for var_id, var in self.symbol_table.items()
+                          if isinstance(var, Variable) and var.is_reassigned == modified_variable]
 
         if not self.can_init_static_fields:
             for imported in self.symbol_table.values():
                 if isinstance(imported, Import):
                     # tried to use set and just update, but we need the variables to be ordered
                     for var_id, var in imported.variables.items():
-                        if isinstance(var, Variable) and var_id not in module_globals:
+                        if (isinstance(var, Variable)
+                                and var.is_reassigned == modified_variable
+                                and var_id not in module_globals):
                             module_globals.append(var_id)
         return module_globals
 
@@ -269,21 +319,20 @@ class CodeGenerator:
         if self.initialized_static_fields:
             return False
 
-        num_static_fields = len(self._globals)
+        num_static_fields = len(self._statics)
         if num_static_fields > 0:
             init_data = bytearray([num_static_fields])
             self.__insert1(OpcodeInfo.INITSSLOT, init_data)
 
-            from boa3.constants import INITIALIZE_METHOD_ID
-            if INITIALIZE_METHOD_ID in self.symbol_table:
+            if constants.INITIALIZE_METHOD_ID in self.symbol_table:
                 from boa3.helpers import get_auxiliary_name
-                method = self.symbol_table.pop(INITIALIZE_METHOD_ID)
-                new_id = get_auxiliary_name(INITIALIZE_METHOD_ID, method)
+                method = self.symbol_table.pop(constants.INITIALIZE_METHOD_ID)
+                new_id = get_auxiliary_name(constants.INITIALIZE_METHOD_ID, method)
                 self.symbol_table[new_id] = method
 
             init_method = Method(is_public=True)
             init_method.init_bytecode = self.last_code
-            self.symbol_table[INITIALIZE_METHOD_ID] = init_method
+            self.symbol_table[constants.INITIALIZE_METHOD_ID] = init_method
 
         return num_static_fields > 0
 
@@ -294,9 +343,8 @@ class CodeGenerator:
         self.__insert1(OpcodeInfo.RET)
         self.initialized_static_fields = True
 
-        from boa3.constants import INITIALIZE_METHOD_ID
-        if INITIALIZE_METHOD_ID in self.symbol_table:
-            init_method = self.symbol_table[INITIALIZE_METHOD_ID]
+        if constants.INITIALIZE_METHOD_ID in self.symbol_table:
+            init_method = self.symbol_table[constants.INITIALIZE_METHOD_ID]
             init_method.end_bytecode = self.last_code
 
     def convert_begin_method(self, method: Method):
@@ -718,7 +766,7 @@ class CodeGenerator:
 
         :param value: the value to be converted
         """
-        array = bytes(value, ENCODING)
+        array = bytes(value, constants.ENCODING)
         self.insert_push_data(array)
         self.convert_cast(Type.str)
 
@@ -1061,7 +1109,12 @@ class CodeGenerator:
             if value is not None:
                 self.convert_literal(value)
 
-    def convert_store_variable(self, var_id: str):
+        elif var_id in self._globals:
+            var = self.get_symbol(var_id)
+            storage_key = codegenerator.get_storage_key_for_variable(var)
+            self._convert_builtin_storage_get_or_put(True, storage_key)
+
+    def convert_store_variable(self, var_id: str, value_start_address: int = None):
         """
         Converts the assignment of a variable
 
@@ -1088,6 +1141,29 @@ class CodeGenerator:
                         var.set_type(stored_type)
                         self._current_scope.include_symbol(var_id, var)
 
+        elif var_id in self._globals:
+            var = self.get_symbol(var_id)
+            storage_key = codegenerator.get_storage_key_for_variable(var)
+            if value_start_address is None:
+                value_start_address = self.bytecode_size
+            self._convert_builtin_storage_get_or_put(False, storage_key, value_start_address)
+
+    def _convert_builtin_storage_get_or_put(self, is_get: bool, storage_key: bytes, arg_address: int = None):
+        addresses = [arg_address] if arg_address is not None else [self.bytecode_size]
+        if not is_get:
+            # must serialized before storing the value
+            self.convert_builtin_method_call(Interop.Serialize, addresses)
+
+        self.convert_literal(storage_key)
+        self.convert_builtin_method_call(Interop.StorageGetContext)
+
+        builtin_method = Interop.StorageGet if is_get else Interop.StoragePut
+        self.convert_builtin_method_call(builtin_method)
+
+        if is_get:
+            # once the value is retrieved, it must be deserialized
+            self.convert_builtin_method_call(Interop.Deserialize, addresses)
+
     def _get_variable_info(self, var_id: str) -> Tuple[int, bool, bool]:
         """
         Gets the necessary information about the variable to get the correct opcode
@@ -1099,6 +1175,10 @@ class CodeGenerator:
             `is_arg` is True only if the variable is a parameter of the function.
         If the variable is not found, returns (-1, False, False)
         """
+        is_arg: bool = False
+        local: bool = False
+        scope = None
+
         if var_id in self._args:
             is_arg: bool = True
             local: bool = True
@@ -1107,12 +1187,14 @@ class CodeGenerator:
             is_arg = False
             local: bool = True
             scope = self._locals
-        else:
-            is_arg: bool = False
-            local: bool = False
-            scope = self._globals
+        elif var_id in self._statics:
+            scope = self._statics
 
-        index: int = scope.index(var_id) if var_id in scope else -1
+        if scope is not None:
+            index: int = scope.index(var_id) if var_id in scope else -1
+        else:
+            index = -1
+
         return index, local, is_arg
 
     def convert_builtin_method_call(self, function: IBuiltinMethod, args_address: List[int] = None):

--- a/boa3/compiler/codegenerator/codegeneratorvisitor.py
+++ b/boa3/compiler/codegenerator/codegeneratorvisitor.py
@@ -630,7 +630,12 @@ class VisitorCodeGenerator(IAstAnalyser):
         :param name: the python ast name identifier node
         :return: the identifier of the name
         """
-        return name.id
+        name = name.id
+        if name not in self.symbols:
+            hashed_name = '{0}{2}{1}'.format(self._tree.__hash__(), name, constants.VARIABLE_NAME_SEPARATOR)
+            if hashed_name in self.symbols:
+                name = hashed_name
+        return name
 
     def visit_Starred(self, starred: ast.Starred):
         self.visit_to_generate(starred.value)

--- a/boa3/compiler/codegenerator/initstatementsvisitor.py
+++ b/boa3/compiler/codegenerator/initstatementsvisitor.py
@@ -1,0 +1,114 @@
+import ast
+from typing import Dict, List, Tuple
+
+from boa3 import constants
+from boa3.analyser.astanalyser import IAstAnalyser
+from boa3.model.symbol import ISymbol
+
+
+class InitStatementsVisitor(IAstAnalyser):
+    """
+    This class is separate the instructions that should be included in the '_deploy" internal method from those
+    from the '_initialize' internal method.
+
+    The methods with the name starting with 'visit_' are implementations of methods from the :class:`NodeVisitor` class.
+    These methods are used to walk through the Python abstract syntax tree.
+
+    """
+
+    def __init__(self, symbols: Dict[str, ISymbol]):
+        super().__init__(ast.parse(""), log=True)
+        self.symbols = symbols.copy()
+
+        self._deploy_instructions: List[ast.AST] = []
+        self._init_instructions: List[ast.AST] = []
+
+    @classmethod
+    def separate_global_statements(cls,
+                                   symbol_table: Dict[str, ISymbol],
+                                   statements: List[ast.AST]) -> Tuple[List[ast.AST], List[ast.AST]]:
+
+        visitor = InitStatementsVisitor(symbol_table)
+
+        root_ast = ast.parse("")
+        root_ast.body = statements
+        visitor.visit(root_ast)
+
+        return visitor._deploy_instructions, visitor._init_instructions
+
+    def get_symbol_id(self, node: ast.AST, parent: ast.AST) -> str:
+        symbol_id = self.visit(node)
+        # filter to find the imported variables
+        if symbol_id not in self.symbols and hasattr(parent, 'origin') and isinstance(parent.origin, ast.AST):
+            symbol_id = '{0}{2}{1}'.format(parent.origin.__hash__(), symbol_id, constants.VARIABLE_NAME_SEPARATOR)
+        return symbol_id
+
+    def append_symbol(self, symbol: ISymbol, node: ast.AST):
+        if self._should_be_on_deploy(symbol):
+            if node not in self._deploy_instructions:
+                self._deploy_instructions.append(node)
+        else:
+            if node not in self._init_instructions:
+                self._init_instructions.append(node)
+
+    def _should_be_on_deploy(self, symbol: ISymbol) -> bool:
+        return hasattr(symbol, 'is_reassigned') and symbol.is_reassigned
+
+    # region AST visitors
+
+    def visit_Assign(self, node: ast.Assign):
+        deploy_var_nodes = []
+        init_var_nodes = []
+
+        deploy_symbol = None
+        init_symbol = None
+        for target in node.targets:
+            target_id = self.get_symbol_id(target, node)
+            symbol = self.get_symbol(target_id)
+
+            if self._should_be_on_deploy(symbol):
+                deploy_var_nodes.append(target)
+                deploy_symbol = symbol
+            else:
+                init_var_nodes.append(target)
+                init_symbol = symbol
+
+        if len(deploy_var_nodes) == len(node.targets) or len(init_var_nodes) == len(node.targets):
+            self.append_symbol(deploy_symbol if deploy_symbol is not None else init_symbol,
+                               node)
+        else:
+            deploy_ast = ast.Assign(targets=deploy_var_nodes,
+                                    value=node.value)
+            ast.copy_location(deploy_ast, node)
+
+            init_ast = ast.Assign(targets=init_var_nodes,
+                                  value=node.value)
+            ast.copy_location(init_ast, node)
+
+            if hasattr(node, 'origin'):
+                deploy_ast.origin = node.origin
+                init_ast.origin = node.origin
+
+            self.append_symbol(deploy_symbol, deploy_ast)
+            self.append_symbol(init_symbol, init_ast)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign):
+        var_id = self.get_symbol_id(node.target, node)
+        symbol = self.get_symbol(var_id)
+        self.append_symbol(symbol, node)
+
+    def visit_AugAssign(self, node: ast.AugAssign):
+        var_id = self.get_symbol_id(node.target, node)
+        symbol = self.get_symbol(var_id)
+        self.append_symbol(symbol, node)
+
+    def visit_Name(self, name: ast.Name) -> str:
+        """
+        Visitor of a name node
+
+        :param name: the python ast name identifier node
+        :return: the identifier of the name
+        """
+        return name.id
+
+    # endregion

--- a/boa3/compiler/filegenerator.py
+++ b/boa3/compiler/filegenerator.py
@@ -47,7 +47,7 @@ class FileGenerator:
         :return: a dictionary that maps each global variable with its identifier
         """
         return {name: variable for name, variable in self._symbols.items()
-                if isinstance(variable, Variable)}
+                if isinstance(variable, Variable) and not variable.is_reassigned}
 
     @property
     def _methods(self) -> Dict[str, Method]:
@@ -56,9 +56,11 @@ class FileGenerator:
 
         :return: a dictionary that maps each method with its identifier
         """
-        from boa3.model.builtin.decorator.builtindecorator import IBuiltinCallable
+        from boa3.model.builtin.method import IBuiltinMethod
         return {name: method for name, method in self._symbols.items()
-                if method.defined_by_entry and isinstance(method, Method) and not isinstance(method, IBuiltinCallable)}
+                if ((isinstance(method, Method) and method.defined_by_entry)
+                    or (isinstance(method, IBuiltinMethod) and method.is_public)
+                    )}
 
     @property
     def _methods_with_imports(self) -> Dict[Tuple[str, str], Method]:

--- a/boa3/exception/CompilerError.py
+++ b/boa3/exception/CompilerError.py
@@ -108,8 +108,8 @@ class InternalIncorrectSignature(CompilerError):
     @property
     def _error_message(self) -> Optional[str]:
         return "The implementation of '{0}' is different " \
-               "from the expected '{1}.".format(self.expected_method.raw_identifier,
-                                                self.expected_method)
+               "from the expected '{1}'.".format(self.expected_method.raw_identifier,
+                                                 self.expected_method)
 
 
 class MetadataImplementationMissing(CompilerError):

--- a/boa3/exception/CompilerError.py
+++ b/boa3/exception/CompilerError.py
@@ -1,6 +1,8 @@
 from abc import ABC
 from typing import Iterable, Optional, Union
 
+from boa3.model.builtin.internal.internalmethod import IInternalMethod
+
 
 class CompilerError(ABC, BaseException):
     """
@@ -92,6 +94,22 @@ class InternalError(CompilerError):
         if self.raised_exception is not None:
             message += ". {0}: {1}".format(type(self.raised_exception).__name__, str(self.raised_exception))
         return message
+
+
+class InternalIncorrectSignature(CompilerError):
+    """
+    An error raised when an internal method is defined by the user, but with an incorrect signature
+    """
+
+    def __init__(self, line: int, col: int, expected_method: IInternalMethod):
+        self.expected_method: IInternalMethod = expected_method
+        super().__init__(line, col)
+
+    @property
+    def _error_message(self) -> Optional[str]:
+        return "The implementation of '{0}' is different " \
+               "from the expected '{1}.".format(self.expected_method.raw_identifier,
+                                                self.expected_method)
 
 
 class MetadataImplementationMissing(CompilerError):

--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -6,6 +6,7 @@ from boa3.model.builtin.classmethod import *
 from boa3.model.builtin.contract import *
 from boa3.model.builtin.decorator.metadatadecorator import MetadataDecorator
 from boa3.model.builtin.decorator.publicdecorator import PublicDecorator
+from boa3.model.builtin.internal.innerdeploymethod import InnerDeployMethod
 from boa3.model.builtin.interop.interop import Interop
 from boa3.model.builtin.method import *
 from boa3.model.builtin.neometadatatype import MetadataTypeSingleton as NeoMetadataType
@@ -168,3 +169,7 @@ class Builtin:
                           UInt256
                           ]
     }
+
+    _internal_methods = [InnerDeployMethod.instance()
+                         ]
+    internal_methods = {method.raw_identifier: method for method in _internal_methods}

--- a/boa3/model/builtin/internal/innerdeploymethod.py
+++ b/boa3/model/builtin/internal/innerdeploymethod.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import ast
+from typing import Dict, Optional
+
+from boa3 import constants
+from boa3.model import set_internal_call
+from boa3.model.builtin.internal.internalmethod import IInternalMethod
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.method import Method
+from boa3.model.symbol import ISymbol
+from boa3.model.variable import Variable
+
+
+class InnerDeployMethod(IInternalMethod):
+
+    @classmethod
+    def instance(cls) -> InnerDeployMethod:
+        return _INNER_DEPLOY_METHOD
+
+    def __init__(self):
+        from boa3.model.type.type import Type
+        identifier = constants.DEPLOY_METHOD_ID
+        args: Dict[str, Variable] = {
+            'data': Variable(Type.any),
+            'update': Variable(Type.bool)
+        }
+        super().__init__(identifier, args, return_type=Type.none)
+
+        self.is_public = True
+        self._origin_node = set_internal_call(ast.parse(self._body).body[0])
+
+    @property
+    def _body(self) -> Optional[str]:
+        method_args = [f"{var_id}: {var_type.type.raw_identifier}"
+                       for var_id, var_type in self.args.items()
+                       ]
+
+        return f"def {self.identifier}({', '.join(method_args)}): return"
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    def copy(self) -> InnerDeployMethod:
+        return InnerDeployMethod()
+
+    @classmethod
+    def is_valid_deploy_method(cls, symbol: ISymbol) -> bool:
+        if isinstance(symbol, InnerDeployMethod):
+            return True
+        if isinstance(symbol, IBuiltinMethod):
+            return False
+        if not isinstance(symbol, Method):
+            return False
+        else:
+            if not symbol.is_public:
+                return False
+
+            reference_args = list(_INNER_DEPLOY_METHOD.args.values())
+            from boa3.model.type.type import Type
+            if symbol.return_type is not Type.none:
+                return False
+
+            if len(symbol.args) != len(reference_args):
+                return False
+
+            for index, arg in enumerate(symbol.args.values()):
+                if not reference_args[index].type.is_equal(arg.type):
+                    return False
+
+        return True
+
+
+_INNER_DEPLOY_METHOD = InnerDeployMethod()

--- a/boa3/model/builtin/internal/internalmethod.py
+++ b/boa3/model/builtin/internal/internalmethod.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import abc
+import ast
+from typing import Dict, List, Optional, Tuple
+
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.symbol import ISymbol
+from boa3.model.type.itype import IType
+from boa3.model.variable import Variable
+
+
+class IInternalMethod(IBuiltinMethod, abc.ABC):
+
+    def __init__(self, identifier: str, args: Dict[str, Variable] = None,
+                 defaults: List[ast.AST] = None, return_type: IType = None,
+                 vararg: Optional[Tuple[str, Variable]] = None):
+
+        super().__init__(identifier, args, defaults, return_type, vararg)
+
+    @classmethod
+    @abc.abstractmethod
+    def instance(cls) -> IInternalMethod:
+        pass
+
+    @classmethod
+    @abc.abstractmethod
+    def is_valid_deploy_method(cls, symbol: ISymbol) -> bool:
+        return False

--- a/boa3/model/builtin/interop/contract/__init__.py
+++ b/boa3/model/builtin/interop/contract/__init__.py
@@ -18,7 +18,7 @@ from boa3.model.builtin.interop.contract.createmethod import CreateMethod
 from boa3.model.builtin.interop.contract.createstandardaccountmethod import CreateStandardAccountMethod
 from boa3.model.builtin.interop.contract.destroymethod import DestroyMethod
 from boa3.model.builtin.interop.contract.getcallflagsmethod import GetCallFlagsMethod
-from boa3.model.builtin.interop.contract.getminimumdeploymentfeemethod import GetMinimumDeploymentFeeMethod
 from boa3.model.builtin.interop.contract.getgasscripthashmethod import GasProperty
+from boa3.model.builtin.interop.contract.getminimumdeploymentfeemethod import GetMinimumDeploymentFeeMethod
 from boa3.model.builtin.interop.contract.getneoscripthashmethod import NeoProperty
 from boa3.model.builtin.interop.contract.updatemethod import UpdateMethod

--- a/boa3/model/type/itype.py
+++ b/boa3/model/type/itype.py
@@ -165,3 +165,8 @@ class IType(IdentifiedSymbol):
 
         from boa3.model.type.type import Type
         return Type.none
+
+    def is_equal(self, other: Any) -> bool:
+        if not isinstance(other, IType):
+            return False
+        return self.is_type_of(other) and other.is_type_of(self)

--- a/boa3/model/variable.py
+++ b/boa3/model/variable.py
@@ -19,8 +19,14 @@ class Variable(IExpression):
         self.defined_by_entry = True
         self._var_type: Optional[IType] = var_type
 
+        self.is_reassigned = False
+        self._origin_variable: Optional[Variable] = None
+
     def copy(self) -> Variable:
-        return Variable(self._var_type, self._origin_node)
+        var = Variable(self._var_type, self._origin_node)
+        var.is_reassigned = self.is_reassigned
+        var._origin_variable = self._origin_variable if self._origin_variable is not None else self
+        return var
 
     @property
     def shadowing_name(self) -> str:
@@ -43,3 +49,9 @@ class Variable(IExpression):
         :param var_type:
         """
         self._var_type = var_type
+
+    def set_is_reassigned(self):
+        if not self.is_reassigned:
+            self.is_reassigned = True
+        if hasattr(self._origin_variable, 'set_is_reassigned'):
+            self._origin_variable.set_is_reassigned()

--- a/boa3_test/test_sc/boa_built_in_methods_test/DeployDef.py
+++ b/boa3_test/test_sc/boa_built_in_methods_test/DeployDef.py
@@ -1,0 +1,19 @@
+from typing import Any
+
+from boa3.builtin import public
+
+example_var: int = 0
+
+
+@public
+def _deploy(some_data: Any, is_updating: bool):
+    if is_updating:
+        return
+
+    global example_var
+    example_var = 10
+
+
+@public
+def get_var() -> int:
+    return example_var

--- a/boa3_test/test_sc/boa_built_in_methods_test/DeployDefWrongSignature.py
+++ b/boa3_test/test_sc/boa_built_in_methods_test/DeployDefWrongSignature.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+
+
+@public
+def _deploy(is_updating: bool):
+    if is_updating:
+        return

--- a/boa3_test/test_sc/variable_test/GlobalAssignmentInFunctionWithArgument.py
+++ b/boa3_test/test_sc/variable_test/GlobalAssignmentInFunctionWithArgument.py
@@ -9,3 +9,8 @@ def Main(a: int) -> int:
 
 
 b: int = 0
+
+
+@public
+def get_b() -> int:
+    return b

--- a/boa3_test/test_sc/variable_test/GlobalMultipleAssignments.py
+++ b/boa3_test/test_sc/variable_test/GlobalMultipleAssignments.py
@@ -1,0 +1,26 @@
+from boa3.builtin import public
+
+a = b = c = d = 10
+c += 5
+
+
+@public
+def get_a() -> int:
+    return a
+
+
+@public
+def get_c() -> int:
+    return c
+
+
+@public
+def set_a(value: int):
+    global a
+    a = value
+
+
+@public
+def set_b(value: int):
+    global b
+    b = value

--- a/boa3_test/tests/compiler_tests/test_boa_builtin_method.py
+++ b/boa3_test/tests/compiler_tests/test_boa_builtin_method.py
@@ -1,3 +1,4 @@
+from boa3.exception import CompilerError
 from boa3_test.tests.boa_test import BoaTest
 from boa3_test.tests.test_classes.TestExecutionException import TestExecutionException
 from boa3_test.tests.test_classes.testengine import TestEngine
@@ -16,3 +17,14 @@ class TestBuiltinMethod(BoaTest):
 
         with self.assertRaises(TestExecutionException, msg=self.ABORTED_CONTRACT_MSG):
             self.run_smart_contract(engine, path, 'main', True)
+
+    def test_deploy_def(self):
+        path = self.get_contract_path('DeployDef.py')
+        engine = TestEngine()
+        
+        result = self.run_smart_contract(engine, path, 'get_var')
+        self.assertEqual(10, result)
+
+    def test_deploy_def_incorrect_signature(self):
+        path = self.get_contract_path('DeployDefWrongSignature.py')
+        self.assertCompilerLogs(CompilerError.InternalIncorrectSignature, path)

--- a/boa3_test/tests/compiler_tests/test_variable.py
+++ b/boa3_test/tests/compiler_tests/test_variable.py
@@ -478,6 +478,22 @@ class TestVariable(BoaTest):
         path = self.get_contract_path('GlobalAssignmentWithTuples.py')
         self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
 
+    def test_global_chained_multiple_assignments(self):
+        path = self.get_contract_path('GlobalMultipleAssignments.py')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'get_a')
+        self.assertEqual(10, result)
+
+        result = self.run_smart_contract(engine, path, 'get_c')
+        self.assertEqual(15, result)
+
+        result = self.run_smart_contract(engine, path, 'set_a', 100)
+        self.assertIsVoid(result)
+
+        result = self.run_smart_contract(engine, path, 'get_a')
+        self.assertEqual(100, result)
+
     def test_many_global_assignments(self):
         expected_output = (
             Opcode.LDSFLD + b'\x07'
@@ -611,29 +627,22 @@ class TestVariable(BoaTest):
         self.assertEqual(-140, result)
 
     def test_assign_global_in_function_with_global_keyword(self):
-        expected_output = (
-            Opcode.INITSLOT     # function signature
-            + b'\x00'
-            + b'\x01'
-            + Opcode.LDARG0     # b = a
-            + Opcode.STSFLD0
-            + Opcode.LDSFLD0    # return b
-            + Opcode.RET
-            + Opcode.INITSSLOT  # global variables
-            + b'\x01'           # number of globals
-            + Opcode.PUSH0      # b = 0
-            + Opcode.STSFLD0
-            + Opcode.RET
-        )
         path = self.get_contract_path('GlobalAssignmentInFunctionWithArgument.py')
-        output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
-
         engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'get_b')
+        self.assertEqual(0, result)
+
         result = self.run_smart_contract(engine, path, 'Main', 10)
         self.assertEqual(10, result)
 
+        result = self.run_smart_contract(engine, path, 'get_b')
+        self.assertEqual(10, result)
+
         result = self.run_smart_contract(engine, path, 'Main', -140)
+        self.assertEqual(-140, result)
+
+        result = self.run_smart_contract(engine, path, 'get_b')
         self.assertEqual(-140, result)
 
     def test_assign_void_function_call(self):


### PR DESCRIPTION
**Related issue**
#265

**Summary or solution description**
Changed the instructions related to module variables that are modified by functions to be able to persist the updated values, binding them with the contract storage.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/7e30bcc70da6b1ca41a160276ae1c174e6b0406b/boa3_test/test_sc/variable_test/GlobalAssignmentInFunctionWithArgument.py#L4-L16

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/7e30bcc70da6b1ca41a160276ae1c174e6b0406b/boa3_test/tests/compiler_tests/test_variable.py#L629-L646
https://github.com/CityOfZion/neo3-boa/blob/7e30bcc70da6b1ca41a160276ae1c174e6b0406b/boa3_test/tests/compiler_tests/test_variable.py#L481-L495

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7