### PR TITLE
Implement interface for RoleManagement native contract

### DIFF
--- a/boa3/builtin/nativecontract/rolemanagement.py
+++ b/boa3/builtin/nativecontract/rolemanagement.py
@@ -1,0 +1,23 @@
+from boa3.builtin.interop.role.roletype import Role
+from boa3.builtin.type import ECPoint
+
+
+class RoleManagement:
+    """
+    A class used to represent the RoleManagement native contract
+    """
+    
+    @classmethod
+    def get_designated_by_role(cls, role: Role, index: int) -> ECPoint:
+        """
+        Gets the list of nodes for the specified role.
+
+        :param role: the type of the role
+        :type role: Role
+        :param index: the index of the block to be queried
+        :type index: int
+
+        :return: the public keys of the nodes
+        :rtype: ECPoint
+        """
+        pass

--- a/boa3/model/builtin/native/__init__.py
+++ b/boa3/model/builtin/native/__init__.py
@@ -1,8 +1,10 @@
 __all__ = ['CryptoLibClass',
            'LedgerClass',
            'PolicyClass',
+           'RoleManagementClass',
            ]
 
 from boa3.model.builtin.native.cryptolibclass import CryptoLibClass
 from boa3.model.builtin.native.ledgerclass import LedgerClass
 from boa3.model.builtin.native.policyclass import PolicyClass
+from boa3.model.builtin.native.rolemanagementclass import RoleManagementClass

--- a/boa3/model/builtin/native/nativecontract.py
+++ b/boa3/model/builtin/native/nativecontract.py
@@ -1,7 +1,6 @@
 from typing import List
 
-from boa3.model.builtin.interop.blockchain import BlockType, TransactionType
-from boa3.model.builtin.interop.role import RoleType
+from boa3.model.builtin.interop.interop import Interop
 from boa3.model.builtin.native import *
 from boa3.model.identifiedsymbol import IdentifiedSymbol
 from boa3.model.imports.package import Package
@@ -9,16 +8,11 @@ from boa3.model.imports.package import Package
 
 class NativeContract:
 
-    # Interop Types
-    BlockType = BlockType.build()
-    RoleType = RoleType()
-    TransactionType = TransactionType.build()
-
     # Class Interfaces
     CryptoLib = CryptoLibClass()
     Ledger = LedgerClass()
     Policy = PolicyClass()
-    Role = RoleManagementClass()
+    RoleManagement = RoleManagementClass()
 
     # region Packages
 
@@ -27,18 +21,18 @@ class NativeContract:
 
     LedgerModule = Package(identifier=Ledger.identifier.lower(),
                            types=[Ledger,
-                                  BlockType,
-                                  TransactionType]
+                                  Interop.BlockType,
+                                  Interop.TransactionType]
                            )
 
     PolicyModule = Package(identifier=Policy.identifier.lower(),
                            types=[Policy]
                            )
 
-    RoleModule = Package(identifier=Role.identifier.lower(),
-                         types=[Role,
-                                RoleType]
-                         )
+    RoleManagementModule = Package(identifier=RoleManagement.identifier.lower(),
+                                   types=[RoleManagement,
+                                          Interop.RoleType]
+                                   )
 
     # endregion
 
@@ -46,5 +40,5 @@ class NativeContract:
         CryptoLibModule,
         LedgerModule,
         PolicyModule,
-        RoleModule,
+        RoleManagementModule,
     ]

--- a/boa3/model/builtin/native/nativecontract.py
+++ b/boa3/model/builtin/native/nativecontract.py
@@ -1,6 +1,7 @@
 from typing import List
 
 from boa3.model.builtin.interop.blockchain import BlockType, TransactionType
+from boa3.model.builtin.interop.role import RoleType
 from boa3.model.builtin.native import *
 from boa3.model.identifiedsymbol import IdentifiedSymbol
 from boa3.model.imports.package import Package
@@ -10,12 +11,14 @@ class NativeContract:
 
     # Interop Types
     BlockType = BlockType.build()
+    RoleType = RoleType()
     TransactionType = TransactionType.build()
 
     # Class Interfaces
     CryptoLib = CryptoLibClass()
     Ledger = LedgerClass()
     Policy = PolicyClass()
+    Role = RoleManagementClass()
 
     # region Packages
 
