### PR TITLE
Implement sequence slicing with negative stride with start and end

### DIFF
--- a/boa3_test/test_sc/bytes_test/SliceOmittedWithNegativeStride.py
+++ b/boa3_test/test_sc/bytes_test/SliceOmittedWithNegativeStride.py
@@ -2,6 +2,54 @@ from boa3.builtin import public
 
 
 @public
-def main() -> bytes:
-    a = b'12345'
-    return a[::-1]
+def omitted_values() -> bytes:
+    a = b'unit_test'
+    return a[::-2]
+
+
+@public
+def omitted_start() -> bytes:
+    a = b'unit_test'
+    return a[:5:-2]
+
+
+@public
+def omitted_end() -> bytes:
+    a = b'unit_test'
+    return a[2::-2]
+
+
+@public
+def negative_start() -> bytes:
+    a = b'unit_test'
+    return a[-6::-2]
+
+
+@public
+def negative_end() -> bytes:
+    a = b'unit_test'
+    return a[:-1:-2]
+
+
+@public
+def negative_really_low_start() -> bytes:
+    a = b'unit_test'
+    return a[-999::-2]
+
+
+@public
+def negative_really_low_end() -> bytes:
+    a = b'unit_test'
+    return a[:-999:-2]
+
+
+@public
+def really_high_start() -> bytes:
+    a = b'unit_test'
+    return a[999::-2]
+
+
+@public
+def really_high_end() -> bytes:
+    a = b'unit_test'
+    return a[:999:-2]

--- a/boa3_test/test_sc/bytes_test/SliceOmittedWithStride.py
+++ b/boa3_test/test_sc/bytes_test/SliceOmittedWithStride.py
@@ -2,6 +2,54 @@ from boa3.builtin import public
 
 
 @public
-def main() -> bytes:
-    a = b'12345'
+def omitted_values() -> bytes:
+    a = b'unit_test'
     return a[::2]
+
+
+@public
+def omitted_start() -> bytes:
+    a = b'unit_test'
+    return a[:5:2]
+
+
+@public
+def omitted_end() -> bytes:
+    a = b'unit_test'
+    return a[2::2]
+
+
+@public
+def negative_start() -> bytes:
+    a = b'unit_test'
+    return a[-6::2]
+
+
+@public
+def negative_end() -> bytes:
+    a = b'unit_test'
+    return a[:-1:2]
+
+
+@public
+def negative_really_low_start() -> bytes:
+    a = b'unit_test'
+    return a[-999::2]
+
+
+@public
+def negative_really_low_end() -> bytes:
+    a = b'unit_test'
+    return a[:-999:2]
+
+
+@public
+def really_high_start() -> bytes:
+    a = b'unit_test'
+    return a[999::2]
+
+
+@public
+def really_high_end() -> bytes:
+    a = b'unit_test'
+    return a[:999:2]

--- a/boa3_test/test_sc/bytes_test/SliceWithNegativeStride.py
+++ b/boa3_test/test_sc/bytes_test/SliceWithNegativeStride.py
@@ -2,6 +2,60 @@ from boa3.builtin import public
 
 
 @public
-def main() -> bytes:
-    a = b'12345'
-    return a[0:5:-1]
+def literal_values() -> bytes:
+    a = b'unit_test'
+    return a[2:5:-1]
+
+
+@public
+def negative_start() -> bytes:
+    a = b'unit_test'
+    return a[-6:5:-1]
+
+
+@public
+def negative_end() -> bytes:
+    a = b'unit_test'
+    return a[0:-1:-1]
+
+
+@public
+def negative_values() -> bytes:
+    a = b'unit_test'
+    return a[-6:-1:-1]
+
+
+@public
+def negative_really_low_start() -> bytes:
+    a = b'unit_test'
+    return a[-999:5:-1]
+
+
+@public
+def negative_really_low_end() -> bytes:
+    a = b'unit_test'
+    return a[0:-999:-1]
+
+
+@public
+def negative_really_low_values() -> bytes:
+    a = b'unit_test'
+    return a[-999:-999:-1]
+
+
+@public
+def really_high_start() -> bytes:
+    a = b'unit_test'
+    return a[999:5:-1]
+
+
+@public
+def really_high_end() -> bytes:
+    a = b'unit_test'
+    return a[0:999:-1]
+
+
+@public
+def really_high_values() -> bytes:
+    a = b'unit_test'
+    return a[999:999:-1]

--- a/boa3_test/test_sc/bytes_test/SliceWithStride.py
+++ b/boa3_test/test_sc/bytes_test/SliceWithStride.py
@@ -2,6 +2,60 @@ from boa3.builtin import public
 
 
 @public
-def main() -> bytes:
-    a = b'12345'
-    return a[0:5:2]
+def literal_values() -> bytes:
+    a = b'unit_test'
+    return a[2:5:2]
+
+
+@public
+def negative_start() -> bytes:
+    a = b'unit_test'
+    return a[-6:5:2]
+
+
+@public
+def negative_end() -> bytes:
+    a = b'unit_test'
+    return a[0:-1:2]
+
+
+@public
+def negative_values() -> bytes:
+    a = b'unit_test'
+    return a[-6:-1:2]
+
+
+@public
+def negative_really_low_start() -> bytes:
+    a = b'unit_test'
+    return a[-999:5:2]
+
+
+@public
+def negative_really_low_end() -> bytes:
+    a = b'unit_test'
+    return a[0:-999:2]
+
+
+@public
+def negative_really_low_values() -> bytes:
+    a = b'unit_test'
+    return a[-999:-999:2]
+
+
+@public
+def really_high_start() -> bytes:
+    a = b'unit_test'
+    return a[999:5:2]
+
+
+@public
+def really_high_end() -> bytes:
+    a = b'unit_test'
+    return a[0:999:2]
+
+
+@public
+def really_high_values() -> bytes:
+    a = b'unit_test'
+    return a[999:999:2]

--- a/boa3_test/test_sc/list_test/ListSlicingOmittedWithNegativeStride.py
+++ b/boa3_test/test_sc/list_test/ListSlicingOmittedWithNegativeStride.py
@@ -2,6 +2,54 @@ from boa3.builtin import public
 
 
 @public
-def Main() -> list:
+def omitted_values() -> list:
     a = [0, 1, 2, 3, 4, 5]
-    return a[::-2]   # expect [5, 3, 1]
+    return a[::-2]
+
+
+@public
+def omitted_start() -> list:
+    a = [0, 1, 2, 3, 4, 5]
+    return a[:5:-2]
+
+
+@public
+def omitted_end() -> list:
+    a = [0, 1, 2, 3, 4, 5, 6]
+    return a[2::-2]
+
+
+@public
+def negative_start() -> list:
+    a = [0, 1, 2, 3, 4, 5]
+    return a[-6::-2]
+
+
+@public
+def negative_end() -> list:
+    a = [0, 1, 2, 3, 4, 5]
+    return a[:-1:-2]
+
+
+@public
+def negative_really_low_start() -> list:
+    a = [0, 1, 2, 3, 4, 5]
+    return a[-999::-2]
+
+
+@public
+def negative_really_low_end() -> list:
+    a = [0, 1, 2, 3, 4, 5]
+    return a[:-999:-2]
+
+
+@public
+def really_high_start() -> list:
+    a = [0, 1, 2, 3, 4, 5]
+    return a[999::-2]
+
+
+@public
+def really_high_end() -> list:
+    a = [0, 1, 2, 3, 4, 5]
+    return a[:999:-2]

--- a/boa3_test/test_sc/list_test/ListSlicingOmittedWithStride.py
+++ b/boa3_test/test_sc/list_test/ListSlicingOmittedWithStride.py
@@ -2,6 +2,54 @@ from boa3.builtin import public
 
 
 @public
-def Main() -> list:
+def omitted_values() -> list:
     a = [0, 1, 2, 3, 4, 5]
-    return a[::2]   # expect [0, 2, 4]
+    return a[::2]
+
+
+@public
+def omitted_start() -> list:
+    a = [0, 1, 2, 3, 4, 5]
+    return a[:5:2]
+
+
+@public
+def omitted_end() -> list:
+    a = [0, 1, 2, 3, 4, 5, 6]
+    return a[2::2]
+
+
+@public
+def negative_start() -> list:
+    a = [0, 1, 2, 3, 4, 5]
+    return a[-6::2]
+
+
+@public
+def negative_end() -> list:
+    a = [0, 1, 2, 3, 4, 5]
+    return a[:-1:2]
+
+
+@public
+def negative_really_low_start() -> list:
+    a = [0, 1, 2, 3, 4, 5]
+    return a[-999::2]
+
+
+@public
+def negative_really_low_end() -> list:
+    a = [0, 1, 2, 3, 4, 5]
+    return a[:-999:2]
+
+
+@public
+def really_high_start() -> list:
+    a = [0, 1, 2, 3, 4, 5]
+    return a[999::2]
+
+
+@public
+def really_high_end() -> list:
+    a = [0, 1, 2, 3, 4, 5]
+    return a[:999:2]

--- a/boa3_test/test_sc/list_test/ListSlicingWithNegativeStride.py
+++ b/boa3_test/test_sc/list_test/ListSlicingWithNegativeStride.py
@@ -2,6 +2,60 @@ from boa3.builtin import public
 
 
 @public
-def Main() -> list:
+def literal_values() -> list:
     a = [0, 1, 2, 3, 4, 5]
-    return a[0:5:-2]    # expected []
+    return a[2:5:-1]
+
+
+@public
+def negative_start() -> list:
+    a = [0, 1, 2, 3, 4, 5]
+    return a[-6:5:-1]
+
+
+@public
+def negative_end() -> list:
+    a = [0, 1, 2, 3, 4, 5]
+    return a[0:-1:-1]
+
+
+@public
+def negative_values() -> list:
+    a = [0, 1, 2, 3, 4, 5]
+    return a[-6:-1:-1]
+
+
+@public
+def negative_really_low_start() -> list:
+    a = [0, 1, 2, 3, 4, 5]
+    return a[-999:5:-1]
+
+
+@public
+def negative_really_low_end() -> list:
+    a = [0, 1, 2, 3, 4, 5]
+    return a[0:-999:-1]
+
+
+@public
+def negative_really_low_values() -> list:
+    a = [0, 1, 2, 3, 4, 5]
+    return a[-999:-999:-1]
+
+
+@public
+def really_high_start() -> list:
+    a = [0, 1, 2, 3, 4, 5]
+    return a[999:5:-1]
+
+
+@public
+def really_high_end() -> list:
+    a = [0, 1, 2, 3, 4, 5]
+    return a[0:999:-1]
+
+
+@public
+def really_high_values() -> list:
+    a = [0, 1, 2, 3, 4, 5]
+    return a[999:999:-1]

--- a/boa3_test/test_sc/list_test/ListSlicingWithStride.py
+++ b/boa3_test/test_sc/list_test/ListSlicingWithStride.py
@@ -2,6 +2,60 @@ from boa3.builtin import public
 
 
 @public
-def Main() -> list:
+def literal_values() -> list:
     a = [0, 1, 2, 3, 4, 5]
     return a[2:5:2]
+
+
+@public
+def negative_start() -> list:
+    a = [0, 1, 2, 3, 4, 5]
+    return a[-6:5:2]
+
+
+@public
+def negative_end() -> list:
+    a = [0, 1, 2, 3, 4, 5]
+    return a[0:-1:2]
+
+
+@public
+def negative_values() -> list:
+    a = [0, 1, 2, 3, 4, 5]
+    return a[-6:-1:2]
+
+
+@public
+def negative_really_low_start() -> list:
+    a = [0, 1, 2, 3, 4, 5]
+    return a[-999:5:2]
+
+
+@public
+def negative_really_low_end() -> list:
+    a = [0, 1, 2, 3, 4, 5]
+    return a[0:-999:2]
+
+
+@public
+def negative_really_low_values() -> list:
+    a = [0, 1, 2, 3, 4, 5]
+    return a[-999:-999:2]
+
+
+@public
+def really_high_start() -> list:
+    a = [0, 1, 2, 3, 4, 5]
+    return a[999:5:2]
+
+
+@public
+def really_high_end() -> list:
+    a = [0, 1, 2, 3, 4, 5]
+    return a[0:999:2]
+
+
+@public
+def really_high_values() -> list:
+    a = [0, 1, 2, 3, 4, 5]
+    return a[999:999:2]

--- a/boa3_test/test_sc/range_test/RangeSlicingOmittedWithNegativeStride.py
+++ b/boa3_test/test_sc/range_test/RangeSlicingOmittedWithNegativeStride.py
@@ -2,6 +2,54 @@ from boa3.builtin import public
 
 
 @public
-def Main() -> range:
+def omitted_values() -> range:
     a = range(6)
-    return a[::-2]   # expect range(5,-1, -2)
+    return a[::-2]
+
+
+@public
+def omitted_start() -> range:
+    a = range(6)
+    return a[:5:-2]
+
+
+@public
+def omitted_end() -> range:
+    a = range(6)
+    return a[2::-2]
+
+
+@public
+def negative_start() -> range:
+    a = range(6)
+    return a[-6::-2]
+
+
+@public
+def negative_end() -> range:
+    a = range(6)
+    return a[:-1:-2]
+
+
+@public
+def negative_really_low_start() -> range:
+    a = range(6)
+    return a[-999::-2]
+
+
+@public
+def negative_really_low_end() -> range:
+    a = range(6)
+    return a[:-999:-2]
+
+
+@public
+def really_high_start() -> range:
+    a = range(6)
+    return a[999::-2]
+
+
+@public
+def really_high_end() -> range:
+    a = range(6)
+    return a[:999:-2]

--- a/boa3_test/test_sc/range_test/RangeSlicingOmittedWithStride.py
+++ b/boa3_test/test_sc/range_test/RangeSlicingOmittedWithStride.py
@@ -2,6 +2,54 @@ from boa3.builtin import public
 
 
 @public
