### PR TITLE
Extend metadata to enable supportedStandards as a default field

### DIFF
--- a/boa3/analyser/analyser.py
+++ b/boa3/analyser/analyser.py
@@ -8,6 +8,7 @@ from boa3.analyser.astanalyser import IAstAnalyser
 from boa3.analyser.astoptimizer import AstOptimizer
 from boa3.analyser.constructanalyser import ConstructAnalyser
 from boa3.analyser.moduleanalyser import ModuleAnalyser
+from boa3.analyser.supportedstandard.standardanalyser import StandardAnalyser
 from boa3.analyser.typeanalyser import TypeAnalyser
 from boa3.builtin import NeoMetadata
 from boa3.exception.CompilerError import CompilerError
@@ -60,6 +61,9 @@ class Analyser:
         # fill symbol table
         if not analyser.__analyse_modules(analysed_files):
             return analyser
+        # check if standards are correctly implemented
+        if not analyser.__check_standards():
+            return analyser
         # check is the types are correct
         if not analyser.__check_types():
             return analyser
@@ -107,6 +111,16 @@ class Analyser:
         self.ast_tree.body.extend(module_analyser.imported_nodes)
         self.__update_logs(module_analyser)
         return not module_analyser.has_errors
+
+    def __check_standards(self) -> bool:
+        """
+        Verify if the standards included in the metadata are fully implemented
+
+        :return: a boolean value that represents if the analysis was successful
+        """
+        standards_analyser = StandardAnalyser(self, self.symbol_table, log=self._log)
+        self.__update_logs(standards_analyser)
+        return not standards_analyser.has_errors
 
     def __update_logs(self, analyser: IAstAnalyser):
         self._errors.extend(analyser.errors)

--- a/boa3/analyser/supportedstandard/__init__.py
+++ b/boa3/analyser/supportedstandard/__init__.py
@@ -1,0 +1,8 @@
+"""
+Use Upper Kebab Case to name the standards in this dictionary
+"""
+from boa3.model.standards.nep17standard import Nep17Standard
+
+neo_standards = {
+    'NEP-17': Nep17Standard()
+}

--- a/boa3/analyser/supportedstandard/standardanalyser.py
+++ b/boa3/analyser/supportedstandard/standardanalyser.py
@@ -1,0 +1,84 @@
+import re
+from typing import Dict, List
+
+from boa3.analyser import supportedstandard
+from boa3.analyser.astanalyser import IAstAnalyser
+from boa3.exception import CompilerError
+from boa3.model.event import Event
+from boa3.model.method import Method
+from boa3.model.symbol import ISymbol
+
+
+class StandardAnalyser(IAstAnalyser):
+    """
+    This class is responsible for the checking if the given contract standards are implemented
+
+    :ivar symbols: a dictionary that maps the global symbols.
+    """
+
+    def __init__(self, analyser, symbol_table: Dict[str, ISymbol], log: bool = False):
+        from boa3.builtin import NeoMetadata
+
+        super().__init__(analyser.ast_tree, log=log)
+
+        self.symbols: Dict[str, ISymbol] = symbol_table
+
+        if isinstance(analyser.metadata, NeoMetadata):
+            # filter only strings
+            analyser.metadata.supported_standards = [standard for standard in analyser.metadata.supported_standards
+                                                     if isinstance(standard, str)]
+            standards = analyser.metadata.supported_standards
+        else:
+            standards = []
+
+        self.standards: List[str] = standards
+        self._filter_standards_names()
+        self._validate_standards()
+
+    def _filter_standards_names(self):
+        """
+        Converts all the standards names to upper kebab case
+        """
+        filtered_standards = set()
+        for standard in self.standards:
+            rebab_case = re.sub(r'([a-z]+|[A-Z]+[a-z]*|\d+)[^a-zA-Z\d]?', r'\g<1>-', standard)
+            if rebab_case.endswith('-'):
+                rebab_case = rebab_case[:-1]
+            rebab_case = rebab_case.upper()
+            filtered_standards.add(rebab_case)
+
+        self.standards.clear()
+        self.standards.extend(filtered_standards)
+
+    def _validate_standards(self):
+        for standard in self.standards:
+            if standard in supportedstandard.neo_standards:
+                current_standard = supportedstandard.neo_standards[standard]
+
+                # validade standard's methods
+                for method_id, standard_method in current_standard.methods.items():
+                    if (method_id not in self.symbols or 
+                            not isinstance(self.symbols[method_id], Method) or 
+                            not current_standard.match_definition(method_id, self.symbols[method_id])):
+                        self._log_error(
+                            CompilerError.MissingStandardDefinition(standard, method_id, standard_method)
+                        )
+
+                # validade standard's events
+                events = [symbol for symbol in self.symbols.values() if isinstance(symbol, Event)]
+                for standard_event in current_standard.events.values():
+                    events_with_same_name = [event for event in events if event.name == standard_event.name]
+                    if (len(events_with_same_name) == 0 or
+                            all(not current_standard.match_definition(event.name, event)
+                                for event in events_with_same_name
+                                )):
+
+                        self._log_error(
+                            CompilerError.MissingStandardDefinition(standard,
+                                                                    standard_event.name,
+                                                                    standard_event)
+                        )
+
+    def _check_other_implemented_standards(self):
+        # TODO: Implement when detecting standards from implemented methods and events
+        pass

