### PR TITLE
Complement max builtin with str and bytes values

### DIFF
--- a/boa3/builtin/contract/__init__.py
+++ b/boa3/builtin/contract/__init__.py
@@ -1,7 +1,7 @@
 from typing import Union
 
 from boa3.builtin import CreateNewEvent, Event
-from boa3.builtin.type import UInt160, ECPoint
+from boa3.builtin.type import ECPoint, UInt160
 
 Nep5TransferEvent: Event = CreateNewEvent(
     [

--- a/boa3/builtin/nativecontract/neo.py
+++ b/boa3/builtin/nativecontract/neo.py
@@ -1,7 +1,7 @@
 from typing import Any, List, Tuple
 
 from boa3.builtin.contract import NeoAccountState
-from boa3.builtin.type import UInt160, ECPoint
+from boa3.builtin.type import ECPoint, UInt160
 
 
 class NEO:

--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -44,7 +44,7 @@ class Builtin:
     IsInstance = IsInstanceMethod()
     Len = LenMethod()
     NewEvent = CreateEventMethod()
-    Max = MaxMethod()
+    Max = MaxIntMethod()
     Min = MinMethod()
     Print = PrintMethod()
     ScriptHash = ScriptHashMethod()

--- a/boa3/model/builtin/method/__init__.py
+++ b/boa3/model/builtin/method/__init__.py
@@ -7,7 +7,8 @@ __all__ = ['AbsMethod',
            'ExitMethod',
            'IsInstanceMethod',
            'LenMethod',
-           'MaxMethod',
+           'MaxIntMethod',
+           'MaxByteStringMethod',
            'MinMethod',
            'PrintMethod',
            'RangeMethod',
@@ -26,7 +27,8 @@ from boa3.model.builtin.method.exceptionmethod import ExceptionMethod
 from boa3.model.builtin.method.exitmethod import ExitMethod
 from boa3.model.builtin.method.isinstancemethod import IsInstanceMethod
 from boa3.model.builtin.method.lenmethod import LenMethod
-from boa3.model.builtin.method.maxmethod import MaxMethod
+from boa3.model.builtin.method.maxbytestringmethod import MaxByteStringMethod
+from boa3.model.builtin.method.maxintmethod import MaxIntMethod
 from boa3.model.builtin.method.minmethod import MinMethod
 from boa3.model.builtin.method.printmethod import PrintMethod
 from boa3.model.builtin.method.rangemethod import RangeMethod

--- a/boa3/model/builtin/method/maxbytestringmethod.py
+++ b/boa3/model/builtin/method/maxbytestringmethod.py
@@ -1,0 +1,110 @@
+from typing import List, Optional, Tuple
+
+from boa3.compiler.codegenerator import get_bytes_count
+from boa3.model.builtin.method.maxmethod import MaxMethod
+from boa3.model.type.itype import IType
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class MaxByteStringMethod(MaxMethod):
+
+    def __init__(self, arg_value: Optional[IType] = None):
+        from boa3.model.type.type import Type
+        is_valid_type = Type.str.is_type_of(arg_value) or Type.bytes.is_type_of(arg_value)
+        super().__init__(arg_value if is_valid_type else Type.str)
+
+    def _compare_values(self) -> List[Tuple[Opcode, bytes]]:
+        from boa3.neo.vm.type.Integer import Integer
+
+        jmp_place_holder = (Opcode.JMP, b'\x01')
+
+        test_if_are_equal = [
+            (Opcode.OVER, b''),
+            (Opcode.OVER, b''),
+            (Opcode.EQUAL, b''),  # if str1 == str2:
+            Opcode.get_jump_and_data(Opcode.JMPIFNOT, 4),
+            (Opcode.PUSH1, b''),
+            jmp_place_holder,     # go to final test
+        ]
+
+        get_limit_index = [
+            (Opcode.OVER, b''),   # limit = min((len(str1), len(str2))
+            (Opcode.SIZE, b''),
+            (Opcode.OVER, b''),
+            (Opcode.SIZE, b''),
+            (Opcode.MIN, b''),
+            (Opcode.PUSH0, b''),  # index = 0
+        ]
+
+        while_body_before_compare = [
+            (Opcode.PUSH3, b''),  # value1 = str1[index]
+            (Opcode.get_dup(3), b''),
+            (Opcode.OVER, b''),
+            (Opcode.PICKITEM, b''),
+            (Opcode.OVER, b''),
+            (Opcode.PUSH4, b''),  # value2 = str2[index]
+            (Opcode.get_dup(4), b''),
+            (Opcode.SWAP, b''),
+            (Opcode.PICKITEM, b''),
+        ]
+        while_body_compare = [
+            (Opcode.OVER, b''),
+            (Opcode.OVER, b''),
+            (Opcode.JMPEQ, Integer(7).to_byte_array(signed=True)),     # if value1 != value2 jmp to end
+            (Opcode.GT, b''),
+            (Opcode.NIP, b''),
+            (Opcode.NIP, b''),
+            jmp_place_holder,     # jmp to end
+        ]
+        while_body_after_compare = [
+            (Opcode.DROP, b''),
+            (Opcode.DROP, b''),
+            (Opcode.INC, b''),    # index++
+        ]
+
+        while_full_body = while_body_before_compare + while_body_compare + while_body_after_compare
+        while_bytes_size = get_bytes_count(while_full_body)
+        get_limit_index.append(
+            Opcode.get_jump_and_data(Opcode.JMP, while_bytes_size, True)
+        )
+
+        while_condition = [
+            (Opcode.OVER, b''),
+            (Opcode.OVER, b'')
+        ]
+        while_condition_bytes_size = get_bytes_count(while_condition)
+        while_condition.append(Opcode.get_jump_and_data(Opcode.JMPGT, -while_bytes_size - while_condition_bytes_size))
+
+        while_else_body = [
+            (Opcode.DROP, b''),
+            (Opcode.DROP, b''),
+            (Opcode.OVER, b''),  # if len(str1) > len(str2) jmp to end
+            (Opcode.SIZE, b''),
+            (Opcode.OVER, b''),
+            (Opcode.SIZE, b''),
+            (Opcode.GT, b''),
+        ]
+
+        everything_after_while_check = while_body_after_compare + while_condition + while_else_body
+        jmp_while_check = Opcode.get_jump_and_data(Opcode.JMP, get_bytes_count(everything_after_while_check), True)
+        while_body_compare[-1] = jmp_while_check
+
+        everything_after_equal_check = (get_limit_index +
+                                        while_body_before_compare +
+                                        while_body_compare +
+                                        everything_after_while_check)
+        jmp_test_equal = Opcode.get_jump_and_data(Opcode.JMP, get_bytes_count(everything_after_equal_check), True)
+        test_if_are_equal[-1] = jmp_test_equal
+
+        final_test = [
+            (Opcode.JMPIFNOT, Integer(4).to_byte_array(signed=True)),   # if condition is True
+            (Opcode.DROP, b''),                                            # remove str2 <=> return str1
+            (Opcode.JMP, Integer(3).to_byte_array(signed=True)),        # else
+            (Opcode.NIP, b'')                                              # remove str1 <=> return str2
+        ]
+
+        return (
+            test_if_are_equal +
+            everything_after_equal_check +
+            final_test
+        )

--- a/boa3/model/builtin/method/maxintmethod.py
+++ b/boa3/model/builtin/method/maxintmethod.py
@@ -1,0 +1,11 @@
+from typing import Optional
+
+from boa3.model.builtin.method.maxmethod import MaxMethod
+from boa3.model.type.itype import IType
+
+
+class MaxIntMethod(MaxMethod):
+
+    def __init__(self, arg_value: Optional[IType] = None):
+        from boa3.model.type.type import Type
+        super().__init__(arg_value if Type.int.is_type_of(arg_value) else Type.int)

--- a/boa3/model/builtin/native/neo_contract_methods/getcandidatesmethod.py
+++ b/boa3/model/builtin/native/neo_contract_methods/getcandidatesmethod.py
@@ -15,6 +15,6 @@ class GetCandidatesMethod(NeoContractMethod):
         args: Dict[str, Variable] = {}
         super().__init__(identifier, native_identifier, args,
                          return_type=Type.list.build_collection([
-                                        Type.tuple.build_collection([
-                                            ECPointType.build(),
-                                            Type.int])]))
+                             Type.tuple.build_collection([
+                                 ECPointType.build(),
+                                 Type.int])]))

