### PR TITLE
change features to empty object

### DIFF
--- a/boa3/compiler/filegenerator.py
+++ b/boa3/compiler/filegenerator.py
@@ -158,7 +158,7 @@ class FileGenerator:
                 }
             ],
             "trusts": [],
-            "features": [],
+            "features": {},
             "supportedstandards": self._metadata.supported_standards,
             "extra": self._metadata.extra if len(self._metadata.extra) > 0 else None
         }


### PR DESCRIPTION
`features` should be an empty object according to NEP-15, instead of an array

**Related issue**
https://github.com/CityOfZion/neo3-boa/issues/578

**Summary or solution description**
Changed `features` to be an empty object instead of an array

**How to Reproduce**
Steps to reproduce the behaviour:
Compile any contract
Examine the manifest to see `features` is an array

**Tests**
Manually compiled contract to verify `features` in manifest is now an object

**Screenshots**
None

**Platform:**
All
