### PR TITLE
Include variable to Block class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
 
             git clone https://github.com/simplitech/neo-devpack-dotnet.git -b test-engine-executable --single-branch
             cd ./neo-devpack-dotnet
-            git checkout 8b662eef3b53854dabb0001f6c741f0ece30d309
+            git checkout 0033226de2888759bdce149cfefca23b42639a59
             cd ..
             dotnet build ./neo-devpack-dotnet/src/Neo.TestEngine/Neo.TestEngine.csproj -o ./Neo.TestEngine
             python -m unittest discover boa3_test

--- a/boa3/builtin/interop/blockchain/block.py
+++ b/boa3/builtin/interop/blockchain/block.py
@@ -15,6 +15,8 @@ class Block:
     :vartype merkle_root: UInt256
     :ivar timestamp: UTC timestamp of the block in milliseconds
     :vartype timestamp: int
+    :ivar nonce: a random number used once in the cryptography
+    :vartype nonce: int
     :ivar index: the index of the block
     :vartype index: int
     :ivar primary_index: the primary index of the consensus node that generated this block
@@ -31,6 +33,7 @@ class Block:
         self.previous_hash: UInt256 = UInt256()
         self.merkle_root: UInt256 = UInt256()
         self.timestamp: int = 0
+        self.nonce: int = 0
         self.index: int = 0
         self.primary_index: int = 0
         self.next_consensus: UInt160 = UInt160()

--- a/boa3/model/builtin/interop/blockchain/blocktype.py
+++ b/boa3/model/builtin/interop/blockchain/blocktype.py
@@ -30,6 +30,7 @@ class BlockType(ClassArrayType):
             'previous_hash': Variable(uint256),
             'merkle_root': Variable(uint256),
             'timestamp': Variable(Type.int),
+            'nonce': Variable(Type.int),
             'index': Variable(Type.int),
             'primary_index': Variable(Type.int),
             'next_consensus': Variable(UInt160Type.build()),
@@ -94,12 +95,13 @@ class BlockMethod(IBuiltinMethod):
             (Opcode.PUSHDATA1, uint160_default),  # next_consensus
             (Opcode.PUSH0, b''),  # primary_index
             (Opcode.PUSH0, b''),  # index
+            (Opcode.PUSH0, b''),  # nonce
             (Opcode.PUSH0, b''),  # timestamp
             (Opcode.PUSHDATA1, uint256_default),  # merkle_root
             (Opcode.PUSHDATA1, uint256_default),  # previous_hash
             (Opcode.PUSH0, b''),  # version
             (Opcode.PUSHDATA1, uint256_default),  # hash
-            (Opcode.PUSH9, b''),
+            (Opcode.PUSH10, b''),
             (Opcode.PACK, b'')
         ]
 

--- a/boa3_test/test_sc/interop_test/blockchain/Block.py
+++ b/boa3_test/test_sc/interop_test/blockchain/Block.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.interop.blockchain import Block
+
+
+@public
+def main() -> Block:
+    return Block()

--- a/boa3_test/tests/compiler_tests/test_interop/test_blockchain.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_blockchain.py
@@ -17,6 +17,27 @@ class TestBlockchainInterop(BoaTest):
 
     default_folder: str = 'test_sc/interop_test/blockchain'
 
+    def test_block_constructor(self):
+        path = self.get_contract_path('Block.py')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'main')
+        self.assertIsInstance(result, list)
+        self.assertEqual(10, len(result))
+        for k in range(len(result)):
+            if isinstance(result[k], str):
+                result[k] = String(result[k]).to_bytes()
+        self.assertEqual(UInt256(), UInt256(result[0]))   # hash
+        self.assertEqual(0, result[1])   # version
+        self.assertEqual(UInt256(), UInt256(result[2]))   # previous_hash
+        self.assertEqual(UInt256(), UInt256(result[3]))   # merkle_root
+        self.assertEqual(0, result[4])   # timestamp
+        self.assertEqual(0, result[5])   # nonce
+        self.assertEqual(0, result[6])   # index
+        self.assertEqual(0, result[7])   # primary_index
+        self.assertEqual(UInt160(), UInt160(result[8]))   # next_consensus
+        self.assertEqual(0, result[9])   # transaction_count
+
     def test_get_current_height(self):
         expected_output = (
             Opcode.SYSCALL
@@ -72,8 +93,8 @@ class TestBlockchainInterop(BoaTest):
         index = 0
         result = self.run_smart_contract(engine, path, 'Main', index)
         self.assertIsInstance(result, list)
-        self.assertEqual(9, len(result))
-        self.assertEqual(index, result[5])
+        self.assertEqual(10, len(result))
+        self.assertEqual(index, result[6])
 
         index = 10
         result = self.run_smart_contract(engine, path, 'Main', index)
@@ -82,8 +103,8 @@ class TestBlockchainInterop(BoaTest):
         engine.increase_block(10)
         result = self.run_smart_contract(engine, path, 'Main', index)
         self.assertIsInstance(result, list)
-        self.assertEqual(9, len(result))
-        self.assertEqual(index, result[5])
+        self.assertEqual(10, len(result))
+        self.assertEqual(index, result[6])
 
     def test_get_block_by_hash(self):
         path = self.get_contract_path('GetBlockByHash.py')
@@ -96,13 +117,13 @@ class TestBlockchainInterop(BoaTest):
 
         from boa3.neo import from_hex_str
         # TODO: using genesis block hash for testing, change when TestEngine returns blocks hashes
-        block_hash = from_hex_str('0xc3db4ba50ede4f9e749bd97e1499953ae17e65a415c6bf9e38c01cf92b03d156')
+        block_hash = from_hex_str('0x1f4d1defa46faa5e7b9b8d3f79a06bec777d7c26c4aa5f6f5899a291daa87c15')
 
         result = self.run_smart_contract(engine, path, 'Main', block_hash)
         self.assertIsInstance(result, list)
-        self.assertEqual(9, len(result))
+        self.assertEqual(10, len(result))
         self.assertEqual(block_hash, result[0])
-        self.assertEqual(0, result[5])  # genesis block's index is zero
+        self.assertEqual(0, result[6])  # genesis block's index is zero
 
     def test_get_block_mismatched_types(self):
         path = self.get_contract_path('GetBlockMismatchedTypes.py')


### PR DESCRIPTION
**Related issue**
#547 

**Summary or solution description**
Included `nonce` to the Block class.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/8839208ac3ee09d7f02bc84a8fd645abaa257b89/boa3_test/test_sc/interop_test/blockchain/Block.py#L1-L7

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/8839208ac3ee09d7f02bc84a8fd645abaa257b89/boa3_test/tests/compiler_tests/test_interop/test_blockchain.py#L20-L39

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8

**(Optional) Additional context**
Also changed the commit targeted for the checkout.
