### PR TITLE
Implement OracleRequestCode enum

### DIFF
--- a/boa3/builtin/interop/__init__.py
+++ b/boa3/builtin/interop/__init__.py
@@ -1,5 +1,3 @@
-from typing import Any, Union
-
 # for package imports in the smart contract
 import boa3.builtin.interop.binary
 import boa3.builtin.interop.blockchain
@@ -7,57 +5,6 @@ import boa3.builtin.interop.contract
 import boa3.builtin.interop.crypto
 import boa3.builtin.interop.iterator
 import boa3.builtin.interop.json
+import boa3.builtin.interop.oracle
 import boa3.builtin.interop.runtime
 import boa3.builtin.interop.storage
-
-
-class Oracle:
-    """
-    Neo Oracle Service is an out-of-chain data access service built into Neo N3. It allows users to request the external
-    data sources in smart contracts, and Oracle nodes designated by the committee will access the specified data source
-    then pass the result in the callback function to continue executing the smart contract logic.
-    """
-
-    @classmethod
-    def request(cls, url: str, request_filter: Union[str, None], callback: str, user_data: Any, gas_for_response: int):
-        """
-        Requests an information from outside the blockchain.
-
-        This method just requests data from the oracle, it won't return the result.
-
-        :param url: External url to retrieve the data
-        :type url: str
-        :param request_filter:
-            Filter to the request.
-
-            See JSONPath format https://github.com/atifaziz/JSONPath
-
-        :type request_filter: str or None
-        :param callback:
-            Method name that will be as a callback.
-
-            This method must be public and implement the following interface:
-
-            ``(url: str, user_data: Any, code: int, result: bytes) -> None``
-
-        :type callback: str
-        :param user_data: Optional data. It'll be returned as the same when the callback is called
-        :type user_data: Any
-        :param gas_for_response:
-            Amount of GAS needed to run the callback method.
-
-            It MUST NOT be specified as the user representation.
-
-            If it costs 1 gas, this value must be 1_00000000 (with the 8 decimals)
-        :type gas_for_response: int
-        """
-        pass
-
-    @classmethod
-    def get_price(cls) -> int:
-        """
-        Gets the price for an Oracle request.
-
-        :return: the price for an Oracle request
-        """
-        pass

--- a/boa3/builtin/interop/oracle/__init__.py
+++ b/boa3/builtin/interop/oracle/__init__.py
@@ -1,0 +1,55 @@
+from typing import Any, Union
+
+from boa3.builtin.interop.oracle.oracleresponsecode import OracleResponseCode
+
+
+class Oracle:
+    """
+    Neo Oracle Service is an out-of-chain data access service built into Neo N3. It allows users to request the external
+    data sources in smart contracts, and Oracle nodes designated by the committee will access the specified data source
+    then pass the result in the callback function to continue executing the smart contract logic.
+    """
+
+    @classmethod
+    def request(cls, url: str, request_filter: Union[str, None], callback: str, user_data: Any, gas_for_response: int):
+        """
+        Requests an information from outside the blockchain.
+
+        This method just requests data from the oracle, it won't return the result.
+
+        :param url: External url to retrieve the data
+        :type url: str
+        :param request_filter:
+            Filter to the request.
+
+            See JSONPath format https://github.com/atifaziz/JSONPath
+
+        :type request_filter: str or None
+        :param callback:
+            Method name that will be as a callback.
+
+            This method must be public and implement the following interface:
+
+            ``(url: str, user_data: Any, code: int, result: bytes) -> None``
+
+        :type callback: str
+        :param user_data: Optional data. It'll be returned as the same when the callback is called
+        :type user_data: Any
+        :param gas_for_response:
+            Amount of GAS needed to run the callback method.
+
+            It MUST NOT be specified as the user representation.
+
+            If it costs 1 gas, this value must be 1_00000000 (with the 8 decimals)
+        :type gas_for_response: int
+        """
+        pass
+
+    @classmethod
+    def get_price(cls) -> int:
+        """
+        Gets the price for an Oracle request.
+
+        :return: the price for an Oracle request
+        """
+        pass

--- a/boa3/builtin/interop/oracle/oracleresponsecode.py
+++ b/boa3/builtin/interop/oracle/oracleresponsecode.py
@@ -1,0 +1,3 @@
+from boa3.neo3.network.payloads import OracleResponseCode
+
+__all__ = ['OracleResponseCode']

