### PR TITLE
Implement interface for CryptoLib native contract

### DIFF
--- a/boa3/builtin/nativecontract/cryptolib.py
+++ b/boa3/builtin/nativecontract/cryptolib.py
@@ -1,0 +1,69 @@
+from typing import Any
+
+from boa3.builtin.type import ECPoint
+
+
+class CryptoLib:
+    """
+    A class used to represent the CryptoLib native contract
+    """
+
+    @classmethod
+    def sha256(cls, key: Any) -> bytes:
+        """
+        Encrypts a key using SHA-256.
+
+        :param key: the key to be encrypted
+        :type key: Any
+        :return: a byte value that represents the encrypted key
+        :rtype: bytes
+        """
+        pass
+
+    @classmethod
+    def ripemd160(cls, key: Any) -> bytes:
+        """
+        Encrypts a key using RIPEMD-160.
+
+        :param key: the key to be encrypted
+        :type key: Any
+        :return: a byte value that represents the encrypted key
+        :rtype: bytes
+        """
+        pass
+
+    # TODO: Change it to verify_with_ecdsa when implemented
+    @classmethod
+    def verify_with_ecdsa_secp256k1(cls, item: Any, pubkey: ECPoint, signature: bytes) -> bool:
+        """
+        Using the elliptic curve secp256k1, it checks if the signature of the any item was originally produced by the
+        public key.
+
+        :param item: the encrypted message
+        :type item: Any
+        :param pubkey: the public key that might have created the item
+        :type pubkey: ECPoint
+        :param signature: the signature of the item
+        :type signature: bytes
+        :return: a boolean value that represents whether the signature is valid
+        :rtype: bool
+        """
+        pass
+
+    # TODO: Change it to verify_with_ecdsa when implemented
+    @classmethod
+    def verify_with_ecdsa_secp256r1(cls, item: Any, pubkey: ECPoint, signature: bytes) -> bool:
+        """
+        Using the elliptic curve secp256r1, it checks if the signature of the any item was originally produced by the
+        public key.
+
+        :param item: the encrypted message
+        :type item: Any
+        :param pubkey: the public key that might have created the item
+        :type pubkey: ECPoint
+        :param signature: the signature of the item
+        :type signature: bytes
+        :return: a boolean value that represents whether the signature is valid
+        :rtype: bool
+        """
+        pass

