### PR TITLE
Implement empty user class

### DIFF
--- a/boa3/model/builtin/interop/blockchain/blocktype.py
+++ b/boa3/model/builtin/interop/blockchain/blocktype.py
@@ -39,11 +39,19 @@ class BlockType(ClassArrayType):
         self._constructor: Method = None
 
     @property
-    def variables(self) -> Dict[str, Variable]:
+    def class_variables(self) -> Dict[str, Variable]:
+        return {}
+
+    @property
+    def instance_variables(self) -> Dict[str, Variable]:
         return self._variables.copy()
 
     @property
     def properties(self) -> Dict[str, Property]:
+        return {}
+
+    @property
+    def static_methods(self) -> Dict[str, Method]:
         return {}
 
     @property

--- a/boa3/model/builtin/interop/blockchain/transactiontype.py
+++ b/boa3/model/builtin/interop/blockchain/transactiontype.py
@@ -35,11 +35,19 @@ class TransactionType(ClassArrayType):
         self._constructor: Method = None
 
     @property
-    def variables(self) -> Dict[str, Variable]:
+    def class_variables(self) -> Dict[str, Variable]:
+        return {}
+
+    @property
+    def instance_variables(self) -> Dict[str, Variable]:
         return self._variables.copy()
 
     @property
     def properties(self) -> Dict[str, Property]:
+        return {}
+
+    @property
+    def static_methods(self) -> Dict[str, Method]:
         return {}
 
     @property

--- a/boa3/model/builtin/interop/contract/contractmanifest/contractabitype.py
+++ b/boa3/model/builtin/interop/contract/contractmanifest/contractabitype.py
@@ -28,11 +28,19 @@ class ContractAbiType(ClassStructType):
         self._constructor: Method = None
 
     @property
-    def variables(self) -> Dict[str, Variable]:
+    def class_variables(self) -> Dict[str, Variable]:
+        return {}
+
+    @property
+    def instance_variables(self) -> Dict[str, Variable]:
         return self._variables.copy()
 
     @property
     def properties(self) -> Dict[str, Property]:
+        return {}
+
+    @property
+    def static_methods(self) -> Dict[str, Method]:
         return {}
 
     @property

--- a/boa3/model/builtin/interop/contract/contractmanifest/contracteventdescriptortype.py
+++ b/boa3/model/builtin/interop/contract/contractmanifest/contracteventdescriptortype.py
@@ -26,11 +26,19 @@ class ContractEventDescriptorType(ClassStructType):
         self._constructor: Method = None
 
     @property
-    def variables(self) -> Dict[str, Variable]:
+    def class_variables(self) -> Dict[str, Variable]:
+        return {}
+
+    @property
+    def instance_variables(self) -> Dict[str, Variable]:
         return self._variables.copy()
 
     @property
     def properties(self) -> Dict[str, Property]:
+        return {}
+
+    @property
+    def static_methods(self) -> Dict[str, Method]:
         return {}
 
     @property

--- a/boa3/model/builtin/interop/contract/contractmanifest/contractgrouptype.py
+++ b/boa3/model/builtin/interop/contract/contractmanifest/contractgrouptype.py
@@ -25,11 +25,19 @@ class ContractGroupType(ClassStructType):
         self._constructor: Method = None
 
     @property
-    def variables(self) -> Dict[str, Variable]:
+    def class_variables(self) -> Dict[str, Variable]:
+        return {}
+
+    @property
+    def instance_variables(self) -> Dict[str, Variable]:
         return self._variables.copy()
 
     @property
     def properties(self) -> Dict[str, Property]:
+        return {}
+
+    @property
+    def static_methods(self) -> Dict[str, Method]:
         return {}
 
     @property

--- a/boa3/model/builtin/interop/contract/contractmanifest/contractmanifesttype.py
+++ b/boa3/model/builtin/interop/contract/contractmanifest/contractmanifesttype.py
@@ -30,11 +30,19 @@ class ContractManifestType(ClassStructType):
         self._constructor: Method = None
 
     @property
