### PR TITLE
Complement min builtin with str and bytes values

### DIFF
--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -45,7 +45,7 @@ class Builtin:
     Len = LenMethod()
     NewEvent = CreateEventMethod()
     Max = MaxIntMethod()
-    Min = MinMethod()
+    Min = MinIntMethod()
     Print = PrintMethod()
     ScriptHash = ScriptHashMethod()
     Sqrt = SqrtMethod()

--- a/boa3/model/builtin/method/__init__.py
+++ b/boa3/model/builtin/method/__init__.py
@@ -9,7 +9,8 @@ __all__ = ['AbsMethod',
            'LenMethod',
            'MaxIntMethod',
            'MaxByteStringMethod',
-           'MinMethod',
+           'MinByteStringMethod',
+           'MinIntMethod',
            'PrintMethod',
            'RangeMethod',
            'ReversedMethod',
@@ -29,7 +30,8 @@ from boa3.model.builtin.method.isinstancemethod import IsInstanceMethod
 from boa3.model.builtin.method.lenmethod import LenMethod
 from boa3.model.builtin.method.maxbytestringmethod import MaxByteStringMethod
 from boa3.model.builtin.method.maxintmethod import MaxIntMethod
-from boa3.model.builtin.method.minmethod import MinMethod
+from boa3.model.builtin.method.minbytestringmethod import MinByteStringMethod
+from boa3.model.builtin.method.minintmethod import MinIntMethod
 from boa3.model.builtin.method.printmethod import PrintMethod
 from boa3.model.builtin.method.rangemethod import RangeMethod
 from boa3.model.builtin.method.reversedmethod import ReversedMethod

--- a/boa3/model/builtin/method/minbytestringmethod.py
+++ b/boa3/model/builtin/method/minbytestringmethod.py
@@ -1,0 +1,110 @@
+from typing import List, Optional, Tuple
+
+from boa3.compiler.codegenerator import get_bytes_count
+from boa3.model.builtin.method.minmethod import MinMethod
+from boa3.model.type.itype import IType
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class MinByteStringMethod(MinMethod):
+
+    def __init__(self, arg_value: Optional[IType] = None):
+        from boa3.model.type.type import Type
+        is_valid_type = Type.str.is_type_of(arg_value) or Type.bytes.is_type_of(arg_value)
+        super().__init__(arg_value if is_valid_type else Type.str)
+
+    def _compare_values(self) -> List[Tuple[Opcode, bytes]]:
+        from boa3.neo.vm.type.Integer import Integer
+
+        jmp_place_holder = (Opcode.JMP, b'\x01')
+
+        test_if_are_equal = [
+            (Opcode.OVER, b''),
+            (Opcode.OVER, b''),
+            (Opcode.EQUAL, b''),  # if str1 == str2:
+            Opcode.get_jump_and_data(Opcode.JMPIFNOT, 4),
+            (Opcode.PUSH1, b''),
+            jmp_place_holder,     # go to final test
+        ]
+
+        get_limit_index = [
+            (Opcode.OVER, b''),   # limit = min((len(str1), len(str2))
+            (Opcode.SIZE, b''),
+            (Opcode.OVER, b''),
+            (Opcode.SIZE, b''),
+            (Opcode.MIN, b''),
+            (Opcode.PUSH0, b''),  # index = 0
+        ]
+
+        while_body_before_compare = [
+            (Opcode.PUSH3, b''),  # value1 = str1[index]
+            (Opcode.get_dup(3), b''),
+            (Opcode.OVER, b''),
+            (Opcode.PICKITEM, b''),
+            (Opcode.OVER, b''),
+            (Opcode.PUSH4, b''),  # value2 = str2[index]
+            (Opcode.get_dup(4), b''),
+            (Opcode.SWAP, b''),
+            (Opcode.PICKITEM, b''),
+        ]
+        while_body_compare = [
+            (Opcode.OVER, b''),
+            (Opcode.OVER, b''),
+            (Opcode.JMPEQ, Integer(7).to_byte_array(signed=True)),     # if value1 != value2 jmp to end
+            (Opcode.GT, b''),
+            (Opcode.NIP, b''),
+            (Opcode.NIP, b''),
+            jmp_place_holder,     # jmp to end
+        ]
+        while_body_after_compare = [
+            (Opcode.DROP, b''),
+            (Opcode.DROP, b''),
+            (Opcode.INC, b''),    # index++
+        ]
+
+        while_full_body = while_body_before_compare + while_body_compare + while_body_after_compare
+        while_bytes_size = get_bytes_count(while_full_body)
+        get_limit_index.append(
+            Opcode.get_jump_and_data(Opcode.JMP, while_bytes_size, True)
+        )
+
+        while_condition = [
+            (Opcode.OVER, b''),
+            (Opcode.OVER, b'')
+        ]
+        while_condition_bytes_size = get_bytes_count(while_condition)
+        while_condition.append(Opcode.get_jump_and_data(Opcode.JMPGT, -while_bytes_size - while_condition_bytes_size))
+
+        while_else_body = [
+            (Opcode.DROP, b''),
+            (Opcode.DROP, b''),
+            (Opcode.OVER, b''),  # if len(str1) > len(str2) jmp to end
+            (Opcode.SIZE, b''),
+            (Opcode.OVER, b''),
+            (Opcode.SIZE, b''),
+            (Opcode.GT, b''),
+        ]
+
+        everything_after_while_check = while_body_after_compare + while_condition + while_else_body
+        jmp_while_check = Opcode.get_jump_and_data(Opcode.JMP, get_bytes_count(everything_after_while_check), True)
+        while_body_compare[-1] = jmp_while_check
+
+        everything_after_equal_check = (get_limit_index +
+                                        while_body_before_compare +
+                                        while_body_compare +
+                                        everything_after_while_check)
+        jmp_test_equal = Opcode.get_jump_and_data(Opcode.JMP, get_bytes_count(everything_after_equal_check), True)
+        test_if_are_equal[-1] = jmp_test_equal
+
+        final_test = [
+            (Opcode.JMPIF, Integer(4).to_byte_array(signed=True)),      # if condition is not True
+            (Opcode.DROP, b''),                                            # remove str1 <=> return str2
+            (Opcode.JMP, Integer(3).to_byte_array(signed=True)),        # else
+            (Opcode.NIP, b'')                                              # remove str2 <=> return str1
+        ]
+
+        return (
+            test_if_are_equal +
+            everything_after_equal_check +
+            final_test
+        )

--- a/boa3/model/builtin/method/minintmethod.py
+++ b/boa3/model/builtin/method/minintmethod.py
@@ -1,0 +1,11 @@
+from typing import Optional
+
+from boa3.model.builtin.method.minmethod import MinMethod
+from boa3.model.type.itype import IType
+
+
+class MinIntMethod(MinMethod):
+
+    def __init__(self, arg_value: Optional[IType] = None):
+        from boa3.model.type.type import Type
+        super().__init__(arg_value if Type.int.is_type_of(arg_value) else Type.int)

--- a/boa3/model/builtin/method/minmethod.py
+++ b/boa3/model/builtin/method/minmethod.py
@@ -14,17 +14,29 @@ class MinMethod(IBuiltinMethod):
     def __init__(self, arg_value: Optional[IType] = None):
         from boa3.model.type.type import Type
         identifier = 'min'
-        allowed_types = Type.int
-        if not isinstance(arg_value, IType):
-            arg_value = allowed_types
+
+        self._allowed_types = [Type.int, Type.str, Type.bytes]
+        default_type = Type.int
+        if not self._is_valid_type(arg_value):
+            arg_value = default_type
 
         args: Dict[str, Variable] = {
-            'args1': Variable(Type.int),
-            'args2': Variable(Type.int)
+            'args1': Variable(arg_value),
+            'args2': Variable(arg_value)
         }
         vararg = ('values', Variable(arg_value))
         super().__init__(identifier, args, return_type=arg_value, vararg=vararg)
-        self._allowed_types = allowed_types
+
+    def _is_valid_type(self, arg_type: Optional[IType]) -> bool:
+        return (isinstance(arg_type, IType) and
+                any(allowed_type.is_type_of(arg_type) for allowed_type in self._allowed_types))
+
+    @property
+    def identifier(self) -> str:
+        from boa3.model.type.type import Type
+        if self._arg_values.type is Type.int:
+            return self._identifier
+        return '-{0}_from_{1}'.format(self._identifier, self._arg_values.type._identifier)
 
     @property
     def _arg_values(self) -> Variable:
@@ -92,12 +104,14 @@ class MinMethod(IBuiltinMethod):
             (Opcode.PUSH2, b''),
             (Opcode.PICK, b''),         # min = min if min < array[index] else array[index]
             (Opcode.PICKITEM, b''),
-            (Opcode.MIN, b''),
+        ]
+        is_int_while.extend(self._compare_values())
+        is_int_while.extend([
             (Opcode.OVER, b''),
             (Opcode.SIGN, b'')
             # if index != 0: go back to index--
             # else go to the end
-        ]
+        ])
 
         jmp_back_to_while_statement = (Opcode.JMPIF, Integer(-get_bytes_count(is_int_while)).to_byte_array(signed=True))
         is_int_while.append(jmp_back_to_while_statement)
