### PR TITLE
Investigate Circle CI errors with Python 3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,11 +28,11 @@ jobs:
       - run:
           name: Test
           command: |
-            sudo apt-get update
+            sudo apt update
             sudo apt-get install -y apt-transport-https
             wget https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
             sudo dpkg -i packages-microsoft-prod.deb
-            sudo apt-get update && \
+            sudo apt update && \
               sudo apt-get install -y dotnet-sdk-5.0
 
             git clone https://github.com/simplitech/neo-devpack-dotnet.git -b rc4


### PR DESCRIPTION
**Related issue**
#625 

**Summary or solution description**
Fixed issue with CircleCI's Python 3.8 workflow that didn't even begin the tests

**Platform:**
 - Python version: Python 3.8