-    def variables(self) -> Dict[str, Variable]:
+    def class_variables(self) -> Dict[str, Variable]:
+        return {}
+
+    @property
+    def instance_variables(self) -> Dict[str, Variable]:
         return self._variables.copy()
 
     @property
     def properties(self) -> Dict[str, Property]:
+        return {}
+
+    @property
+    def static_methods(self) -> Dict[str, Method]:
         return {}
 
     @property

--- a/boa3/model/builtin/interop/contract/contractmanifest/contractmethoddescriptortype.py
+++ b/boa3/model/builtin/interop/contract/contractmanifest/contractmethoddescriptortype.py
@@ -30,11 +30,19 @@ class ContractMethodDescriptorType(ClassStructType):
         self._constructor: Method = None
 
     @property
-    def variables(self) -> Dict[str, Variable]:
+    def class_variables(self) -> Dict[str, Variable]:
+        return {}
+
+    @property
+    def instance_variables(self) -> Dict[str, Variable]:
         return self._variables.copy()
 
     @property
     def properties(self) -> Dict[str, Property]:
+        return {}
+
+    @property
+    def static_methods(self) -> Dict[str, Method]:
         return {}
 
     @property

--- a/boa3/model/builtin/interop/contract/contractmanifest/contractparameterdefinitiontype.py
+++ b/boa3/model/builtin/interop/contract/contractmanifest/contractparameterdefinitiontype.py
@@ -25,11 +25,19 @@ class ContractParameterDefinitionType(ClassStructType):
         self._constructor: Method = None
 
     @property
-    def variables(self) -> Dict[str, Variable]:
+    def class_variables(self) -> Dict[str, Variable]:
+        return {}
+
+    @property
+    def instance_variables(self) -> Dict[str, Variable]:
         return self._variables.copy()
 
     @property
     def properties(self) -> Dict[str, Property]:
+        return {}
+
+    @property
+    def static_methods(self) -> Dict[str, Method]:
         return {}
 
     @property

--- a/boa3/model/builtin/interop/contract/contractmanifest/contractpermissiondescriptortype.py
+++ b/boa3/model/builtin/interop/contract/contractmanifest/contractpermissiondescriptortype.py
@@ -26,11 +26,19 @@ class ContractPermissionDescriptorType(ClassStructType):
         self._constructor: Method = None
 
     @property
-    def variables(self) -> Dict[str, Variable]:
+    def class_variables(self) -> Dict[str, Variable]:
+        return {}
+
+    @property
+    def instance_variables(self) -> Dict[str, Variable]:
         return self._variables.copy()
 
     @property
     def properties(self) -> Dict[str, Property]:
+        return {}
+
+    @property
+    def static_methods(self) -> Dict[str, Method]:
         return {}
 
     @property

--- a/boa3/model/builtin/interop/contract/contractmanifest/contractpermissiontype.py
+++ b/boa3/model/builtin/interop/contract/contractmanifest/contractpermissiontype.py
@@ -24,11 +24,19 @@ class ContractPermissionType(ClassArrayType):
         self._constructor: Method = None
 
     @property
-    def variables(self) -> Dict[str, Variable]:
+    def class_variables(self) -> Dict[str, Variable]:
+        return {}
+
+    @property
+    def instance_variables(self) -> Dict[str, Variable]:
         return self._variables.copy()
 
     @property
     def properties(self) -> Dict[str, Property]:
+        return {}
+
+    @property
+    def static_methods(self) -> Dict[str, Method]:
         return {}
 
     @property

--- a/boa3/model/builtin/interop/contract/contracttype.py
+++ b/boa3/model/builtin/interop/contract/contracttype.py
@@ -32,11 +32,19 @@ class ContractType(ClassArrayType):
         self._constructor: Method = None
 
     @property
-    def variables(self) -> Dict[str, Variable]:
+    def class_variables(self) -> Dict[str, Variable]:
+        return {}
+
+    @property
+    def instance_variables(self) -> Dict[str, Variable]:
         return self._variables.copy()
 
     @property
     def properties(self) -> Dict[str, Property]:
+        return {}
+
+    @property
+    def static_methods(self) -> Dict[str, Method]:
         return {}
 
     @property

--- a/boa3/model/builtin/interop/iterator/iteratortype.py
+++ b/boa3/model/builtin/interop/iterator/iteratortype.py
@@ -36,7 +36,11 @@ class IteratorType(InteropInterfaceType, ICollectionType):
         return '{0}[{1}, {2}]'.format(self._identifier, self.valid_key.identifier, self.item_type.identifier)
 
     @property
-    def variables(self) -> Dict[str, Variable]:
+    def class_variables(self) -> Dict[str, Variable]:
+        return {}
+
+    @property
+    def instance_variables(self) -> Dict[str, Variable]:
         return {}
 
     @property
@@ -48,6 +52,10 @@ class IteratorType(InteropInterfaceType, ICollectionType):
             }
 
         return self._properties.copy()
+
+    @property
+    def static_methods(self) -> Dict[str, Method]:
+        return {}
 
     @property
     def class_methods(self) -> Dict[str, Method]:

--- a/boa3/model/builtin/interop/oracle/oracletype.py
+++ b/boa3/model/builtin/interop/oracle/oracletype.py
@@ -21,11 +21,19 @@ class OracleType(ClassArrayType):
         self._constructor: Method = None
 
     @property
-    def variables(self) -> Dict[str, Variable]:
+    def instance_variables(self) -> Dict[str, Variable]:
         return self._variables.copy()
 
     @property
+    def class_variables(self) -> Dict[str, Variable]:
+        return {}
+
+    @property
     def properties(self) -> Dict[str, Property]:
+        return {}
+
+    @property
+    def static_methods(self) -> Dict[str, Method]:
         return {}
 
     @property

--- a/boa3/model/builtin/interop/runtime/notificationtype.py
+++ b/boa3/model/builtin/interop/runtime/notificationtype.py
@@ -29,11 +29,19 @@ class NotificationType(ClassArrayType):
         self._constructor: Method = None
 
     @property
-    def variables(self) -> Dict[str, Variable]:
+    def instance_variables(self) -> Dict[str, Variable]:
         return self._variables.copy()
 
     @property
+    def class_variables(self) -> Dict[str, Variable]:
+        return {}
+
+    @property
     def properties(self) -> Dict[str, Property]:
+        return {}
+
+    @property
+    def static_methods(self) -> Dict[str, Method]:
         return {}
 
     @property

--- a/boa3/model/builtin/interop/storage/storagecontext/storagecontexttype.py
+++ b/boa3/model/builtin/interop/storage/storagecontext/storagecontexttype.py
@@ -21,11 +21,19 @@ class StorageContextType(InteropInterfaceType):
         self._constructor: Method = None
 
     @property
-    def variables(self) -> Dict[str, Variable]:
+    def instance_variables(self) -> Dict[str, Variable]:
         return self._variables.copy()
 
     @property
+    def class_variables(self) -> Dict[str, Variable]:
+        return {}
+
+    @property
     def properties(self) -> Dict[str, Property]:
+        return {}
+
+    @property
+    def static_methods(self) -> Dict[str, Method]:
         return {}
 
     @property

--- a/boa3/model/builtin/interop/storage/storagemap/storagemaptype.py
+++ b/boa3/model/builtin/interop/storage/storagemap/storagemaptype.py
@@ -24,8 +24,12 @@ class StorageMapType(ClassArrayType):
         self._instance_methods: Dict[str, Method] = {}
 
     @property
-    def variables(self) -> Dict[str, Variable]:
+    def instance_variables(self) -> Dict[str, Variable]:
         return self._variables.copy()
+
+    @property
+    def class_variables(self) -> Dict[str, Variable]:
+        return {}
 
     @property
     def _all_variables(self) -> Dict[str, Variable]:
@@ -38,12 +42,16 @@ class StorageMapType(ClassArrayType):
                                                   Type.str
                                                   ]))
         }