@@ -118,6 +132,9 @@ class MinMethod(IBuiltinMethod):
             clean_stack
         )
 
+    def _compare_values(self) -> List[Tuple[Opcode, bytes]]:
+        return [(Opcode.MIN, b'')]
+
     @property
     def _args_on_stack(self) -> int:
         return len(self.args)
@@ -133,4 +150,12 @@ class MinMethod(IBuiltinMethod):
             value = value.value_type
         if type(value) == type(self._arg_values.type):
             return self
-        return MinMethod(value)
+
+        from boa3.model.builtin.method.minbytestringmethod import MinByteStringMethod
+        from boa3.model.builtin.method.minintmethod import MinIntMethod
+        from boa3.model.type.type import Type
+
+        if Type.str.is_type_of(value) or Type.bytes.is_type_of(value):
+            return MinByteStringMethod(value)
+
+        return MinIntMethod(value)

--- a/boa3_test/test_sc/built_in_methods_test/MaxMismatchedTypes.py
+++ b/boa3_test/test_sc/built_in_methods_test/MaxMismatchedTypes.py
@@ -1,6 +1,2 @@
-from boa3.builtin import public
-
-
-@public
 def main() -> int:
     return max(123, '123')

--- a/boa3_test/test_sc/built_in_methods_test/MaxTooFewParameters.py
+++ b/boa3_test/test_sc/built_in_methods_test/MaxTooFewParameters.py
@@ -1,6 +1,2 @@
-from boa3.builtin import public
-
-
-@public
 def main() -> int:
     return max()