-def Main() -> range:
+def omitted_values() -> range:
     a = range(6)
-    return a[::2]   # expect range(0, 6, 2)
+    return a[::2]
+
+
+@public
+def omitted_start() -> range:
+    a = range(6)
+    return a[:5:2]
+
+
+@public
+def omitted_end() -> range:
+    a = range(6)
+    return a[2::2]
+
+
+@public
+def negative_start() -> range:
+    a = range(6)
+    return a[-6::2]
+
+
+@public
+def negative_end() -> range:
+    a = range(6)
+    return a[:-1:2]
+
+
+@public
+def negative_really_low_start() -> range:
+    a = range(6)
+    return a[-999::2]
+
+
+@public
+def negative_really_low_end() -> range:
+    a = range(6)
+    return a[:-999:2]
+
+
+@public
+def really_high_start() -> range:
+    a = range(6)
+    return a[999::2]
+
+
+@public
+def really_high_end() -> range:
+    a = range(6)
+    return a[:999:2]

--- a/boa3_test/test_sc/range_test/RangeSlicingWithNegativeStride.py
+++ b/boa3_test/test_sc/range_test/RangeSlicingWithNegativeStride.py
@@ -2,6 +2,60 @@ from boa3.builtin import public
 
 
 @public
-def Main() -> range:
+def literal_values() -> range:
     a = range(6)
-    return a[0:6:-2]   # expect range(0, 5, -2)
+    return a[2:5:-1]
+
+
+@public
+def negative_start() -> range:
+    a = range(6)
+    return a[-6:5:-1]
+
+
+@public
+def negative_end() -> range:
+    a = range(6)
+    return a[0:-1:-1]
+
+
+@public
+def negative_values() -> range:
+    a = range(6)
+    return a[-6:-1:-1]
+
+
+@public
+def negative_really_low_start() -> range:
+    a = range(6)
+    return a[-999:5:-1]
+
+
+@public
+def negative_really_low_end() -> range:
+    a = range(6)
+    return a[0:-999:-1]
+
+
+@public
+def negative_really_low_values() -> range:
+    a = range(6)
+    return a[-999:-999:-1]
+
+
+@public
+def really_high_start() -> range:
+    a = range(6)
+    return a[999:5:-1]
+
+
+@public
+def really_high_end() -> range:
+    a = range(6)
+    return a[0:999:-1]
+
+
+@public
+def really_high_values() -> range:
+    a = range(6)
+    return a[999:999:-1]

--- a/boa3_test/test_sc/range_test/RangeSlicingWithStride.py
+++ b/boa3_test/test_sc/range_test/RangeSlicingWithStride.py
@@ -2,6 +2,60 @@ from boa3.builtin import public
 
 
 @public
-def Main() -> range:
+def literal_values() -> range:
     a = range(6)
     return a[2:5:2]   # expect range(2, 5, 2)
+
+
+@public
+def negative_start() -> range:
+    a = range(6)
+    return a[-6:5:2]
+
+
+@public
+def negative_end() -> range:
+    a = range(6)
+    return a[0:-1:2]
+
+
+@public
+def negative_values() -> range:
+    a = range(6)
+    return a[-6:-1:2]
+
+
+@public
+def negative_really_low_start() -> range:
+    a = range(6)
+    return a[-999:5:2]
+
+
+@public
+def negative_really_low_end() -> range:
+    a = range(6)
+    return a[0:-999:2]
+
+
+@public
+def negative_really_low_values() -> range:
+    a = range(6)
+    return a[-999:-999:2]
+
+
+@public
+def really_high_start() -> range:
+    a = range(6)
+    return a[999:5:2]
+
+
+@public
+def really_high_end() -> range:
+    a = range(6)
+    return a[0:999:2]
+
+
+@public
+def really_high_values() -> range:
+    a = range(6)
+    return a[999:999:2]

--- a/boa3_test/test_sc/string_test/StringSlicingOmittedWithNegativeStride.py
+++ b/boa3_test/test_sc/string_test/StringSlicingOmittedWithNegativeStride.py
@@ -2,6 +2,54 @@ from boa3.builtin import public
 
 
 @public
-def Main() -> str:
+def omitted_values() -> str:
     a = 'unit_test'
     return a[::-2]
+
+
+@public
+def omitted_start() -> str:
+    a = 'unit_test'
+    return a[:5:-2]
+
+
+@public
+def omitted_end() -> str:
+    a = 'unit_test'
+    return a[2::-2]
+
+
+@public
+def negative_start() -> str:
+    a = 'unit_test'
+    return a[-6::-2]
+
+
+@public
+def negative_end() -> str:
+    a = 'unit_test'
+    return a[:-1:-2]
+
+
+@public
+def negative_really_low_start() -> str:
+    a = 'unit_test'
+    return a[-999::-2]
+
+
+@public
+def negative_really_low_end() -> str:
+    a = 'unit_test'
+    return a[:-999:-2]
+
+
+@public
+def really_high_start() -> str:
+    a = 'unit_test'
+    return a[999::-2]
+
+
+@public
+def really_high_end() -> str:
+    a = 'unit_test'
+    return a[:999:-2]

--- a/boa3_test/test_sc/string_test/StringSlicingOmittedWithStride.py
+++ b/boa3_test/test_sc/string_test/StringSlicingOmittedWithStride.py
@@ -2,6 +2,54 @@ from boa3.builtin import public
 
 
 @public
-def Main() -> str:
+def omitted_values() -> str:
     a = 'unit_test'
-    return a[::2]   # expect 'ui_et'
+    return a[::2]
+
+
+@public
+def omitted_start() -> str:
+    a = 'unit_test'
+    return a[:5:2]
+
+
+@public
+def omitted_end() -> str:
+    a = 'unit_test'
+    return a[2::2]
+
+
+@public
+def negative_start() -> str:
+    a = 'unit_test'
+    return a[-6::2]
+
+
+@public
+def negative_end() -> str:
+    a = 'unit_test'
+    return a[:-1:2]
+
+
+@public
+def negative_really_low_start() -> str:
+    a = 'unit_test'
+    return a[-999::2]
+
+
+@public
+def negative_really_low_end() -> str:
+    a = 'unit_test'
+    return a[:-999:2]
+
+
+@public
+def really_high_start() -> str:
+    a = 'unit_test'
+    return a[999::2]
+
+
+@public
+def really_high_end() -> str:
+    a = 'unit_test'
+    return a[:999:2]

--- a/boa3_test/test_sc/string_test/StringSlicingWithNegativeStride.py
+++ b/boa3_test/test_sc/string_test/StringSlicingWithNegativeStride.py
@@ -2,6 +2,60 @@ from boa3.builtin import public
 
 
 @public
-def Main() -> str:
+def literal_values() -> str:
     a = 'unit_test'
-    return a[2:5:-2]
+    return a[2:5:-1]
+
+
+@public
+def negative_start() -> str:
+    a = 'unit_test'
+    return a[-6:5:-1]
+
+
+@public
+def negative_end() -> str:
+    a = 'unit_test'
+    return a[0:-1:-1]
+
+
+@public
+def negative_values() -> str:
+    a = 'unit_test'
+    return a[-6:-1:-1]
+
+
+@public
+def negative_really_low_start() -> str:
+    a = 'unit_test'
+    return a[-999:5:-1]
+
+
+@public
+def negative_really_low_end() -> str:
+    a = 'unit_test'
+    return a[0:-999:-1]
+
+
+@public
+def negative_really_low_values() -> str:
+    a = 'unit_test'
+    return a[-999:-999:-1]
+
+
+@public
+def really_high_start() -> str:
+    a = 'unit_test'
+    return a[999:5:-1]
+
+
+@public
+def really_high_end() -> str:
+    a = 'unit_test'
+    return a[0:999:-1]
+
+
+@public
+def really_high_values() -> str:
+    a = 'unit_test'
+    return a[999:999:-1]

--- a/boa3_test/test_sc/string_test/StringSlicingWithStride.py
+++ b/boa3_test/test_sc/string_test/StringSlicingWithStride.py
@@ -2,6 +2,60 @@ from boa3.builtin import public
 
 
 @public
-def Main() -> str:
+def literal_values() -> str:
     a = 'unit_test'
-    return a[2:5:2]   # expect 'i_'
+    return a[2:5:2]
+
+
+@public
+def negative_start() -> str:
+    a = 'unit_test'
+    return a[-6:5:2]
+
+
+@public
+def negative_end() -> str:
+    a = 'unit_test'
+    return a[0:-1:2]
+
+
+@public
+def negative_values() -> str:
+    a = 'unit_test'
+    return a[-6:-1:2]
+
+
+@public
+def negative_really_low_start() -> str:
+    a = 'unit_test'
+    return a[-999:5:2]
+
+
+@public
+def negative_really_low_end() -> str:
+    a = 'unit_test'
+    return a[0:-999:2]
+
+
+@public
+def negative_really_low_values() -> str:
+    a = 'unit_test'
+    return a[-999:-999:2]
+
+
+@public
+def really_high_start() -> str:
+    a = 'unit_test'
+    return a[999:5:2]
+
+
+@public
+def really_high_end() -> str:
+    a = 'unit_test'
+    return a[0:999:2]
+
+
+@public
+def really_high_values() -> str:
+    a = 'unit_test'
+    return a[999:999:2]

--- a/boa3_test/test_sc/tuple_test/TupleSlicingOmittedWithNegativeStride.py
+++ b/boa3_test/test_sc/tuple_test/TupleSlicingOmittedWithNegativeStride.py
@@ -2,6 +2,54 @@ from boa3.builtin import public
 
 
 @public
-def Main() -> tuple:
+def omitted_values() -> tuple:
     a = (0, 1, 2, 3, 4, 5)
     return a[::-2]
+
+
+@public
+def omitted_start() -> tuple:
+    a = (0, 1, 2, 3, 4, 5)
+    return a[:5:-2]
+
+
+@public
+def omitted_end() -> tuple:
+    a = (0, 1, 2, 3, 4, 5)
+    return a[2::-2]
+
+
+@public
+def negative_start() -> tuple:
+    a = (0, 1, 2, 3, 4, 5)
+    return a[-6::-2]
+
+
+@public
+def negative_end() -> tuple:
+    a = (0, 1, 2, 3, 4, 5)
+    return a[:-1:-2]
+
+
+@public
+def negative_really_low_start() -> tuple:
+    a = (0, 1, 2, 3, 4, 5)
+    return a[-999::-2]
+
+
+@public
+def negative_really_low_end() -> tuple:
+    a = (0, 1, 2, 3, 4, 5)
+    return a[:-999:-2]
+
+
+@public
+def really_high_start() -> tuple:
+    a = (0, 1, 2, 3, 4, 5)
+    return a[999::-2]
+
+
+@public
+def really_high_end() -> tuple:
+    a = (0, 1, 2, 3, 4, 5)
+    return a[:999:-2]

--- a/boa3_test/test_sc/tuple_test/TupleSlicingOmittedWithStride.py
+++ b/boa3_test/test_sc/tuple_test/TupleSlicingOmittedWithStride.py
@@ -2,6 +2,54 @@ from boa3.builtin import public
 
 
 @public
-def Main() -> tuple:
+def omitted_values() -> tuple:
     a = (0, 1, 2, 3, 4, 5)
-    return a[::2]   # expect (0, 2, 4)
+    return a[::2]
+
+
+@public
+def omitted_start() -> tuple:
+    a = (0, 1, 2, 3, 4, 5)
+    return a[:5:2]
+
+
+@public
+def omitted_end() -> tuple:
+    a = (0, 1, 2, 3, 4, 5)
+    return a[2::2]
+
+
+@public
+def negative_start() -> tuple:
+    a = (0, 1, 2, 3, 4, 5)
+    return a[-6::2]
+
+
+@public
+def negative_end() -> tuple:
+    a = (0, 1, 2, 3, 4, 5)
+    return a[:-1:2]
+
+
+@public
+def negative_really_low_start() -> tuple:
+    a = (0, 1, 2, 3, 4, 5)
+    return a[-999::2]
+
+
+@public
+def negative_really_low_end() -> tuple:
+    a = (0, 1, 2, 3, 4, 5)
+    return a[:-999:2]
+
+
+@public
+def really_high_start() -> tuple:
+    a = (0, 1, 2, 3, 4, 5)
+    return a[999::2]
+
+
+@public
+def really_high_end() -> tuple:
+    a = (0, 1, 2, 3, 4, 5)
+    return a[:999:2]

--- a/boa3_test/test_sc/tuple_test/TupleSlicingWithNegativeStride.py
+++ b/boa3_test/test_sc/tuple_test/TupleSlicingWithNegativeStride.py
@@ -2,6 +2,60 @@ from boa3.builtin import public
 
 
 @public
-def Main() -> tuple:
+def literal_values() -> tuple:
     a = (0, 1, 2, 3, 4, 5)
-    return a[2:5:-2]
+    return a[2:5:-1]
+
+
+@public
+def negative_start() -> tuple:
+    a = (0, 1, 2, 3, 4, 5)
+    return a[-6:5:-1]
+
+
+@public
+def negative_end() -> tuple:
+    a = (0, 1, 2, 3, 4, 5)
+    return a[0:-1:-1]
+
+
+@public
+def negative_values() -> tuple:
+    a = (0, 1, 2, 3, 4, 5)
+    return a[-6:-1:-1]
+
+
+@public
+def negative_really_low_start() -> tuple:
+    a = (0, 1, 2, 3, 4, 5)
+    return a[-999:5:-1]
+
+
+@public
+def negative_really_low_end() -> tuple:
+    a = (0, 1, 2, 3, 4, 5)
+    return a[0:-999:-1]
+
+
+@public
+def negative_really_low_values() -> tuple:
+    a = (0, 1, 2, 3, 4, 5)
+    return a[-999:-999:-1]
+
+
+@public
+def really_high_start() -> tuple:
+    a = (0, 1, 2, 3, 4, 5)
+    return a[999:5:-1]
+
+
+@public
+def really_high_end() -> tuple:
+    a = (0, 1, 2, 3, 4, 5)
+    return a[0:999:-1]
+
+
+@public
+def really_high_values() -> tuple:
+    a = (0, 1, 2, 3, 4, 5)
+    return a[999:999:-1]