-        variables = self.variables.copy()
+        variables = super()._all_variables
         variables.update(private_variables)
         return variables
 
     @property
     def properties(self) -> Dict[str, Property]:
+        return {}
+
+    @property
+    def static_methods(self) -> Dict[str, Method]:
         return {}
 
     @property

--- a/boa3/model/module.py
+++ b/boa3/model/module.py
@@ -3,6 +3,7 @@ from typing import Dict
 from boa3.model.callable import Callable
 from boa3.model.method import Method
 from boa3.model.symbol import ISymbol
+from boa3.model.type.classes.classtype import ClassType
 from boa3.model.variable import Variable
 
 
@@ -13,6 +14,7 @@ class Module(ISymbol):
     :ivar variables: a dictionary that maps each variable with its name. Empty by default.
     :ivar methods: a dictionary that maps each method with its name. Empty by default.
     :ivar callables: a dictionary that maps each callable object with its name. Empty by default.
+    :ivar classes: a dictionary that maps each class with its name. Empty by default.
     :ivar imported_symbols: a dictionary that maps each imported symbol with its name. Empty by default.
     """
 
@@ -25,6 +27,7 @@ class Module(ISymbol):
             methods = {}
         self.methods = methods
         self.callables: Dict[str, Callable] = {}
+        self.classes: Dict[str, ClassType] = {}
 
         self.defined_by_entry = True
         self.imported_symbols = {}
@@ -75,6 +78,16 @@ class Module(ISymbol):
             else:
                 self.callables[method_id] = method
 
+    def include_class(self, class_id: str, class_obj: ClassType):
+        """
+        Includes a class into the scope of the module
+
+        :param class_id: class identifier
+        :param class_obj: class object to be included
+        """
+        if class_id not in self.symbols:
+            self.classes[class_id] = class_obj
+
     def include_symbol(self, symbol_id: str, symbol: ISymbol):
         """
         Includes a method into the scope of the module
@@ -87,6 +100,8 @@ class Module(ISymbol):
                 self.include_variable(symbol_id, symbol)
             elif isinstance(symbol, Callable):
                 self.include_callable(symbol_id, symbol)
+            elif isinstance(symbol, ClassType):
+                self.include_class(symbol_id, symbol)
             else:
                 self.imported_symbols[symbol_id] = symbol
 
@@ -102,4 +117,5 @@ class Module(ISymbol):
         symbols.update(self.variables)
         symbols.update(self.methods)
         symbols.update(self.callables)
+        symbols.update(self.classes)
         return symbols

--- a/boa3/model/type/classes/classscope.py
+++ b/boa3/model/type/classes/classscope.py
@@ -1,0 +1,7 @@
+import enum
+
+
+class ClassScope(enum.Enum):
+    STATIC = enum.auto()
+    CLASS = enum.auto()
+    INSTANCE = enum.auto()

--- a/boa3/model/type/classes/classtype.py
+++ b/boa3/model/type/classes/classtype.py
@@ -23,8 +23,19 @@ class ClassType(IType, ABC):
 
     @property
     @abstractmethod
-    def variables(self) -> Dict[str, Variable]:
+    def class_variables(self) -> Dict[str, Variable]:
         return {}
+
+    @property
+    @abstractmethod
+    def instance_variables(self) -> Dict[str, Variable]:
+        return {}
+
+    @property
+    def variables(self) -> Dict[str, Variable]:
+        variables = self.class_variables.copy()
+        variables.update(self.instance_variables)
+        return variables
 
     @property
     def _all_variables(self) -> Dict[str, Variable]:
@@ -37,18 +48,13 @@ class ClassType(IType, ABC):
 
     @property
     @abstractmethod
-    def class_methods(self) -> Dict[str, Method]:
+    def static_methods(self) -> Dict[str, Method]:
         return {}
 
     @property
-    def symbols(self) -> Dict[str, ISymbol]:
-        # TODO: Change to return only class symbols or instance symbols
-        s = {}
-        s.update(self.class_methods)
-        s.update(self.variables)
-        s.update(self.properties)
-        s.update(self.instance_methods)
-        return s
+    @abstractmethod
+    def class_methods(self) -> Dict[str, Method]:
+        return {}
 
     @property
     @abstractmethod