--- a/boa3/model/builtin/interop/interop.py
+++ b/boa3/model/builtin/interop/interop.py
@@ -1,7 +1,6 @@
 from enum import Enum
 from typing import Dict, List
 
-from boa3.model.builtin.interop import *
 from boa3.model.builtin.interop.binary import *
 from boa3.model.builtin.interop.blockchain import *
 from boa3.model.builtin.interop.contract import *
@@ -10,6 +9,7 @@ from boa3.model.builtin.interop.crypto import *
 from boa3.model.builtin.interop.iterator import *
 from boa3.model.builtin.interop.json import *
 from boa3.model.builtin.interop.nativecontract import *
+from boa3.model.builtin.interop.oracle import *
 from boa3.model.builtin.interop.policy import *
 from boa3.model.builtin.interop.role import *
 from boa3.model.builtin.interop.runtime import *
@@ -25,6 +25,7 @@ class InteropPackage(str, Enum):
     Crypto = 'crypto'
     Iterator = 'iterator'
     Json = 'json'
+    Oracle = 'oracle'
     Policy = 'policy'
     Role = 'role'
     Runtime = 'runtime'
@@ -53,6 +54,7 @@ class Interop:
     FindOptionsType = FindOptionsType()
     Iterator = IteratorType.build()
     NotificationType = NotificationType.build()
+    OracleResponseCode = OracleResponseCodeType.build()
     OracleType = OracleType.build()
     RoleType = RoleType.build()
     StorageContextType = StorageContextType.build()
@@ -267,6 +269,23 @@ class Interop:
                                  types=[NotificationType]
                                  )
 
+    OracleResponseCodeModule = Package(identifier=OracleResponseCode.identifier.lower(),
+                                       types=[OracleResponseCode]
+                                       )
+
+    OracleModule = Package(identifier=OracleType.identifier.lower(),
+                           types=[OracleType]
+                           )
+
+    OraclePackage = Package(identifier=InteropPackage.Oracle,
+                            types=[OracleResponseCode,
+                                   OracleType
+                                   ],
+                            packages=[OracleModule,
+                                      OracleResponseCodeModule
+                                      ]
+                            )
+
     TriggerTypeModule = Package(identifier=TriggerType.identifier.lower(),
                                 types=[TriggerType]
                                 )
