### PR TITLE
Functions with same name not working

### DIFF
--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -11,6 +11,7 @@ from boa3.model.builtin.builtin import Builtin
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.callable import Callable
 from boa3.model.expression import IExpression
+from boa3.model.identifiedsymbol import IdentifiedSymbol
 from boa3.model.imports.importsymbol import Import
 from boa3.model.imports.package import Package
 from boa3.model.method import Method
@@ -49,6 +50,7 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
         self.modules: Dict[str, Module] = {}
         self.symbols: Dict[str, ISymbol] = symbol_table
 
+        self._current_class: UserClass = None
         self._current_method: Method = None
         self._scope_stack: List[SymbolScope] = []
         self.visit(self._tree)
@@ -135,6 +137,15 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
         for stmt in module.body:
             self.visit(stmt)
 
+    def visit_ClassDef(self, node: ast.ClassDef) -> Any:
+        if node.name in self.symbols:
+            class_symbol = self.symbols[node.name]
+            if isinstance(class_symbol, UserClass):
+                self._current_class = class_symbol
+
+        self.generic_visit(node)
+        self._current_class = None
+
     def visit_FunctionDef(self, function: ast.FunctionDef):
         """
         Visitor of the function node
@@ -144,7 +155,8 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
         :param function: the python ast function definition node
         """
         self.visit(function.args)
-        method = self.symbols[function.name]
+        symbols = self.symbols if self._current_class is None else self._current_class.symbols
+        method = symbols[function.name]
 
         from boa3.model.event import Event
         if isinstance(method, Method):
@@ -1092,6 +1104,8 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
                 package = package.parent
                 package_symbol = self.get_symbol(package.identifier, check_raw_id=True)
             arg0_identifier = package_symbol if package_symbol else package.identifier
+        elif isinstance(arg0, UserClass):
+            arg0_identifier = arg0.identifier
         else:
             arg0_identifier = self.visit(arg0)
 
@@ -1372,7 +1386,7 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
                 (not hasattr(attribute, 'generate_value') or not attribute.generate_value)):
             attribute.generate_value = True
 
-        if isinstance(symbol, Package) or isinstance(value, Attribute):
+        if isinstance(symbol, (Package, Attribute, ClassType)):
             attr_value = symbol
         else:
             attr_value = attribute.value

--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -1386,7 +1386,8 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
                 (not hasattr(attribute, 'generate_value') or not attribute.generate_value)):
             attribute.generate_value = True
 
-        if isinstance(symbol, (Package, Attribute, ClassType)):
+        if (isinstance(symbol, (Package, Attribute))
+                or (isinstance(symbol, ClassType) and isinstance(value, (Package, Attribute)))):
             attr_value = symbol
         else:
             attr_value = attribute.value

--- a/boa3/model/type/classes/userclass.py
+++ b/boa3/model/type/classes/userclass.py
@@ -64,7 +64,7 @@ class UserClass(ClassArrayType):
         # TODO: change when user class variables are implemented
         pass
 
-    def include_callable(self, method_id: str, method: Callable, scope: ClassScope):
+    def include_callable(self, method_id: str, method: Callable, scope: ClassScope = ClassScope.INSTANCE):
         """
         Includes a method into the scope of the class
 
@@ -72,8 +72,14 @@ class UserClass(ClassArrayType):
         :param method: method to be included
         :param scope: which class scope this method should be included
         """
-        # TODO: change when user class methods are implemented
-        pass
+        from boa3.model.builtin.builtin import Builtin
+        if isinstance(method, Method):
+            if Builtin.ClassMethodDecorator in method.decorators or scope is ClassScope.CLASS:
+                self._class_methods[method_id] = method
+            elif Builtin.StaticMethodDecorator in method.decorators or scope is ClassScope.STATIC:
+                self._static_methods[method_id] = method
+            else:
+                self._instance_methods[method_id] = method
 
     def include_symbol(self, symbol_id: str, symbol: ISymbol, scope: ClassScope = ClassScope.INSTANCE):
         """

--- a/boa3_test/test_sc/class_test/UserClassWithStaticMethodFromClassWithSameNameMethod.py
+++ b/boa3_test/test_sc/class_test/UserClassWithStaticMethodFromClassWithSameNameMethod.py
@@ -1,0 +1,16 @@
+from boa3.builtin import public
+
+
+class Example:
+    @staticmethod
+    def some_method() -> int:
+        return 42
+
+
+def some_method() -> int:
+    return 24
+
+
+@public
+def call_by_class_name() -> int:
+    return Example.some_method()

--- a/boa3_test/test_sc/function_test/CallFunctionsWithSameNameInDifferentScopes.py
+++ b/boa3_test/test_sc/function_test/CallFunctionsWithSameNameInDifferentScopes.py
@@ -1,0 +1,22 @@
+from typing import Tuple
+
+from boa3.builtin import public
+
+
+class Example:
+    @staticmethod
+    def test() -> int:
+        return 10
+
+
+@public
+def test() -> int:
+    return 20
+
+
+@public
+def result() -> Tuple[int, int]:
+    a = Example.test()
+    b = test()
+    c = (a, b)
+    return c

--- a/boa3_test/tests/compiler_tests/test_class.py
+++ b/boa3_test/tests/compiler_tests/test_class.py
@@ -103,6 +103,14 @@ class TestClass(BoaTest):
         result = self.run_smart_contract(engine, path, 'call_by_class_name')
         self.assertEqual(42, result)
 
+    def test_user_class_with_static_method_from_class_with_same_method_name(self):
+        path = self.get_contract_path('UserClassWithStaticMethodFromClassWithSameNameMethod.py')
+        self.compile_and_save(path)
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'call_by_class_name')
+        self.assertEqual(42, result)
+
     def test_user_class_with_static_method_from_object(self):
         path = self.get_contract_path('UserClassWithStaticMethodFromObject.py')
         self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)

--- a/boa3_test/tests/compiler_tests/test_function.py
+++ b/boa3_test/tests/compiler_tests/test_function.py
@@ -1027,3 +1027,10 @@ class TestFunction(BoaTest):
 
         result = self.run_smart_contract(engine, path, 'main', [1, 2, 3])
         self.assertEqual(3, result)
+
+    def test_call_function_with_same_name_in_different_scopes(self):
+        path = self.get_contract_path('CallFunctionsWithSameNameInDifferentScopes.py')
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'result')
+        self.assertEqual([10, 20], result)


### PR DESCRIPTION
**Related issue**
#581 

**Summary or solution description**
Fixed the issue caused when naming functions in different scopes with the same name

**How to Reproduce**
```python
class Example:
    @staticmethod
    def test() -> int:
        return 10

@public
def test() -> int:
    return 20

@public
def result() -> Tuple[int, int]:
    a = Example.test()
    b = test()
    c = (a, b)
    return c
```
This example compiles, but both `a` and `b` calls the same method.

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/b569c5a24e57d7bae5e71ac5f0fd20d8a371f3fc/boa3_test/tests/compiler_tests/test_function.py#L1031-L1036
https://github.com/CityOfZion/neo3-boa/blob/b569c5a24e57d7bae5e71ac5f0fd20d8a371f3fc/boa3_test/tests/compiler_tests/test_class.py#L106-L112

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