--- a/boa3/builtin/__init__.py
+++ b/boa3/builtin/__init__.py
@@ -32,6 +32,20 @@ def to_script_hash(data_bytes: Any) -> bytes:
     pass
 
 
+def sqrt(x: int) -> int:
+    """
+    Gets the square root of a number.
+
+    :param x: a non-negative number
+    :type x: int
+    :return: the square root of a number
+    :rtype: int
+
+    :raise Exception: raised when number is negative.
+    """
+    pass
+
+
 def Event(*args, **kwargs):
     """
     Describes an action that happened in the blockchain.
@@ -68,6 +82,8 @@ class NeoMetadata:
     def __init__(self):
         from typing import Optional
 
+        self.supported_standards: List[str] = []
+
         # extras
         self.author: Optional[str] = None
         self.email: Optional[str] = None
@@ -89,17 +105,3 @@ class NeoMetadata:
         if isinstance(self.description, str):
             extra['Description'] = self.description
         return extra
-
-
-def sqrt(x: int) -> int:
-    """
-    Gets the square root of a number.
-
-    :param x: a non-negative number
-    :type x: int
-    :return: the square root of a number
-    :rtype: int
-
-    :raise Exception: raised when number is negative.
-    """
-    pass

--- a/boa3/builtin/interop/contract/__init__.py
+++ b/boa3/builtin/interop/contract/__init__.py
@@ -1,4 +1,4 @@
-from typing import Any, Sequence, List
+from typing import Any, List, Sequence
 
 from boa3.builtin.interop.contract.callflagstype import CallFlags
 from boa3.builtin.interop.contract.contract import Contract

--- a/boa3/builtin/interop/oracle/__init__.py
+++ b/boa3/builtin/interop/oracle/__init__.py
@@ -1,7 +1,5 @@
 from typing import Any, Union
 
-from boa3.builtin.interop.oracle.oracleresponsecode import OracleResponseCode
-
 
 class Oracle:
     """

--- a/boa3/compiler/filegenerator.py
+++ b/boa3/compiler/filegenerator.py
@@ -159,7 +159,7 @@ class FileGenerator:
             ],
             "trusts": [],
             "features": [],
-            "supportedstandards": [],
+            "supportedstandards": self._metadata.supported_standards,
             "extra": self._metadata.extra if len(self._metadata.extra) > 0 else None
         }
 

--- a/boa3/exception/CompilerError.py
+++ b/boa3/exception/CompilerError.py
@@ -2,6 +2,8 @@ from abc import ABC
 from typing import Iterable, Optional, Union
 
 from boa3.model.builtin.internal.internalmethod import IInternalMethod
+from boa3.model.event import Event
+from boa3.model.method import Method
 
 
 class CompilerError(ABC, BaseException):
@@ -159,7 +161,8 @@ class MetadataInformationMissing(CompilerError):
 
     @property
     def _error_message(self) -> Optional[str]:
-        return "'{0}' requires '{1}' attribute, which is missing in the metadata".format(self.symbol_id, self.metadata_attr_id)
+        return "'{0}' requires '{1}' attribute, which is missing in the metadata".format(self.symbol_id,
+                                                                                         self.metadata_attr_id)
 
 
 class MismatchedTypes(CompilerError):