--- a/boa3_test/test_sc/tuple_test/TupleSlicingWithStride.py
+++ b/boa3_test/test_sc/tuple_test/TupleSlicingWithStride.py
@@ -2,6 +2,60 @@ from boa3.builtin import public
 
 
 @public
-def Main() -> tuple:
+def literal_values() -> tuple:
     a = (0, 1, 2, 3, 4, 5)
-    return a[2:5:2]   # expect (2, 4)
+    return a[2:5:2]
+
+
+@public
+def negative_start() -> tuple:
+    a = (0, 1, 2, 3, 4, 5)
+    return a[-6:5:2]
+
+
+@public
+def negative_end() -> tuple:
+    a = (0, 1, 2, 3, 4, 5)
+    return a[0:-1:2]
+
+
+@public
+def negative_values() -> tuple:
+    a = (0, 1, 2, 3, 4, 5)
+    return a[-6:-1:2]
+
+
+@public
+def negative_really_low_start() -> tuple:
+    a = (0, 1, 2, 3, 4, 5)
+    return a[-999:5:2]
+
+
+@public
+def negative_really_low_end() -> tuple:
+    a = (0, 1, 2, 3, 4, 5)
+    return a[0:-999:2]
+
+
+@public
+def negative_really_low_values() -> tuple:
+    a = (0, 1, 2, 3, 4, 5)
+    return a[-999:-999:2]
+
+
+@public
+def really_high_start() -> tuple:
+    a = (0, 1, 2, 3, 4, 5)
+    return a[999:5:2]
+
+
+@public
+def really_high_end() -> tuple:
+    a = (0, 1, 2, 3, 4, 5)
+    return a[0:999:2]
+
+
+@public
+def really_high_values() -> tuple:
+    a = (0, 1, 2, 3, 4, 5)
+    return a[999:999:2]

--- a/boa3_test/tests/compiler_tests/test_bytes.py
+++ b/boa3_test/tests/compiler_tests/test_bytes.py
@@ -110,7 +110,6 @@ class TestBytes(BoaTest):
 
     def test_bytes_to_int_with_builtin(self):
         path = self.get_contract_path('BytesToIntWithBuiltin.py')
-        output = Boa3.compile(path)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'bytes_to_int')
@@ -126,7 +125,6 @@ class TestBytes(BoaTest):
 
     def test_bytes_to_bool(self):
         path = self.get_contract_path('BytesToBool.py')
-        output = Boa3.compile(path)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'bytes_to_bool', b'\x00')
@@ -140,7 +138,6 @@ class TestBytes(BoaTest):
 
     def test_bytes_to_bool_with_builtin(self):
         path = self.get_contract_path('BytesToBoolWithBuiltin.py')
-        output = Boa3.compile(path)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'bytes_to_bool', b'\x00')
@@ -154,7 +151,6 @@ class TestBytes(BoaTest):
 
     def test_bytes_to_bool_with_builtin_hard_coded_false(self):
         path = self.get_contract_path('BytesToBoolWithBuiltinHardCodedFalse.py')
-        output = Boa3.compile(path)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'bytes_to_bool', expected_result_type=bool)
@@ -162,7 +158,6 @@ class TestBytes(BoaTest):
 
     def test_bytes_to_bool_with_builtin_hard_coded_true(self):
         path = self.get_contract_path('BytesToBoolWithBuiltinHardCodedTrue.py')
-        output = Boa3.compile(path)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'bytes_to_bool')
@@ -174,7 +169,6 @@ class TestBytes(BoaTest):
 
     def test_bytes_to_str(self):
         path = self.get_contract_path('BytesToStr.py')
-        output = Boa3.compile(path)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'bytes_to_str')
@@ -182,7 +176,6 @@ class TestBytes(BoaTest):
 
     def test_bytes_to_str_with_builtin(self):
         path = self.get_contract_path('BytesToStrWithBuiltin.py')
-        output = Boa3.compile(path)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'bytes_to_str')
@@ -223,8 +216,9 @@ class TestBytes(BoaTest):
                                          expected_result_type=bytearray)
         self.assertEqual(b'123'[1:2], result)
 
-        with self.assertRaises(TestExecutionException):
-            self.run_smart_contract(engine, path, 'main', bytearray())
+        result = self.run_smart_contract(engine, path, 'main', bytearray(),
+                                         expected_result_type=bytearray)
+        self.assertEqual(bytearray()[1:2], result)
 
     def test_slice_with_cast(self):
         path = self.get_contract_path('SliceWithCast.py')
@@ -237,8 +231,9 @@ class TestBytes(BoaTest):
                                          expected_result_type=bytes)
         self.assertEqual(b'123'[1:2], result)
 
-        with self.assertRaises(TestExecutionException):
-            self.run_smart_contract(engine, path, 'main', bytearray())
+        result = self.run_smart_contract(engine, path, 'main', bytearray(),
+                                         expected_result_type=bytearray)
+        self.assertEqual(bytearray()[1:2], result)
 
         result = self.run_smart_contract(engine, path, 'main', 12345,
                                          expected_result_type=bytes)
@@ -248,9 +243,63 @@ class TestBytes(BoaTest):
         path = self.get_contract_path('SliceWithStride.py')
         engine = TestEngine()
 