--- a/boa3_test/test_sc/built_in_methods_test/MinBytes.py
+++ b/boa3_test/test_sc/built_in_methods_test/MinBytes.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main(val1: bytes, val2: bytes) -> bytes:
+    return min(val1, val2)

--- a/boa3_test/test_sc/built_in_methods_test/MinBytesMoreArguments.py
+++ b/boa3_test/test_sc/built_in_methods_test/MinBytesMoreArguments.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main() -> bytes:
+    return min(b'Lorem', b'ipsum', b'dolor', b'sit', b'amet')

--- a/boa3_test/test_sc/built_in_methods_test/MinMismatchedTypes.py
+++ b/boa3_test/test_sc/built_in_methods_test/MinMismatchedTypes.py
@@ -1,6 +1,2 @@
-from boa3.builtin import public
-
-
-@public
 def main() -> int:
     return min(10, 'test')

--- a/boa3_test/test_sc/built_in_methods_test/MinStr.py
+++ b/boa3_test/test_sc/built_in_methods_test/MinStr.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main(val1: str, val2: str) -> str:
+    return min(val1, val2)

--- a/boa3_test/test_sc/built_in_methods_test/MinStrMoreArguments.py
+++ b/boa3_test/test_sc/built_in_methods_test/MinStrMoreArguments.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main() -> str:
+    return min('Lorem', 'ipsum', 'dolor', 'sit', 'amet')

