### PR TITLE
Implement Sequence count for list and tuple 

### DIFF
--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -69,6 +69,7 @@ class Builtin:
     # python class method
     SequenceAppend = AppendMethod()
     SequenceClear = ClearMethod()
+    SequenceCount = CountMethod()
     SequenceExtend = ExtendMethod()
     SequenceInsert = InsertMethod()
     SequencePop = PopMethod()
@@ -100,6 +101,7 @@ class Builtin:
                                                 ScriptHash,
                                                 SequenceAppend,
                                                 SequenceClear,
+                                                SequenceCount,
                                                 SequenceExtend,
                                                 SequenceInsert,
                                                 SequencePop,

--- a/boa3/model/builtin/classmethod/__init__.py
+++ b/boa3/model/builtin/classmethod/__init__.py
@@ -1,5 +1,6 @@
 __all__ = ['AppendMethod',
            'ClearMethod',
+           'CountMethod',
            'ExtendMethod',
            'InsertMethod',
            'MapKeysMethod',
@@ -14,6 +15,7 @@ __all__ = ['AppendMethod',
 
 from boa3.model.builtin.classmethod.appendmethod import AppendMethod
 from boa3.model.builtin.classmethod.clearmethod import ClearMethod
+from boa3.model.builtin.classmethod.countmethod import CountMethod
 from boa3.model.builtin.classmethod.extendmethod import ExtendMethod
 from boa3.model.builtin.classmethod.insertmethod import InsertMethod
 from boa3.model.builtin.classmethod.mapkeysmethod import MapKeysMethod

--- a/boa3/model/builtin/classmethod/countmethod.py
+++ b/boa3/model/builtin/classmethod/countmethod.py
@@ -28,6 +28,27 @@ class CountMethod(IBuiltinMethod):
     def _arg_self(self) -> Variable:
         return self.args['self']
 
+    @property
+    def _arg_value(self) -> Variable:
+        return self.args['value']
+
+    @property
+    def is_supported(self) -> bool:
+        sequence_type: IType = self._arg_self.type
+        value_type: IType = self._arg_value.type
+
+        # TODO: change when 'str.count()' is supported
+        from boa3.model.type.primitive.strtype import StrType
+        if isinstance(sequence_type, StrType):
+            return False
+
+        # TODO: change when 'sequence.count(list or tuple)' is supported
+        from boa3.model.type.collection.sequence.mutable.listtype import ListType
+        from boa3.model.type.collection.sequence.tupletype import TupleType
+        if isinstance(value_type, (ListType, TupleType)):
+            return False
+        return True
+
     def validate_parameters(self, *params: IExpression) -> bool:
         if len(params) != 2:
             return False

--- a/boa3/model/builtin/classmethod/countmethod.py
+++ b/boa3/model/builtin/classmethod/countmethod.py
@@ -1,0 +1,146 @@
+from typing import Any, Dict, List, Optional, Tuple
+
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.expression import IExpression
+from boa3.model.type.collection.sequence.sequencetype import SequenceType
+from boa3.model.type.itype import IType
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class CountMethod(IBuiltinMethod):
+
+    def __init__(self, sequence_type: Optional[SequenceType] = None, arg_value: Optional[IType] = None):
+        from boa3.model.type.type import Type
+        identifier = 'count'
+        if not isinstance(sequence_type, SequenceType):
+            sequence_type = Type.sequence
+        if not isinstance(arg_value, IType):
+            arg_value = Type.any
+
+        args: Dict[str, Variable] = {
+            'self': Variable(sequence_type),
+            'value': Variable(arg_value)
+        }
+        super().__init__(identifier, args, return_type=Type.int)
+
+    @property
+    def _arg_self(self) -> Variable:
+        return self.args['self']
+
+    def validate_parameters(self, *params: IExpression) -> bool:
+        if len(params) != 2:
+            return False
+        if not all(isinstance(param, IExpression) for param in params):
+            return False
+
+        from boa3.model.type.itype import IType
+        sequence_type: IType = params[0].type
+
+        if not isinstance(sequence_type, SequenceType):
+            return False
+        from boa3.model.type.collection.sequence.mutable.listtype import ListType
+        from boa3.model.type.collection.sequence.tupletype import TupleType
+        from boa3.model.type.collection.sequence.rangetype import RangeType
+        if not (isinstance(sequence_type, ListType) or isinstance(sequence_type, TupleType) or isinstance(sequence_type, RangeType)):
+            return False
+        return True
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        from boa3.compiler.codegenerator import get_bytes_count
+
+        jmp_place_holder = (Opcode.JMP, b'\x01')
+
+        repack_array = [            # recreates an array to not change the original one
+            (Opcode.UNPACK, b''),
+            (Opcode.PACK, b''),
+        ]
+
+        sequence_initialize = [     # initializes variables
+            (Opcode.PUSH0, b''),    # count = 0
+            (Opcode.OVER, b''),
+            (Opcode.SIZE, b''),
+            (Opcode.DEC, b''),      # index = len(sequence) - -1
+        ]
+
+        sequence_verify_while = [   # verifies if all the elements from the sequence were visited
+            (Opcode.DUP, b''),      # would be equivalent to: while (index >= 0)
+            (Opcode.SIGN, b''),
+            (Opcode.PUSH0, b''),    # if index < 0:
+            jmp_place_holder,           # jump to clean the stack
+        ]
+
+        sequence_get_element = [    # gets a element from the sequence
+            (Opcode.PUSH2, b''),
+            (Opcode.PICK, b''),
+            (Opcode.OVER, b''),
+            (Opcode.PICKITEM, b'')  # element = sequence[index]
+        ]
+
+        sequence_equals = [         # verifies if the element and the given value are the same
+            (Opcode.PUSH4, b''),
+            (Opcode.PICK, b''),
+            (Opcode.EQUAL, b''),    # if element != value:
+            jmp_place_holder            # jump to list_tuple_count_index_dec
+        ]
+
+        sequence_count_inc = [      # increment count if element == value
+            (Opcode.SWAP, b''),
+            (Opcode.INC, b''),      # count++
+            (Opcode.SWAP, b''),
+        ]
+
+        num_jmp_code = get_bytes_count(sequence_count_inc)
+        jmp_to_dec_statement = Opcode.get_jump_and_data(Opcode.JMPIFNOT, num_jmp_code, True)
+        sequence_equals[-1] = jmp_to_dec_statement
+
+        list_tuple_count_index_dec = [  # decreases the index
+            (Opcode.DEC, b''),          # index--
+            # return to the while verification
+        ]
+
+        num_jmp_code = -get_bytes_count(list_tuple_count_index_dec + sequence_count_inc + sequence_equals +
+                                        sequence_get_element + sequence_verify_while)
+        jmp_back_to_while_verify_statement = Opcode.get_jump_and_data(Opcode.JMP, num_jmp_code)
+        list_tuple_count_index_dec.append(jmp_back_to_while_verify_statement)
+
+        num_jmp_code = get_bytes_count(sequence_get_element + sequence_equals +
+                                       sequence_count_inc + list_tuple_count_index_dec)
+        jmp_to_clean_statement = Opcode.get_jump_and_data(Opcode.JMPLT, num_jmp_code, True)
+        sequence_verify_while[-1] = jmp_to_clean_statement
+
+        clean_stack = [
+            (Opcode.DROP, b''),
+            (Opcode.REVERSE3, b''),
+            (Opcode.DROP, b''),
+            (Opcode.DROP, b''),
+        ]
+
+        return (
+            repack_array +
+            sequence_initialize +
+            sequence_verify_while +
+            sequence_get_element +
+            sequence_equals +
+            sequence_count_inc +
+            list_tuple_count_index_dec +
+            clean_stack
+        )
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> Optional[str]:
+        return
+
+    def build(self, value: Any) -> IBuiltinMethod:
+        if isinstance(value, List) or isinstance(value, list):
+            if len(value) == 2:
+                if type(value[0]) == type(self.args['self'].type) and type(value[1]) == type(self.args['value'].type):
+                    return self
+
+                return CountMethod(value[0], value[1])
+        return super().build(value)

--- a/boa3/model/builtin/classmethod/countmethod.py
+++ b/boa3/model/builtin/classmethod/countmethod.py
@@ -42,7 +42,7 @@ class CountMethod(IBuiltinMethod):
         from boa3.model.type.collection.sequence.mutable.listtype import ListType
         from boa3.model.type.collection.sequence.tupletype import TupleType
         from boa3.model.type.collection.sequence.rangetype import RangeType
-        if not (isinstance(sequence_type, ListType) or isinstance(sequence_type, TupleType) or isinstance(sequence_type, RangeType)):
+        if not isinstance(sequence_type, (ListType, TupleType, RangeType)):
             return False
         return True
 

--- a/boa3_test/test_sc/built_in_methods_test/CountListBytes.py
+++ b/boa3_test/test_sc/built_in_methods_test/CountListBytes.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+
+
+@public
+def main() -> int:
+    a = [b'unit', b'test', b'unit', b'unit', b'random', b'string']
+    return a.count(b'unit')

--- a/boa3_test/test_sc/built_in_methods_test/CountListDifferentNonPrimitiveTypes.py
+++ b/boa3_test/test_sc/built_in_methods_test/CountListDifferentNonPrimitiveTypes.py
@@ -1,10 +1,10 @@
-from typing import Tuple
+from typing import Tuple, List, Any
 
 from boa3.builtin import public
 
 
 @public
 def main() -> Tuple[int, int, int]:
-    a = [[b'unit', 'test'], [b'unit', b'unit'], [123, 123], [True, False], [True, False]]
+    a: List[Any] = [[b'unit', 'test'], [b'unit', b'unit'], [123, 123], [True, False], [True, False]]
     b: Tuple[int, int, int] = a.count([b'unit', 'test']), a.count([123, 123]), a.count([True, False])
     return b

--- a/boa3_test/test_sc/built_in_methods_test/CountListDifferentNonPrimitiveTypes.py
+++ b/boa3_test/test_sc/built_in_methods_test/CountListDifferentNonPrimitiveTypes.py
@@ -6,5 +6,5 @@ from boa3.builtin import public
 @public
 def main() -> Tuple[int, int, int]:
     a: List[Any] = [[b'unit', 'test'], [b'unit', b'unit'], [123, 123], [True, False], [True, False]]
-    b: Tuple[int, int, int] = a.count([b'unit', 'test']), a.count([123, 123]), a.count([True, False])
+    b: Tuple[int, int, int] = (a.count([b'unit', 'test']), a.count([123, 123]), a.count([True, False]))
     return b

--- a/boa3_test/test_sc/built_in_methods_test/CountListDifferentNonPrimitiveTypes.py
+++ b/boa3_test/test_sc/built_in_methods_test/CountListDifferentNonPrimitiveTypes.py
@@ -1,0 +1,10 @@
+from typing import Tuple
+
+from boa3.builtin import public
+
+
+@public
+def main() -> Tuple[int, int, int]:
+    a = [[b'unit', 'test'], [b'unit', b'unit'], [123, 123], [True, False], [True, False]]
+    b: Tuple[int, int, int] = a.count([b'unit', 'test']), a.count([123, 123]), a.count([True, False])
+    return b

--- a/boa3_test/test_sc/built_in_methods_test/CountListDifferentTypes.py
+++ b/boa3_test/test_sc/built_in_methods_test/CountListDifferentTypes.py
@@ -1,0 +1,10 @@
+from typing import Tuple
+
+from boa3.builtin import public
+
+
+@public
+def main() -> Tuple[int, int, int]:
+    a = [b'unit', 'test', b'unit', b'unit', 123, 123, True, False]
+    b: Tuple[int, int, int] = a.count(b'unit'), a.count('test'), a.count(123)
+    return b

--- a/boa3_test/test_sc/built_in_methods_test/CountListDifferentTypes.py
+++ b/boa3_test/test_sc/built_in_methods_test/CountListDifferentTypes.py
@@ -6,5 +6,5 @@ from boa3.builtin import public
 @public
 def main() -> Tuple[int, int, int]:
     a = [b'unit', 'test', b'unit', b'unit', 123, 123, True, False]
-    b: Tuple[int, int, int] = a.count(b'unit'), a.count('test'), a.count(123)
+    b: Tuple[int, int, int] = (a.count(b'unit'), a.count('test'), a.count(123))
     return b

--- a/boa3_test/test_sc/built_in_methods_test/CountListEmpty.py
+++ b/boa3_test/test_sc/built_in_methods_test/CountListEmpty.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+
+
+@public
+def main() -> int:
+    a = []
+    return a.count(1)

--- a/boa3_test/test_sc/built_in_methods_test/CountListInt.py
+++ b/boa3_test/test_sc/built_in_methods_test/CountListInt.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+
+
+@public
+def main() -> int:
+    a = [1, 2, 3, 4, 1, 1, 0]
+    return a.count(1)

--- a/boa3_test/test_sc/built_in_methods_test/CountListStr.py
+++ b/boa3_test/test_sc/built_in_methods_test/CountListStr.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+
+
+@public
+def main() -> int:
+    a = ['unit', 'test', 'unit', 'unit', 'random', 'string']
+    return a.count('unit')

--- a/boa3_test/test_sc/built_in_methods_test/CountRange.py
+++ b/boa3_test/test_sc/built_in_methods_test/CountRange.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main() -> int:
+    return range(10).count(1)

--- a/boa3_test/test_sc/built_in_methods_test/CountStr.py
+++ b/boa3_test/test_sc/built_in_methods_test/CountStr.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main(string: str, substring: str, beginning: int, end: int) -> int:
+    return string.count(substring, beginning, end)

--- a/boa3_test/test_sc/built_in_methods_test/CountTupleBytes.py
+++ b/boa3_test/test_sc/built_in_methods_test/CountTupleBytes.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+
+
+@public
+def main() -> int:
+    a = (b'unit', b'test', b'unit', b'unit', b'random', b'string')
+    return a.count(b'unit')

--- a/boa3_test/test_sc/built_in_methods_test/CountTupleDifferentNonPrimitiveTypes.py
+++ b/boa3_test/test_sc/built_in_methods_test/CountTupleDifferentNonPrimitiveTypes.py
@@ -1,10 +1,10 @@
-from typing import Tuple
+from typing import Tuple, Any
 
 from boa3.builtin import public
 
 
 @public
 def main() -> Tuple[int, int, int]:
-    a = ([b'unit', 'test'], [b'unit', b'unit'], [123, 123], [True, False], [True, False])
+    a: Tuple[Any] = ([b'unit', 'test'], [b'unit', b'unit'], [123, 123], [True, False], [True, False])
     b: Tuple[int, int, int] = a.count([b'unit', 'test']), a.count([123, 123]), a.count([True, False])
     return b

--- a/boa3_test/test_sc/built_in_methods_test/CountTupleDifferentNonPrimitiveTypes.py
+++ b/boa3_test/test_sc/built_in_methods_test/CountTupleDifferentNonPrimitiveTypes.py
@@ -6,5 +6,5 @@ from boa3.builtin import public
 @public
 def main() -> Tuple[int, int, int]:
     a: Tuple[Any] = ([b'unit', 'test'], [b'unit', b'unit'], [123, 123], [True, False], [True, False])
-    b: Tuple[int, int, int] = a.count([b'unit', 'test']), a.count([123, 123]), a.count([True, False])
+    b: Tuple[int, int, int] = (a.count([b'unit', 'test']), a.count([123, 123]), a.count([True, False]))
     return b

--- a/boa3_test/test_sc/built_in_methods_test/CountTupleDifferentNonPrimitiveTypes.py
+++ b/boa3_test/test_sc/built_in_methods_test/CountTupleDifferentNonPrimitiveTypes.py
@@ -1,0 +1,10 @@
+from typing import Tuple
+
+from boa3.builtin import public
+
+
+@public
+def main() -> Tuple[int, int, int]:
+    a = ([b'unit', 'test'], [b'unit', b'unit'], [123, 123], [True, False], [True, False])
+    b: Tuple[int, int, int] = a.count([b'unit', 'test']), a.count([123, 123]), a.count([True, False])
+    return b

--- a/boa3_test/test_sc/built_in_methods_test/CountTupleDifferentTypes.py
+++ b/boa3_test/test_sc/built_in_methods_test/CountTupleDifferentTypes.py
@@ -1,0 +1,10 @@
+from typing import Tuple
+
+from boa3.builtin import public
+
+
+@public
+def main() -> Tuple[int, int, int]:
+    a = (b'unit', 'test', b'unit', b'unit', 123, 123, True, False)
+    b: Tuple[int, int, int] = a.count(b'unit'), a.count('test'), a.count(123)
+    return b

--- a/boa3_test/test_sc/built_in_methods_test/CountTupleDifferentTypes.py
+++ b/boa3_test/test_sc/built_in_methods_test/CountTupleDifferentTypes.py
@@ -6,5 +6,5 @@ from boa3.builtin import public
 @public
 def main() -> Tuple[int, int, int]:
     a = (b'unit', 'test', b'unit', b'unit', 123, 123, True, False)
-    b: Tuple[int, int, int] = a.count(b'unit'), a.count('test'), a.count(123)
+    b: Tuple[int, int, int] = (a.count(b'unit'), a.count('test'), a.count(123))
     return b

--- a/boa3_test/test_sc/built_in_methods_test/CountTupleEmpty.py
+++ b/boa3_test/test_sc/built_in_methods_test/CountTupleEmpty.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+
+
+@public
+def main() -> int:
+    a = ()
+    return a.count(1)

--- a/boa3_test/test_sc/built_in_methods_test/CountTupleInt.py
+++ b/boa3_test/test_sc/built_in_methods_test/CountTupleInt.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+
+
+@public
+def main() -> int:
+    a = (1, 2, 3, 4, 1, 1, 0)
+    return a.count(1)

--- a/boa3_test/test_sc/built_in_methods_test/CountTupleStr.py
+++ b/boa3_test/test_sc/built_in_methods_test/CountTupleStr.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+
+
+@public
+def main() -> int:
+    a = ('unit', 'test', 'unit', 'unit', 'random', 'string')
+    return a.count('unit')

--- a/boa3_test/tests/compiler_tests/test_builtin_method.py
+++ b/boa3_test/tests/compiler_tests/test_builtin_method.py
@@ -1051,16 +1051,8 @@ class TestBuiltinMethod(BoaTest):
 
     def test_count_list_different_non_primitive_types(self):
         path = self.get_contract_path('CountListDifferentNonPrimitiveTypes.py')
-        engine = TestEngine()
-
-        list_ = [[b'unit', 'test'], [b'unit', b'unit'], [123, 123], [True, False], [True, False]]
-        expected_result = list_.count([b'unit', 'test']), list_.count([123, 123]), list_.count([True, False])
-
         # TODO: change test when comparison of non primitive types are implemented in the Opcode
-        result = self.run_smart_contract(engine, path, 'main')
-
-        with self.assertRaises(AssertionError):
-            self.assertEqual(expected_result, tuple(result))
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
 
     def test_count_list_empty(self):
         path = self.get_contract_path('CountListEmpty.py')
@@ -1109,15 +1101,8 @@ class TestBuiltinMethod(BoaTest):
 
     def test_count_tuple_different_non_primitive_types(self):
         path = self.get_contract_path('CountTupleDifferentNonPrimitiveTypes.py')
-        engine = TestEngine()
-
-        tuple_ = ([b'unit', 'test'], [b'unit', b'unit'], [123, 123], [True, False], [True, False])
-        expected_result = tuple_.count([b'unit', 'test']), tuple_.count([123, 123]), tuple_.count([True, False])
-
         # TODO: change test when comparison of non primitive types are implemented in the Opcode
-        result = self.run_smart_contract(engine, path, 'main')
-        with self.assertRaises(AssertionError):
-            self.assertEqual(expected_result, tuple(result))
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
 
     def test_count_tuple_empty(self):
         path = self.get_contract_path('CountTupleEmpty.py')

--- a/boa3_test/tests/compiler_tests/test_builtin_method.py
+++ b/boa3_test/tests/compiler_tests/test_builtin_method.py
@@ -1010,3 +1010,119 @@ class TestBuiltinMethod(BoaTest):
         self.assertEqual(expected_result, result)
 
     # endregion
+
+    # region count test
+
+    def test_count_list_int(self):
+        path = self.get_contract_path('CountListInt.py')
+        engine = TestEngine()
+
+        list_ = [1, 2, 3, 4, 1, 1, 0]
+        expected_result = list_.count(1)
+        result = self.run_smart_contract(engine, path, 'main')
+        self.assertEqual(expected_result, result)
+
+    def test_count_list_str(self):
+        path = self.get_contract_path('CountListStr.py')
+        engine = TestEngine()
+
+        list_ = ['unit', 'test', 'unit', 'unit', 'random', 'string']
+        expected_result = list_.count('unit')
+        result = self.run_smart_contract(engine, path, 'main')
+        self.assertEqual(expected_result, result)
+
+    def test_count_list_bytes(self):
+        path = self.get_contract_path('CountListBytes.py')
+        engine = TestEngine()
+
+        list_ = [b'unit', b'test', b'unit', b'unit', b'random', b'string']
+        expected_result = list_.count(b'unit')
+        result = self.run_smart_contract(engine, path, 'main')
+        self.assertEqual(expected_result, result)
+
+    def test_count_list_different_types(self):
+        path = self.get_contract_path('CountListDifferentTypes.py')
+        engine = TestEngine()
+
+        list_ = [b'unit', 'test', b'unit', b'unit', 123, 123, True, False]
+        expected_result = list_.count(b'unit'), list_.count('test'), list_.count(123)
+        result = self.run_smart_contract(engine, path, 'main')
+        self.assertEqual(expected_result, tuple(result))
+
+    def test_count_list_different_non_primitive_types(self):
+        path = self.get_contract_path('CountListDifferentNonPrimitiveTypes.py')
+        engine = TestEngine()
+
+        list_ = [[b'unit', 'test'], [b'unit', b'unit'], [123, 123], [True, False], [True, False]]
+        expected_result = list_.count([b'unit', 'test']), list_.count([123, 123]), list_.count([True, False])
+
+        # TODO: uncomment comments when comparison of non primitive types are implemented in an Opcode
+        # result = self.run_smart_contract(engine, path, 'main')
+        # self.assertEqual(expected_result, tuple(result))
+
+    def test_count_list_empty(self):
+        path = self.get_contract_path('CountListEmpty.py')
+        engine = TestEngine()
+
+        list_ = []
+        expected_result = list_.count(1)
+        result = self.run_smart_contract(engine, path, 'main')
+        self.assertEqual(expected_result, result)
+
+    def test_count_tuple_int(self):
+        path = self.get_contract_path('CountTupleInt.py')
+        engine = TestEngine()
+
+        tuple_ = (1, 2, 3, 4, 1, 1, 0)
+        expected_result = tuple_.count(1)
+        result = self.run_smart_contract(engine, path, 'main')
+        self.assertEqual(expected_result, result)
+
+    def test_count_tuple_str(self):
+        path = self.get_contract_path('CountTupleStr.py')
+        engine = TestEngine()
+
+        tuple_ = ('unit', 'test', 'unit', 'unit', 'random', 'string')
+        expected_result = tuple_.count('unit')
+        result = self.run_smart_contract(engine, path, 'main')
+        self.assertEqual(expected_result, result)
+
+    def test_count_tuple_bytes(self):
+        path = self.get_contract_path('CountTupleBytes.py')
+        engine = TestEngine()
+
+        tuple_ = (b'unit', b'test', b'unit', b'unit', b'random', b'string')
+        expected_result = tuple_.count(b'unit')
+        result = self.run_smart_contract(engine, path, 'main')
+        self.assertEqual(expected_result, result)
+
+    def test_count_tuple_different_types(self):
+        path = self.get_contract_path('CountTupleDifferentTypes.py')
+        engine = TestEngine()
+
+        tuple_ = (b'unit', 'test', b'unit', b'unit', 123, 123, True, False)
+        expected_result = tuple_.count(b'unit'), tuple_.count('test'), tuple_.count(123)
+        result = self.run_smart_contract(engine, path, 'main')
+        self.assertEqual(expected_result, tuple(result))
+
+    def test_count_tuple_different_non_primitive_types(self):
+        path = self.get_contract_path('CountTupleDifferentNonPrimitiveTypes.py')
+        engine = TestEngine()
+
+        tuple_ = ([b'unit', 'test'], [b'unit', b'unit'], [123, 123], [True, False], [True, False])
+        expected_result = tuple_.count([b'unit', 'test']), tuple_.count([123, 123]), tuple_.count([True, False])
+
+        # TODO: uncomment comments when comparison of non primitive types are implemented in an Opcode
+        # result = self.run_smart_contract(engine, path, 'main')
+        # self.assertEqual(expected_result, tuple(result))
+
+    def test_count_tuple_empty(self):
+        path = self.get_contract_path('CountTupleEmpty.py')
+        engine = TestEngine()
+
+        tuple_ = ()
+        expected_result = tuple_.count(1)
+        result = self.run_smart_contract(engine, path, 'main')
+        self.assertEqual(expected_result, result)
+
+    # endregion

--- a/boa3_test/tests/compiler_tests/test_builtin_method.py
+++ b/boa3_test/tests/compiler_tests/test_builtin_method.py
@@ -1125,4 +1125,12 @@ class TestBuiltinMethod(BoaTest):
         result = self.run_smart_contract(engine, path, 'main')
         self.assertEqual(expected_result, result)
 
+    def test_count_range(self):
+        path = self.get_contract_path('CountRange.py')
+        engine = TestEngine()
+
+        expected_result = range(10).count(1)
+        result = self.run_smart_contract(engine, path, 'main')
+        self.assertEqual(expected_result, result)
+
     # endregion

--- a/boa3_test/tests/compiler_tests/test_builtin_method.py
+++ b/boa3_test/tests/compiler_tests/test_builtin_method.py
@@ -1056,9 +1056,11 @@ class TestBuiltinMethod(BoaTest):
         list_ = [[b'unit', 'test'], [b'unit', b'unit'], [123, 123], [True, False], [True, False]]
         expected_result = list_.count([b'unit', 'test']), list_.count([123, 123]), list_.count([True, False])
 
-        # TODO: uncomment comments when comparison of non primitive types are implemented in an Opcode
-        # result = self.run_smart_contract(engine, path, 'main')
-        # self.assertEqual(expected_result, tuple(result))
+        # TODO: change test when comparison of non primitive types are implemented in the Opcode
+        result = self.run_smart_contract(engine, path, 'main')
+
+        with self.assertRaises(AssertionError):
+            self.assertEqual(expected_result, tuple(result))
 
     def test_count_list_empty(self):
         path = self.get_contract_path('CountListEmpty.py')
@@ -1112,9 +1114,10 @@ class TestBuiltinMethod(BoaTest):
         tuple_ = ([b'unit', 'test'], [b'unit', b'unit'], [123, 123], [True, False], [True, False])
         expected_result = tuple_.count([b'unit', 'test']), tuple_.count([123, 123]), tuple_.count([True, False])
 
-        # TODO: uncomment comments when comparison of non primitive types are implemented in an Opcode
-        # result = self.run_smart_contract(engine, path, 'main')
-        # self.assertEqual(expected_result, tuple(result))
+        # TODO: change test when comparison of non primitive types are implemented in the Opcode
+        result = self.run_smart_contract(engine, path, 'main')
+        with self.assertRaises(AssertionError):
+            self.assertEqual(expected_result, tuple(result))
 
     def test_count_tuple_empty(self):
         path = self.get_contract_path('CountTupleEmpty.py')
@@ -1132,5 +1135,10 @@ class TestBuiltinMethod(BoaTest):
         expected_result = range(10).count(1)
         result = self.run_smart_contract(engine, path, 'main')
         self.assertEqual(expected_result, result)
+
+    def test_count_str(self):
+        path = self.get_contract_path('CountStr.py')
+        # TODO: change test when str.count(substring, start, end) is implemented in the Opcode
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
 
     # endregion


### PR DESCRIPTION
**Related issue**
#256 

**How to Reproduce**
Use `.count(value)` in a list, tuple or range.
https://github.com/CityOfZion/neo3-boa/blob/87207cd11e5111e5e72c58112ef14587e10fa648/boa3_test/test_sc/built_in_methods_test/CountListInt.py#L1-L7

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/87207cd11e5111e5e72c58112ef14587e10fa648/boa3_test/tests/compiler_tests/test_builtin_method.py#L1014-L1136

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8

**(Optional) Additional context**
The method currently does not work for `str.count()` or when using to count non-primitive types in the sequence.