-        expected_result = b'12345'
-        expected_result = expected_result[0:5:2]
-        result = self.run_smart_contract(engine, path, 'main',
+        a = b'unit_test'
+        expected_result = a[2:5:2]
+        result = self.run_smart_contract(engine, path, 'literal_values',
+                                         expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        a = b'unit_test'
+        expected_result = a[-6:5:2]
+        result = self.run_smart_contract(engine, path, 'negative_start',
+                                         expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        a = b'unit_test'
+        expected_result = a[0:-1:2]
+        result = self.run_smart_contract(engine, path, 'negative_end',
+                                         expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        a = b'unit_test'
+        expected_result = a[-6:-1:2]
+        result = self.run_smart_contract(engine, path, 'negative_values',
+                                         expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        a = b'unit_test'
+        expected_result = a[-999:5:2]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_start',
+                                         expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        a = b'unit_test'
+        expected_result = a[0:-999:2]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_end',
+                                         expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        a = b'unit_test'
+        expected_result = a[-999:-999:2]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_values',
+                                         expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        a = b'unit_test'
+        expected_result = a[999:5:2]
+        result = self.run_smart_contract(engine, path, 'really_high_start',
+                                         expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        a = b'unit_test'
+        expected_result = a[0:999:2]
+        result = self.run_smart_contract(engine, path, 'really_high_end',
+                                         expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        a = b'unit_test'
+        expected_result = a[999:999:2]
+        result = self.run_smart_contract(engine, path, 'really_high_values',
                                          expected_result_type=bytes)
         self.assertEqual(expected_result, result)
 
@@ -258,21 +307,121 @@ class TestBytes(BoaTest):
         path = self.get_contract_path('SliceWithNegativeStride.py')
         engine = TestEngine()
 
-        expected_result = b'12345'
-        expected_result = expected_result[0:5:-1]
-        result = self.run_smart_contract(engine, path, 'main',
+        a = b'unit_test'
+        expected_result = a[2:5:-1]
+        result = self.run_smart_contract(engine, path, 'literal_values',
                                          expected_result_type=bytes)
-        # TODO: Remove assertRaises when the slicing with negative stride is correctly implemented
-        with self.assertRaises(AssertionError):
-            self.assertEqual(expected_result, result)
+        self.assertEqual(expected_result, result)
+
+        a = b'unit_test'
+        expected_result = a[-6:5:-1]
+        result = self.run_smart_contract(engine, path, 'negative_start',
+                                         expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        a = b'unit_test'
+        expected_result = a[0:-1:-1]
+        result = self.run_smart_contract(engine, path, 'negative_end',
+                                         expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        a = b'unit_test'
+        expected_result = a[-6:-1:-1]
+        result = self.run_smart_contract(engine, path, 'negative_values',
+                                         expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        a = b'unit_test'
+        expected_result = a[-999:5:-1]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_start',
+                                         expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        a = b'unit_test'
+        expected_result = a[0:-999:-1]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_end',
+                                         expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        a = b'unit_test'
+        expected_result = a[-999:-999:-1]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_values',
+                                         expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        a = b'unit_test'
+        expected_result = a[999:5:-1]
+        result = self.run_smart_contract(engine, path, 'really_high_start',
+                                         expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        a = b'unit_test'
+        expected_result = a[0:999:-1]
+        result = self.run_smart_contract(engine, path, 'really_high_end',
+                                         expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        a = b'unit_test'
+        expected_result = a[999:999:-1]
+        result = self.run_smart_contract(engine, path, 'really_high_values',
+                                         expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
 
     def test_slice_omitted_with_stride(self):
         path = self.get_contract_path('SliceOmittedWithStride.py')
         engine = TestEngine()
 
-        expected_result = b'12345'
-        expected_result = expected_result[::2]
-        result = self.run_smart_contract(engine, path, 'main',
+        a = b'unit_test'
+        expected_result = a[::2]
+        result = self.run_smart_contract(engine, path, 'omitted_values',
+                                         expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        a = b'unit_test'
+        expected_result = a[:5:2]
+        result = self.run_smart_contract(engine, path, 'omitted_start',
+                                         expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        a = b'unit_test'
+        expected_result = a[2::2]
+        result = self.run_smart_contract(engine, path, 'omitted_end',
+                                         expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        a = b'unit_test'
+        expected_result = a[-6::2]
+        result = self.run_smart_contract(engine, path, 'negative_start',
+                                         expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        a = b'unit_test'
+        expected_result = a[:-1:2]
+        result = self.run_smart_contract(engine, path, 'negative_end',
+                                         expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        a = b'unit_test'
+        expected_result = a[-999::2]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_start',
+                                         expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        a = b'unit_test'
+        expected_result = a[:-999:2]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_end',
+                                         expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        a = b'unit_test'
+        expected_result = a[999::2]
+        result = self.run_smart_contract(engine, path, 'really_high_start',
+                                         expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        a = b'unit_test'
+        expected_result = a[:999:2]
+        result = self.run_smart_contract(engine, path, 'really_high_end',
                                          expected_result_type=bytes)
         self.assertEqual(expected_result, result)
 
@@ -280,9 +429,57 @@ class TestBytes(BoaTest):
         path = self.get_contract_path('SliceOmittedWithNegativeStride.py')
         engine = TestEngine()
 
-        expected_result = b'12345'
-        expected_result = expected_result[::-1]
-        result = self.run_smart_contract(engine, path, 'main',
+        a = b'unit_test'
+        expected_result = a[::-2]
+        result = self.run_smart_contract(engine, path, 'omitted_values',
+                                         expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        a = b'unit_test'
+        expected_result = a[:5:-2]
+        result = self.run_smart_contract(engine, path, 'omitted_start',
+                                         expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        a = b'unit_test'
+        expected_result = a[2::-2]
+        result = self.run_smart_contract(engine, path, 'omitted_end',
+                                         expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        a = b'unit_test'
+        expected_result = a[-6::-2]
+        result = self.run_smart_contract(engine, path, 'negative_start',
+                                         expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        a = b'unit_test'
+        expected_result = a[:-1:-2]
+        result = self.run_smart_contract(engine, path, 'negative_end',
+                                         expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        a = b'unit_test'
+        expected_result = a[-999::-2]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_start',
+                                         expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        a = b'unit_test'
+        expected_result = a[:-999:-2]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_end',
+                                         expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        a = b'unit_test'
+        expected_result = a[999::-2]
+        result = self.run_smart_contract(engine, path, 'really_high_start',
+                                         expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        a = b'unit_test'
+        expected_result = a[:999:-2]
+        result = self.run_smart_contract(engine, path, 'really_high_end',
                                          expected_result_type=bytes)
         self.assertEqual(expected_result, result)
 
@@ -469,7 +666,6 @@ class TestBytes(BoaTest):
 
     def test_byte_array_append(self):
         path = self.get_contract_path('BytearrayAppend.py')
-        output = Boa3.compile(path)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main',
@@ -478,7 +674,6 @@ class TestBytes(BoaTest):
 
     def test_byte_array_append_with_builtin(self):
         path = self.get_contract_path('BytearrayAppendWithBuiltin.py')
-        output = Boa3.compile(path)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main',
@@ -487,7 +682,6 @@ class TestBytes(BoaTest):
 
     def test_byte_array_append_mutable_sequence_with_builtin(self):
         path = self.get_contract_path('BytearrayAppendWithMutableSequence.py')
-        output = Boa3.compile(path)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main',
@@ -496,7 +690,6 @@ class TestBytes(BoaTest):
 
     def test_byte_array_clear(self):
         path = self.get_contract_path('BytearrayClear.py')
-        output = Boa3.compile(path)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main',
@@ -533,7 +726,6 @@ class TestBytes(BoaTest):
 
     def test_byte_array_to_int(self):
         path = self.get_contract_path('BytearrayToInt.py')
-        output = Boa3.compile(path)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'bytes_to_int')
@@ -541,7 +733,6 @@ class TestBytes(BoaTest):
 
     def test_byte_array_to_int_with_builtin(self):
         path = self.get_contract_path('BytearrayToIntWithBuiltin.py')
-        output = Boa3.compile(path)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'bytes_to_int')
@@ -549,7 +740,6 @@ class TestBytes(BoaTest):
 
     def test_byte_array_to_int_with_bytes_builtin(self):
         path = self.get_contract_path('BytearrayToIntWithBytesBuiltin.py')
-        output = Boa3.compile(path)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'bytes_to_int')

--- a/boa3_test/tests/compiler_tests/test_list.py
+++ b/boa3_test/tests/compiler_tests/test_list.py
@@ -392,192 +392,21 @@ class TestList(BoaTest):
         self.assertEqual([2, 3, 4, 5], result)
 
     def test_list_slicing_negative_end(self):
-        expected_output = (
-            Opcode.INITSLOT     # function signature
-            + b'\x01'
-            + b'\x00'
-            + Opcode.PUSH5      # a = [0, 1, 2, 3, 4, 5]
-            + Opcode.PUSH4
-            + Opcode.PUSH3
-            + Opcode.PUSH2
-            + Opcode.PUSH1
-            + Opcode.PUSH0
-            + Opcode.PUSH6
-            + Opcode.PACK
-            + Opcode.STLOC0
-            + Opcode.LDLOC0     # return a[:-4]
-            + Opcode.PUSH4
-            + Opcode.NEGATE         # slice end
-            + Opcode.DUP
-            + Opcode.SIGN
-            + Opcode.PUSHM1
-            + Opcode.JMPNE
-            + Integer(5).to_byte_array(min_length=1, signed=True)
-            + Opcode.OVER
-            + Opcode.SIZE
-            + Opcode.ADD
-            + Opcode.PUSH0
-            + Opcode.SWAP
-            + Opcode.NEWARRAY0  # slice
-            + Opcode.PUSH2
-            + Opcode.PICK       # index
-            + Opcode.JMP        # while index < end
-            + Integer(32).to_byte_array(min_length=1)
-            + Opcode.DUP            # if index >= slice start
-            + Opcode.PUSH4
-            + Opcode.PICK
-            + Opcode.GE
-            + Opcode.JMPIFNOT
-            + Integer(25).to_byte_array(min_length=1)
-            + Opcode.OVER               # slice.append(array[index])
-            + Opcode.PUSH5
-            + Opcode.PICK
-            + Opcode.PUSH2
-            + Opcode.PICK
-            + Opcode.DUP
-            + Opcode.SIGN
-            + Opcode.PUSHM1
-            + Opcode.JMPNE
-            + Integer(5).to_byte_array(min_length=1)
-            + Opcode.OVER
-            + Opcode.SIZE
-            + Opcode.ADD
-            + Opcode.PICKITEM
-            + Opcode.OVER
-            + Opcode.ISTYPE
-            + Type.bytearray.stack_item
-            + Opcode.JMPIFNOT
-            + Integer(5).to_byte_array(signed=True, min_length=1)
-            + Opcode.CAT
-            + Opcode.JMP
-            + Integer(5).to_byte_array(min_length=1)
-            + Opcode.APPEND
-            + Opcode.INC            # index += 1
-            + Opcode.DUP
-            + Opcode.PUSH3
-            + Opcode.PICK
-            + Opcode.LT
-            + Opcode.JMPIF          # end while index < slice end
-            + Integer(-34).to_byte_array(min_length=1)
-            + Opcode.DROP
-            + Opcode.REVERSE4
-            + Opcode.DROP
-            + Opcode.DROP
-            + Opcode.DROP
-            + Opcode.RET        # return
-        )
         path = self.get_contract_path('ListSlicingNegativeEnd.py')
-        output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([0, 1], result)
 
     def test_list_slicing_start_omitted(self):
-        expected_output = (
-            Opcode.INITSLOT     # function signature
-            + b'\x01'
-            + b'\x00'
-            + Opcode.PUSH5      # a = [0, 1, 2, 3, 4, 5]
-            + Opcode.PUSH4
-            + Opcode.PUSH3
-            + Opcode.PUSH2
-            + Opcode.PUSH1
-            + Opcode.PUSH0
-            + Opcode.PUSH6
-            + Opcode.PACK
-            + Opcode.STLOC0
-            + Opcode.LDLOC0     # return a[:3]
-            + Opcode.PUSH3          # slice end
-            + Opcode.DUP
-            + Opcode.SIGN
-            + Opcode.PUSHM1
-            + Opcode.JMPNE
-            + Integer(5).to_byte_array(min_length=1, signed=True)
-            + Opcode.OVER
-            + Opcode.SIZE
-            + Opcode.ADD
-            + Opcode.PUSH0
-            + Opcode.SWAP
-            + Opcode.NEWARRAY0  # slice
-            + Opcode.PUSH2
-            + Opcode.PICK       # index
-            + Opcode.JMP        # while index < end
-            + Integer(32).to_byte_array(min_length=1)
-            + Opcode.DUP            # if index >= slice start
-            + Opcode.PUSH4
-            + Opcode.PICK
-            + Opcode.GE
-            + Opcode.JMPIFNOT
-            + Integer(25).to_byte_array(min_length=1)
-            + Opcode.OVER               # slice.append(array[index])
-            + Opcode.PUSH5
-            + Opcode.PICK
-            + Opcode.PUSH2
-            + Opcode.PICK
-            + Opcode.DUP
-            + Opcode.SIGN
-            + Opcode.PUSHM1
-            + Opcode.JMPNE
-            + Integer(5).to_byte_array(min_length=1)
-            + Opcode.OVER
-            + Opcode.SIZE
-            + Opcode.ADD
-            + Opcode.PICKITEM
-            + Opcode.OVER
-            + Opcode.ISTYPE
-            + Type.bytearray.stack_item
-            + Opcode.JMPIFNOT
-            + Integer(5).to_byte_array(signed=True, min_length=1)
-            + Opcode.CAT
-            + Opcode.JMP
-            + Integer(5).to_byte_array(min_length=1)
-            + Opcode.APPEND
-            + Opcode.INC            # index += 1
-            + Opcode.DUP
-            + Opcode.PUSH3
-            + Opcode.PICK
-            + Opcode.LT
-            + Opcode.JMPIF          # end while index < slice end
-            + Integer(-34).to_byte_array(min_length=1)
-            + Opcode.DROP
-            + Opcode.REVERSE4
-            + Opcode.DROP
-            + Opcode.DROP
-            + Opcode.DROP
-            + Opcode.RET        # return
-        )
         path = self.get_contract_path('ListSlicingStartOmitted.py')
-        output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([0, 1, 2], result)
 
     def test_list_slicing_omitted(self):
-        expected_output = (
-            Opcode.INITSLOT     # function signature
-            + b'\x01'
-            + b'\x00'
-            + Opcode.PUSH5      # a = [0, 1, 2, 3, 4, 5]
-            + Opcode.PUSH4
-            + Opcode.PUSH3
-            + Opcode.PUSH2
-            + Opcode.PUSH1
-            + Opcode.PUSH0
-            + Opcode.PUSH6
-            + Opcode.PACK
-            + Opcode.STLOC0
-            + Opcode.LDLOC0     # return a[:]
-            + Opcode.UNPACK
-            + Opcode.PACK
-            + Opcode.RET        # return
-        )
         path = self.get_contract_path('ListSlicingOmitted.py')
-        output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
@@ -596,7 +425,52 @@ class TestList(BoaTest):
 
         a = [0, 1, 2, 3, 4, 5]
         expected_result = a[2:5:2]
-        result = self.run_smart_contract(engine, path, 'Main')
+        result = self.run_smart_contract(engine, path, 'literal_values')
+        self.assertEqual(expected_result, result)
+
+        a = [0, 1, 2, 3, 4, 5]
+        expected_result = a[-6:5:2]
+        result = self.run_smart_contract(engine, path, 'negative_start')
+        self.assertEqual(expected_result, result)
+
+        a = [0, 1, 2, 3, 4, 5]
+        expected_result = a[0:-1:2]
+        result = self.run_smart_contract(engine, path, 'negative_end')
+        self.assertEqual(expected_result, result)
+
+        a = [0, 1, 2, 3, 4, 5]
+        expected_result = a[-6:-1:2]
+        result = self.run_smart_contract(engine, path, 'negative_values')
+        self.assertEqual(expected_result, result)
+
+        a = [0, 1, 2, 3, 4, 5]
+        expected_result = a[-999:5:2]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_start')
+        self.assertEqual(expected_result, result)
+
+        a = [0, 1, 2, 3, 4, 5]
+        expected_result = a[0:-999:2]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_end')
+        self.assertEqual(expected_result, result)
+
+        a = [0, 1, 2, 3, 4, 5]
+        expected_result = a[-999:-999:2]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_values')
+        self.assertEqual(expected_result, result)
+
+        a = [0, 1, 2, 3, 4, 5]
+        expected_result = a[999:5:2]
+        result = self.run_smart_contract(engine, path, 'really_high_start')
+        self.assertEqual(expected_result, result)
+
+        a = [0, 1, 2, 3, 4, 5]
+        expected_result = a[0:999:2]
+        result = self.run_smart_contract(engine, path, 'really_high_end')
+        self.assertEqual(expected_result, result)
+
+        a = [0, 1, 2, 3, 4, 5]
+        expected_result = a[999:999:2]
+        result = self.run_smart_contract(engine, path, 'really_high_values')
         self.assertEqual(expected_result, result)
 
     def test_list_slicing_with_negative_stride(self):
@@ -604,12 +478,54 @@ class TestList(BoaTest):
         engine = TestEngine()
 
         a = [0, 1, 2, 3, 4, 5]
-        expected_result = a[0:5:2]
-        result = self.run_smart_contract(engine, path, 'Main')
+        expected_result = a[2:5:-1]
+        result = self.run_smart_contract(engine, path, 'literal_values')
+        self.assertEqual(expected_result, result)
 
-        # TODO: Remove assertRaises when the slicing with negative stride is correctly implemented
-        with self.assertRaises(AssertionError):
-            self.assertEqual(expected_result, result)
+        a = [0, 1, 2, 3, 4, 5]
+        expected_result = a[-6:5:-1]
+        result = self.run_smart_contract(engine, path, 'negative_start')
+        self.assertEqual(expected_result, result)
+
+        a = [0, 1, 2, 3, 4, 5]
+        expected_result = a[0:-1:-1]
+        result = self.run_smart_contract(engine, path, 'negative_end')
+        self.assertEqual(expected_result, result)
+
+        a = [0, 1, 2, 3, 4, 5]
+        expected_result = a[-6:-1:-1]
+        result = self.run_smart_contract(engine, path, 'negative_values')
+        self.assertEqual(expected_result, result)
+
+        a = [0, 1, 2, 3, 4, 5]
+        expected_result = a[-999:5:-1]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_start')
+        self.assertEqual(expected_result, result)
+
+        a = [0, 1, 2, 3, 4, 5]
+        expected_result = a[0:-999:-1]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_end')
+        self.assertEqual(expected_result, result)
+
+        a = [0, 1, 2, 3, 4, 5]
+        expected_result = a[-999:-999:-1]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_values')
+        self.assertEqual(expected_result, result)
+
+        a = [0, 1, 2, 3, 4, 5]
+        expected_result = a[999:5:-1]
+        result = self.run_smart_contract(engine, path, 'really_high_start')
+        self.assertEqual(expected_result, result)
+
+        a = [0, 1, 2, 3, 4, 5]
+        expected_result = a[0:999:-1]
+        result = self.run_smart_contract(engine, path, 'really_high_end')
+        self.assertEqual(expected_result, result)
+
+        a = [0, 1, 2, 3, 4, 5]
+        expected_result = a[999:999:-1]
+        result = self.run_smart_contract(engine, path, 'really_high_values')
+        self.assertEqual(expected_result, result)
 
     def test_list_slicing_omitted_with_stride(self):
         path = self.get_contract_path('ListSlicingOmittedWithStride.py')
@@ -617,7 +533,47 @@ class TestList(BoaTest):
 
         a = [0, 1, 2, 3, 4, 5]
         expected_result = a[::2]
-        result = self.run_smart_contract(engine, path, 'Main')
+        result = self.run_smart_contract(engine, path, 'omitted_values')
+        self.assertEqual(expected_result, result)
+
+        a = [0, 1, 2, 3, 4, 5]
+        expected_result = a[:5:2]
+        result = self.run_smart_contract(engine, path, 'omitted_start')
+        self.assertEqual(expected_result, result)
+
+        a = [0, 1, 2, 3, 4, 5, 6]
+        expected_result = a[2::2]
+        result = self.run_smart_contract(engine, path, 'omitted_end')
+        self.assertEqual(expected_result, result)
+
+        a = [0, 1, 2, 3, 4, 5]
+        expected_result = a[-6::2]
+        result = self.run_smart_contract(engine, path, 'negative_start')
+        self.assertEqual(expected_result, result)
+
+        a = [0, 1, 2, 3, 4, 5]
+        expected_result = a[:-1:2]
+        result = self.run_smart_contract(engine, path, 'negative_end')
+        self.assertEqual(expected_result, result)
+
+        a = [0, 1, 2, 3, 4, 5]
+        expected_result = a[-999::2]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_start')
+        self.assertEqual(expected_result, result)
+
+        a = [0, 1, 2, 3, 4, 5]
+        expected_result = a[:-999:2]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_end')
+        self.assertEqual(expected_result, result)
+
+        a = [0, 1, 2, 3, 4, 5]
+        expected_result = a[999::2]
+        result = self.run_smart_contract(engine, path, 'really_high_start')
+        self.assertEqual(expected_result, result)
+
+        a = [0, 1, 2, 3, 4, 5]
+        expected_result = a[:999:2]
+        result = self.run_smart_contract(engine, path, 'really_high_end')
         self.assertEqual(expected_result, result)
 
     def test_list_slicing_omitted_with_negative_stride(self):
@@ -626,7 +582,47 @@ class TestList(BoaTest):
 
         a = [0, 1, 2, 3, 4, 5]
         expected_result = a[::-2]
-        result = self.run_smart_contract(engine, path, 'Main')
+        result = self.run_smart_contract(engine, path, 'omitted_values')
+        self.assertEqual(expected_result, result)
+
+        a = [0, 1, 2, 3, 4, 5]
+        expected_result = a[:5:-2]
+        result = self.run_smart_contract(engine, path, 'omitted_start')
+        self.assertEqual(expected_result, result)
+
+        a = [0, 1, 2, 3, 4, 5, 6]
+        expected_result = a[2::-2]
+        result = self.run_smart_contract(engine, path, 'omitted_end')
+        self.assertEqual(expected_result, result)
+
+        a = [0, 1, 2, 3, 4, 5]
+        expected_result = a[-6::-2]
+        result = self.run_smart_contract(engine, path, 'negative_start')
+        self.assertEqual(expected_result, result)
+
+        a = [0, 1, 2, 3, 4, 5]
+        expected_result = a[:-1:-2]
+        result = self.run_smart_contract(engine, path, 'negative_end')
+        self.assertEqual(expected_result, result)
+
+        a = [0, 1, 2, 3, 4, 5]
+        expected_result = a[-999::-2]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_start')
+        self.assertEqual(expected_result, result)
+
+        a = [0, 1, 2, 3, 4, 5]
+        expected_result = a[:-999:-2]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_end')
+        self.assertEqual(expected_result, result)
+
+        a = [0, 1, 2, 3, 4, 5]
+        expected_result = a[999::-2]
+        result = self.run_smart_contract(engine, path, 'really_high_start')
+        self.assertEqual(expected_result, result)
+
+        a = [0, 1, 2, 3, 4, 5]
+        expected_result = a[:999:-2]
+        result = self.run_smart_contract(engine, path, 'really_high_end')
         self.assertEqual(expected_result, result)
 
     # endregion
@@ -835,7 +831,6 @@ class TestList(BoaTest):
 
     def test_list_extend_tuple_value(self):
         path = self.get_contract_path('ExtendTupleValue.py')
-        output = Boa3.compile(path)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
@@ -843,7 +838,6 @@ class TestList(BoaTest):
 
     def test_list_extend_any_value(self):
         path = self.get_contract_path('ExtendAnyValue.py')
-        output = Boa3.compile(path)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
@@ -859,7 +853,6 @@ class TestList(BoaTest):
 
     def test_list_extend_with_builtin(self):
         path = self.get_contract_path('ExtendWithBuiltin.py')
-        output = Boa3.compile(path)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')

--- a/boa3_test/tests/compiler_tests/test_range.py
+++ b/boa3_test/tests/compiler_tests/test_range.py
@@ -1,6 +1,5 @@
 from boa3.boa3 import Boa3
 from boa3.exception import CompilerError
-from boa3.model.type.type import Type
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.String import String
@@ -327,409 +326,28 @@ class TestRange(BoaTest):
         self.assertEqual([2], result)
 
     def test_range_slicing_negative_start(self):
-        expected_output = (
-            Opcode.INITSLOT     # function signature
-            + b'\x01'
-            + b'\x00'
-            + Opcode.PUSH1      # range(6)
-            + Opcode.PUSH0
-            + Opcode.PUSH6
-            + Opcode.PUSH2
-            + Opcode.PICK
-            + Opcode.SIGN
-            + Opcode.JMPIF
-            + Integer(5 + len(self.RANGE_ERROR_MESSAGE)).to_byte_array(signed=True, min_length=1)
-            + Opcode.PUSHDATA1
-            + Integer(len(self.RANGE_ERROR_MESSAGE)).to_byte_array(signed=True, min_length=1)
-            + self.RANGE_ERROR_MESSAGE
-            + Opcode.THROW
-            + Opcode.NEWARRAY0
-            + Opcode.REVERSE4
-            + Opcode.SWAP
-            + Opcode.JMP
-            + Integer(8).to_byte_array(signed=True, min_length=1)
-            + Opcode.PUSH3
-            + Opcode.PICK
-            + Opcode.OVER
-            + Opcode.APPEND
-            + Opcode.OVER
-            + Opcode.ADD
-            + Opcode.DUP
-            + Opcode.PUSH3
-            + Opcode.PICK
-            + Opcode.PUSH3
-            + Opcode.PICK
-            + Opcode.SIGN
-            + Opcode.PUSH0
-            + Opcode.JMPGT
-            + Integer(5).to_byte_array(signed=True, min_length=1)
-            + Opcode.GT
-            + Opcode.JMP
-            + Integer(3).to_byte_array(signed=True, min_length=1)
-            + Opcode.LT
-            + Opcode.JMPIF
-            + Integer(-19).to_byte_array(signed=True, min_length=1)
-            + Opcode.DROP
-            + Opcode.DROP
-            + Opcode.DROP
-            + Opcode.STLOC0
-            + Opcode.LDLOC0     # return a[-4:]
-            + Opcode.DUP
-            + Opcode.SIZE       # slice end
-            + Opcode.PUSH4
-            + Opcode.NEGATE
-            + Opcode.DUP
-            + Opcode.SIGN
-            + Opcode.PUSHM1
-            + Opcode.JMPNE
-            + Integer(6).to_byte_array(min_length=1, signed=True)
-            + Opcode.PUSH2
-            + Opcode.PICK
-            + Opcode.SIZE
-            + Opcode.ADD
-            + Opcode.SWAP       # get slice
-            + Opcode.NEWARRAY0  # slice
-            + Opcode.PUSH2
-            + Opcode.PICK       # index
-            + Opcode.JMP        # while index < end
-            + Integer(32).to_byte_array(min_length=1)
-            + Opcode.DUP            # if index >= slice start
-            + Opcode.PUSH4
-            + Opcode.PICK
-            + Opcode.GE
-            + Opcode.JMPIFNOT
-            + Integer(25).to_byte_array(min_length=1)
-            + Opcode.OVER               # slice.append(array[index])
-            + Opcode.PUSH5
-            + Opcode.PICK
-            + Opcode.PUSH2
-            + Opcode.PICK
-            + Opcode.DUP
-            + Opcode.SIGN
-            + Opcode.PUSHM1
-            + Opcode.JMPNE
-            + Integer(5).to_byte_array(min_length=1)
-            + Opcode.OVER
-            + Opcode.SIZE
-            + Opcode.ADD
-            + Opcode.PICKITEM
-            + Opcode.OVER
-            + Opcode.ISTYPE
-            + Type.bytearray.stack_item
-            + Opcode.JMPIFNOT
-            + Integer(5).to_byte_array(signed=True, min_length=1)
-            + Opcode.CAT
-            + Opcode.JMP
-            + Integer(5).to_byte_array(min_length=1)
-            + Opcode.APPEND
-            + Opcode.INC            # index += 1
-            + Opcode.DUP
-            + Opcode.PUSH3
-            + Opcode.PICK
-            + Opcode.LT
-            + Opcode.JMPIF          # end while index < slice end
-            + Integer(-34).to_byte_array(min_length=1)
-            + Opcode.DROP
-            + Opcode.REVERSE4
-            + Opcode.DROP
-            + Opcode.DROP
-            + Opcode.DROP
-            + Opcode.RET        # return
-        )
         path = self.get_contract_path('RangeSlicingNegativeStart.py')
-        output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([2, 3, 4, 5], result)
 
     def test_range_slicing_negative_end(self):
-        expected_output = (
-            Opcode.INITSLOT     # function signature
-            + b'\x01'
-            + b'\x00'
-            + Opcode.PUSH1      # range(6)
-            + Opcode.PUSH0
-            + Opcode.PUSH6
-            + Opcode.PUSH2
-            + Opcode.PICK
-            + Opcode.SIGN
-            + Opcode.JMPIF
-            + Integer(5 + len(self.RANGE_ERROR_MESSAGE)).to_byte_array(signed=True, min_length=1)
-            + Opcode.PUSHDATA1
-            + Integer(len(self.RANGE_ERROR_MESSAGE)).to_byte_array(signed=True, min_length=1)
-            + self.RANGE_ERROR_MESSAGE
-            + Opcode.THROW
-            + Opcode.NEWARRAY0
-            + Opcode.REVERSE4
-            + Opcode.SWAP
-            + Opcode.JMP
-            + Integer(8).to_byte_array(signed=True, min_length=1)
-            + Opcode.PUSH3
-            + Opcode.PICK
-            + Opcode.OVER
-            + Opcode.APPEND
-            + Opcode.OVER
-            + Opcode.ADD
-            + Opcode.DUP
-            + Opcode.PUSH3
-            + Opcode.PICK
-            + Opcode.PUSH3
-            + Opcode.PICK
-            + Opcode.SIGN
-            + Opcode.PUSH0
-            + Opcode.JMPGT
-            + Integer(5).to_byte_array(signed=True, min_length=1)
-            + Opcode.GT
-            + Opcode.JMP
-            + Integer(3).to_byte_array(signed=True, min_length=1)
-            + Opcode.LT
-            + Opcode.JMPIF
-            + Integer(-19).to_byte_array(signed=True, min_length=1)
-            + Opcode.DROP
-            + Opcode.DROP
-            + Opcode.DROP
-            + Opcode.STLOC0
-            + Opcode.LDLOC0     # return a[:-4]
-            + Opcode.PUSH4
-            + Opcode.NEGATE         # slice end
-            + Opcode.DUP
-            + Opcode.SIGN
-            + Opcode.PUSHM1
-            + Opcode.JMPNE
-            + Integer(5).to_byte_array(min_length=1, signed=True)
-            + Opcode.OVER
-            + Opcode.SIZE
-            + Opcode.ADD
-            + Opcode.PUSH0
-            + Opcode.SWAP
-            + Opcode.NEWARRAY0  # slice
-            + Opcode.PUSH2
-            + Opcode.PICK       # index
-            + Opcode.JMP        # while index < end
-            + Integer(32).to_byte_array(min_length=1)
-            + Opcode.DUP            # if index >= slice start
-            + Opcode.PUSH4
-            + Opcode.PICK
-            + Opcode.GE
-            + Opcode.JMPIFNOT
-            + Integer(25).to_byte_array(min_length=1)
-            + Opcode.OVER               # slice.append(array[index])
-            + Opcode.PUSH5
-            + Opcode.PICK
-            + Opcode.PUSH2
-            + Opcode.PICK
-            + Opcode.DUP
-            + Opcode.SIGN
-            + Opcode.PUSHM1
-            + Opcode.JMPNE
-            + Integer(5).to_byte_array(min_length=1)
-            + Opcode.OVER
-            + Opcode.SIZE
-            + Opcode.ADD
-            + Opcode.PICKITEM
-            + Opcode.OVER
-            + Opcode.ISTYPE
-            + Type.bytearray.stack_item
-            + Opcode.JMPIFNOT
-            + Integer(5).to_byte_array(signed=True, min_length=1)
-            + Opcode.CAT
-            + Opcode.JMP
-            + Integer(5).to_byte_array(min_length=1)
-            + Opcode.APPEND
-            + Opcode.INC            # index += 1
-            + Opcode.DUP
-            + Opcode.PUSH3
-            + Opcode.PICK
-            + Opcode.LT
-            + Opcode.JMPIF          # end while index < slice end
-            + Integer(-34).to_byte_array(min_length=1)
-            + Opcode.DROP
-            + Opcode.REVERSE4
-            + Opcode.DROP
-            + Opcode.DROP
-            + Opcode.DROP
-            + Opcode.RET        # return
-        )
         path = self.get_contract_path('RangeSlicingNegativeEnd.py')
-        output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([0, 1], result)
 
     def test_range_slicing_start_omitted(self):
-        expected_output = (
-            Opcode.INITSLOT     # function signature
-            + b'\x01'
-            + b'\x00'
-            + Opcode.PUSH1      # range(6)
-            + Opcode.PUSH0
-            + Opcode.PUSH6
-            + Opcode.PUSH2
-            + Opcode.PICK
-            + Opcode.SIGN
-            + Opcode.JMPIF
-            + Integer(5 + len(self.RANGE_ERROR_MESSAGE)).to_byte_array(signed=True, min_length=1)
-            + Opcode.PUSHDATA1
-            + Integer(len(self.RANGE_ERROR_MESSAGE)).to_byte_array(signed=True, min_length=1)
-            + self.RANGE_ERROR_MESSAGE
-            + Opcode.THROW
-            + Opcode.NEWARRAY0
-            + Opcode.REVERSE4
-            + Opcode.SWAP
-            + Opcode.JMP
-            + Integer(8).to_byte_array(signed=True, min_length=1)
-            + Opcode.PUSH3
-            + Opcode.PICK
-            + Opcode.OVER
-            + Opcode.APPEND
-            + Opcode.OVER
-            + Opcode.ADD
-            + Opcode.DUP
-            + Opcode.PUSH3
-            + Opcode.PICK
-            + Opcode.PUSH3
-            + Opcode.PICK
-            + Opcode.SIGN
-            + Opcode.PUSH0
-            + Opcode.JMPGT
-            + Integer(5).to_byte_array(signed=True, min_length=1)
-            + Opcode.GT
-            + Opcode.JMP
-            + Integer(3).to_byte_array(signed=True, min_length=1)
-            + Opcode.LT
-            + Opcode.JMPIF
-            + Integer(-19).to_byte_array(signed=True, min_length=1)
-            + Opcode.DROP
-            + Opcode.DROP
-            + Opcode.DROP
-            + Opcode.STLOC0
-            + Opcode.LDLOC0     # return a[:3]
-            + Opcode.PUSH3          # slice end
-            + Opcode.DUP
-            + Opcode.SIGN
-            + Opcode.PUSHM1
-            + Opcode.JMPNE
-            + Integer(5).to_byte_array(min_length=1, signed=True)
-            + Opcode.OVER
-            + Opcode.SIZE
-            + Opcode.ADD
-            + Opcode.PUSH0
-            + Opcode.SWAP
-            + Opcode.NEWARRAY0  # slice
-            + Opcode.PUSH2
-            + Opcode.PICK       # index
-            + Opcode.JMP        # while index < end
-            + Integer(32).to_byte_array(min_length=1)
-            + Opcode.DUP            # if index >= slice start
-            + Opcode.PUSH4
-            + Opcode.PICK
-            + Opcode.GE
-            + Opcode.JMPIFNOT
-            + Integer(25).to_byte_array(min_length=1)
-            + Opcode.OVER               # slice.append(array[index])
-            + Opcode.PUSH5
-            + Opcode.PICK
-            + Opcode.PUSH2
-            + Opcode.PICK
-            + Opcode.DUP
-            + Opcode.SIGN
-            + Opcode.PUSHM1
-            + Opcode.JMPNE
-            + Integer(5).to_byte_array(min_length=1)
-            + Opcode.OVER
-            + Opcode.SIZE
-            + Opcode.ADD
-            + Opcode.PICKITEM
-            + Opcode.OVER
-            + Opcode.ISTYPE
-            + Type.bytearray.stack_item
-            + Opcode.JMPIFNOT
-            + Integer(5).to_byte_array(signed=True, min_length=1)
-            + Opcode.CAT
-            + Opcode.JMP
-            + Integer(5).to_byte_array(min_length=1)
-            + Opcode.APPEND
-            + Opcode.INC            # index += 1
-            + Opcode.DUP
-            + Opcode.PUSH3
-            + Opcode.PICK
-            + Opcode.LT
-            + Opcode.JMPIF          # end while index < slice end
-            + Integer(-34).to_byte_array(min_length=1)
-            + Opcode.DROP
-            + Opcode.REVERSE4
-            + Opcode.DROP
-            + Opcode.DROP
-            + Opcode.DROP
-            + Opcode.RET        # return
-        )
         path = self.get_contract_path('RangeSlicingStartOmitted.py')
-        output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([0, 1, 2], result)
 
     def test_range_slicing_omitted(self):
-        expected_output = (
-            Opcode.INITSLOT     # function signature
-            + b'\x01'
-            + b'\x00'
-            + Opcode.PUSH1      # range(6)
-            + Opcode.PUSH0
-            + Opcode.PUSH6
-            + Opcode.PUSH2
-            + Opcode.PICK
-            + Opcode.SIGN
-            + Opcode.JMPIF
-            + Integer(5 + len(self.RANGE_ERROR_MESSAGE)).to_byte_array(signed=True, min_length=1)
-            + Opcode.PUSHDATA1
-            + Integer(len(self.RANGE_ERROR_MESSAGE)).to_byte_array(signed=True, min_length=1)
-            + self.RANGE_ERROR_MESSAGE
-            + Opcode.THROW
-            + Opcode.NEWARRAY0
-            + Opcode.REVERSE4
-            + Opcode.SWAP
-            + Opcode.JMP
-            + Integer(8).to_byte_array(signed=True, min_length=1)
-            + Opcode.PUSH3
-            + Opcode.PICK
-            + Opcode.OVER
-            + Opcode.APPEND
-            + Opcode.OVER
-            + Opcode.ADD
-            + Opcode.DUP
-            + Opcode.PUSH3
-            + Opcode.PICK
-            + Opcode.PUSH3
-            + Opcode.PICK
-            + Opcode.SIGN
-            + Opcode.PUSH0
-            + Opcode.JMPGT
-            + Integer(5).to_byte_array(signed=True, min_length=1)
-            + Opcode.GT
-            + Opcode.JMP
-            + Integer(3).to_byte_array(signed=True, min_length=1)
-            + Opcode.LT
-            + Opcode.JMPIF
-            + Integer(-19).to_byte_array(signed=True, min_length=1)
-            + Opcode.DROP
-            + Opcode.DROP
-            + Opcode.DROP
-            + Opcode.STLOC0
-            + Opcode.LDLOC0     # return a[:]
-            + Opcode.UNPACK
-            + Opcode.PACK
-            + Opcode.RET        # return
-        )
         path = self.get_contract_path('RangeSlicingOmitted.py')
-        output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
@@ -746,31 +364,212 @@ class TestRange(BoaTest):
         path = self.get_contract_path('RangeSlicingWithStride.py')
         engine = TestEngine()
 
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(list(range(2, 5, 2)), result)
+        a = range(6)
+        expected_result = a[2:5:2]
+        result = self.run_smart_contract(engine, path, 'literal_values')
+        self.assertEqual(list(expected_result), result)
+
+        a = range(6)
+        expected_result = a[2:5:2]
+        result = self.run_smart_contract(engine, path, 'literal_values')
+        self.assertEqual(list(expected_result), result)
+
+        a = range(6)
+        expected_result = a[-6:5:2]
+        result = self.run_smart_contract(engine, path, 'negative_start')
+        self.assertEqual(list(expected_result), result)
+
+        a = range(6)
+        expected_result = a[0:-1:2]
+        result = self.run_smart_contract(engine, path, 'negative_end')
+        self.assertEqual(list(expected_result), result)
+
+        a = range(6)
+        expected_result = a[-6:-1:2]
+        result = self.run_smart_contract(engine, path, 'negative_values')
+        self.assertEqual(list(expected_result), result)
+
+        a = range(6)
+        expected_result = a[-999:5:2]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_start')
+        self.assertEqual(list(expected_result), result)
+
+        a = range(6)
+        expected_result = a[0:-999:2]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_end')
+        self.assertEqual(list(expected_result), result)
+
+        a = range(6)
+        expected_result = a[-999:-999:2]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_values')
+        self.assertEqual(list(expected_result), result)
+
+        a = range(6)
+        expected_result = a[999:5:2]
+        result = self.run_smart_contract(engine, path, 'really_high_start')
+        self.assertEqual(list(expected_result), result)
+
+        a = range(6)
+        expected_result = a[0:999:2]
+        result = self.run_smart_contract(engine, path, 'really_high_end')
+        self.assertEqual(list(expected_result), result)
+
+        a = range(6)
+        expected_result = a[999:999:2]
+        result = self.run_smart_contract(engine, path, 'really_high_values')
+        self.assertEqual(list(expected_result), result)
 
     def test_range_slicing_with_negative_stride(self):
         path = self.get_contract_path('RangeSlicingWithNegativeStride.py')
         engine = TestEngine()
 
-        result = self.run_smart_contract(engine, path, 'Main')
-        # TODO: Remove assertRaises when the slicing with negative stride is correctly implemented
-        with self.assertRaises(AssertionError):
-            self.assertEqual(list(range(0, 5, -2)), result)
+        a = range(6)
+        expected_result = a[2:5:-1]
+        result = self.run_smart_contract(engine, path, 'literal_values')
+        self.assertEqual(list(expected_result), result)
+
+        a = range(6)
+        expected_result = a[-6:5:-1]
+        result = self.run_smart_contract(engine, path, 'negative_start')
+        self.assertEqual(list(expected_result), result)
+
+        a = range(6)
+        expected_result = a[0:-1:-1]
+        result = self.run_smart_contract(engine, path, 'negative_end')
+        self.assertEqual(list(expected_result), result)
+
+        a = range(6)
+        expected_result = a[-6:-1:-1]
+        result = self.run_smart_contract(engine, path, 'negative_values')
+        self.assertEqual(list(expected_result), result)
+
+        a = range(6)
+        expected_result = a[-999:5:-1]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_start')
+        self.assertEqual(list(expected_result), result)
+
+        a = range(6)
+        expected_result = a[0:-999:-1]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_end')
+        self.assertEqual(list(expected_result), result)
+
+        a = range(6)
+        expected_result = a[-999:-999:-1]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_values')
+        self.assertEqual(list(expected_result), result)
+
+        a = range(6)
+        expected_result = a[999:5:-1]
+        result = self.run_smart_contract(engine, path, 'really_high_start')
+        self.assertEqual(list(expected_result), result)
+
+        a = range(6)
+        expected_result = a[0:999:-1]
+        result = self.run_smart_contract(engine, path, 'really_high_end')
+        self.assertEqual(list(expected_result), result)
+
+        a = range(6)
+        expected_result = a[999:999:-1]
+        result = self.run_smart_contract(engine, path, 'really_high_values')
+        self.assertEqual(list(expected_result), result)
 
     def test_range_slicing_omitted_with_stride(self):
         path = self.get_contract_path('RangeSlicingOmittedWithStride.py')
         engine = TestEngine()
 
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(list(range(0, 6, 2)), result)
+        a = range(6)
+        expected_result = a[::2]
+        result = self.run_smart_contract(engine, path, 'omitted_values')
+        self.assertEqual(list(expected_result), result)
+
+        a = range(6)
+        expected_result = a[:5:2]
+        result = self.run_smart_contract(engine, path, 'omitted_start')
+        self.assertEqual(list(expected_result), result)
+
+        a = range(6)
+        expected_result = a[2::2]
+        result = self.run_smart_contract(engine, path, 'omitted_end')
+        self.assertEqual(list(expected_result), result)
+
+        a = range(6)
+        expected_result = a[-6::2]
+        result = self.run_smart_contract(engine, path, 'negative_start')
+        self.assertEqual(list(expected_result), result)
+
+        a = range(6)
+        expected_result = a[:-1:2]
+        result = self.run_smart_contract(engine, path, 'negative_end')
+        self.assertEqual(list(expected_result), result)
+
+        a = range(6)
+        expected_result = a[-999::2]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_start')
+        self.assertEqual(list(expected_result), result)
+
+        a = range(6)
+        expected_result = a[:-999:2]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_end')
+        self.assertEqual(list(expected_result), result)
+
+        a = range(6)
+        expected_result = a[999::2]
+        result = self.run_smart_contract(engine, path, 'really_high_start')
+        self.assertEqual(list(expected_result), result)
+
+        a = range(6)
+        expected_result = a[:999:2]
+        result = self.run_smart_contract(engine, path, 'really_high_end')
+        self.assertEqual(list(expected_result), result)
 
     def test_range_slicing_omitted_with_negative_stride(self):
         path = self.get_contract_path('RangeSlicingOmittedWithNegativeStride.py')
         engine = TestEngine()
 
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(list(range(5, -1, -2)), result)
+        a = range(6)
+        expected_result = a[::-2]
+        result = self.run_smart_contract(engine, path, 'omitted_values')
+        self.assertEqual(list(expected_result), result)
+
+        a = range(6)
+        expected_result = a[:5:-2]
+        result = self.run_smart_contract(engine, path, 'omitted_start')
+        self.assertEqual(list(expected_result), result)
+
+        a = range(6)
+        expected_result = a[2::-2]
+        result = self.run_smart_contract(engine, path, 'omitted_end')
+        self.assertEqual(list(expected_result), result)
+
+        a = range(6)
+        expected_result = a[-6::-2]
+        result = self.run_smart_contract(engine, path, 'negative_start')
+        self.assertEqual(list(expected_result), result)
+
+        a = range(6)
+        expected_result = a[:-1:-2]
+        result = self.run_smart_contract(engine, path, 'negative_end')
+        self.assertEqual(list(expected_result), result)
+
+        a = range(6)
+        expected_result = a[-999::-2]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_start')
+        self.assertEqual(list(expected_result), result)
+
+        a = range(6)
+        expected_result = a[:-999:-2]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_end')
+        self.assertEqual(list(expected_result), result)
+
+        a = range(6)
+        expected_result = a[999::-2]
+        result = self.run_smart_contract(engine, path, 'really_high_start')
+        self.assertEqual(list(expected_result), result)
+
+        a = range(6)
+        expected_result = a[:999:-2]
+        result = self.run_smart_contract(engine, path, 'really_high_end')
+        self.assertEqual(list(expected_result), result)
 
     def test_boa2_range_test(self):
         path = self.get_contract_path('RangeBoa2Test.py')

--- a/boa3_test/tests/compiler_tests/test_string.py
+++ b/boa3_test/tests/compiler_tests/test_string.py
@@ -45,7 +45,6 @@ class TestString(BoaTest):
 
     def test_string_slicing(self):
         path = self.get_contract_path('StringSlicingLiteralValues.py')
-        output = Boa3.compile(path)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
@@ -65,37 +64,7 @@ class TestString(BoaTest):
         self.assertEqual('i', result)
 
     def test_string_slicing_negative_start(self):
-        string_value = 'unit_test'
-        byte_input = String(string_value).to_bytes()
-
-        expected_output = (
-            Opcode.INITSLOT     # function signature
-            + b'\x01'
-            + b'\x00'
-            + Opcode.PUSHDATA1  # a = 'unit_test'
-            + Integer(len(byte_input)).to_byte_array()
-            + byte_input
-            + Opcode.STLOC0
-            + Opcode.PUSHDATA1  # return a[:-4]
-            + Integer(len(byte_input)).to_byte_array()
-            + byte_input
-            + Opcode.PUSH4            # size of the substring: len(a) - 4
-            + Opcode.NEGATE
-            + Opcode.DUP
-            + Opcode.SIGN
-            + Opcode.PUSHM1
-            + Opcode.JMPNE
-            + Integer(5).to_byte_array(min_length=1, signed=True)
-            + Opcode.OVER
-            + Opcode.SIZE
-            + Opcode.ADD
-            + Opcode.LEFT
-            + Opcode.CONVERT + Type.str.stack_item
-            + Opcode.RET        # return
-        )
         path = self.get_contract_path('StringSlicingNegativeStart.py')
-        output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main',
@@ -154,38 +123,206 @@ class TestString(BoaTest):
         path = self.get_contract_path('StringSlicingWithStride.py')
         engine = TestEngine()
 
-        expected_result = 'unit_test'
-        expected_result = expected_result[2:5:2]
-        result = self.run_smart_contract(engine, path, 'Main')
+        a = 'unit_test'
+        expected_result = a[2:5:2]
+        result = self.run_smart_contract(engine, path, 'literal_values')
+        self.assertEqual(expected_result, result)
+
+        a = 'unit_test'
+        expected_result = a[-6:5:2]
+        result = self.run_smart_contract(engine, path, 'negative_start')
+        self.assertEqual(expected_result, result)
+
+        a = 'unit_test'
+        expected_result = a[0:-1:2]
+        result = self.run_smart_contract(engine, path, 'negative_end')
+        self.assertEqual(expected_result, result)
+
+        a = 'unit_test'
+        expected_result = a[-6:-1:2]
+        result = self.run_smart_contract(engine, path, 'negative_values')
+        self.assertEqual(expected_result, result)
+
+        a = 'unit_test'
+        expected_result = a[-999:5:2]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_start')
+        self.assertEqual(expected_result, result)
+
+        a = 'unit_test'
+        expected_result = a[0:-999:2]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_end')
+        self.assertEqual(expected_result, result)
+
+        a = 'unit_test'
+        expected_result = a[-999:-999:2]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_values')
+        self.assertEqual(expected_result, result)
+
+        a = 'unit_test'
+        expected_result = a[999:5:2]
+        result = self.run_smart_contract(engine, path, 'really_high_start')
+        self.assertEqual(expected_result, result)
+
+        a = 'unit_test'
+        expected_result = a[0:999:2]
+        result = self.run_smart_contract(engine, path, 'really_high_end')
+        self.assertEqual(expected_result, result)
+
+        a = 'unit_test'
+        expected_result = a[999:999:2]
+        result = self.run_smart_contract(engine, path, 'really_high_values')
         self.assertEqual(expected_result, result)
 
     def test_string_slicing_with_negative_stride(self):
         path = self.get_contract_path('StringSlicingWithNegativeStride.py')
         engine = TestEngine()
 
-        expected_result = 'unit_test'
-        expected_result = expected_result[2:5:-2]
-        result = self.run_smart_contract(engine, path, 'Main')
-        # TODO: Remove assertRaises when the slicing with negative stride is correctly implemented
-        with self.assertRaises(AssertionError):
-            self.assertEqual(expected_result, result)
+        a = 'unit_test'
+        expected_result = a[2:5:-1]
+        result = self.run_smart_contract(engine, path, 'literal_values')
+        self.assertEqual(expected_result, result)
+
+        a = 'unit_test'
+        expected_result = a[-6:5:-1]
+        result = self.run_smart_contract(engine, path, 'negative_start')
+        self.assertEqual(expected_result, result)
+
+        a = 'unit_test'
+        expected_result = a[0:-1:-1]
+        result = self.run_smart_contract(engine, path, 'negative_end')
+        self.assertEqual(expected_result, result)
+
+        a = 'unit_test'
+        expected_result = a[-6:-1:-1]
+        result = self.run_smart_contract(engine, path, 'negative_values')
+        self.assertEqual(expected_result, result)
+
+        a = 'unit_test'
+        expected_result = a[-999:5:-1]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_start')
+        self.assertEqual(expected_result, result)
+
+        a = 'unit_test'
+        expected_result = a[0:-999:-1]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_end')
+        self.assertEqual(expected_result, result)
+
+        a = 'unit_test'
+        expected_result = a[-999:-999:-1]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_values')
+        self.assertEqual(expected_result, result)
+
+        a = 'unit_test'
+        expected_result = a[999:5:-1]
+        result = self.run_smart_contract(engine, path, 'really_high_start')
+        self.assertEqual(expected_result, result)
+
+        a = 'unit_test'
+        expected_result = a[0:999:-1]
+        result = self.run_smart_contract(engine, path, 'really_high_end')
+        self.assertEqual(expected_result, result)
+
+        a = 'unit_test'
+        expected_result = a[999:999:-1]
+        result = self.run_smart_contract(engine, path, 'really_high_values')
+        self.assertEqual(expected_result, result)
 
     def test_string_slicing_omitted_with_stride(self):
         path = self.get_contract_path('StringSlicingOmittedWithStride.py')
         engine = TestEngine()
 
-        expected_result = 'unit_test'
-        expected_result = expected_result[::2]
-        result = self.run_smart_contract(engine, path, 'Main')
+        a = 'unit_test'
+        expected_result = a[::2]
+        result = self.run_smart_contract(engine, path, 'omitted_values')
+        self.assertEqual(expected_result, result)
+
+        a = 'unit_test'
+        expected_result = a[:5:2]
+        result = self.run_smart_contract(engine, path, 'omitted_start')
+        self.assertEqual(expected_result, result)
+
+        a = 'unit_test'
+        expected_result = a[2::2]
+        result = self.run_smart_contract(engine, path, 'omitted_end')
+        self.assertEqual(expected_result, result)
+
+        a = 'unit_test'
+        expected_result = a[-6::2]
+        result = self.run_smart_contract(engine, path, 'negative_start')
+        self.assertEqual(expected_result, result)
+
+        a = 'unit_test'
+        expected_result = a[:-1:2]
+        result = self.run_smart_contract(engine, path, 'negative_end')
+        self.assertEqual(expected_result, result)
+
+        a = 'unit_test'
+        expected_result = a[-999::2]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_start')
+        self.assertEqual(expected_result, result)
+
+        a = 'unit_test'
+        expected_result = a[:-999:2]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_end')
+        self.assertEqual(expected_result, result)
+
+        a = 'unit_test'
+        expected_result = a[999::2]
+        result = self.run_smart_contract(engine, path, 'really_high_start')
+        self.assertEqual(expected_result, result)
+
+        a = 'unit_test'
+        expected_result = a[:999:2]
+        result = self.run_smart_contract(engine, path, 'really_high_end')
         self.assertEqual(expected_result, result)
 
     def test_string_slicing_omitted_with_negative_stride(self):
         path = self.get_contract_path('StringSlicingOmittedWithNegativeStride.py')
         engine = TestEngine()
 
-        expected_result = 'unit_test'
-        expected_result = expected_result[::-2]
-        result = self.run_smart_contract(engine, path, 'Main')
+        a = 'unit_test'
+        expected_result = a[::-2]
+        result = self.run_smart_contract(engine, path, 'omitted_values')
+        self.assertEqual(expected_result, result)
+
+        a = 'unit_test'
+        expected_result = a[:5:-2]
+        result = self.run_smart_contract(engine, path, 'omitted_start')
+        self.assertEqual(expected_result, result)
+
+        a = 'unit_test'
+        expected_result = a[2::-2]
+        result = self.run_smart_contract(engine, path, 'omitted_end')
+        self.assertEqual(expected_result, result)
+
+        a = 'unit_test'
+        expected_result = a[-6::-2]
+        result = self.run_smart_contract(engine, path, 'negative_start')
+        self.assertEqual(expected_result, result)
+
+        a = 'unit_test'
+        expected_result = a[:-1:-2]
+        result = self.run_smart_contract(engine, path, 'negative_end')
+        self.assertEqual(expected_result, result)
+
+        a = 'unit_test'
+        expected_result = a[-999::-2]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_start')
+        self.assertEqual(expected_result, result)
+
+        a = 'unit_test'
+        expected_result = a[:-999:-2]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_end')
+        self.assertEqual(expected_result, result)
+
+        a = 'unit_test'
+        expected_result = a[999::-2]
+        result = self.run_smart_contract(engine, path, 'really_high_start')
+        self.assertEqual(expected_result, result)
+
+        a = 'unit_test'
+        expected_result = a[:999:-2]
+        result = self.run_smart_contract(engine, path, 'really_high_end')
         self.assertEqual(expected_result, result)
 
     def test_string_simple_concat(self):

--- a/boa3_test/tests/compiler_tests/test_tuple.py
+++ b/boa3_test/tests/compiler_tests/test_tuple.py
@@ -2,7 +2,6 @@ import unittest
 
 from boa3.boa3 import Boa3
 from boa3.exception import CompilerError
-from boa3.model.type.type import Type
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.String import String
@@ -262,251 +261,21 @@ class TestTuple(BoaTest):
         self.assertEqual([2], result)
 
     def test_tuple_slicing_negative_start(self):
-        expected_output = (
-            Opcode.INITSLOT     # function signature
-            + b'\x01'
-            + b'\x00'
-            + Opcode.PUSH5      # a = [0, 1, 2, 3, 4, 5]
-            + Opcode.PUSH4
-            + Opcode.PUSH3
-            + Opcode.PUSH2
-            + Opcode.PUSH1
-            + Opcode.PUSH0
-            + Opcode.PUSH6
-            + Opcode.PACK
-            + Opcode.STLOC0
-            + Opcode.LDLOC0     # return a[-4:]
-            + Opcode.DUP
-            + Opcode.SIZE       # slice end
-            + Opcode.PUSH4
-            + Opcode.NEGATE
-            + Opcode.DUP
-            + Opcode.SIGN
-            + Opcode.PUSHM1
-            + Opcode.JMPNE
-            + Integer(6).to_byte_array(min_length=1, signed=True)
-            + Opcode.PUSH2
-            + Opcode.PICK
-            + Opcode.SIZE
-            + Opcode.ADD
-            + Opcode.SWAP       # get slice
-            + Opcode.NEWARRAY0  # slice
-            + Opcode.PUSH2
-            + Opcode.PICK       # index
-            + Opcode.JMP        # while index < end
-            + Integer(32).to_byte_array(min_length=1)
-            + Opcode.DUP            # if index >= slice start
-            + Opcode.PUSH4
-            + Opcode.PICK
-            + Opcode.GE
-            + Opcode.JMPIFNOT
-            + Integer(25).to_byte_array(min_length=1)
-            + Opcode.OVER               # slice.append(array[index])
-            + Opcode.PUSH5
-            + Opcode.PICK
-            + Opcode.PUSH2
-            + Opcode.PICK
-            + Opcode.DUP
-            + Opcode.SIGN
-            + Opcode.PUSHM1
-            + Opcode.JMPNE
-            + Integer(5).to_byte_array(min_length=1)
-            + Opcode.OVER
-            + Opcode.SIZE
-            + Opcode.ADD
-            + Opcode.PICKITEM
-            + Opcode.OVER
-            + Opcode.ISTYPE
-            + Type.bytearray.stack_item
-            + Opcode.JMPIFNOT
-            + Integer(5).to_byte_array(signed=True, min_length=1)
-            + Opcode.CAT
-            + Opcode.JMP
-            + Integer(5).to_byte_array(min_length=1)
-            + Opcode.APPEND
-            + Opcode.INC            # index += 1
-            + Opcode.DUP
-            + Opcode.PUSH3
-            + Opcode.PICK
-            + Opcode.LT
-            + Opcode.JMPIF          # end while index < slice end
-            + Integer(-34).to_byte_array(min_length=1)
-            + Opcode.DROP
-            + Opcode.REVERSE4
-            + Opcode.DROP
-            + Opcode.DROP
-            + Opcode.DROP
-            + Opcode.RET        # return
-        )
         path = self.get_contract_path('TupleSlicingNegativeStart.py')
-        output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([2, 3, 4, 5], result)
 
     def test_tuple_slicing_negative_end(self):
-        expected_output = (
-            Opcode.INITSLOT     # function signature
-            + b'\x01'
-            + b'\x00'
-            + Opcode.PUSH5      # a = [0, 1, 2, 3, 4, 5]
-            + Opcode.PUSH4
-            + Opcode.PUSH3
-            + Opcode.PUSH2
-            + Opcode.PUSH1
-            + Opcode.PUSH0
-            + Opcode.PUSH6
-            + Opcode.PACK
-            + Opcode.STLOC0
-            + Opcode.LDLOC0     # return a[:-4]
-            + Opcode.PUSH4
-            + Opcode.NEGATE         # slice end
-            + Opcode.DUP
-            + Opcode.SIGN
-            + Opcode.PUSHM1
-            + Opcode.JMPNE
-            + Integer(5).to_byte_array(min_length=1, signed=True)
-            + Opcode.OVER
-            + Opcode.SIZE
-            + Opcode.ADD
-            + Opcode.PUSH0
-            + Opcode.SWAP
-            + Opcode.NEWARRAY0  # slice
-            + Opcode.PUSH2
-            + Opcode.PICK       # index
-            + Opcode.JMP        # while index < end
-            + Integer(32).to_byte_array(min_length=1)
-            + Opcode.DUP            # if index >= slice start
-            + Opcode.PUSH4
-            + Opcode.PICK
-            + Opcode.GE
-            + Opcode.JMPIFNOT
-            + Integer(25).to_byte_array(min_length=1)
-            + Opcode.OVER               # slice.append(array[index])
-            + Opcode.PUSH5
-            + Opcode.PICK
-            + Opcode.PUSH2
-            + Opcode.PICK
-            + Opcode.DUP
-            + Opcode.SIGN
-            + Opcode.PUSHM1
-            + Opcode.JMPNE
-            + Integer(5).to_byte_array(min_length=1)
-            + Opcode.OVER
-            + Opcode.SIZE
-            + Opcode.ADD
-            + Opcode.PICKITEM
-            + Opcode.OVER
-            + Opcode.ISTYPE
-            + Type.bytearray.stack_item
-            + Opcode.JMPIFNOT
-            + Integer(5).to_byte_array(signed=True, min_length=1)
-            + Opcode.CAT
-            + Opcode.JMP
-            + Integer(5).to_byte_array(min_length=1)
-            + Opcode.APPEND
-            + Opcode.INC            # index += 1
-            + Opcode.DUP
-            + Opcode.PUSH3
-            + Opcode.PICK
-            + Opcode.LT
-            + Opcode.JMPIF          # end while index < slice end
-            + Integer(-34).to_byte_array(min_length=1)
-            + Opcode.DROP
-            + Opcode.REVERSE4
-            + Opcode.DROP
-            + Opcode.DROP
-            + Opcode.DROP
-            + Opcode.RET        # return
-        )
         path = self.get_contract_path('TupleSlicingNegativeEnd.py')
-        output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([0, 1], result)
 
     def test_tuple_slicing_start_omitted(self):
-        expected_output = (
-            Opcode.INITSLOT     # function signature
-            + b'\x01'
-            + b'\x00'
-            + Opcode.PUSH5      # a = [0, 1, 2, 3, 4, 5]
-            + Opcode.PUSH4
-            + Opcode.PUSH3
-            + Opcode.PUSH2
-            + Opcode.PUSH1
-            + Opcode.PUSH0
-            + Opcode.PUSH6
-            + Opcode.PACK
-            + Opcode.STLOC0
-            + Opcode.LDLOC0     # return a[:3]
-            + Opcode.PUSH3          # slice end
-            + Opcode.DUP
-            + Opcode.SIGN
-            + Opcode.PUSHM1
-            + Opcode.JMPNE
-            + Integer(5).to_byte_array(min_length=1, signed=True)
-            + Opcode.OVER
-            + Opcode.SIZE
-            + Opcode.ADD
-            + Opcode.PUSH0
-            + Opcode.SWAP
-            + Opcode.NEWARRAY0  # slice
-            + Opcode.PUSH2
-            + Opcode.PICK       # index
-            + Opcode.JMP        # while index < end
-            + Integer(32).to_byte_array(min_length=1)
-            + Opcode.DUP            # if index >= slice start
-            + Opcode.PUSH4
-            + Opcode.PICK
-            + Opcode.GE
-            + Opcode.JMPIFNOT
-            + Integer(25).to_byte_array(min_length=1)
-            + Opcode.OVER               # slice.append(array[index])
-            + Opcode.PUSH5
-            + Opcode.PICK
-            + Opcode.PUSH2
-            + Opcode.PICK
-            + Opcode.DUP
-            + Opcode.SIGN
-            + Opcode.PUSHM1
-            + Opcode.JMPNE
-            + Integer(5).to_byte_array(min_length=1)
-            + Opcode.OVER
-            + Opcode.SIZE
-            + Opcode.ADD
-            + Opcode.PICKITEM
-            + Opcode.OVER
-            + Opcode.ISTYPE
-            + Type.bytearray.stack_item
-            + Opcode.JMPIFNOT
-            + Integer(5).to_byte_array(signed=True, min_length=1)
-            + Opcode.CAT
-            + Opcode.JMP
-            + Integer(5).to_byte_array(min_length=1)
-            + Opcode.APPEND
-            + Opcode.INC            # index += 1
-            + Opcode.DUP
-            + Opcode.PUSH3
-            + Opcode.PICK
-            + Opcode.LT
-            + Opcode.JMPIF          # end while index < slice end
-            + Integer(-34).to_byte_array(min_length=1)
-            + Opcode.DROP
-            + Opcode.REVERSE4
-            + Opcode.DROP
-            + Opcode.DROP
-            + Opcode.DROP
-            + Opcode.RET        # return
-        )
-
         path = self.get_contract_path('TupleSlicingStartOmitted.py')
-        output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
@@ -517,7 +286,7 @@ class TestTuple(BoaTest):
             Opcode.INITSLOT     # function signature
             + b'\x01'
             + b'\x00'
-            + Opcode.PUSH5      # a = [0, 1, 2, 3, 4, 5]
+            + Opcode.PUSH5      # a = (0, 1, 2, 3, 4, 5)
             + Opcode.PUSH4
             + Opcode.PUSH3
             + Opcode.PUSH2
@@ -550,32 +319,204 @@ class TestTuple(BoaTest):
         path = self.get_contract_path('TupleSlicingWithStride.py')
         engine = TestEngine()
 
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual([2, 4], result)
+        a = (0, 1, 2, 3, 4, 5)
+        expected_result = a[2:5:2]
+        result = self.run_smart_contract(engine, path, 'literal_values')
+        self.assertEqual(expected_result, tuple(result))
+
+        a = (0, 1, 2, 3, 4, 5)
+        expected_result = a[-6:5:2]
+        result = self.run_smart_contract(engine, path, 'negative_start')
+        self.assertEqual(expected_result, tuple(result))
+
+        a = (0, 1, 2, 3, 4, 5)
+        expected_result = a[0:-1:2]
+        result = self.run_smart_contract(engine, path, 'negative_end')
+        self.assertEqual(expected_result, tuple(result))
+
+        a = (0, 1, 2, 3, 4, 5)
+        expected_result = a[-6:-1:2]
+        result = self.run_smart_contract(engine, path, 'negative_values')
+        self.assertEqual(expected_result, tuple(result))
+
+        a = (0, 1, 2, 3, 4, 5)
+        expected_result = a[-999:5:2]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_start')
+        self.assertEqual(expected_result, tuple(result))
+
+        a = (0, 1, 2, 3, 4, 5)
+        expected_result = a[0:-999:2]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_end')
+        self.assertEqual(expected_result, tuple(result))
+
+        a = (0, 1, 2, 3, 4, 5)
+        expected_result = a[-999:-999:2]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_values')
+        self.assertEqual(expected_result, tuple(result))
+
+        a = (0, 1, 2, 3, 4, 5)
+        expected_result = a[999:5:2]
+        result = self.run_smart_contract(engine, path, 'really_high_start')
+        self.assertEqual(expected_result, tuple(result))
+
+        a = (0, 1, 2, 3, 4, 5)
+        expected_result = a[0:999:2]
+        result = self.run_smart_contract(engine, path, 'really_high_end')
+        self.assertEqual(expected_result, tuple(result))
+
+        a = (0, 1, 2, 3, 4, 5)
+        expected_result = a[999:999:2]
+        result = self.run_smart_contract(engine, path, 'really_high_values')
+        self.assertEqual(expected_result, tuple(result))
 
     def test_tuple_slicing_with_negative_stride(self):
         path = self.get_contract_path('TupleSlicingWithNegativeStride.py')
         engine = TestEngine()
 
-        expected_result = (0, 1, 2, 3, 4, 5)
-        expected_result = expected_result[2:5:-2]
-        result = self.run_smart_contract(engine, path, 'Main')
-        # TODO: Remove assertRaises when the slicing with negative stride is correctly implemented
-        with self.assertRaises(AssertionError):
-            self.assertEqual(expected_result, tuple(result))
+        a = (0, 1, 2, 3, 4, 5)
+        expected_result = a[2:5:-1]
+        result = self.run_smart_contract(engine, path, 'literal_values')
+        self.assertEqual(expected_result, tuple(result))
+
+        a = (0, 1, 2, 3, 4, 5)
+        expected_result = a[-6:5:-1]
+        result = self.run_smart_contract(engine, path, 'negative_start')
+        self.assertEqual(expected_result, tuple(result))
+
+        a = (0, 1, 2, 3, 4, 5)
+        expected_result = a[0:-1:-1]
+        result = self.run_smart_contract(engine, path, 'negative_end')
+        self.assertEqual(expected_result, tuple(result))
+
+        a = (0, 1, 2, 3, 4, 5)
+        expected_result = a[-6:-1:-1]
+        result = self.run_smart_contract(engine, path, 'negative_values')
+        self.assertEqual(expected_result, tuple(result))
+
+        a = (0, 1, 2, 3, 4, 5)
+        expected_result = a[-999:5:-1]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_start')
+        self.assertEqual(expected_result, tuple(result))
+
+        a = (0, 1, 2, 3, 4, 5)
+        expected_result = a[0:-999:-1]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_end')
+        self.assertEqual(expected_result, tuple(result))
+
+        a = (0, 1, 2, 3, 4, 5)
+        expected_result = a[-999:-999:-1]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_values')
+        self.assertEqual(expected_result, tuple(result))
+
+        a = (0, 1, 2, 3, 4, 5)
+        expected_result = a[999:5:-1]
+        result = self.run_smart_contract(engine, path, 'really_high_start')
+        self.assertEqual(expected_result, tuple(result))
+
+        a = (0, 1, 2, 3, 4, 5)
+        expected_result = a[0:999:-1]
+        result = self.run_smart_contract(engine, path, 'really_high_end')
+        self.assertEqual(expected_result, tuple(result))
+
+        a = (0, 1, 2, 3, 4, 5)
+        expected_result = a[999:999:-1]
+        result = self.run_smart_contract(engine, path, 'really_high_values')
+        self.assertEqual(expected_result, tuple(result))
 
     def test_tuple_slicing_omitted_with_stride(self):
         path = self.get_contract_path('TupleSlicingOmittedWithStride.py')
         engine = TestEngine()
 
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual([0, 2, 4], result)
+        a = (0, 1, 2, 3, 4, 5)
+        expected_result = a[::2]
+        result = self.run_smart_contract(engine, path, 'omitted_values')
+        self.assertEqual(expected_result, tuple(result))
+
+        a = (0, 1, 2, 3, 4, 5)
+        expected_result = a[:5:2]
+        result = self.run_smart_contract(engine, path, 'omitted_start')
+        self.assertEqual(expected_result, tuple(result))
+
+        a = (0, 1, 2, 3, 4, 5)
+        expected_result = a[2::2]
+        result = self.run_smart_contract(engine, path, 'omitted_end')
+        self.assertEqual(expected_result, tuple(result))
+
+        a = (0, 1, 2, 3, 4, 5)
+        expected_result = a[-6::2]
+        result = self.run_smart_contract(engine, path, 'negative_start')
+        self.assertEqual(expected_result, tuple(result))
+
+        a = (0, 1, 2, 3, 4, 5)
+        expected_result = a[:-1:2]
+        result = self.run_smart_contract(engine, path, 'negative_end')
+        self.assertEqual(expected_result, tuple(result))
+
+        a = (0, 1, 2, 3, 4, 5)
+        expected_result = a[-999::2]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_start')
+        self.assertEqual(expected_result, tuple(result))
+
+        a = (0, 1, 2, 3, 4, 5)
+        expected_result = a[:-999:2]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_end')
+        self.assertEqual(expected_result, tuple(result))
+
+        a = (0, 1, 2, 3, 4, 5)
+        expected_result = a[999::2]
+        result = self.run_smart_contract(engine, path, 'really_high_start')
+        self.assertEqual(expected_result, tuple(result))
+
+        a = (0, 1, 2, 3, 4, 5)
+        expected_result = a[:999:2]
+        result = self.run_smart_contract(engine, path, 'really_high_end')
+        self.assertEqual(expected_result, tuple(result))
 
     def test_tuple_slicing_omitted_with_negative_stride(self):
         path = self.get_contract_path('TupleSlicingOmittedWithNegativeStride.py')
         engine = TestEngine()
 
-        expected_result = (0, 1, 2, 3, 4, 5)
-        expected_result = expected_result[::-2]
-        result = self.run_smart_contract(engine, path, 'Main')
+        a = (0, 1, 2, 3, 4, 5)
+        expected_result = a[::-2]
+        result = self.run_smart_contract(engine, path, 'omitted_values')
+        self.assertEqual(expected_result, tuple(result))
+
+        a = (0, 1, 2, 3, 4, 5)
+        expected_result = a[:5:-2]
+        result = self.run_smart_contract(engine, path, 'omitted_start')
+        self.assertEqual(expected_result, tuple(result))
+
+        a = (0, 1, 2, 3, 4, 5)
+        expected_result = a[2::-2]
+        result = self.run_smart_contract(engine, path, 'omitted_end')
+        self.assertEqual(expected_result, tuple(result))
+
+        a = (0, 1, 2, 3, 4, 5)
+        expected_result = a[-6::-2]
+        result = self.run_smart_contract(engine, path, 'negative_start')
+        self.assertEqual(expected_result, tuple(result))
+
+        a = (0, 1, 2, 3, 4, 5)
+        expected_result = a[:-1:-2]
+        result = self.run_smart_contract(engine, path, 'negative_end')
+        self.assertEqual(expected_result, tuple(result))
+
+        a = (0, 1, 2, 3, 4, 5)
+        expected_result = a[-999::-2]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_start')
+        self.assertEqual(expected_result, tuple(result))
+
+        a = (0, 1, 2, 3, 4, 5)
+        expected_result = a[:-999:-2]
+        result = self.run_smart_contract(engine, path, 'negative_really_low_end')
+        self.assertEqual(expected_result, tuple(result))
+
+        a = (0, 1, 2, 3, 4, 5)
+        expected_result = a[999::-2]
+        result = self.run_smart_contract(engine, path, 'really_high_start')
+        self.assertEqual(expected_result, tuple(result))
+
+        a = (0, 1, 2, 3, 4, 5)
+        expected_result = a[:999:-2]
+        result = self.run_smart_contract(engine, path, 'really_high_end')
         self.assertEqual(expected_result, tuple(result))


### PR DESCRIPTION
**Related issue**
#594 

**Summary or solution description**
Correctly implemented slicing with negative stride.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/0da8d1f0d279cc3e56732803673682e8aba92350/boa3_test/test_sc/list_test/ListSlicingWithNegativeStride.py#L1-L61

**Tests**
Bytes:
https://github.com/CityOfZion/neo3-boa/blob/0da8d1f0d279cc3e56732803673682e8aba92350/boa3_test/tests/compiler_tests/test_bytes.py#L242-L484
List:
https://github.com/CityOfZion/neo3-boa/blob/0da8d1f0d279cc3e56732803673682e8aba92350/boa3_test/tests/compiler_tests/test_list.py#L422-L626
Range:
https://github.com/CityOfZion/neo3-boa/blob/0da8d1f0d279cc3e56732803673682e8aba92350/boa3_test/tests/compiler_tests/test_range.py#L363-L572
String:
https://github.com/CityOfZion/neo3-boa/blob/0da8d1f0d279cc3e56732803673682e8aba92350/boa3_test/tests/compiler_tests/test_string.py#L122-L326
Tuple:
https://github.com/CityOfZion/neo3-boa/blob/0da8d1f0d279cc3e56732803673682e8aba92350/boa3_test/tests/compiler_tests/test_tuple.py#L318-L522

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8

**(Optional) Additional context**
Also corrected the way slicing works with numbers that are greater than len(array) or less than -len(array) - 1 on neo3-boa to properly mimic Python behavior.