--- a/boa3_test/test_sc/built_in_methods_test/MinTooFewParameters.py
+++ b/boa3_test/test_sc/built_in_methods_test/MinTooFewParameters.py
@@ -1,6 +1,2 @@
-from boa3.builtin import public
-
-
-@public
 def main() -> int:
     return min()

--- a/boa3_test/test_sc/built_in_methods_test/SumMismatchedTypes.py
+++ b/boa3_test/test_sc/built_in_methods_test/SumMismatchedTypes.py
@@ -1,6 +1,2 @@
-from boa3.builtin import public
-
-
-@public
 def main(x: str) -> int:
     return sum(x)

--- a/boa3_test/test_sc/built_in_methods_test/SumTooFewParameters.py
+++ b/boa3_test/test_sc/built_in_methods_test/SumTooFewParameters.py
@@ -1,8 +1,5 @@
 from typing import List
 
-from boa3.builtin import public
 
-
-@public
 def main(x: List[int], start: int) -> int:
     return sum()

--- a/boa3_test/test_sc/built_in_methods_test/SumTooManyParameters.py
+++ b/boa3_test/test_sc/built_in_methods_test/SumTooManyParameters.py
@@ -1,8 +1,5 @@
 from typing import List
 
-from boa3.builtin import public
 
-
-@public
 def main(x: List[int], start: int) -> int:
     return sum(x, start, 10)

--- a/boa3_test/tests/compiler_tests/test_builtin_method.py
+++ b/boa3_test/tests/compiler_tests/test_builtin_method.py
@@ -97,7 +97,6 @@ class TestBuiltinMethod(BoaTest):
 
     def test_len_of_bytes(self):
         path = self.get_contract_path('LenBytes.py')
-        output = Boa3.compile(path)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
@@ -370,7 +369,6 @@ class TestBuiltinMethod(BoaTest):
 
     def test_extend_mutable_sequence(self):
         path = self.get_contract_path('ExtendMutableSequence.py')
-        output = Boa3.compile(path)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
@@ -378,7 +376,6 @@ class TestBuiltinMethod(BoaTest):
 
     def test_extend_mutable_sequence_with_builtin(self):
         path = self.get_contract_path('ExtendMutableSequenceBuiltinCall.py')
-        output = Boa3.compile(path)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
@@ -401,7 +398,6 @@ class TestBuiltinMethod(BoaTest):
         script_hash = to_script_hash(Integer(123).to_byte_array())
 
         path = self.get_contract_path('ScriptHashInt.py')
-        output = Boa3.compile(path)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
@@ -412,7 +408,6 @@ class TestBuiltinMethod(BoaTest):
         script_hash = to_script_hash(Integer(123).to_byte_array())
 
         path = self.get_contract_path('ScriptHashIntBuiltinCall.py')
-        output = Boa3.compile(path)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
@@ -423,7 +418,6 @@ class TestBuiltinMethod(BoaTest):
         script_hash = to_script_hash(String('123').to_bytes())
 
         path = self.get_contract_path('ScriptHashStr.py')
-        output = Boa3.compile(path)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main',
@@ -435,7 +429,6 @@ class TestBuiltinMethod(BoaTest):
         script_hash = to_script_hash(String('123').to_bytes())
 
         path = self.get_contract_path('ScriptHashStrBuiltinCall.py')