--- a/boa3_test/test_sc/built_in_methods_test/MaxBytes.py
+++ b/boa3_test/test_sc/built_in_methods_test/MaxBytes.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main(val1: bytes, val2: bytes) -> bytes:
+    return max(val1, val2)

--- a/boa3_test/test_sc/built_in_methods_test/MaxBytesMoreArguments.py
+++ b/boa3_test/test_sc/built_in_methods_test/MaxBytesMoreArguments.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main() -> bytes:
+    return max(b'Lorem', b'ipsum', b'dolor', b'sit', b'amet')

--- a/boa3_test/test_sc/built_in_methods_test/MaxStr.py
+++ b/boa3_test/test_sc/built_in_methods_test/MaxStr.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main(val1: str, val2: str) -> str:
+    return max(val1, val2)

--- a/boa3_test/test_sc/built_in_methods_test/MaxStrMoreArguments.py
+++ b/boa3_test/test_sc/built_in_methods_test/MaxStrMoreArguments.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main() -> str:
+    return max('Lorem', 'ipsum', 'dolor', 'sit', 'amet')

--- a/boa3_test/test_sc/native_test/neo/GetCandidates.py
+++ b/boa3_test/test_sc/native_test/neo/GetCandidates.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Any
+from typing import Any, List, Tuple
 
 from boa3.builtin import public
 from boa3.builtin.nativecontract.neo import NEO