@@ -167,7 +170,8 @@ class MismatchedTypes(CompilerError):
     An error raised when the evaluated and expected types are not the same
     """
 
-    def __init__(self, line: int, col: int, expected_type_id: Union[str, Iterable[str]], actual_type_id: Union[str, Iterable[str]]):
+    def __init__(self, line: int, col: int, expected_type_id: Union[str, Iterable[str]],
+                 actual_type_id: Union[str, Iterable[str]]):
         if isinstance(expected_type_id, str):
             expected_type_id = [expected_type_id]
         if isinstance(actual_type_id, str):
@@ -196,6 +200,29 @@ class MissingReturnStatement(CompilerError):
     @property
     def _error_message(self) -> Optional[str]:
         return "'%s': Missing return statement" % self.symbol_id
+
+
+class MissingStandardDefinition(CompilerError):
+    """
+    An error raised when a contract standard is defined in the metadata and are required symbols missing
+    """
+
+    def __init__(self, standard_id: str, symbol_id: str, symbol: Union[Method, Event]):
+        self.standard = standard_id
+        self.symbol_id = symbol_id
+        self.symbol = symbol
+        super().__init__(0, 0)
+
+    @property
+    def _error_message(self) -> Optional[str]:
+        return "'{0}': Missing '{1}' {2} definition '{3}'".format(self.standard,
+                                                                  self.symbol_id,
+                                                                  self.symbol.shadowing_name,
+                                                                  self.symbol)
+
+    @property
+    def message(self) -> str:
+        return self._error_message
 
 
 class NotSupportedOperation(CompilerError):
@@ -270,7 +297,8 @@ class UnresolvedOperation(CompilerError):
 
     @property
     def _error_message(self) -> Optional[str]:
-        return "Unresolved reference: '%s' does not have a definition of '%s' operator" % (self.type_id, self.operation_id)
+        return "Unresolved reference: '{0}' does not have a definition of '{1}' operator".format(self.type_id,
+                                                                                                 self.operation_id)
 
 
 class TooManyReturns(CompilerError):

--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -139,6 +139,7 @@ class Builtin:
                                             ]
 
     metadata_fields: Dict[str, Union[type, Tuple[type]]] = {
+        'supported_standards': list,
         'author': (str, type(None)),
         'email': (str, type(None)),
         'description': (str, type(None)),

--- a/boa3/model/callable.py
+++ b/boa3/model/callable.py
@@ -115,3 +115,12 @@ class Callable(IExpression, ABC):
         else:
             from boa3.compiler.codegenerator.vmcodemapping import VMCodeMapping
             return VMCodeMapping.instance().get_end_address(self.end_bytecode)
+
+    def __str__(self) -> str:
+        args_types: List[str] = [str(arg.type) for arg in self.args.values()]
+        if self.return_type is not Type.none:
+            signature = '({0}) -> {1}'.format(', '.join(args_types), self.return_type)
+        else:
+            signature = '({0})'.format(', '.join(args_types))
+        public = 'public ' if self.is_public else ''
+        return '{0}{1}'.format(public, signature)

--- a/boa3/model/method.py
+++ b/boa3/model/method.py
@@ -50,15 +50,6 @@ class Method(Callable):
             else:
                 self.locals[var_id] = var
 
-    def __str__(self) -> str:
-        args_types: List[str] = [str(arg.type) for arg in self.args.values()]
-        if self.return_type is not Type.none:
-            signature = '({0}) -> {1}'.format(', '.join(args_types), self.return_type)
-        else:
-            signature = '({0})'.format(', '.join(args_types))
-        public = 'public ' if self.is_public else ''
-        return '{0}{1}'.format(public, signature)
-
     @property
     def symbols(self) -> Dict[str, Variable]:
         """

--- a/boa3/model/standards/neostandard.py
+++ b/boa3/model/standards/neostandard.py
@@ -1,0 +1,44 @@
+import abc
+from typing import Dict, List, Union
+
+from boa3.model.event import Event
+from boa3.model.method import Method
+
+
+class INeoStandard(abc.ABC):
+    def __init__(self, methods: Dict[str, Method], events: List[Event]):
+        self.methods: Dict[str, Method] = methods
+        self.events: Dict[str, Event] = {event.name: event for event in events}
+
+    def match_definition(self, symbol_id: str, symbol: Union[Method, Event]) -> bool:
+        if not isinstance(symbol, (Method, Event)) or not isinstance(symbol_id, str):
+            return False
+
+        standard_symbols = self.methods if isinstance(symbol, Method) else self.events
+        if symbol_id not in standard_symbols:
+            return False
+
+        standard_def = standard_symbols[symbol_id]
+        return self._have_same_signature(standard_def, symbol)
+
+    def _have_same_signature(self, symbol: Union[Method, Event], other: Union[Method, Event]) -> bool:
+        if (isinstance(symbol, Method) and not isinstance(other, Method)
+                or isinstance(symbol, Event) and not isinstance(other, Event)):
+            return False
+
+        if symbol.return_type != other.return_type:
+            return False
+
+        if symbol.is_public != other.is_public:
+            return False
+
+        if len(symbol.args) != len(other.args):
+            return False
+
+        method_args = list(symbol.args.values())
+        other_args = list(other.args.values())
+        for index in range(len(method_args)):
+            if method_args[index].type != other_args[index].type:
+                return False
+
+        return True