@@ -32,10 +35,16 @@ class NativeContract:
                            types=[Policy]
                            )
 
+    RoleModule = Package(identifier=Role.identifier.lower(),
+                         types=[Role,
+                                RoleType]
+                         )
+
     # endregion
 
     package_symbols: List[IdentifiedSymbol] = [
         CryptoLibModule,
         LedgerModule,
         PolicyModule,
+        RoleModule,
     ]

--- a/boa3/model/builtin/native/rolemanagementclass.py
+++ b/boa3/model/builtin/native/rolemanagementclass.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from boa3.model.method import Method
+from boa3.model.property import Property
+from boa3.model.type.classes.classarraytype import ClassArrayType
+from boa3.model.variable import Variable
+
+
+class RoleManagementClass(ClassArrayType):
+    """
+    A class used to represent RoleManagement native contract
+    """
+
+    def __init__(self):
+        super().__init__('RoleManagement')
+
+        self._variables: Dict[str, Variable] = {}
+        self._class_methods: Dict[str, Method] = {}
+        self._constructor: Optional[Method] = None
+
+    @property
+    def instance_variables(self) -> Dict[str, Variable]:
+        return self._variables.copy()
+
+    @property
+    def class_variables(self) -> Dict[str, Variable]:
+        return {}
+
+    @property
+    def properties(self) -> Dict[str, Property]:
+        return {}
+
+    @property
+    def static_methods(self) -> Dict[str, Method]:
+        return {}
+
+    @property
+    def class_methods(self) -> Dict[str, Method]:
+        # avoid recursive import
+        from boa3.model.builtin.interop.role import GetDesignatedByRoleMethod
+        if len(self._class_methods) == 0:
+            self._class_methods = {
+                'get_designated_by_role': GetDesignatedByRoleMethod()
+            }
+        return self._class_methods
+
+    @property
+    def instance_methods(self) -> Dict[str, Method]:
+        return {}
+
+    def constructor_method(self) -> Optional[Method]:
+        return self._constructor
+
+    @classmethod
+    def build(cls, value: Any = None) -> RoleManagementClass:
+        if value is None or cls._is_type_of(value):
+            return _RoleManagement
+
+    @classmethod
+    def _is_type_of(cls, value: Any):
+        return isinstance(value, RoleManagementClass)
+
+
+_RoleManagement = RoleManagementClass()

--- a/boa3_test/test_sc/interop_test/role/GetDesignatedByRoleTooFewArguments.py
+++ b/boa3_test/test_sc/interop_test/role/GetDesignatedByRoleTooFewArguments.py
@@ -1,0 +1,6 @@
+from boa3.builtin.interop.role import Role, get_designated_by_role
+from boa3.builtin.type import ECPoint
+
+
+def main(role: Role) -> ECPoint:
+    return get_designated_by_role(role)

--- a/boa3_test/test_sc/interop_test/role/GetDesignatedByRoleTooManyArguments.py
+++ b/boa3_test/test_sc/interop_test/role/GetDesignatedByRoleTooManyArguments.py
@@ -1,0 +1,6 @@
+from boa3.builtin.interop.role import Role, get_designated_by_role
+from boa3.builtin.type import ECPoint
+
+
+def main(role: Role, index: int) -> ECPoint:
+    return get_designated_by_role(role, index, 'arg')

--- a/boa3_test/test_sc/native_test/rolemanagement/GetDesignatedByRole.py
+++ b/boa3_test/test_sc/native_test/rolemanagement/GetDesignatedByRole.py
@@ -1,0 +1,9 @@
+from boa3.builtin import public
+from boa3.builtin.interop.role import Role
+from boa3.builtin.nativecontract.rolemanagement import RoleManagement
+from boa3.builtin.type import ECPoint
+
+
+@public
+def main(role: Role, index: int) -> ECPoint:
+    return RoleManagement.get_designated_by_role(role, index)

--- a/boa3_test/test_sc/native_test/rolemanagement/GetDesignatedByRoleTooFewArguments.py
+++ b/boa3_test/test_sc/native_test/rolemanagement/GetDesignatedByRoleTooFewArguments.py
@@ -1,0 +1,7 @@
+from boa3.builtin.interop.role import Role
+from boa3.builtin.nativecontract.rolemanagement import RoleManagement
+from boa3.builtin.type import ECPoint
+
+
+def main(role: Role) -> ECPoint:
+    return RoleManagement.get_designated_by_role(role)

