### PR TITLE
Implement interface for ContractManagement native contract

### DIFF
--- a/boa3/builtin/nativecontract/contractmanagement.py
+++ b/boa3/builtin/nativecontract/contractmanagement.py
@@ -1,0 +1,26 @@
+from typing import Any
+
+from boa3.builtin.interop.contract import Contract
+from boa3.builtin.type import UInt160
+
+
+class ContractManagement:
+    @classmethod
+    def get_minimum_deployment_fee(cls) -> int:
+        pass
+
+    @classmethod
+    def get_contract(cls, script_hash: UInt160) -> Contract:
+        pass
+
+    @classmethod
+    def deploy(cls, nef_file: bytes, manifest: bytes, data: Any = None) -> Contract:
+        pass
+
+    @classmethod
+    def update(cls, nef_file: bytes, manifest: bytes, data: Any = None):
+        pass
+
+    @classmethod
+    def destroy(cls):
+        pass

--- a/boa3/compiler/codegenerator/codegeneratorvisitor.py
+++ b/boa3/compiler/codegenerator/codegeneratorvisitor.py
@@ -754,10 +754,10 @@ class VisitorCodeGenerator(IAstAnalyser):
             value_id = self.visit(value)
             value_symbol = self.generator.get_symbol(value_id)
 
-            if isinstance(value_symbol, UserClass):
-                if attribute.attr in value_symbol.symbols:
-                    attr = value_symbol.symbols[attribute.attr]
+            if isinstance(value_symbol, ClassType) and attribute.attr in value_symbol.symbols:
+                attr = value_symbol.symbols[attribute.attr]
 
+            if isinstance(value_symbol, UserClass):
                 if isinstance(attr, Method) and attr.has_cls_or_self:
                     self.generator.convert_load_symbol(value_id)
 
@@ -768,7 +768,7 @@ class VisitorCodeGenerator(IAstAnalyser):
 
         if attr is not Type.none and not hasattr(attribute, 'generate_value'):
             return (attribute.attr
-                    if not isinstance(value_symbol, UserClass)
+                    if not isinstance(value_symbol, ClassType)
                     else f'{value_symbol.identifier}{constants.ATTRIBUTE_NAME_SEPARATOR}{attribute.attr}'
                     )
 