--- a/boa3/model/standards/nep17standard.py
+++ b/boa3/model/standards/nep17standard.py
@@ -1,0 +1,31 @@
+from boa3.model.builtin.builtin import Builtin
+from boa3.model.standards.neostandard import INeoStandard
+from boa3.model.standards.standardmethod import StandardMethod
+from boa3.model.type.collection.sequence.uint160type import UInt160Type
+from boa3.model.type.type import Type
+
+
+class Nep17Standard(INeoStandard):
+    def __init__(self):
+        type_uint160 = UInt160Type.build()
+
+        methods = {
+            'symbol': StandardMethod(args={},
+                                     return_type=Type.str),
+            'decimals': StandardMethod(args={},
+                                       return_type=Type.int),
+            'totalSupply': StandardMethod(args={},
+                                          return_type=Type.int),
+            'balanceOf': StandardMethod(args={'account': type_uint160},
+                                        return_type=Type.int),
+            'transfer': StandardMethod(args={'from': type_uint160,
+                                             'to': type_uint160,
+                                             'amount': Type.int,
+                                             'data': Type.any},
+                                       return_type=Type.bool)
+        }
+        events = [
+            Builtin.Nep17Transfer
+        ]
+
+        super().__init__(methods, events)

--- a/boa3/model/standards/standardmethod.py
+++ b/boa3/model/standards/standardmethod.py
@@ -1,0 +1,14 @@
+from typing import Dict
+
+from boa3.model.method import Method
+from boa3.model.type.itype import IType
+from boa3.model.type.type import Type
+from boa3.model.variable import Variable
+
+
+class StandardMethod(Method):
+    def __init__(self, args: Dict[str, IType] = None, return_type: IType = Type.none):
+        if not isinstance(args, dict):
+            args = {}
+        method_args = {key: Variable(value) for key, value in args.items()}
+        super().__init__(args=method_args, return_type=return_type, is_public=True)

--- a/boa3/neo3/network/payloads/oracleresponsecode.py
+++ b/boa3/neo3/network/payloads/oracleresponsecode.py
@@ -16,21 +16,21 @@ class OracleResponseCode(IntFlag):
     PROTOCOL_NOT_SUPPORTED = 0x10
     """
     Indicates that the protocol of the request is not supported.
-    
+
     :meta hide-value:
     """
 
     CONSENSUS_UNREACHABLE = 0x12
     """
     Indicates that the oracle nodes cannot reach a consensus on the result of the request.
-    
+
     :meta hide-value:
     """
 
     NOT_FOUND = 0x14
     """
     Indicates that the requested Uri does not exist.
-    
+
     :meta hide-value:
     """
 
@@ -65,7 +65,7 @@ class OracleResponseCode(IntFlag):
     CONTENT_TYPE_NOT_SUPPORTED = 0x1F
     """
     Indicates that the content-type of the request is not supported.
-    
+
     :meta hide-value:
     """
 

--- a/boa3_test/examples/NEP17.py
+++ b/boa3_test/examples/NEP17.py
@@ -19,6 +19,7 @@ def manifest_metadata() -> NeoMetadata:
     Defines this smart contract's metadata information
     """
     meta = NeoMetadata()
+    meta.supported_standards = ['NEP-17']
     meta.author = "Mirella Medeiros, Ricardo Prado and Lucas Uezu. COZ in partnership with Simpli"
     meta.description = "NEP-17 Example"
     meta.email = "contact@coz.io"

--- a/boa3_test/examples/amm.py
+++ b/boa3_test/examples/amm.py
@@ -19,6 +19,7 @@ def manifest_metadata() -> NeoMetadata:
     Defines this smart contract's metadata information
     """
     meta = NeoMetadata()
+    meta.supported_standards = ['NEP-17']
     meta.author = "Mirella Medeiros, Ricardo Prado and Lucas Uezu. COZ in partnership with Simpli"
     meta.description = "Automated Market Maker Example"
     meta.email = "contact@coz.io"

