### PR TITLE
Implement Crypto CheckSig Interop

### DIFF
--- a/boa3/builtin/interop/crypto/__init__.py
+++ b/boa3/builtin/interop/crypto/__init__.py
@@ -51,12 +51,12 @@ def hash256(key: Any) -> bytes:
     pass
 
 
-def check_sig(pub_key: bytes, signature: bytes) -> bool:
+def check_sig(pub_key: ECPoint, signature: bytes) -> bool:
     """
     Checks the signature for the current script container.
 
     :param pub_key: the public key of the account
-    :type pub_key: bytes
+    :type pub_key: ECPoint
     :param signature: the signature of the current script container
     :type signature: bytes
     :return: whether the signature is valid or not

--- a/boa3/builtin/interop/crypto/__init__.py
+++ b/boa3/builtin/interop/crypto/__init__.py
@@ -51,6 +51,20 @@ def hash256(key: Any) -> bytes:
     pass
 
 
+def check_sig(pub_key: bytes, signature: bytes) -> bool:
+    """
+    Checks the signature for the current script container.
+
+    :param pub_key: the public key of the account
+    :type pub_key: bytes
+    :param signature: the signature of the current script container
+    :type signature: bytes
+    :return: whether the signature is valid or not
+    :rtype: bool
+    """
+    pass
+
+
 def check_multisig(pubkeys: List[ECPoint], signatures: List[bytes]) -> bool:
     """
     Checks the signatures for the current script container.

--- a/boa3/model/builtin/interop/crypto/__init__.py
+++ b/boa3/model/builtin/interop/crypto/__init__.py
@@ -1,4 +1,5 @@
 __all__ = ['CheckMultisigMethod',
+           'CheckSigMethod',
            'Hash160Method',
            'Hash256Method',
            'Ripemd160Method',
@@ -8,6 +9,7 @@ __all__ = ['CheckMultisigMethod',
            ]
 
 from boa3.model.builtin.interop.crypto.checkmultisigmethod import CheckMultisigMethod
+from boa3.model.builtin.interop.crypto.checksigmethod import CheckSigMethod
 from boa3.model.builtin.interop.crypto.hash160method import Hash160Method
 from boa3.model.builtin.interop.crypto.hash256method import Hash256Method
 from boa3.model.builtin.interop.crypto.ripemd160method import Ripemd160Method

--- a/boa3/model/builtin/interop/crypto/checksigmethod.py
+++ b/boa3/model/builtin/interop/crypto/checksigmethod.py
@@ -4,16 +4,16 @@ from boa3.model.builtin.interop.interopmethod import InteropMethod
 from boa3.model.variable import Variable
 
 
-class CheckMultisigMethod(InteropMethod):
+class CheckSigMethod(InteropMethod):
 
     def __init__(self):
         from boa3.model.type.type import Type
         from boa3.model.type.collection.sequence.ecpointtype import ECPointType
 
-        identifier = 'check_multisig'
-        syscall = 'System.Crypto.CheckMultisig'
+        identifier = 'check_sig'
+        syscall = 'System.Crypto.CheckSig'
         args: Dict[str, Variable] = {
-            'pubkeys': Variable(Type.list.build_collection([ECPointType.build()])),
-            'signatures': Variable(Type.list.build_collection([Type.bytes]))
+            'pubkeys': Variable(ECPointType.build()),
+            'signatures': Variable(Type.bytes)
         }
         super().__init__(identifier, syscall, args, return_type=Type.bool)

--- a/boa3/model/builtin/interop/interop.py
+++ b/boa3/model/builtin/interop/interop.py
@@ -102,6 +102,7 @@ class Interop:
 
     # Crypto Interops
     CheckMultisig = CheckMultisigMethod()
+    CheckSig = CheckSigMethod()
     Hash160 = Hash160Method()
     Hash256 = Hash256Method()
     Ripemd160 = Ripemd160Method()
@@ -238,6 +239,7 @@ class Interop:
 
     CryptoPackage = Package(identifier=InteropPackage.Crypto,
                             methods=[CheckMultisig,
+                                     CheckSig,
                                      Hash160,
                                      Hash256,
                                      Ripemd160,

--- a/boa3_test/test_sc/interop_test/crypto/CheckMultisig.py
+++ b/boa3_test/test_sc/interop_test/crypto/CheckMultisig.py
@@ -6,8 +6,8 @@ from boa3.builtin.type import ECPoint
 
 
 @public
-def Main():
-    pubkeys: List[ECPoint] = [ECPoint(b'123456789012345678901234567890123'),
-                              ECPoint(b'abcdefghijklmnopqrstuvwxyz1234567')]
-    assignatures: List[bytes] = [b'098', b'765']
-    check_multisig(pubkeys, assignatures)
+def main() -> bool:
+    pubkeys: List[ECPoint] = [ECPoint(b'\x03\xcd\xb0g\xd90\xfdZ\xda\xa6\xc6\x85E\x01`D\xaa\xdd\xecd\xba9\xe5H%\x0e\xae\xa5Q\x17.S\\'),
+                              ECPoint(b'\x03l\x841\xccx\xb31w\xa6\x0bK\xcc\x02\xba\xf6\r\x05\xfe\xe5\x03\x8es9\xd3\xa6\x88\xe3\x94\xc2\xcb\xd8C')]
+    signatures: List[bytes] = [b'wrongsignature1', b'wrongsignature2']
+    return check_multisig(pubkeys, signatures)

--- a/boa3_test/test_sc/interop_test/crypto/CheckSig.py
+++ b/boa3_test/test_sc/interop_test/crypto/CheckSig.py
@@ -1,0 +1,10 @@
+from boa3.builtin import public
+from boa3.builtin.interop.crypto import check_sig
+from boa3.builtin.type import ECPoint
+
+
+@public
+def main() -> bool:
+    pubkey: ECPoint = ECPoint(b'\x03\x5a\x92\x8f\x20\x16\x39\x20\x4e\x06\xb4\x36\x8b\x1a\x93\x36\x54\x62\xa8\xeb\xbf\xf0\xb8\x81\x81\x51\xb7\x4f\xaa\xb3\xa2\xb6\x1a')
+    signature: bytes = b'wrongsignature'
+    return check_sig(pubkey, signature)


### PR DESCRIPTION
**Related issue**
#491 

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/02c7d8a24a3c1ed0a60d8126e289c513d689dc0d/boa3_test/test_sc/interop_test/crypto/CheckSig.py#L1-L10

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/02c7d8a24a3c1ed0a60d8126e289c513d689dc0d/boa3_test/tests/compiler_tests/test_interop/test_crypto.py#L169-L201

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8

**(Optional) Additional context**
Also changed the syscall at [checkmultisigmethod.py](https://github.com/CityOfZion/neo3-boa/blob/02c7d8a24a3c1ed0a60d8126e289c513d689dc0d/boa3/model/builtin/interop/crypto/checkmultisigmethod.py) and its test.