--- a/boa3/model/builtin/native/__init__.py
+++ b/boa3/model/builtin/native/__init__.py
@@ -1,9 +1,11 @@
-__all__ = ['CryptoLibClass',
+__all__ = ['ContractManagementClass',
+           'CryptoLibClass',
            'LedgerClass',
            'PolicyClass',
            'RoleManagementClass',
            ]
 
+from boa3.model.builtin.native.contractmanagementclass import ContractManagementClass
 from boa3.model.builtin.native.cryptolibclass import CryptoLibClass
 from boa3.model.builtin.native.ledgerclass import LedgerClass
 from boa3.model.builtin.native.policyclass import PolicyClass

--- a/boa3/model/builtin/native/contractmanagementclass.py
+++ b/boa3/model/builtin/native/contractmanagementclass.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from boa3.model.method import Method
+from boa3.model.property import Property
+from boa3.model.type.classes.classarraytype import ClassArrayType
+from boa3.model.variable import Variable
+
+
+class ContractManagementClass(ClassArrayType):
+    """
+    A class used to represent ContractManagement native contract
+    """
+
+    def __init__(self):
+        super().__init__('ContractManagement')
+
+        self._variables: Dict[str, Variable] = {}
+        self._class_methods: Dict[str, Method] = {}
+        self._constructor: Method = None
+
+    @property
+    def instance_variables(self) -> Dict[str, Variable]:
+        return self._variables.copy()
+
+    @property
+    def class_variables(self) -> Dict[str, Variable]:
+        return {}
+
+    @property
+    def properties(self) -> Dict[str, Property]:
+        return {}
+
+    @property
+    def static_methods(self) -> Dict[str, Method]:
+        return {}
+
+    @property
+    def class_methods(self) -> Dict[str, Method]:
+        # avoid recursive import
+        from boa3.model.builtin.interop.blockchain import GetContractMethod
+        from boa3.model.builtin.interop.contract import (CreateMethod, DestroyMethod, GetMinimumDeploymentFeeMethod,
+                                                         UpdateMethod)
+        from boa3.model.builtin.interop.interop import Interop
+
+        if len(self._class_methods) == 0:
+            self._class_methods = {
+                'get_minimum_deployment_fee': GetMinimumDeploymentFeeMethod(),
+                'get_contract': GetContractMethod(Interop.ContractType),
+                'deploy': CreateMethod(Interop.ContractType),
+                'update': UpdateMethod(),
+                'destroy': DestroyMethod()
+            }
+        return self._class_methods
+
+    @property
+    def instance_methods(self) -> Dict[str, Method]:
+        return {}
+
+    def constructor_method(self) -> Optional[Method]:
+        return self._constructor
+
+    @classmethod
+    def build(cls, value: Any = None) -> ContractManagementClass:
+        if value is None or cls._is_type_of(value):
+            return _ContractManagement
+
+    @classmethod
+    def _is_type_of(cls, value: Any):
+        return isinstance(value, ContractManagementClass)
+
+
+_ContractManagement = ContractManagementClass()

--- a/boa3/model/builtin/native/nativecontract.py
+++ b/boa3/model/builtin/native/nativecontract.py
@@ -1,5 +1,6 @@
 from typing import List
 
+from boa3.model.builtin.builtin import Builtin
 from boa3.model.builtin.interop.interop import Interop
 from boa3.model.builtin.native import *
 from boa3.model.identifiedsymbol import IdentifiedSymbol
@@ -9,12 +10,18 @@ from boa3.model.imports.package import Package
 class NativeContract:
 
     # Class Interfaces
+    ContractManagement = ContractManagementClass()
     CryptoLib = CryptoLibClass()
     Ledger = LedgerClass()
     Policy = PolicyClass()
     RoleManagement = RoleManagementClass()
 
     # region Packages
+
+    ContractManagementModule = Package(identifier=ContractManagement.identifier.lower(),
+                                       types=[ContractManagement,
+                                              Interop.ContractType,
+                                              Builtin.UInt160])
 
     CryptoLibModule = Package(identifier=CryptoLib.identifier.lower(),
                               types=[CryptoLib])
@@ -37,6 +44,7 @@ class NativeContract:
     # endregion
 
     package_symbols: List[IdentifiedSymbol] = [
+        ContractManagementModule,
         CryptoLibModule,
         LedgerModule,
         PolicyModule,

--- a/boa3_test/test_sc/native_test/contractmanagement/DeployContract.py
+++ b/boa3_test/test_sc/native_test/contractmanagement/DeployContract.py
@@ -1,0 +1,10 @@
+from typing import Any
+
+from boa3.builtin import public
+from boa3.builtin.interop.contract import Contract
+from boa3.builtin.nativecontract.contractmanagement import ContractManagement
+
+
+@public
+def Main(script: bytes, manifest: bytes, data: Any) -> Contract:
+    return ContractManagement.deploy(script, manifest, data)

--- a/boa3_test/test_sc/native_test/contractmanagement/DeployContractTooFewArguments.py
+++ b/boa3_test/test_sc/native_test/contractmanagement/DeployContractTooFewArguments.py
@@ -1,0 +1,5 @@
+from boa3.builtin.nativecontract.contractmanagement import ContractManagement
+
+
+def Main(scripthash: bytes):
+    ContractManagement.deploy(scripthash)

--- a/boa3_test/test_sc/native_test/contractmanagement/DeployContractTooManyArguments.py
+++ b/boa3_test/test_sc/native_test/contractmanagement/DeployContractTooManyArguments.py
@@ -1,0 +1,7 @@
+from typing import Any
+
+from boa3.builtin.nativecontract.contractmanagement import ContractManagement
+
+
+def Main(script: bytes, manifest: bytes, data: Any, arg0: Any):
+    ContractManagement.deploy(script, manifest, data, arg0)

--- a/boa3_test/test_sc/native_test/contractmanagement/DestroyContract.py
+++ b/boa3_test/test_sc/native_test/contractmanagement/DestroyContract.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.nativecontract.contractmanagement import ContractManagement
+
+
+@public
+def Main():
+    ContractManagement.destroy()

--- a/boa3_test/test_sc/native_test/contractmanagement/DestroyContractTooManyArguments.py
+++ b/boa3_test/test_sc/native_test/contractmanagement/DestroyContractTooManyArguments.py
@@ -1,0 +1,7 @@
+from typing import Any
+
+from boa3.builtin.nativecontract.contractmanagement import ContractManagement
+
+
+def Main(arg0: Any):
+    ContractManagement.destroy(arg0)

--- a/boa3_test/test_sc/native_test/contractmanagement/GetContract.py
+++ b/boa3_test/test_sc/native_test/contractmanagement/GetContract.py
@@ -1,0 +1,9 @@
+from boa3.builtin import public
+from boa3.builtin.interop.contract import Contract
+from boa3.builtin.nativecontract.contractmanagement import ContractManagement
+from boa3.builtin.type import UInt160
+
+
+@public
+def main(hash: UInt160) -> Contract:
+    return ContractManagement.get_contract(hash)

--- a/boa3_test/test_sc/native_test/contractmanagement/GetMinimumDeploymentFee.py
+++ b/boa3_test/test_sc/native_test/contractmanagement/GetMinimumDeploymentFee.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.nativecontract.contractmanagement import ContractManagement
+
+
+@public
+def main() -> int:
+    return ContractManagement.get_minimum_deployment_fee()

--- a/boa3_test/test_sc/native_test/contractmanagement/GetMinimumDeploymentFeeTooManyArguments.py
+++ b/boa3_test/test_sc/native_test/contractmanagement/GetMinimumDeploymentFeeTooManyArguments.py
@@ -1,0 +1,9 @@
+from typing import Any
+
+from boa3.builtin import public
+from boa3.builtin.nativecontract.contractmanagement import ContractManagement
+
+
+@public
+def main(arg: Any) -> int:
+    return ContractManagement.get_minimum_deployment_fee(arg)

--- a/boa3_test/test_sc/native_test/contractmanagement/UpdateContract.py
+++ b/boa3_test/test_sc/native_test/contractmanagement/UpdateContract.py
@@ -1,0 +1,9 @@
+from typing import Any
+
+from boa3.builtin import public
+from boa3.builtin.nativecontract.contractmanagement import ContractManagement
+
+
+@public
+def update(script: bytes, manifest: bytes, data: Any):
+    ContractManagement.update(script, manifest, data)

--- a/boa3_test/test_sc/native_test/contractmanagement/UpdateContractTooFewArguments.py
+++ b/boa3_test/test_sc/native_test/contractmanagement/UpdateContractTooFewArguments.py
@@ -1,0 +1,5 @@
+from boa3.builtin.nativecontract.contractmanagement import ContractManagement
+
+
+def Main(script: bytes):
+    ContractManagement.update(script)

--- a/boa3_test/test_sc/native_test/contractmanagement/UpdateContractTooManyArguments.py
+++ b/boa3_test/test_sc/native_test/contractmanagement/UpdateContractTooManyArguments.py
@@ -1,0 +1,7 @@
+from typing import Any
+
+from boa3.builtin.nativecontract.contractmanagement import ContractManagement
+
+
+def Main(script: bytes, manifest: str, data: Any, arg0: Any):
+    ContractManagement.update(script, manifest, data, arg0)

--- a/boa3_test/tests/compiler_tests/test_native/test_contract_management.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_contract_management.py
@@ -1,0 +1,163 @@
+import json
+
+from boa3 import constants
+from boa3.boa3 import Boa3
+from boa3.exception import CompilerError, CompilerWarning
+from boa3.model.builtin.interop.interop import Interop
+from boa3.neo.cryptography import hash160
+from boa3.neo.vm.opcode.Opcode import Opcode
+from boa3.neo.vm.type.Integer import Integer
+from boa3.neo.vm.type.String import String
+from boa3_test.tests.boa_test import BoaTest
+from boa3_test.tests.test_classes.TestExecutionException import TestExecutionException
+from boa3_test.tests.test_classes.contract.neomanifeststruct import NeoManifestStruct
+from boa3_test.tests.test_classes.testengine import TestEngine
+
+
+class TestContractManagementContract(BoaTest):
+
+    default_folder: str = 'test_sc/native_test/contractmanagement'
+
+    def test_get_minimum_deployment_fee(self):
+        path = self.get_contract_path('GetMinimumDeploymentFee.py')
+        engine = TestEngine()
+
+        minimum_cost = 10 * 10**8   # minimum deployment cost is 10 GAS right now
+        result = self.run_smart_contract(engine, path, 'main')
+        self.assertEqual(minimum_cost, result)
+
+    def test_get_minimum_deployment_fee_too_many_parameters(self):
+        path = self.get_contract_path('GetMinimumDeploymentFeeTooManyArguments.py')
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+
+    def test_get_contract(self):
+        path = self.get_contract_path('GetContract.py')
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'main', bytes(20))
+        self.assertIsNone(result)
+
+        call_contract_path = self.get_contract_path('test_sc/arithmetic_test', 'Addition.py')
+        Boa3.compile_and_save(call_contract_path)
+
+        script, manifest = self.get_output(call_contract_path)
+        nef, manifest = self.get_bytes_output(call_contract_path)
+        call_hash = hash160(script)
+        call_contract_path = call_contract_path.replace('.py', '.nef')
+
+        engine.add_contract(call_contract_path)
+
+        result = self.run_smart_contract(engine, path, 'main', call_hash)
+        self.assertEqual(5, len(result))
+        self.assertEqual(call_hash, result[2])
+        self.assertEqual(nef, result[3])
+        manifest_struct = NeoManifestStruct.from_json(manifest)
+        self.assertEqual(manifest_struct, result[4])
+
+    def test_deploy_contract(self):
+        path = self.get_contract_path('DeployContract.py')
+        call_contract_path = self.get_contract_path('test_sc/arithmetic_test', 'Addition.py')
+        Boa3.compile_and_save(call_contract_path)
+
+        nef_file, manifest = self.get_bytes_output(call_contract_path)
+        arg_manifest = String(json.dumps(manifest, separators=(',', ':'))).to_bytes()
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'Main', nef_file, arg_manifest, None)
+
+        self.assertEqual(5, len(result))
+        self.assertEqual(nef_file, result[3])
+        manifest_struct = NeoManifestStruct.from_json(manifest)
+        self.assertEqual(manifest_struct, result[4])
+
+    def test_deploy_contract_data_deploy(self):
+        path = self.get_contract_path('DeployContract.py')
+        call_contract_path = self.get_contract_path('boa3_test/test_sc/interop_test/contract', 'NewContract.py')
+        self.compile_and_save(call_contract_path)
+
+        nef_file, manifest = self.get_bytes_output(call_contract_path)
+        arg_manifest = String(json.dumps(manifest, separators=(',', ':'))).to_bytes()
+
+        engine = TestEngine()
+        data = 'some sort of data'
+        result = self.run_smart_contract(engine, path, 'Main', nef_file, arg_manifest, data)
+
+        self.assertEqual(5, len(result))
+        self.assertEqual(nef_file, result[3])
+        manifest_struct = NeoManifestStruct.from_json(manifest)
+        self.assertEqual(manifest_struct, result[4])
+
+        notifies = engine.get_events('notify')
+        self.assertEqual(2, len(notifies))
+        self.assertEqual(False, notifies[0].arguments[0])   # not updated
+        self.assertEqual(data, notifies[1].arguments[0])    # data
+        result = self.run_smart_contract(engine, call_contract_path, 'main')
+        self.assertEqual(data, result)
+
+    def test_deploy_contract_too_many_parameters(self):
+        path = self.get_contract_path('DeployContractTooManyArguments.py')
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+
+    def test_deploy_contract_too_few_parameters(self):
+        path = self.get_contract_path('DeployContractTooFewArguments.py')
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+
+    def test_update_contract(self):
+        path = self.get_contract_path('UpdateContract.py')
+        engine = TestEngine()
+        with self.assertRaises(TestExecutionException):
+            self.run_smart_contract(engine, path, 'new_method')
+
+        new_path = self.get_contract_path('test_sc/interop_test', 'UpdateContract.py')
+        self.compile_and_save(new_path)
+        new_nef, new_manifest = self.get_bytes_output(new_path)
+        arg_manifest = String(json.dumps(new_manifest, separators=(',', ':'))).to_bytes()
+
+        result = self.run_smart_contract(engine, path, 'update', new_nef, arg_manifest, None)
+        self.assertIsVoid(result)
+
+        result = self.run_smart_contract(engine, path, 'new_method')
+        self.assertEqual(42, result)
+
+    def test_update_contract_data_deploy(self):
+        path = self.get_contract_path('UpdateContract.py')
+        engine = TestEngine()
+        with self.assertRaises(TestExecutionException):
+            self.run_smart_contract(engine, path, 'new_method')
+
+        new_path = self.get_contract_path('test_sc/interop_test', 'UpdateContract.py')
+        self.compile_and_save(new_path)
+        new_nef, new_manifest = self.get_bytes_output(new_path)
+        arg_manifest = String(json.dumps(new_manifest, separators=(',', ':'))).to_bytes()
+
+        data = 'this function was deployed'
+        result = self.run_smart_contract(engine, path, 'update', new_nef, arg_manifest, data)
+        self.assertIsVoid(result)
+        notifies = engine.get_events('notify')
+        self.assertEqual(2, len(notifies))
+        self.assertEqual(True, notifies[0].arguments[0])
+        self.assertEqual(data, notifies[1].arguments[0])
+
+    def test_update_contract_too_many_parameters(self):
+        path = self.get_contract_path('UpdateContractTooManyArguments.py')
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+
+    def test_update_contract_too_few_parameters(self):
+        path = self.get_contract_path('UpdateContractTooFewArguments.py')
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+
+    def test_destroy_contract(self):
+        path = self.get_contract_path('DestroyContract.py')
+        output = Boa3.compile(path)
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'Main')
+        self.assertIsVoid(result)
+
+        script_hash = hash160(output)
+        call_contract_path = self.get_contract_path('boa3_test/test_sc/interop_test/contract', 'CallScriptHash.py')
+        with self.assertRaises(TestExecutionException):
+            self.run_smart_contract(engine, call_contract_path, 'Main',
+                                    script_hash, 'Main', [])
+
+    def test_destroy_contract_too_many_parameters(self):
+        path = self.get_contract_path('DestroyContractTooManyArguments.py')
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)