--- a/boa3_test/examples/ico.py
+++ b/boa3_test/examples/ico.py
@@ -20,6 +20,7 @@ def manifest_metadata() -> NeoMetadata:
     Defines this smart contract's metadata information
     """
     meta = NeoMetadata()
+    meta.supported_standards = ['NEP-17']
     meta.author = "Mirella Medeiros, Ricardo Prado and Lucas Uezu. COZ in partnership with Simpli"
     meta.description = "ICO Example"
     meta.email = "contact@coz.io"

--- a/boa3_test/examples/nep5.py
+++ b/boa3_test/examples/nep5.py
@@ -22,6 +22,7 @@ def manifest_metadata() -> NeoMetadata:
     Defines this smart contract's metadata information
     """
     meta = NeoMetadata()
+    meta.supported_standards = ['NEP-5']
     meta.author = "Mirella Medeiros and Ricardo Prado. COZ in partnership with Simpli"
     meta.description = "NEP-5 Example"
     meta.email = "contact@coz.io"

--- a/boa3_test/examples/wrapped_gas.py
+++ b/boa3_test/examples/wrapped_gas.py
@@ -19,6 +19,7 @@ def manifest_metadata() -> NeoMetadata:
     Defines this smart contract's metadata information
     """
     meta = NeoMetadata()
+    meta.supported_standards = ['NEP-17']
     meta.author = "Mirella Medeiros, Ricardo Prado and Lucas Uezu. COZ in partnership with Simpli"
     meta.description = "Wrapped GAS Example"
     meta.email = "contact@coz.io"

--- a/boa3_test/examples/wrapped_neo.py
+++ b/boa3_test/examples/wrapped_neo.py
@@ -19,6 +19,7 @@ def manifest_metadata() -> NeoMetadata:
     Defines this smart contract's metadata information
     """
     meta = NeoMetadata()
+    meta.supported_standards = ['NEP-17']
     meta.author = "Mirella Medeiros, Ricardo Prado and Lucas Uezu. COZ in partnership with Simpli"
     meta.description = "Wrapped NEO Example"
     meta.email = "contact@coz.io"

--- a/boa3_test/test_sc/built_in_methods_test/CountListDifferentNonPrimitiveTypes.py
+++ b/boa3_test/test_sc/built_in_methods_test/CountListDifferentNonPrimitiveTypes.py
@@ -1,4 +1,4 @@
-from typing import Tuple, List, Any
+from typing import Any, List, Tuple
 
 from boa3.builtin import public
 

--- a/boa3_test/test_sc/built_in_methods_test/CountTupleDifferentNonPrimitiveTypes.py
+++ b/boa3_test/test_sc/built_in_methods_test/CountTupleDifferentNonPrimitiveTypes.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Any
+from typing import Any, Tuple
 
 from boa3.builtin import public
 

--- a/boa3_test/test_sc/interop_test/binary/MemorySearchTooFewArguments.py
+++ b/boa3_test/test_sc/interop_test/binary/MemorySearchTooFewArguments.py
@@ -3,5 +3,5 @@ from typing import Union
 from boa3.builtin.interop.binary import memory_search
 
 
-def main(mem: Union[bytes,str]) -> int:
+def main(mem: Union[bytes, str]) -> int:
     return memory_search(mem)

--- a/boa3_test/test_sc/interop_test/contract/CreateMultisigAccountTooManyArguments.py
+++ b/boa3_test/test_sc/interop_test/contract/CreateMultisigAccountTooManyArguments.py
@@ -1,4 +1,4 @@
-from typing import List, Any
+from typing import Any, List
 
 from boa3.builtin.interop.contract import create_multisig_account
 from boa3.builtin.type import ECPoint, UInt160

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandards.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandards.py
@@ -1,0 +1,12 @@
+from boa3.builtin import NeoMetadata, metadata
+
+
+def Main() -> int:
+    return 5
+
+
+@metadata
+def standards_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+    meta.supported_standards = ['NEP-11']
+    return meta

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsMismatchedType.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsMismatchedType.py
@@ -1,0 +1,12 @@
+from boa3.builtin import NeoMetadata, metadata
+
+
+def Main() -> int:
+    return 5
+
+
+@metadata
+def standards_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+    meta.supported_standards = 'NEP-11'
+    return meta

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsMissingImplementation.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsMissingImplementation.py
@@ -1,0 +1,12 @@
+from boa3.builtin import NeoMetadata, metadata
+
+
+def Main() -> int:
+    return 5
+
+
+@metadata
+def standards_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+    meta.supported_standards = ['NEP-17']  # for nep17, boa checks if the standard is implemented
+    return meta