@@ -61,6 +67,17 @@ class ClassType(IType, ABC):
         If the class constructor is None, it mustn't allow instantiation of this class
         """
         pass
+
+    @property
+    def symbols(self) -> Dict[str, ISymbol]:
+        # TODO: Change to return only class symbols or instance symbols
+        s = {}
+        s.update(self.static_methods)
+        s.update(self.class_methods)
+        s.update(self.instance_methods)
+        s.update(self.variables)
+        s.update(self.properties)
+        return s
 
     @property
     @abstractmethod

--- a/boa3/model/type/classes/userclass.py
+++ b/boa3/model/type/classes/userclass.py
@@ -1,0 +1,104 @@
+from typing import Any, Dict, Optional
+
+from boa3.model.callable import Callable
+from boa3.model.method import Method
+from boa3.model.property import Property
+from boa3.model.symbol import ISymbol
+from boa3.model.type.classes.classarraytype import ClassArrayType
+from boa3.model.type.classes.classscope import ClassScope
+from boa3.model.type.itype import IType
+from boa3.model.variable import Variable
+
+
+class UserClass(ClassArrayType):
+    def __init__(self, identifier: str):
+        super(ClassArrayType, self).__init__(identifier)
+
+        self._static_methods: Dict[str, Method] = {}
+
+        self._class_variables: Dict[str, Variable] = {}
+        self._class_methods: Dict[str, Method] = {}
+
+        self._instance_variables: Dict[str, Variable] = {}
+        self._instance_methods: Dict[str, Method] = {}
+        self._properties: Dict[str, Property] = {}
+
+        self.imported_symbols = {}
+
+    @property
+    def shadowing_name(self) -> str:
+        return 'class'
+
+    @property
+    def class_variables(self) -> Dict[str, Variable]:
+        return self._class_variables.copy()
+
+    @property
+    def instance_variables(self) -> Dict[str, Variable]:
+        return self._instance_variables.copy()
+
+    @property
+    def properties(self) -> Dict[str, Property]:
+        return self._properties.copy()
+
+    @property
+    def static_methods(self) -> Dict[str, Method]:
+        return self._static_methods.copy()
+
+    @property
+    def class_methods(self) -> Dict[str, Method]:
+        return self._class_methods.copy()
+
+    @property
+    def instance_methods(self) -> Dict[str, Method]:
+        return self._instance_methods.copy()
+
+    def include_variable(self, var_id: str, var: Variable, is_instance: bool):
+        """
+        Includes a variable into the list of class variables
+
+        :param var_id: variable identifier
+        :param var: variable to be included
+        :param is_instance: whether is a instance variable or a class variable
+        """
+        # TODO: change when user class variables are implemented
+        pass
+
+    def include_callable(self, method_id: str, method: Callable, scope: ClassScope):
+        """
+        Includes a method into the scope of the class
+
+        :param method_id: method identifier
+        :param method: method to be included
+        :param scope: which class scope this method should be included
+        """
+        # TODO: change when user class methods are implemented
+        pass
+
+    def include_symbol(self, symbol_id: str, symbol: ISymbol, scope: ClassScope = ClassScope.INSTANCE):
+        """
+        Includes a method into the scope of the module
+
+        :param symbol_id: method identifier
+        :param symbol: method to be included
+        :param scope: which class scope this symbol should be included
+        """
+        if symbol_id not in self.symbols:
+            if isinstance(symbol, Variable):
+                self.include_variable(symbol_id, symbol, scope == ClassScope.INSTANCE)
+            elif isinstance(symbol, Callable):
+                self.include_callable(symbol_id, symbol, scope)
+            else:
+                self.imported_symbols[symbol_id] = symbol
+
+    def constructor_method(self) -> Optional[Method]:
+        # TODO: change when user class init is implemented
+        return None
+
+    @classmethod
+    def _is_type_of(cls, value: Any) -> bool:
+        return False
+
+    @classmethod
+    def build(cls, value: Any) -> IType:
+        return cls()

--- a/boa3/model/type/collection/sequence/ecpointtype.py
+++ b/boa3/model/type/collection/sequence/ecpointtype.py
@@ -30,11 +30,19 @@ class ECPointType(BytesType, ClassType):
         return AbiType.PublicKey
 
     @property
-    def variables(self) -> Dict[str, Variable]:
+    def instance_variables(self) -> Dict[str, Variable]:
+        return {}
+
+    @property
+    def class_variables(self) -> Dict[str, Variable]:
         return {}
 
     @property
     def properties(self) -> Dict[str, Property]:
+        return {}
+
+    @property
+    def static_methods(self) -> Dict[str, Method]:
         return {}
 
     @property

--- a/boa3/model/type/collection/sequence/uint160type.py
+++ b/boa3/model/type/collection/sequence/uint160type.py
@@ -35,11 +35,19 @@ class UInt160Type(BytesType, ClassType):
         return StackItemType.ByteString
 
     @property
-    def variables(self) -> Dict[str, Variable]:
+    def instance_variables(self) -> Dict[str, Variable]:
+        return {}
+
+    @property
+    def class_variables(self) -> Dict[str, Variable]:
         return {}
 
     @property
     def properties(self) -> Dict[str, Property]:
+        return {}
+
+    @property
+    def static_methods(self) -> Dict[str, Method]:
         return {}
 
     @property

--- a/boa3/model/type/collection/sequence/uint256type.py
+++ b/boa3/model/type/collection/sequence/uint256type.py
@@ -35,11 +35,19 @@ class UInt256Type(BytesType, ClassType):
         return StackItemType.ByteString
 
     @property
-    def variables(self) -> Dict[str, Variable]:
+    def instance_variables(self) -> Dict[str, Variable]:
+        return {}
+
+    @property
+    def class_variables(self) -> Dict[str, Variable]:
         return {}
 
     @property
     def properties(self) -> Dict[str, Property]:
+        return {}
+
+    @property
+    def static_methods(self) -> Dict[str, Method]:
         return {}
 
     @property

--- a/boa3_test/test_sc/class_test/UserClassEmpty.py
+++ b/boa3_test/test_sc/class_test/UserClassEmpty.py
@@ -1,0 +1,2 @@
+class Example:
+    pass

--- a/boa3_test/test_sc/class_test/UserClassWithBase.py
+++ b/boa3_test/test_sc/class_test/UserClassWithBase.py
@@ -1,0 +1,2 @@
+class Example(object):
+    pass

--- a/boa3_test/test_sc/class_test/UserClassWithClassMethod.py
+++ b/boa3_test/test_sc/class_test/UserClassWithClassMethod.py
@@ -1,0 +1,12 @@
+from boa3.builtin import public
+
+
+class Example:
+    @classmethod
+    def some_method(cls) -> int:
+        return 42
+
+
+@public
+def call_by_class_name() -> int:
+    return Example.some_method()

--- a/boa3_test/test_sc/class_test/UserClassWithClassVariable.py
+++ b/boa3_test/test_sc/class_test/UserClassWithClassVariable.py
@@ -1,0 +1,16 @@
+from boa3.builtin import public
+
+
+class Example:
+    val1 = 1
+    val2 = 2
+
+
+@public
+def get_val1() -> int:
+    return Example.val1
+
+
+@public
+def get_val2() -> int:
+    return Example.val2

--- a/boa3_test/test_sc/class_test/UserClassWithDecorator.py
+++ b/boa3_test/test_sc/class_test/UserClassWithDecorator.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+class Example:
+    pass

--- a/boa3_test/test_sc/class_test/UserClassWithInit.py
+++ b/boa3_test/test_sc/class_test/UserClassWithInit.py
@@ -1,0 +1,11 @@
+from boa3.builtin import public
+
+
+class Example:
+    def __init__(self):
+        pass
+
+
+@public
+def build_example_object() -> Example:
+    return Example()

--- a/boa3_test/test_sc/class_test/UserClassWithInstanceMethod.py
+++ b/boa3_test/test_sc/class_test/UserClassWithInstanceMethod.py
@@ -1,0 +1,11 @@
+from boa3.builtin import public
+
+
+class Example:
+    def some_method(self) -> int:
+        return 42
+
+
+@public
+def call_by_class_name() -> int:
+    return Example().some_method()

--- a/boa3_test/test_sc/class_test/UserClassWithInstanceVariable.py
+++ b/boa3_test/test_sc/class_test/UserClassWithInstanceVariable.py
@@ -1,0 +1,17 @@
+from boa3.builtin import public
+
+
+class Example:
+    def __init__(self):
+        self.val1 = 1
+        self.val2 = 2
+
+
+@public
+def get_val1() -> int:
+    return Example().val1
+
+
+@public
+def get_val2() -> int:
+    return Example().val2

--- a/boa3_test/test_sc/class_test/UserClassWithKeywordBase.py
+++ b/boa3_test/test_sc/class_test/UserClassWithKeywordBase.py
@@ -1,0 +1,2 @@
+class Example(base=object):
+    pass

--- a/boa3_test/test_sc/class_test/UserClassWithStaticMethod.py
+++ b/boa3_test/test_sc/class_test/UserClassWithStaticMethod.py
@@ -1,0 +1,12 @@
+from boa3.builtin import public
+
+
+class Example:
+    @staticmethod
+    def some_method() -> int:
+        return 42
+
+
+@public
+def call_by_class_name() -> int:
+    return Example.some_method()

--- a/boa3_test/tests/compiler_tests/test_class.py
+++ b/boa3_test/tests/compiler_tests/test_class.py
@@ -1,3 +1,5 @@
+from boa3.boa3 import Boa3
+from boa3.exception import CompilerError
 from boa3.neo.cryptography import hash160
 from boa3.neo.vm.type.String import String
 from boa3_test.tests.boa_test import BoaTest
@@ -87,3 +89,45 @@ class TestClass(BoaTest):
         self.assertEqual(bytes(20), result[2])
         self.assertEqual(bytes(), result[3])
         self.assertEqual({}, result[4])
+
+    def test_user_class_empty(self):
+        path = self.get_contract_path('UserClassEmpty.py')
+        output = Boa3.compile(path)
+
+        self.assertEqual(b'', output)
+
+    def test_user_class_with_static_method(self):
+        path = self.get_contract_path('UserClassWithStaticMethod.py')
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+
+    def test_user_class_with_class_method(self):
+        path = self.get_contract_path('UserClassWithClassMethod.py')
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+
+    def test_user_class_with_class_variable(self):
+        path = self.get_contract_path('UserClassWithClassVariable.py')
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+
+    def test_user_class_with_init(self):
+        path = self.get_contract_path('UserClassWithInit.py')
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+
+    def test_user_class_with_instance_method(self):
+        path = self.get_contract_path('UserClassWithInstanceMethod.py')
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+
+    def test_user_class_with_instance_variable(self):
+        path = self.get_contract_path('UserClassWithInstanceVariable.py')
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+
+    def test_user_class_with_base(self):
+        path = self.get_contract_path('UserClassWithBase.py')
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+
+    def test_user_class_with_keyword_base(self):
+        path = self.get_contract_path('UserClassWithKeywordBase.py')
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+
+    def test_user_class_with_decorator(self):
+        path = self.get_contract_path('UserClassWithDecorator.py')
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)


### PR DESCRIPTION
**Related issue**
#550

**Summary or solution description**
Initial structure for class support. For now, the compiler only allows writing empty classes. Object instantiation of custom classes isn't implemented (see #554)

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/4df5dbb16ba0d6a16358425608c543fe84be3c32/boa3_test/test_sc/class_test/UserClassEmpty.py#L1-L2

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/4df5dbb16ba0d6a16358425608c543fe84be3c32/boa3_test/tests/compiler_tests/test_class.py#L93-L133

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7