--- a/boa3_test/tests/compiler_tests/test_native/test_policy.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_policy.py
@@ -3,7 +3,7 @@ from boa3_test.tests.boa_test import BoaTest
 from boa3_test.tests.test_classes.testengine import TestEngine
 
 
-class TestPolicyInterop(BoaTest):
+class TestPolicyContract(BoaTest):
 
     default_folder: str = 'test_sc/native_test/policy'
 


### PR DESCRIPTION
**Related issue**
#602

**Summary or solution description**
Implemented an interface for interacting with the ContractManagement native contract in a clearer way.
https://github.com/CityOfZion/neo3-boa/blob/b9800cdaf82e606f2bdb77b0fc63d3905356e018/boa3/builtin/nativecontract/contractmanagement.py#L7-L26

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/b9800cdaf82e606f2bdb77b0fc63d3905356e018/boa3_test/test_sc/native_test/contractmanagement/DeployContract.py#L8-L10
https://github.com/CityOfZion/neo3-boa/blob/b9800cdaf82e606f2bdb77b0fc63d3905356e018/boa3_test/test_sc/native_test/contractmanagement/GetContract.py#L7-L9

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/b9800cdaf82e606f2bdb77b0fc63d3905356e018/boa3_test/tests/compiler_tests/test_native/test_contract_management.py#L17-L163

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7