-        output = Boa3.compile(path)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main',
@@ -918,6 +911,72 @@ class TestBuiltinMethod(BoaTest):
         result = self.run_smart_contract(engine, path, 'main')
         self.assertEqual(expected_result, result)
 
+    def test_min_str(self):
+        path = self.get_contract_path('MinStr.py')
+        engine = TestEngine()
+
+        value1 = 'foo'
+        value2 = 'bar'
+        expected_result = min(value1, value2)
+        result = self.run_smart_contract(engine, path, 'main', value1, value2)
+        self.assertEqual(expected_result, result)
+
+        result = self.run_smart_contract(engine, path, 'main', value2, value1)
+        self.assertEqual(expected_result, result)
+
+        value1 = 'alg'
+        value2 = 'al'
+        expected_result = min(value1, value2)
+        result = self.run_smart_contract(engine, path, 'main', value1, value2)
+        self.assertEqual(expected_result, result)
+
+        value = 'some string'
+        expected_result = min(value, value)
+        result = self.run_smart_contract(engine, path, 'main', value, value)
+        self.assertEqual(expected_result, result)
+
+    def test_min_str_more_arguments(self):
+        path = self.get_contract_path('MinStrMoreArguments.py')
+        engine = TestEngine()
+
+        values = 'Lorem', 'ipsum', 'dolor', 'sit', 'amet'
+        expected_result = min(values)
+        result = self.run_smart_contract(engine, path, 'main')
+        self.assertEqual(expected_result, result)
+
+    def test_min_bytes(self):
+        path = self.get_contract_path('MinBytes.py')
+        engine = TestEngine()
+
+        value1 = b'foo'
+        value2 = b'bar'
+        expected_result = min(value1, value2)
+        result = self.run_smart_contract(engine, path, 'main', value1, value2, expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        result = self.run_smart_contract(engine, path, 'main', value2, value1, expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        value1 = b'alg'
+        value2 = b'al'
+        expected_result = min(value1, value2)
+        result = self.run_smart_contract(engine, path, 'main', value1, value2, expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        value = b'some string'
+        expected_result = min(value, value)
+        result = self.run_smart_contract(engine, path, 'main', value, value, expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+    def test_min_bytes_more_arguments(self):
+        path = self.get_contract_path('MinBytesMoreArguments.py')
+        engine = TestEngine()
+
+        values = b'Lorem', b'ipsum', b'dolor', b'sit', b'amet'
+        expected_result = min(values)
+        result = self.run_smart_contract(engine, path, 'main', expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
     def test_min_too_few_parameters(self):
         path = self.get_contract_path('MinTooFewParameters.py')
         self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
@@ -956,7 +1015,7 @@ class TestBuiltinMethod(BoaTest):
         self.assertEqual(expected_result, result)
 
         with self.assertRaises(TestExecutionException):
-            result = self.run_smart_contract(engine, path, 'main', -1)
+            self.run_smart_contract(engine, path, 'main', -1)
 
         val = 25
         expected_result = int(sqrt(val))


### PR DESCRIPTION
**Related issue**
#529 

**Summary or solution description**
 Included `str` and `bytes` as valid types for `min` builtin function.

**How to Reproduce**
Bytes:
https://github.com/CityOfZion/neo3-boa/blob/25d933879697a5e461850e24738ad2d9168cbeff/boa3_test/test_sc/built_in_methods_test/MinBytes.py#L1-L6
Str:
https://github.com/CityOfZion/neo3-boa/blob/25d933879697a5e461850e24738ad2d9168cbeff/boa3_test/test_sc/built_in_methods_test/MinStr.py#L1-L6

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/25d933879697a5e461850e24738ad2d9168cbeff/boa3_test/tests/compiler_tests/test_builtin_method.py#L914-L987

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8

**(Optional) Additional context**
Also removed some unnecessary lines of code on some tests and smart contract tests.
