### PR TITLE
Create unit tests when importing role and policy interops from interop

### DIFF
--- a/boa3/builtin/interop/__init__.py
+++ b/boa3/builtin/interop/__init__.py
@@ -6,5 +6,7 @@ import boa3.builtin.interop.crypto
 import boa3.builtin.interop.iterator
 import boa3.builtin.interop.json
 import boa3.builtin.interop.oracle
+import boa3.builtin.interop.policy
+import boa3.builtin.interop.role
 import boa3.builtin.interop.runtime
 import boa3.builtin.interop.storage

--- a/boa3/builtin/interop/oracle/__init__.py
+++ b/boa3/builtin/interop/oracle/__init__.py
@@ -1,5 +1,7 @@
 from typing import Any, Union
 
+from boa3.builtin.interop.oracle.oracleresponsecode import OracleResponseCode
+
 
 class Oracle:
     """

--- a/boa3_test/test_sc/interop_test/oracle/ImportOracle.py
+++ b/boa3_test/test_sc/interop_test/oracle/ImportOracle.py
@@ -1,0 +1,14 @@
+from typing import Any, Union
+
+from boa3.builtin import public
+from boa3.builtin.interop import oracle
+
+
+@public
+def oracle_call(url: str, request_filter: Union[str, None], callback: str, user_data: Any, gas_for_response: int):
+    oracle.Oracle.request(url, request_filter, callback, user_data, gas_for_response)
+
+
+@public
+def test_callback(requested_url: str, user_data: Any, code: int, request_result: oracle.OracleResponseCode):
+    return

--- a/boa3_test/test_sc/interop_test/policy/ImportInteropPolicy.py
+++ b/boa3_test/test_sc/interop_test/policy/ImportInteropPolicy.py
@@ -1,0 +1,6 @@
+from boa3.builtin import interop, public
+
+
+@public
+def main() -> int:
+    return interop.policy.get_exec_fee_factor()

--- a/boa3_test/test_sc/interop_test/policy/ImportPolicy.py
+++ b/boa3_test/test_sc/interop_test/policy/ImportPolicy.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.interop import policy
+
+
+@public
+def main() -> int:
+    return policy.get_exec_fee_factor()

--- a/boa3_test/test_sc/interop_test/role/ImportInteropRole.py
+++ b/boa3_test/test_sc/interop_test/role/ImportInteropRole.py
@@ -1,0 +1,7 @@
+from boa3.builtin import interop, public
+from boa3.builtin.type import ECPoint
+
+
+@public
+def main(role_: interop.role.Role, index: int) -> ECPoint:
+    return interop.role.get_designated_by_role(role_, index)

--- a/boa3_test/test_sc/interop_test/role/ImportRole.py
+++ b/boa3_test/test_sc/interop_test/role/ImportRole.py
@@ -1,0 +1,8 @@
+from boa3.builtin import public
+from boa3.builtin.interop import role
+from boa3.builtin.type import ECPoint
+
+
+@public
+def main(role_: role.Role, index: int) -> ECPoint:
+    return role.get_designated_by_role(role_, index)

--- a/boa3_test/tests/compiler_tests/test_interop/test_policy.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_policy.py
@@ -64,3 +64,17 @@ class TestPolicyInterop(BoaTest):
     def test_is_blocked_too_few_parameters(self):
         path = self.get_contract_path('IsBlockedTooFewArguments.py')
         self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+
+    def test_import_policy(self):
+        path = self.get_contract_path('ImportPolicy.py')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'main')
+        self.assertIsInstance(result, int)
+
+    def test_import_interop_policy(self):
+        path = self.get_contract_path('ImportInteropPolicy.py')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'main')
+        self.assertIsInstance(result, int)

--- a/boa3_test/tests/compiler_tests/test_interop/test_role.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_role.py
@@ -41,3 +41,61 @@ class TestRoleInterop(BoaTest):
         path = self.get_contract_path('GetDesignatedByRole.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
+
+    def test_import_role(self):
+        call_flags = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
+        method = String('getDesignatedByRole').to_bytes()
+
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x00\x02'
+            + Opcode.LDARG1
+            + Opcode.LDARG0
+            + Opcode.PUSH2
+            + Opcode.PACK
+            + Opcode.PUSHDATA1
+            + Integer(len(call_flags)).to_byte_array()
+            + call_flags
+            + Opcode.PUSHDATA1
+            + Integer(len(method)).to_byte_array()
+            + method
+            + Opcode.PUSHDATA1
+            + Integer(len(constants.ROLE_MANAGEMENT)).to_byte_array()
+            + constants.ROLE_MANAGEMENT
+            + Opcode.SYSCALL
+            + Interop.CallContract.interop_method_hash
+            + Opcode.RET
+        )
+
+        path = self.get_contract_path('ImportRole.py')
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_import_interop_role(self):
+        call_flags = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
+        method = String('getDesignatedByRole').to_bytes()
+
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x00\x02'
+            + Opcode.LDARG1
+            + Opcode.LDARG0
+            + Opcode.PUSH2
+            + Opcode.PACK
+            + Opcode.PUSHDATA1
+            + Integer(len(call_flags)).to_byte_array()
+            + call_flags
+            + Opcode.PUSHDATA1
+            + Integer(len(method)).to_byte_array()
+            + method
+            + Opcode.PUSHDATA1
+            + Integer(len(constants.ROLE_MANAGEMENT)).to_byte_array()
+            + constants.ROLE_MANAGEMENT
+            + Opcode.SYSCALL
+            + Interop.CallContract.interop_method_hash
+            + Opcode.RET
+        )
+
+        path = self.get_contract_path('ImportInteropRole.py')
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)

--- a/boa3_test/tests/compiler_tests/test_interop/test_role.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_role.py
@@ -15,7 +15,7 @@ class TestRoleInterop(BoaTest):
 
     def test_get_designated_by_role(self):
         call_flags = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
-        method = String('getDesignatedByRole').to_bytes()
+        method = String(Interop.GetDesignatedByRole.method_name).to_bytes()
 
         expected_output = (
             Opcode.INITSLOT
@@ -44,7 +44,7 @@ class TestRoleInterop(BoaTest):
 
     def test_import_role(self):
         call_flags = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
-        method = String('getDesignatedByRole').to_bytes()
+        method = String(Interop.GetDesignatedByRole.method_name).to_bytes()
 
         expected_output = (
             Opcode.INITSLOT
@@ -73,7 +73,7 @@ class TestRoleInterop(BoaTest):
 
     def test_import_interop_role(self):
         call_flags = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
-        method = String('getDesignatedByRole').to_bytes()
+        method = String(Interop.GetDesignatedByRole.method_name).to_bytes()
 
         expected_output = (
             Opcode.INITSLOT


### PR DESCRIPTION
**Related issue**
#568 

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/a0026eda1919be1d1a336ddbe7cd0c0cfae4a7df/boa3_test/tests/compiler_tests/test_interop/test_role.py#L45-L101
https://github.com/CityOfZion/neo3-boa/blob/a0026eda1919be1d1a336ddbe7cd0c0cfae4a7df/boa3_test/tests/compiler_tests/test_interop/test_policy.py#L68-L80

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8

**(Optional) Additional context**
Also added a `ImportOracle` test.