@@ -342,13 +361,13 @@ class Interop:
     # endregion
 
     package_symbols: List[IdentifiedSymbol] = [
-        OracleType,
         BinaryPackage,
         BlockchainPackage,
         ContractPackage,
         CryptoPackage,
         IteratorPackage,
         JsonPackage,
+        OraclePackage,
         PolicyPackage,
         RolePackage,
         RuntimePackage,

--- a/boa3/model/builtin/interop/oracle/__init__.py
+++ b/boa3/model/builtin/interop/oracle/__init__.py
@@ -1,2 +1,7 @@
-from .oraclerequesmethod import OracleRequesMethod
-from .oracletype import OracleType
+__all__ = ['OracleResponseCodeType',
+           'OracleType',
+           ]
+
+
+from boa3.model.builtin.interop.oracle.oracleresponsecodetype import OracleResponseCodeType
+from boa3.model.builtin.interop.oracle.oracletype import OracleType

--- a/boa3/model/builtin/interop/oracle/oraclerequestmethod.py
+++ b/boa3/model/builtin/interop/oracle/oraclerequestmethod.py
@@ -4,7 +4,7 @@ from boa3.model.builtin.interop.nativecontract import OracleMethod
 from boa3.model.variable import Variable
 
 
-class OracleRequesMethod(OracleMethod):
+class OracleRequestMethod(OracleMethod):
 
     def __init__(self):
         from boa3.model.type.type import Type

--- a/boa3/model/builtin/interop/oracle/oracleresponsecodetype.py
+++ b/boa3/model/builtin/interop/oracle/oracleresponsecodetype.py
@@ -1,0 +1,52 @@
+from typing import Any, Dict
+
+from boa3.model.symbol import ISymbol
+from boa3.model.type.itype import IType
+from boa3.model.type.primitive.inttype import IntType
+
+
+class OracleResponseCodeType(IntType):
+    """
+    A class used to represent Neo's OracleResponseCode.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._identifier = 'OracleResponseCode'
+
+    @classmethod
+    def build(cls, value: Any = None) -> IType:
+        if value is None or cls._is_type_of(value):
+            return _OracleResponseCode
+
+    @classmethod
+    def _is_type_of(cls, value: Any):
+        from boa3.builtin.interop.oracle.oracleresponsecode import OracleResponseCode
+        return isinstance(value, (OracleResponseCode, OracleResponseCodeType))
+
+    @property
+    def symbols(self) -> Dict[str, ISymbol]:
+        """
+        Gets the class symbols of this type.
+
+        :return: a dictionary that maps each symbol in the module with its name
+        """
+        from boa3.builtin.interop.role.roletype import Role
+        from boa3.model.variable import Variable
+
+        return {name: Variable(self) for name in Role.__members__.keys()}
+
+    def get_value(self, symbol_id) -> Any:
+        """
+        Gets the literal value of a symbol.
+
+        :return: the value if this type has this symbol. None otherwise
+        """
+        if symbol_id in self.symbols:
+            from boa3.builtin.interop.oracle.oracleresponsecode import OracleResponseCode
+            return OracleResponseCode.__members__[symbol_id]
+
+        return None
+
+
+_OracleResponseCode = OracleResponseCodeType()

--- a/boa3/model/builtin/interop/oracle/oracletype.py
+++ b/boa3/model/builtin/interop/oracle/oracletype.py
@@ -32,12 +32,12 @@ class OracleType(ClassArrayType):
     def class_methods(self) -> Dict[str, Method]:
         # avoid recursive import
         from boa3.model.builtin.interop.oracle.oraclegetpricemethod import OracleGetPriceMethod
-        from boa3.model.builtin.interop.oracle.oraclerequesmethod import OracleRequesMethod
+        from boa3.model.builtin.interop.oracle.oraclerequestmethod import OracleRequestMethod
 
         if len(self._class_methods) == 0:
             self._class_methods = {
                 'get_price': OracleGetPriceMethod(),
-                'request': OracleRequesMethod()
+                'request': OracleRequestMethod()
             }
         return self._class_methods
 

--- a/boa3/neo3/network/payloads/__init__.py
+++ b/boa3/neo3/network/payloads/__init__.py
@@ -1,0 +1,3 @@
+from boa3.neo3.network.payloads.oracleresponsecode import OracleResponseCode
+
+__all__ = ['OracleResponseCode']

--- a/boa3/neo3/network/payloads/oracleresponsecode.py
+++ b/boa3/neo3/network/payloads/oracleresponsecode.py
@@ -1,0 +1,77 @@
+from enum import IntFlag
+
+
+class OracleResponseCode(IntFlag):
+    """
+    Represents the response code for the oracle request.
+    """
+
+    SUCCESS = 0x00
+    """
+    Indicates that the request has been successfully completed.
+
+    :meta hide-value:
+    """
+
+    PROTOCOL_NOT_SUPPORTED = 0x10
+    """
+    Indicates that the protocol of the request is not supported.
+    
+    :meta hide-value:
+    """
+
+    CONSENSUS_UNREACHABLE = 0x12
+    """
+    Indicates that the oracle nodes cannot reach a consensus on the result of the request.
+    
+    :meta hide-value:
+    """
+
+    NOT_FOUND = 0x14
+    """
+    Indicates that the requested Uri does not exist.
+    
+    :meta hide-value:
+    """
+
+    TIME_OUT = 0x16
+    """
+    Indicates that the request was not completed within the specified time.
+
+    :meta hide-value:
+    """
+
+    FORBIDDEN = 0x18
+    """
+    Indicates that there is no permission to request the resource.
+
+    :meta hide-value:
+    """
+
+    RESPONSE_TOO_LARGE = 0x1A
+    """
+    Indicates that the data for the response is too large.
+
+    :meta hide-value:
+    """
+
+    INSUFFICIENT_FUNDS = 0x1C
+    """
+    Indicates that the request failed due to insufficient balance.
+
+    :meta hide-value:
+    """
+
+    CONTENT_TYPE_NOT_SUPPORTED = 0x1F
+    """
+    Indicates that the content-type of the request is not supported.
+    
+    :meta hide-value:
+    """
+
+    ERROR = 0xFF
+    """
+    Indicates that the request failed due to other errors.
+
+    :meta hide-value:
+    """

--- a/boa3_test/test_sc/interop_test/oracle/ImportInteropOracle.py
+++ b/boa3_test/test_sc/interop_test/oracle/ImportInteropOracle.py
@@ -5,9 +5,9 @@ from boa3.builtin import interop, public
 
 @public
 def oracle_call(url: str, request_filter: Union[str, None], callback: str, user_data: Any, gas_for_response: int):
-    interop.Oracle.request(url, request_filter, callback, user_data, gas_for_response)
+    interop.oracle.Oracle.request(url, request_filter, callback, user_data, gas_for_response)
 
 
 @public
-def test_callback(requested_url: str, user_data: Any, code: int, request_result: bytes):
+def test_callback(requested_url: str, user_data: Any, code: int, request_result: interop.oracle.OracleResponseCode):
     return

--- a/boa3_test/test_sc/interop_test/oracle/OracleGetPrice.py
+++ b/boa3_test/test_sc/interop_test/oracle/OracleGetPrice.py
@@ -1,5 +1,5 @@
 from boa3.builtin import public
-from boa3.builtin.interop import Oracle
+from boa3.builtin.interop.oracle import Oracle
 
 
 @public

--- a/boa3_test/test_sc/interop_test/oracle/OracleRequestCall.py
+++ b/boa3_test/test_sc/interop_test/oracle/OracleRequestCall.py
@@ -1,7 +1,7 @@
 from typing import Any, Union
 
 from boa3.builtin import public
-from boa3.builtin.interop import Oracle
+from boa3.builtin.interop.oracle import Oracle, OracleResponseCode
 
 
 @public
@@ -10,5 +10,5 @@ def oracle_call(url: str, request_filter: Union[str, None], callback: str, user_
 
 
 @public
-def test_callback(requested_url: str, user_data: Any, code: int, request_result: bytes):
+def test_callback(requested_url: str, user_data: Any, code: int, request_result: OracleResponseCode):
     return

--- a/boa3_test/test_sc/interop_test/oracle/OracleRequestCallCallbackMismatchedType.py
+++ b/boa3_test/test_sc/interop_test/oracle/OracleRequestCallCallbackMismatchedType.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from boa3.builtin import public
-from boa3.builtin.interop import Oracle
+from boa3.builtin.interop.oracle import Oracle
 
 
 @public

--- a/boa3_test/test_sc/interop_test/oracle/OracleRequestFilterMismatchedType.py
+++ b/boa3_test/test_sc/interop_test/oracle/OracleRequestFilterMismatchedType.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from boa3.builtin import public
-from boa3.builtin.interop import Oracle
+from boa3.builtin.interop.oracle import Oracle
 
 
 @public

--- a/boa3_test/test_sc/interop_test/oracle/OracleRequestGasMismatchedType.py
+++ b/boa3_test/test_sc/interop_test/oracle/OracleRequestGasMismatchedType.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from boa3.builtin import public
-from boa3.builtin.interop import Oracle
+from boa3.builtin.interop.oracle import Oracle
 
 
 @public

--- a/boa3_test/test_sc/interop_test/oracle/OracleRequestUrlMismatchedType.py
+++ b/boa3_test/test_sc/interop_test/oracle/OracleRequestUrlMismatchedType.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from boa3.builtin import public
-from boa3.builtin.interop import Oracle
+from boa3.builtin.interop.oracle import Oracle
 
 
 @public

--- a/boa3_test/tests/compiler_tests/test_interop/test_oracle.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_oracle.py
@@ -11,7 +11,7 @@ from boa3_test.tests.test_classes.transactionattribute.oracleresponse import Ora
 
 
 class TestNativeContracts(BoaTest):
-    default_folder: str = 'test_sc/interop_test/native_contracts'
+    default_folder: str = 'test_sc/interop_test/oracle'
 
     def test_oracle_request(self):
         path = self.get_contract_path('OracleRequestCall.py')


### PR DESCRIPTION
**Related issue**
#543 

**How to Reproduce**
Import OracleResponseCode from boa3.builtin.interop.oracle.

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8

**(Optional) Additional context**
Also added a new folder called `oracle`, because they reference a NativeContract
