### PR TITLE
 Add support to the 'is' keyword

### DIFF
--- a/boa3/model/operation/binary/relational/identity.py
+++ b/boa3/model/operation/binary/relational/identity.py
@@ -1,8 +1,9 @@
-from typing import List
+from typing import List, Tuple
 
 from boa3.model.operation.binary.binaryoperation import BinaryOperation
 from boa3.model.operation.operator import Operator
 from boa3.model.type.type import IType, Type
+from boa3.neo.vm.opcode.Opcode import Opcode
 
 
 class Identity(BinaryOperation):
@@ -14,7 +15,6 @@ class Identity(BinaryOperation):
     :ivar right: the left operand type. Inherited from :class:`BinaryOperation`
     :ivar result: the result type of the operation.  Inherited from :class:`IOperation`
     """
-    _valid_types: List[IType] = [Type.int]
 
     def __init__(self, left: IType = Type.int, right: IType = None):
         self.operator: Operator = Operator.Is
@@ -23,11 +23,7 @@ class Identity(BinaryOperation):
     def validate_type(self, *types: IType) -> bool:
         if len(types) != self.number_of_operands:
             return False
-        left: IType = types[0]
-        right: IType = types[1]
-
-        # TODO: change the logic of the validation when implement other numeric types
-        return left == right and left in self._valid_types
+        return True
 
     def _get_result(self, left: IType, right: IType) -> IType:
         if self.validate_type(left, right):
@@ -36,6 +32,5 @@ class Identity(BinaryOperation):
             return Type.none
 
     @property
-    def is_supported(self) -> bool:
-        # TODO: change when 'is' is supported
-        return False
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        return [(Opcode.EQUAL, b'')]

--- a/boa3/model/operation/binary/relational/notidentity.py
+++ b/boa3/model/operation/binary/relational/notidentity.py
@@ -1,8 +1,9 @@
-from typing import List
+from typing import List, Tuple
 
 from boa3.model.operation.binary.binaryoperation import BinaryOperation
 from boa3.model.operation.operator import Operator
 from boa3.model.type.type import IType, Type
+from boa3.neo.vm.opcode.Opcode import Opcode
 
 
 class NotIdentity(BinaryOperation):
@@ -23,11 +24,7 @@ class NotIdentity(BinaryOperation):
     def validate_type(self, *types: IType) -> bool:
         if len(types) != self.number_of_operands:
             return False
-        left: IType = types[0]
-        right: IType = types[1]
-
-        # TODO: change the logic of the validation when implement other numeric types
-        return left == right and left in self._valid_types
+        return True
 
     def _get_result(self, left: IType, right: IType) -> IType:
         if self.validate_type(left, right):
@@ -36,6 +33,8 @@ class NotIdentity(BinaryOperation):
             return Type.none
 
     @property
-    def is_supported(self) -> bool:
-        # TODO: change when 'is not' is supported
-        return False
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        return [
+            (Opcode.EQUAL, b''),
+            (Opcode.NOT, b'')
+        ]

--- a/boa3/model/operation/binary/relational/notidentity.py
+++ b/boa3/model/operation/binary/relational/notidentity.py
@@ -35,6 +35,5 @@ class NotIdentity(BinaryOperation):
     @property
     def opcode(self) -> List[Tuple[Opcode, bytes]]:
         return [
-            (Opcode.EQUAL, b''),
-            (Opcode.NOT, b'')
+            (Opcode.NOTEQUAL, b'')
         ]

--- a/boa3_test/test_sc/relational_test/BoolIdentity.py
+++ b/boa3_test/test_sc/relational_test/BoolIdentity.py
@@ -3,20 +3,20 @@ from boa3.builtin import public
 
 @public
 def without_attribution_true() -> bool:
-    a = 1
-    b = 1
+    a = True
+    b = True
     return a is b
 
 
 @public
 def without_attribution_false() -> bool:
-    a = 1
-    b = 2
+    a = True
+    b = False
     return a is b
 
 
 @public
 def with_attribution() -> bool:
-    c = 1
+    c = True
     d = c
     return c is d

--- a/boa3_test/test_sc/relational_test/BoolNotIdentity.py
+++ b/boa3_test/test_sc/relational_test/BoolNotIdentity.py
@@ -3,20 +3,20 @@ from boa3.builtin import public
 
 @public
 def without_attribution_true() -> bool:
-    a = 1
-    b = 1
-    return a is b
+    a = True
+    b = False
+    return a is not b
 
 
 @public
 def without_attribution_false() -> bool:
-    a = 1
-    b = 2
-    return a is b
+    a = True
+    b = True
+    return a is not b
 
 
 @public
 def with_attribution() -> bool:
-    c = 1
+    c = True
     d = c
-    return c is d
+    return c is not d

--- a/boa3_test/test_sc/relational_test/ListIdentity.py
+++ b/boa3_test/test_sc/relational_test/ListIdentity.py
@@ -1,0 +1,17 @@
+from typing import List
+
+from boa3.builtin import public
+
+
+@public
+def with_attribution() -> bool:
+    a: List[int] = [1, 2, 3]
+    b = a
+    return a is b
+
+
+@public
+def without_attribution() -> bool:
+    a: List[int] = [1, 2, 3]
+    b: List[int] = [1, 2, 3]
+    return a is b

--- a/boa3_test/test_sc/relational_test/ListNotIdentity.py
+++ b/boa3_test/test_sc/relational_test/ListNotIdentity.py
@@ -1,0 +1,17 @@
+from typing import List
+
+from boa3.builtin import public
+
+
+@public
+def with_attribution() -> bool:
+    a: List[int] = [1, 2, 3]
+    b = a
+    return a is not b
+
+
+@public
+def without_attribution() -> bool:
+    a: List[int] = [1, 2, 3]
+    b: List[int] = [1, 2, 3]
+    return a is not b

--- a/boa3_test/test_sc/relational_test/MixedIdentity.py
+++ b/boa3_test/test_sc/relational_test/MixedIdentity.py
@@ -1,0 +1,10 @@
+from typing import List, Tuple
+
+from boa3.builtin import public
+
+
+@public
+def mixed() -> bool:
+    a: List[int] = [1, 2, 3]
+    b: Tuple[str, str] = ('unit', 'test')
+    return a is b

--- a/boa3_test/test_sc/relational_test/NoneIdentity.py
+++ b/boa3_test/test_sc/relational_test/NoneIdentity.py
@@ -1,0 +1,8 @@
+from typing import Any
+
+from boa3.builtin import public
+
+
+@public
+def main(a: Any) -> bool:
+    return a is None

--- a/boa3_test/test_sc/relational_test/NoneNotIdentity.py
+++ b/boa3_test/test_sc/relational_test/NoneNotIdentity.py
@@ -1,0 +1,8 @@
+from typing import Any
+
+from boa3.builtin import public
+
+
+@public
+def main(a: Any) -> bool:
+    return a is not None

--- a/boa3_test/test_sc/relational_test/NumNotIdentity.py
+++ b/boa3_test/test_sc/relational_test/NumNotIdentity.py
@@ -4,19 +4,19 @@ from boa3.builtin import public
 @public
 def without_attribution_true() -> bool:
     a = 1
-    b = 1
-    return a is b
+    b = 2
+    return a is not b
 
 
 @public
 def without_attribution_false() -> bool:
     a = 1
-    b = 2
-    return a is b
+    b = 1
+    return a is not b
 
 
 @public
 def with_attribution() -> bool:
     c = 1
     d = c
-    return c is d
+    return c is not d

--- a/boa3_test/test_sc/relational_test/StrIdentity.py
+++ b/boa3_test/test_sc/relational_test/StrIdentity.py
@@ -3,20 +3,20 @@ from boa3.builtin import public
 
 @public
 def without_attribution_true() -> bool:
-    a = 1
-    b = 1
+    a = 'unit'
+    b = 'unit'
     return a is b
 
 
 @public
 def without_attribution_false() -> bool:
-    a = 1
-    b = 2
+    a = 'unit'
+    b = 'test'
     return a is b
 
 
 @public
 def with_attribution() -> bool:
-    c = 1
+    c = 'unit'
     d = c
     return c is d

--- a/boa3_test/test_sc/relational_test/StrNotIdentity.py
+++ b/boa3_test/test_sc/relational_test/StrNotIdentity.py
@@ -3,20 +3,20 @@ from boa3.builtin import public
 
 @public
 def without_attribution_true() -> bool:
-    a = 1
-    b = 1
-    return a is b
+    a = 'unit'
+    b = 'test'
+    return a is not b
 
 
 @public
 def without_attribution_false() -> bool:
-    a = 1
-    b = 2
-    return a is b
+    a = 'unit'
+    b = 'unit'
+    return a is not b
 
 
 @public
 def with_attribution() -> bool:
-    c = 1
+    c = 'unit'
     d = c
-    return c is d
+    return c is not d

--- a/boa3_test/test_sc/relational_test/TupleIdentity.py
+++ b/boa3_test/test_sc/relational_test/TupleIdentity.py
@@ -1,0 +1,17 @@
+from typing import Tuple
+
+from boa3.builtin import public
+
+
+@public
+def with_attribution() -> bool:
+    a: Tuple[int, int, int] = (1, 2, 3)
+    b = a
+    return a is b
+
+
+@public
+def without_attribution() -> bool:
+    a: Tuple[int, int, int] = (1, 2, 3)
+    b: Tuple[int, int, int] = (1, 2, 3)
+    return a is b

--- a/boa3_test/test_sc/relational_test/TupleNotIdentity.py
+++ b/boa3_test/test_sc/relational_test/TupleNotIdentity.py
@@ -1,0 +1,17 @@
+from typing import Tuple
+
+from boa3.builtin import public
+
+
+@public
+def with_attribution() -> bool:
+    a: Tuple[int, int, int] = (1, 2, 3)
+    b = a
+    return a is not b
+
+
+@public
+def without_attribution() -> bool:
+    a: Tuple[int, int, int] = (1, 2, 3)
+    b: Tuple[int, int, int] = (1, 2, 3)
+    return a is not b

--- a/boa3_test/tests/compiler_tests/test_relational.py
+++ b/boa3_test/tests/compiler_tests/test_relational.py
@@ -151,9 +151,49 @@ class TestRelational(BoaTest):
         result = self.run_smart_contract(engine, path, 'Main', 2, 1)
         self.assertEqual(True, result)
 
-    def test_identity_operation(self):
+    def test_number_identity_operation(self):
         path = self.get_contract_path('NumIdentity.py')
-        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+        engine = TestEngine()
+
+        a = 1
+        b = 1
+        expected_result = a is b
+        result = self.run_smart_contract(engine, path, 'without_attribution_true')
+        self.assertEqual(expected_result, result)
+
+        a = 1
+        b = 2
+        expected_result = a is b
+        result = self.run_smart_contract(engine, path, 'without_attribution_false')
+        self.assertEqual(expected_result, result)
+
+        c = 1
+        d = c
+        expected_result = c is d
+        result = self.run_smart_contract(engine, path, 'with_attribution')
+        self.assertEqual(expected_result, result)
+
+    def test_number_not_identity_operation(self):
+        path = self.get_contract_path('NumNotIdentity.py')
+        engine = TestEngine()
+
+        a = 1
+        b = 2
+        expected_result = a is not b
+        result = self.run_smart_contract(engine, path, 'without_attribution_true')
+        self.assertEqual(expected_result, result)
+
+        a = 1
+        b = 1
+        expected_result = a is not b
+        result = self.run_smart_contract(engine, path, 'without_attribution_false')
+        self.assertEqual(expected_result, result)
+
+        c = 1
+        d = c
+        expected_result = c is not d
+        result = self.run_smart_contract(engine, path, 'with_attribution')
+        self.assertEqual(expected_result, result)
 
     def test_boolean_equality_operation(self):
         expected_output = (
@@ -196,6 +236,50 @@ class TestRelational(BoaTest):
         self.assertEqual(True, result)
         result = self.run_smart_contract(engine, path, 'Main', True, True)
         self.assertEqual(False, result)
+
+    def test_boolean_identity_operation(self):
+        path = self.get_contract_path('BoolIdentity.py')
+        engine = TestEngine()
+
+        a = True
+        b = True
+        expected_result = a is b
+        result = self.run_smart_contract(engine, path, 'without_attribution_true')
+        self.assertEqual(expected_result, result)
+
+        a = True
+        b = False
+        expected_result = a is b
+        result = self.run_smart_contract(engine, path, 'without_attribution_false')
+        self.assertEqual(expected_result, result)
+
+        c = True
+        d = c
+        expected_result = c is d
+        result = self.run_smart_contract(engine, path, 'with_attribution')
+        self.assertEqual(expected_result, result)
+
+    def test_boolean_not_identity_operation(self):
+        path = self.get_contract_path('BoolNotIdentity.py')
+        engine = TestEngine()
+
+        a = True
+        b = False
+        expected_result = a is not b
+        result = self.run_smart_contract(engine, path, 'without_attribution_true')
+        self.assertEqual(expected_result, result)
+
+        a = True
+        b = True
+        expected_result = a is not b
+        result = self.run_smart_contract(engine, path, 'without_attribution_false')
+        self.assertEqual(expected_result, result)
+
+        c = True
+        d = c
+        expected_result = c is not d
+        result = self.run_smart_contract(engine, path, 'with_attribution')
+        self.assertEqual(expected_result, result)
 
     def test_multiple_comparisons(self):
         expected_output = (
@@ -360,6 +444,50 @@ class TestRelational(BoaTest):
         result = self.run_smart_contract(engine, path, 'Main', 'unit', 'test')
         self.assertEqual(False, result)
 
+    def test_string_identity_operation(self):
+        path = self.get_contract_path('StrIdentity.py')
+        engine = TestEngine()
+
+        a = 'unit'
+        b = 'unit'
+        expected_result = a is b
+        result = self.run_smart_contract(engine, path, 'without_attribution_true')
+        self.assertEqual(expected_result, result)
+
+        a = 'unit'
+        b = 'test'
+        expected_result = a is b
+        result = self.run_smart_contract(engine, path, 'without_attribution_false')
+        self.assertEqual(expected_result, result)
+
+        c = 'unit'
+        d = c
+        expected_result = c is d
+        result = self.run_smart_contract(engine, path, 'with_attribution')
+        self.assertEqual(expected_result, result)
+
+    def test_string_not_identity_operation(self):
+        path = self.get_contract_path('StrNotIdentity.py')
+        engine = TestEngine()
+
+        a = 'unit'
+        b = 'test'
+        expected_result = a is not b
+        result = self.run_smart_contract(engine, path, 'without_attribution_true')
+        self.assertEqual(expected_result, result)
+
+        a = 'unit'
+        b = 'unit'
+        expected_result = a is not b
+        result = self.run_smart_contract(engine, path, 'without_attribution_false')
+        self.assertEqual(expected_result, result)
+
+        c = 'unit'
+        d = c
+        expected_result = c is not d
+        result = self.run_smart_contract(engine, path, 'with_attribution')
+        self.assertEqual(expected_result, result)
+
     def test_mixed_equality_operation(self):
         expected_output = (
             Opcode.INITSLOT
@@ -422,6 +550,14 @@ class TestRelational(BoaTest):
         path = self.get_contract_path('MixedGreaterOrEqual.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
+    def test_mixed_identity(self):
+        path = self.get_contract_path('MixedIdentity.py')
+        engine = TestEngine()
+
+        # a mixed identity should always result in False, but will compile
+        result = self.run_smart_contract(engine, path, 'mixed', expected_result_type=bool)
+        self.assertEqual(False, result)
+
     def test_list_equality_with_slice(self):
         path = self.get_contract_path('ListEqualityWithSlice.py')
 
@@ -436,6 +572,38 @@ class TestRelational(BoaTest):
 
         with self.assertRaises(TestExecutionException):
             self.run_smart_contract(engine, path, 'main', [], '')
+
+    def test_list_identity(self):
+        path = self.get_contract_path('ListIdentity.py')
+        engine = TestEngine()
+
+        a = [1, 2, 3]
+        b = a
+        expected_result = a is b
+        result = self.run_smart_contract(engine, path, 'with_attribution', expected_result_type=bool)
+        self.assertEqual(expected_result, result)
+
+        a = [1, 2, 3]
+        b = [1, 2, 3]
+        expected_result = a is b
+        result = self.run_smart_contract(engine, path, 'without_attribution', expected_result_type=bool)
+        self.assertEqual(expected_result, result)
+
+    def test_list_not_identity(self):
+        path = self.get_contract_path('ListNotIdentity.py')
+        engine = TestEngine()
+
+        a = [1, 2, 3]
+        b = a
+        expected_result = a is not b
+        result = self.run_smart_contract(engine, path, 'with_attribution', expected_result_type=bool)
+        self.assertEqual(expected_result, result)
+
+        a = [1, 2, 3]
+        b = [1, 2, 3]
+        expected_result = a is not b
+        result = self.run_smart_contract(engine, path, 'without_attribution', expected_result_type=bool)
+        self.assertEqual(expected_result, result)
 
     def test_compare_same_value_hard_coded(self):
         path = self.get_contract_path('CompareSameValueHardCoded.py')
@@ -494,3 +662,71 @@ class TestRelational(BoaTest):
 
         result = self.run_smart_contract(engine, path, 'main', 7)
         self.assertEqual(False, result)
+
+    def test_none_identity_operation(self):
+        path = self.get_contract_path('NoneIdentity.py')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'main', 1)
+        self.assertEqual(False, result)
+
+        result = self.run_smart_contract(engine, path, 'main', True)
+        self.assertEqual(False, result)
+
+        result = self.run_smart_contract(engine, path, 'main', 'string')
+        self.assertEqual(False, result)
+
+        result = self.run_smart_contract(engine, path, 'main', b'bytes')
+        self.assertEqual(False, result)
+
+        result = self.run_smart_contract(engine, path, 'main', None)
+        self.assertEqual(True, result)
+
+    def test_none_not_identity_operation(self):
+        path = self.get_contract_path('NoneNotIdentity.py')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'main', 1)
+        self.assertEqual(True, result)
+
+        result = self.run_smart_contract(engine, path, 'main', True)
+        self.assertEqual(True, result)
+
+        result = self.run_smart_contract(engine, path, 'main', 'string')
+        self.assertEqual(True, result)
+
+        result = self.run_smart_contract(engine, path, 'main', b'bytes')
+        self.assertEqual(True, result)
+
+        result = self.run_smart_contract(engine, path, 'main', None)
+        self.assertEqual(False, result)
+
+    def test_tuple_identity(self):
+        path = self.get_contract_path('TupleIdentity.py')
+        engine = TestEngine()
+
+        a = (1, 2, 3)
+        b = a
+        expected_result = a is b
+        result = self.run_smart_contract(engine, path, 'with_attribution', expected_result_type=bool)
+        self.assertEqual(expected_result, result)
+
+        # Python will try conserve memory and will make a and b reference the same position, since Tuples are immutable
+        # this will deviate from Neo's expected behaviour
+        result = self.run_smart_contract(engine, path, 'without_attribution', expected_result_type=bool)
+        self.assertEqual(False, result)
+
+    def test_tuple_not_identity(self):
+        path = self.get_contract_path('TupleNotIdentity.py')
+        engine = TestEngine()
+
+        a = (1, 2, 3)
+        b = a
+        expected_result = a is not b
+        result = self.run_smart_contract(engine, path, 'with_attribution', expected_result_type=bool)
+        self.assertEqual(expected_result, result)
+
+        # Python will try conserve memory and will make a and b reference the same position, since Tuples are immutable
+        # this will deviate from Neo's expected behaviour
+        result = self.run_smart_contract(engine, path, 'without_attribution', expected_result_type=bool)
+        self.assertEqual(True, result)


### PR DESCRIPTION
**Related issue**
#388 

**Summary or solution description**
Added support to `is` and `is not` keywords.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/d0e8d4a7b28d884d5ea6829b0f5fd26b96123b07/boa3_test/test_sc/relational_test/ListIdentity.py#L1-L17
https://github.com/CityOfZion/neo3-boa/blob/d0e8d4a7b28d884d5ea6829b0f5fd26b96123b07/boa3_test/test_sc/relational_test/ListNotIdentity.py#L1-L17

**Tests**
Tested them at boa3_test/tests/compiler_tests/[test_relational.py](https://github.com/CityOfZion/neo3-boa/blob/d0e8d4a7b28d884d5ea6829b0f5fd26b96123b07/boa3_test/tests/compiler_tests/test_relational.py).

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8
