### PR TITLE
Fixed search for internal symbols

### DIFF
--- a/boa3/model/builtin/interop/runtime/getnotificationsmethod.py
+++ b/boa3/model/builtin/interop/runtime/getnotificationsmethod.py
@@ -1,6 +1,7 @@
 import ast
 from typing import Dict, List, Tuple
 
+from boa3.model import set_internal_call
 from boa3.model.builtin.interop.interopmethod import InteropMethod
 from boa3.model.builtin.interop.runtime.notificationtype import NotificationType
 from boa3.model.variable import Variable
@@ -18,8 +19,8 @@ class GetNotificationsMethod(InteropMethod):
         uint160 = UInt160Type.build()
 
         args: Dict[str, Variable] = {'script_hash': Variable(uint160)}
-        args_default = ast.parse("{0}()".format(uint160.raw_identifier)
-                                 ).body[0].value
+        args_default = set_internal_call(ast.parse("{0}()".format(uint160.raw_identifier)
+                                                   ).body[0].value)
 
         super().__init__(identifier, syscall, args, [args_default],
                          return_type=Type.list.build([notification_type]))

--- a/boa3/model/imports/builtin.py
+++ b/boa3/model/imports/builtin.py
@@ -102,6 +102,9 @@ class CompilerBuiltin:
                 # if didn't find in the current list, go back to the previous list search
                 # if the stack is empty, it doesn't continue the loop because the while condition
                 current_list, current_index = packages_stack.pop()
+                if len(current_list) <= current_index:
+                    # if the previous list has no elements unchecked, just continue the loop
+                    continue
 
             package = current_list[current_index]
             if symbol_id in package.symbols:


### PR DESCRIPTION
**Related issue**
#539

**Summary or solution description**
The issue was in the internal symbols search logic.
When the symbol is not in a package and the parent package has also been fully searched, it was raising an error because it tried to continue the search in the parent

**Tests**
Rerun all unit tests using the latest commits from [development](https://github.com/CityOfZion/neo3-boa/tree/5edeb1ac0a5d5ce05f89df58680900753bb81f77) and [#506](https://github.com/CityOfZion/neo3-boa/tree/d733012d32feba8060110be5526d1957213867db) branches.

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7