--- a/boa3_test/tests/compiler_tests/test_builtin_method.py
+++ b/boa3_test/tests/compiler_tests/test_builtin_method.py
@@ -821,6 +821,72 @@ class TestBuiltinMethod(BoaTest):
         result = self.run_smart_contract(engine, path, 'main')
         self.assertEqual(expected_result, result)
 
+    def test_max_str(self):
+        path = self.get_contract_path('MaxStr.py')
+        engine = TestEngine()
+
+        value1 = 'foo'
+        value2 = 'bar'
+        expected_result = max(value1, value2)
+        result = self.run_smart_contract(engine, path, 'main', value1, value2)
+        self.assertEqual(expected_result, result)
+
+        result = self.run_smart_contract(engine, path, 'main', value2, value1)
+        self.assertEqual(expected_result, result)
+
+        value1 = 'alg'
+        value2 = 'al'
+        expected_result = max(value1, value2)
+        result = self.run_smart_contract(engine, path, 'main', value1, value2)
+        self.assertEqual(expected_result, result)
+
+        value = 'some string'
+        expected_result = max(value, value)
+        result = self.run_smart_contract(engine, path, 'main', value, value)
+        self.assertEqual(expected_result, result)
+
+    def test_max_str_more_arguments(self):
+        path = self.get_contract_path('MaxStrMoreArguments.py')
+        engine = TestEngine()
+
+        values = 'Lorem', 'ipsum', 'dolor', 'sit', 'amet'
+        expected_result = max(values)
+        result = self.run_smart_contract(engine, path, 'main')
+        self.assertEqual(expected_result, result)
+
+    def test_max_bytes(self):
+        path = self.get_contract_path('MaxBytes.py')
+        engine = TestEngine()
+
+        value1 = b'foo'
+        value2 = b'bar'
+        expected_result = max(value1, value2)
+        result = self.run_smart_contract(engine, path, 'main', value1, value2, expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        result = self.run_smart_contract(engine, path, 'main', value2, value1, expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        value1 = b'alg'
+        value2 = b'al'
+        expected_result = max(value1, value2)
+        result = self.run_smart_contract(engine, path, 'main', value1, value2, expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        value = b'some string'
+        expected_result = max(value, value)
+        result = self.run_smart_contract(engine, path, 'main', value, value, expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+    def test_max_bytes_more_arguments(self):
+        path = self.get_contract_path('MaxBytesMoreArguments.py')
+        engine = TestEngine()
+
+        values = b'Lorem', b'ipsum', b'dolor', b'sit', b'amet'
+        expected_result = max(values)
+        result = self.run_smart_contract(engine, path, 'main', expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
     def test_max_too_few_parameters(self):
         path = self.get_contract_path('MaxTooFewParameters.py')
         self.assertCompilerLogs(CompilerError.UnfilledArgument, path)


### PR DESCRIPTION
**Related issue**
#522

**Summary or solution description**
Included `str` and `bytes` as valid types for `max` builtin function

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/0052c941b6523b917b131427c39e6d6c97b8352d/boa3_test/test_sc/built_in_methods_test/MaxStr.py#L5-L6
https://github.com/CityOfZion/neo3-boa/blob/0052c941b6523b917b131427c39e6d6c97b8352d/boa3_test/test_sc/built_in_methods_test/MaxBytesMoreArguments.py#L5-L6

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/0052c941b6523b917b131427c39e6d6c97b8352d/boa3_test/tests/compiler_tests/test_builtin_method.py#L824-L888

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7