--- a/boa3_test/tests/compiler_tests/test_interop/test_contract.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_contract.py
@@ -448,13 +448,13 @@ class TestContractInterop(BoaTest):
 
     def test_create_multisig_account(self):
         expected_output = (
-                Opcode.INITSLOT
-                + b'\x00\x02'
-                + Opcode.LDARG1
-                + Opcode.LDARG0
-                + Opcode.SYSCALL
-                + Interop.CreateMultisigAccount.interop_method_hash
-                + Opcode.RET
+            Opcode.INITSLOT
+            + b'\x00\x02'
+            + Opcode.LDARG1
+            + Opcode.LDARG0
+            + Opcode.SYSCALL
+            + Interop.CreateMultisigAccount.interop_method_hash
+            + Opcode.RET
         )
         path = self.get_contract_path('CreateMultisigAccount.py')
         output = Boa3.compile(path)

--- a/boa3_test/tests/compiler_tests/test_interop/test_crypto.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_crypto.py
@@ -11,7 +11,6 @@ from boa3.neo3.contracts.contracttypes import CallFlags
 from boa3.neo3.contracts.namedcurve import NamedCurve
 from boa3_test.tests.boa_test import BoaTest
 from boa3_test.tests.test_classes.testengine import TestEngine
-from boa3_test.tests.test_classes.TestExecutionException import TestExecutionException
 
 
 class TestCryptoInterop(BoaTest):

--- a/boa3_test/tests/compiler_tests/test_metadata.py
+++ b/boa3_test/tests/compiler_tests/test_metadata.py
@@ -157,3 +157,20 @@ class TestMetadata(BoaTest):
         self.assertEqual(True, manifest['extra']['unittest3'])
         self.assertIn('unittest4', manifest['extra'])
         self.assertEqual(['list', 3210], manifest['extra']['unittest4'])
+
+    def test_metadata_info_supported_standards(self):
+        path = self.get_contract_path('MetadataInfoSupportedStandards.py')
+        output, manifest = self.compile_and_save(path)
+
+        self.assertIn('supportedstandards', manifest)
+        self.assertIsInstance(manifest['supportedstandards'], list)
+        self.assertGreater(len(manifest['supportedstandards']), 0)
+        self.assertIn('NEP-11', manifest['supportedstandards'])
+
+    def test_metadata_info_supported_standards_missing_implementations(self):
+        path = self.get_contract_path('MetadataInfoSupportedStandardsMissingImplementation.py')
+        self.assertCompilerLogs(CompilerError.MissingStandardDefinition, path)
+
+    def test_metadata_info_supported_standards_mismatched_type(self):
+        path = self.get_contract_path('MetadataInfoDescriptionMismatchedType.py')
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)

--- a/boa3_test/tests/examples_tests/test_NEP17.py
+++ b/boa3_test/tests/examples_tests/test_NEP17.py
@@ -18,7 +18,12 @@ class TestNEP17Template(BoaTest):
 
     def test_nep17_compile(self):
         path = self.get_contract_path('NEP17.py')
-        Boa3.compile(path)
+        output, manifest = self.compile_and_save(path)
+
+        self.assertIn('supportedstandards', manifest)
+        self.assertIsInstance(manifest['supportedstandards'], list)
+        self.assertGreater(len(manifest['supportedstandards']), 0)
+        self.assertIn('NEP-17', manifest['supportedstandards'])
 
     def test_nep17_deploy(self):
         path = self.get_contract_path('NEP17.py')


### PR DESCRIPTION
**Related issue**
#473

**Summary or solution description**
Included `supported_variables` to the NeoMetadata object to allow users to define which standards their contracts implement.

Also, for NEP-17 only, included a verification if the standard is actually implemented. Boa won't compile the smart contract if there are methods or events in the standard that weren't implemented in the contract.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/48af6f88a785d4c84bfc15d52305878ad92165a1/boa3_test/examples/NEP17.py#L16-L26

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/48af6f88a785d4c84bfc15d52305878ad92165a1/boa3_test/tests/compiler_tests/test_metadata.py#L161-L176
https://github.com/CityOfZion/neo3-boa/blob/48af6f88a785d4c84bfc15d52305878ad92165a1/boa3_test/tests/examples_tests/test_NEP17.py#L19-L26

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