--- a/boa3/model/builtin/native/__init__.py
+++ b/boa3/model/builtin/native/__init__.py
@@ -1,6 +1,8 @@
-__all__ = ['LedgerClass',
-           'PolicyClass'
+__all__ = ['CryptoLibClass',
+           'LedgerClass',
+           'PolicyClass',
            ]
 
+from boa3.model.builtin.native.cryptolibclass import CryptoLibClass
 from boa3.model.builtin.native.ledgerclass import LedgerClass
 from boa3.model.builtin.native.policyclass import PolicyClass

--- a/boa3/model/builtin/native/cryptolibclass.py
+++ b/boa3/model/builtin/native/cryptolibclass.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from boa3.model.method import Method
+from boa3.model.property import Property
+from boa3.model.type.classes.classarraytype import ClassArrayType
+from boa3.model.variable import Variable
+
+
+class CryptoLibClass(ClassArrayType):
+    """
+    A class used to represent CryptoLib native contract
+    """
+
+    def __init__(self):
+        super().__init__('CryptoLib')
+
+        self._variables: Dict[str, Variable] = {}
+        self._class_methods: Dict[str, Method] = {}
+        self._constructor: Optional[Method] = None
+
+    @property
+    def instance_variables(self) -> Dict[str, Variable]:
+        return self._variables.copy()
+
+    @property
+    def class_variables(self) -> Dict[str, Variable]:
+        return {}
+
+    @property
+    def properties(self) -> Dict[str, Property]:
+        return {}
+
+    @property
+    def static_methods(self) -> Dict[str, Method]:
+        return {}
+
+    @property
+    def class_methods(self) -> Dict[str, Method]:
+        # avoid recursive import
+        from boa3.model.builtin.interop.crypto import (Sha256Method, Ripemd160Method,
+                                                       VerifyWithECDsaSecp256k1Method,
+                                                       VerifyWithECDsaSecp256r1Method)
+
+        if len(self._class_methods) == 0:
+            self._class_methods = {
+                'sha256': Sha256Method(),
+                'ripemd160': Ripemd160Method(),
+                'verify_with_ecdsa_secp256k1': VerifyWithECDsaSecp256k1Method(),
+                'verify_with_ecdsa_secp256r1': VerifyWithECDsaSecp256r1Method()
+            }
+        return self._class_methods
+
+    @property
+    def instance_methods(self) -> Dict[str, Method]:
+        return {}
+
+    def constructor_method(self) -> Optional[Method]:
+        return self._constructor
+
+    @classmethod
+    def build(cls, value: Any = None) -> CryptoLibClass:
+        if value is None or cls._is_type_of(value):
+            return _CryptoLib
+
+    @classmethod
+    def _is_type_of(cls, value: Any):
+        return isinstance(value, CryptoLibClass)
+
+
+_CryptoLib = CryptoLibClass()

--- a/boa3/model/builtin/native/nativecontract.py
+++ b/boa3/model/builtin/native/nativecontract.py
@@ -13,10 +13,14 @@ class NativeContract:
     TransactionType = TransactionType.build()
 
     # Class Interfaces
+    CryptoLib = CryptoLibClass()
     Ledger = LedgerClass()
     Policy = PolicyClass()
 
     # region Packages
+
+    CryptoLibModule = Package(identifier=CryptoLib.identifier.lower(),
+                              types=[CryptoLib])
 
     LedgerModule = Package(identifier=Ledger.identifier.lower(),
                            types=[Ledger,
@@ -31,6 +35,7 @@ class NativeContract:
     # endregion
 
     package_symbols: List[IdentifiedSymbol] = [
+        CryptoLibModule,
         LedgerModule,
-        PolicyModule
+        PolicyModule,
     ]

--- a/boa3_test/test_sc/interop_test/crypto/Ripemd160TooFewArguments.py
+++ b/boa3_test/test_sc/interop_test/crypto/Ripemd160TooFewArguments.py
@@ -1,0 +1,5 @@
+from boa3.builtin.interop.crypto import ripemd160
+
+
+def Main() -> bytes:
+    return ripemd160()

--- a/boa3_test/test_sc/interop_test/crypto/Ripemd160TooManyArguments.py
+++ b/boa3_test/test_sc/interop_test/crypto/Ripemd160TooManyArguments.py
@@ -1,0 +1,5 @@
+from boa3.builtin.interop.crypto import ripemd160
+
+
+def Main() -> bytes:
+    return ripemd160('arg', 'arg')

--- a/boa3_test/test_sc/interop_test/crypto/Sha256TooFewArguments.py
+++ b/boa3_test/test_sc/interop_test/crypto/Sha256TooFewArguments.py
@@ -1,0 +1,5 @@
+from boa3.builtin.interop.crypto import sha256
+
+
+def Main() -> bytes:
+    return sha256()

--- a/boa3_test/test_sc/interop_test/crypto/Sha256TooManyArguments.py
+++ b/boa3_test/test_sc/interop_test/crypto/Sha256TooManyArguments.py
@@ -1,0 +1,5 @@
+from boa3.builtin.interop.crypto import sha256
+
+
+def Main() -> bytes:
+    return sha256('arg', 'arg')

--- a/boa3_test/test_sc/native_test/cryptolib/Ripemd160Bool.py
+++ b/boa3_test/test_sc/native_test/cryptolib/Ripemd160Bool.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.nativecontract.cryptolib import CryptoLib
+
+
+@public
+def Main() -> bytes:
+    return CryptoLib.ripemd160(True)

--- a/boa3_test/test_sc/native_test/cryptolib/Ripemd160Bytes.py
+++ b/boa3_test/test_sc/native_test/cryptolib/Ripemd160Bytes.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.nativecontract.cryptolib import CryptoLib
+
+
+@public
+def Main() -> bytes:
+    return CryptoLib.ripemd160(b'unit test')

--- a/boa3_test/test_sc/native_test/cryptolib/Ripemd160Int.py
+++ b/boa3_test/test_sc/native_test/cryptolib/Ripemd160Int.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.nativecontract.cryptolib import CryptoLib
+
+
+@public
+def Main() -> bytes:
+    return CryptoLib.ripemd160(10)

--- a/boa3_test/test_sc/native_test/cryptolib/Ripemd160Str.py
+++ b/boa3_test/test_sc/native_test/cryptolib/Ripemd160Str.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.nativecontract.cryptolib import CryptoLib
+
+
+@public
+def Main(test: str) -> bytes:
+    return CryptoLib.ripemd160(test)

--- a/boa3_test/test_sc/native_test/cryptolib/Ripemd160TooFewArguments.py
+++ b/boa3_test/test_sc/native_test/cryptolib/Ripemd160TooFewArguments.py
@@ -1,0 +1,5 @@
+from boa3.builtin.nativecontract.cryptolib import CryptoLib
+
+
+def Main() -> bytes:
+    return CryptoLib.ripemd160()

--- a/boa3_test/test_sc/native_test/cryptolib/Ripemd160TooManyArguments.py
+++ b/boa3_test/test_sc/native_test/cryptolib/Ripemd160TooManyArguments.py
@@ -1,0 +1,5 @@
+from boa3.builtin.nativecontract.cryptolib import CryptoLib
+
+
+def Main() -> bytes:
+    return CryptoLib.ripemd160('arg', 'arg')

--- a/boa3_test/test_sc/native_test/cryptolib/Sha256Bool.py
+++ b/boa3_test/test_sc/native_test/cryptolib/Sha256Bool.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.nativecontract.cryptolib import CryptoLib
+
+
+@public
+def Main() -> bytes:
+    return CryptoLib.sha256(True)

--- a/boa3_test/test_sc/native_test/cryptolib/Sha256Bytes.py
+++ b/boa3_test/test_sc/native_test/cryptolib/Sha256Bytes.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.nativecontract.cryptolib import CryptoLib
+
+
+@public
+def Main() -> bytes:
+    return CryptoLib.sha256(b'unit test')

--- a/boa3_test/test_sc/native_test/cryptolib/Sha256Int.py
+++ b/boa3_test/test_sc/native_test/cryptolib/Sha256Int.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.nativecontract.cryptolib import CryptoLib
+
+
+@public
+def Main() -> bytes:
+    return CryptoLib.sha256(10)

--- a/boa3_test/test_sc/native_test/cryptolib/Sha256Str.py
+++ b/boa3_test/test_sc/native_test/cryptolib/Sha256Str.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.nativecontract.cryptolib import CryptoLib
+
+
+@public
+def Main(test: str) -> bytes:
+    return CryptoLib.sha256(test)

--- a/boa3_test/test_sc/native_test/cryptolib/Sha256TooFewArguments.py
+++ b/boa3_test/test_sc/native_test/cryptolib/Sha256TooFewArguments.py
@@ -1,0 +1,5 @@
+from boa3.builtin.nativecontract.cryptolib import CryptoLib
+
+
+def Main() -> bytes:
+    return CryptoLib.sha256()

--- a/boa3_test/test_sc/native_test/cryptolib/Sha256TooManyArguments.py
+++ b/boa3_test/test_sc/native_test/cryptolib/Sha256TooManyArguments.py
@@ -1,0 +1,5 @@
+from boa3.builtin.nativecontract.cryptolib import CryptoLib
+
+
+def Main() -> bytes:
+    return CryptoLib.sha256('arg', 'arg')

--- a/boa3_test/test_sc/native_test/cryptolib/VerifyWithECDsaSecp256k1Bool.py
+++ b/boa3_test/test_sc/native_test/cryptolib/VerifyWithECDsaSecp256k1Bool.py
@@ -1,0 +1,8 @@
+from boa3.builtin import public
+from boa3.builtin.nativecontract.cryptolib import CryptoLib
+from boa3.builtin.type import ECPoint
+
+
+@public
+def Main():
+    CryptoLib.verify_with_ecdsa_secp256k1(False, ECPoint(b'0123456789ABCDEFGHIJKLMNOPQRSTUVW'), b'signature')

--- a/boa3_test/test_sc/native_test/cryptolib/VerifyWithECDsaSecp256k1Bytes.py
+++ b/boa3_test/test_sc/native_test/cryptolib/VerifyWithECDsaSecp256k1Bytes.py
@@ -1,0 +1,8 @@
+from boa3.builtin import public
+from boa3.builtin.nativecontract.cryptolib import CryptoLib
+from boa3.builtin.type import ECPoint
+
+
+@public
+def Main():
+    CryptoLib.verify_with_ecdsa_secp256k1(b'unit test', ECPoint(b'0123456789ABCDEFGHIJKLMNOPQRSTUVW'), b'signature')

--- a/boa3_test/test_sc/native_test/cryptolib/VerifyWithECDsaSecp256k1Int.py
+++ b/boa3_test/test_sc/native_test/cryptolib/VerifyWithECDsaSecp256k1Int.py
@@ -1,0 +1,8 @@
+from boa3.builtin import public
+from boa3.builtin.nativecontract.cryptolib import CryptoLib
+from boa3.builtin.type import ECPoint
+
+
+@public
+def Main():
+    CryptoLib.verify_with_ecdsa_secp256k1(10, ECPoint(b'0123456789ABCDEFGHIJKLMNOPQRSTUVW'), b'signature')

--- a/boa3_test/test_sc/native_test/cryptolib/VerifyWithECDsaSecp256k1MismatchedType.py
+++ b/boa3_test/test_sc/native_test/cryptolib/VerifyWithECDsaSecp256k1MismatchedType.py
@@ -1,0 +1,5 @@
+from boa3.builtin.nativecontract.cryptolib import CryptoLib
+
+
+def Main():
+    CryptoLib.verify_with_ecdsa_secp256k1('unit test', 10, b'signature')

--- a/boa3_test/test_sc/native_test/cryptolib/VerifyWithECDsaSecp256k1Str.py
+++ b/boa3_test/test_sc/native_test/cryptolib/VerifyWithECDsaSecp256k1Str.py
@@ -1,0 +1,8 @@
+from boa3.builtin import public
+from boa3.builtin.nativecontract.cryptolib import CryptoLib
+from boa3.builtin.type import ECPoint
+
+
+@public
+def Main():
+    CryptoLib.verify_with_ecdsa_secp256k1('unit test', ECPoint(b'0123456789ABCDEFGHIJKLMNOPQRSTUVW'), b'signature')

--- a/boa3_test/test_sc/native_test/cryptolib/VerifyWithECDsaSecp256r1Bool.py
+++ b/boa3_test/test_sc/native_test/cryptolib/VerifyWithECDsaSecp256r1Bool.py
@@ -1,0 +1,8 @@
+from boa3.builtin import public
+from boa3.builtin.nativecontract.cryptolib import CryptoLib
+from boa3.builtin.type import ECPoint
+
+
+@public
+def Main():
+    CryptoLib.verify_with_ecdsa_secp256r1(False, ECPoint(b'0123456789ABCDEFGHIJKLMNOPQRSTUVW'), b'signature')

--- a/boa3_test/test_sc/native_test/cryptolib/VerifyWithECDsaSecp256r1Bytes.py
+++ b/boa3_test/test_sc/native_test/cryptolib/VerifyWithECDsaSecp256r1Bytes.py
@@ -1,0 +1,8 @@
+from boa3.builtin import public
+from boa3.builtin.nativecontract.cryptolib import CryptoLib
+from boa3.builtin.type import ECPoint
+
+
+@public
+def Main():
+    CryptoLib.verify_with_ecdsa_secp256r1(b'unit test', ECPoint(b'0123456789ABCDEFGHIJKLMNOPQRSTUVW'), b'signature')

--- a/boa3_test/test_sc/native_test/cryptolib/VerifyWithECDsaSecp256r1Int.py
+++ b/boa3_test/test_sc/native_test/cryptolib/VerifyWithECDsaSecp256r1Int.py
@@ -1,0 +1,8 @@
+from boa3.builtin import public
+from boa3.builtin.nativecontract.cryptolib import CryptoLib
+from boa3.builtin.type import ECPoint
+
+
+@public
+def Main():
+    CryptoLib.verify_with_ecdsa_secp256r1(10, ECPoint(b'0123456789ABCDEFGHIJKLMNOPQRSTUVW'), b'signature')

--- a/boa3_test/test_sc/native_test/cryptolib/VerifyWithECDsaSecp256r1MismatchedType.py
+++ b/boa3_test/test_sc/native_test/cryptolib/VerifyWithECDsaSecp256r1MismatchedType.py
@@ -1,0 +1,5 @@
+from boa3.builtin.nativecontract.cryptolib import CryptoLib
+
+
+def Main():
+    CryptoLib.verify_with_ecdsa_secp256r1('unit test', 10, b'signature')

--- a/boa3_test/test_sc/native_test/cryptolib/VerifyWithECDsaSecp256r1Str.py
+++ b/boa3_test/test_sc/native_test/cryptolib/VerifyWithECDsaSecp256r1Str.py
@@ -1,0 +1,8 @@
+from boa3.builtin import public
+from boa3.builtin.nativecontract.cryptolib import CryptoLib
+from boa3.builtin.type import ECPoint
+
+
+@public
+def Main():
+    CryptoLib.verify_with_ecdsa_secp256r1('unit test', ECPoint(b'0123456789ABCDEFGHIJKLMNOPQRSTUVW'), b'signature')

--- a/boa3_test/tests/compiler_tests/test_native/test_cryptolib.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_cryptolib.py
@@ -14,9 +14,9 @@ from boa3_test.tests.boa_test import BoaTest
 from boa3_test.tests.test_classes.testengine import TestEngine
 
 
-class TestCryptoInterop(BoaTest):
+class TestCryptoLibClass(BoaTest):
 
-    default_folder: str = 'test_sc/interop_test/crypto'
+    default_folder: str = 'test_sc/native_test/cryptolib'
     ecpoint_init = (
         Opcode.CONVERT + Type.bytes.stack_item
         + Opcode.DUP
@@ -69,34 +69,6 @@ class TestCryptoInterop(BoaTest):
         path = self.get_contract_path('Ripemd160TooFewArguments.py')
         self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
 
-    def test_hash160_str(self):
-        path = self.get_contract_path('Hash160Str.py')
-        engine = TestEngine()
-        expected_result = hashlib.new('ripemd160', (hashlib.sha256(b'unit test').digest())).digest()
-        result = self.run_smart_contract(engine, path, 'Main', 'unit test')
-        self.assertEqual(expected_result, result)
-
-    def test_hash160_int(self):
-        path = self.get_contract_path('Hash160Int.py')
-        engine = TestEngine()
-        expected_result = hashlib.new('ripemd160', (hashlib.sha256(Integer(10).to_byte_array()).digest())).digest()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(expected_result, result)
-
-    def test_hash160_bool(self):
-        path = self.get_contract_path('Hash160Bool.py')
-        engine = TestEngine()
-        expected_result = hashlib.new('ripemd160', (hashlib.sha256(Integer(1).to_byte_array()).digest())).digest()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(expected_result, result)
-
-    def test_hash160_bytes(self):
-        path = self.get_contract_path('Hash160Bytes.py')
-        engine = TestEngine()
-        expected_result = hashlib.new('ripemd160', (hashlib.sha256(b'unit test').digest())).digest()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(expected_result, result)
-
     def test_sha256_str(self):
         path = self.get_contract_path('Sha256Str.py')
         engine = TestEngine()
@@ -136,113 +108,6 @@ class TestCryptoInterop(BoaTest):
     def test_sha256_too_few_parameters(self):
         path = self.get_contract_path('Sha256TooFewArguments.py')
         self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
-
-    def test_hash256_str(self):
-        path = self.get_contract_path('Hash256Str.py')
-        engine = TestEngine()
-        expected_result = hashlib.sha256(hashlib.sha256(b'unit test').digest()).digest()
-        result = self.run_smart_contract(engine, path, 'Main', 'unit test')
-        self.assertEqual(expected_result, result)
-
-    def test_hash256_int(self):
-        path = self.get_contract_path('Hash256Int.py')
-        engine = TestEngine()
-        expected_result = hashlib.sha256(hashlib.sha256(Integer(10).to_byte_array()).digest()).digest()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(expected_result, result)
-
-    def test_hash256_bool(self):
-        path = self.get_contract_path('Hash256Bool.py')
-        engine = TestEngine()
-        expected_result = hashlib.sha256(hashlib.sha256(Integer(1).to_byte_array()).digest()).digest()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(expected_result, result)
-
-    def test_hash256_bytes(self):
-        path = self.get_contract_path('Hash256Bytes.py')
-        engine = TestEngine()
-        expected_result = hashlib.sha256(hashlib.sha256(b'unit test').digest()).digest()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(expected_result, result)
-
-    def test_check_sig(self):
-        byte_input0 = b'\x03\x5a\x92\x8f\x20\x16\x39\x20\x4e\x06\xb4\x36\x8b\x1a\x93\x36\x54\x62\xa8\xeb\xbf\xf0\xb8\x81\x81\x51\xb7\x4f\xaa\xb3\xa2\xb6\x1a'
-        byte_input1 = b'wrongsignature'
-
-        expected_output = (
-            Opcode.INITSLOT
-            + b'\x02'
-            + b'\x00'
-            + Opcode.PUSHDATA1
-            + Integer(len(byte_input0)).to_byte_array(min_length=1)
-            + byte_input0
-            + self.ecpoint_init
-            + Opcode.STLOC0
-            + Opcode.PUSHDATA1
-            + Integer(len(byte_input1)).to_byte_array(min_length=1)
-            + byte_input1
-            + Opcode.STLOC1
-            + Opcode.PUSHDATA1
-            + Integer(len(byte_input1)).to_byte_array(min_length=1)
-            + byte_input1
-            + Opcode.LDLOC0
-            + Opcode.SYSCALL
-            + Interop.CheckSig.interop_method_hash
-            + Opcode.RET
-        )
-
-        path = self.get_contract_path('CheckSig.py')
-        output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
-
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(False, result)
-
-    def test_check_multisig(self):
-        byte_input0 = b'\x03\xcd\xb0g\xd90\xfdZ\xda\xa6\xc6\x85E\x01`D\xaa\xdd\xecd\xba9\xe5H%\x0e\xae\xa5Q\x17.S\\'
-        byte_input1 = b'\x03l\x841\xccx\xb31w\xa6\x0bK\xcc\x02\xba\xf6\r\x05\xfe\xe5\x03\x8es9\xd3\xa6\x88\xe3\x94\xc2\xcb\xd8C'
-        byte_input2 = b'wrongsignature1'
-        byte_input3 = b'wrongsignature2'
-
-        expected_output = (
-            Opcode.INITSLOT
-            + b'\x02'
-            + b'\x00'
-            + Opcode.PUSHDATA1
-            + Integer(len(byte_input1)).to_byte_array(min_length=1)
-            + byte_input1
-            + self.ecpoint_init
-            + Opcode.PUSHDATA1
-            + Integer(len(byte_input0)).to_byte_array(min_length=1)
-            + byte_input0
-            + self.ecpoint_init
-            + Opcode.PUSH2
-            + Opcode.PACK
-            + Opcode.STLOC0
-            + Opcode.PUSHDATA1
-            + Integer(len(byte_input3)).to_byte_array(min_length=1)
-            + byte_input3
-            + Opcode.PUSHDATA1
-            + Integer(len(byte_input2)).to_byte_array(min_length=1)
-            + byte_input2
-            + Opcode.PUSH2
-            + Opcode.PACK
-            + Opcode.STLOC1
-            + Opcode.LDLOC1
-            + Opcode.LDLOC0
-            + Opcode.SYSCALL
-            + Interop.CheckMultisig.interop_method_hash
-            + Opcode.RET
-        )
-
-        path = self.get_contract_path('CheckMultisig.py')
-        output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
-
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(False, result)
 
     def test_verify_with_ecdsa_secp256r1_str(self):
         byte_input1 = b'0123456789ABCDEFGHIJKLMNOPQRSTUVW'
@@ -563,17 +428,3 @@ class TestCryptoInterop(BoaTest):
     def test_verify_with_ecdsa_secp256k1_mismatched_type(self):
         path = self.get_contract_path('VerifyWithECDsaSecp256k1MismatchedType.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
-
-    def test_import_crypto(self):
-        path = self.get_contract_path('ImportCrypto.py')
-        engine = TestEngine()
-        expected_result = hashlib.new('ripemd160', (hashlib.sha256(b'unit test').digest())).digest()
-        result = self.run_smart_contract(engine, path, 'main', 'unit test')
-        self.assertEqual(expected_result, result)
-
-    def test_import_interop_crypto(self):
-        path = self.get_contract_path('ImportInteropCrypto.py')
-        engine = TestEngine()
-        expected_result = hashlib.new('ripemd160', (hashlib.sha256(b'unit test').digest())).digest()
-        result = self.run_smart_contract(engine, path, 'main', 'unit test')
-        self.assertEqual(expected_result, result)


### PR DESCRIPTION
**Related issue**
#600 

**Summary or solution description**
 Implemented an interface for interacting with the CryptoLib native contract in a clearer way.
https://github.com/CityOfZion/neo3-boa/blob/6f311e12d12d0236e490fc1c776412ff669a3bbd/boa3/builtin/nativecontract/cryptolib.py#L1-L69

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/6f311e12d12d0236e490fc1c776412ff669a3bbd/boa3_test/test_sc/native_test/cryptolib/Sha256Bytes.py#L1-L7

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/6f311e12d12d0236e490fc1c776412ff669a3bbd/boa3_test/tests/compiler_tests/test_native/test_cryptolib.py#L1-L430

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8

**(Optional) Additional context**
Also added some CompilerError tests to the crypto interop.