--- a/boa3_test/test_sc/native_test/rolemanagement/GetDesignatedByRoleTooManyArguments.py
+++ b/boa3_test/test_sc/native_test/rolemanagement/GetDesignatedByRoleTooManyArguments.py
@@ -1,0 +1,7 @@
+from boa3.builtin.interop.role import Role
+from boa3.builtin.nativecontract.rolemanagement import RoleManagement
+from boa3.builtin.type import ECPoint
+
+
+def main(role: Role, index: int) -> ECPoint:
+    return RoleManagement.get_designated_by_role(role, index, 'arg')

--- a/boa3_test/tests/compiler_tests/test_interop/test_role.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_role.py
@@ -1,6 +1,6 @@
 from boa3 import constants
-
 from boa3.boa3 import Boa3
+from boa3.exception import CompilerError
 from boa3.model.builtin.interop.interop import Interop
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
@@ -41,6 +41,14 @@ class TestRoleInterop(BoaTest):
         path = self.get_contract_path('GetDesignatedByRole.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
+
+    def test_get_designated_by_role_too_many_parameters(self):
+        path = self.get_contract_path('GetDesignatedByRoleTooManyArguments.py')
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+
+    def test_get_designated_by_role_too_few_parameters(self):
+        path = self.get_contract_path('GetDesignatedByRoleTooFewArguments.py')
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
 
     def test_import_role(self):
         call_flags = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)

--- a/boa3_test/tests/compiler_tests/test_native/test_rolemanagement.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_rolemanagement.py
@@ -1,0 +1,51 @@
+from boa3 import constants
+from boa3.boa3 import Boa3
+from boa3.exception import CompilerError
+from boa3.model.builtin.interop.interop import Interop
+from boa3.neo.vm.opcode.Opcode import Opcode
+from boa3.neo.vm.type.Integer import Integer
+from boa3.neo.vm.type.String import String
+from boa3.neo3.contracts import CallFlags
+from boa3_test.tests.boa_test import BoaTest
+
+
+class TestRoleManagementClass(BoaTest):
+
+    default_folder: str = 'test_sc/native_test/rolemanagement'
+
+    def test_get_designated_by_role(self):
+        call_flags = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
+        method = String(Interop.GetDesignatedByRole.method_name).to_bytes()
+
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x00\x02'
+            + Opcode.LDARG1
+            + Opcode.LDARG0
+            + Opcode.PUSH2
+            + Opcode.PACK
+            + Opcode.PUSHDATA1
+            + Integer(len(call_flags)).to_byte_array()
+            + call_flags
+            + Opcode.PUSHDATA1
+            + Integer(len(method)).to_byte_array()
+            + method
+            + Opcode.PUSHDATA1
+            + Integer(len(constants.ROLE_MANAGEMENT)).to_byte_array()
+            + constants.ROLE_MANAGEMENT
+            + Opcode.SYSCALL
+            + Interop.CallContract.interop_method_hash
+            + Opcode.RET
+        )
+
+        path = self.get_contract_path('GetDesignatedByRole.py')
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_get_designated_by_role_too_many_parameters(self):
+        path = self.get_contract_path('GetDesignatedByRoleTooManyArguments.py')
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+
+    def test_get_designated_by_role_too_few_parameters(self):
+        path = self.get_contract_path('GetDesignatedByRoleTooFewArguments.py')
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)


### PR DESCRIPTION
**Related issue**
#611 

**Summary or solution description**
 Implemented an interface for interacting with the RoleManagement native contract in a clearer way.
https://github.com/CityOfZion/neo3-boa/blob/2810402ac0111c632e0835bb8c14a1ff0eae15a1/boa3/builtin/nativecontract/rolemanagement.py#L1-L23

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/2810402ac0111c632e0835bb8c14a1ff0eae15a1/boa3_test/test_sc/native_test/rolemanagement/GetDesignatedByRole.py#L1-L9

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/2810402ac0111c632e0835bb8c14a1ff0eae15a1/boa3_test/tests/compiler_tests/test_native/test_rolemanagement.py#L1-L51

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8

**(Optional) Additional context**
Also added more tests to the role interop.
