### PR TITLE
Change json_serialize and json_deserialize bytes parameters and return to str

### DIFF
--- a/boa3/builtin/interop/json/__init__.py
+++ b/boa3/builtin/interop/json/__init__.py
@@ -1,14 +1,14 @@
 from typing import Any
 
 
-def json_serialize(item: Any) -> bytes:
+def json_serialize(item: Any) -> str:
     """
     Serializes an item into a json.
 
     :param item: The item that will be serialized
     :type item: Any
     :return: The serialized item
-    :rtype: bytes
+    :rtype: str
 
     :raise Exception: raised if the item is an integer value out of the Neo's accepted range, is a dictionary with a
         bytearray key, or isn't serializable.
@@ -16,15 +16,15 @@ def json_serialize(item: Any) -> bytes:
     pass
 
 
-def json_deserialize(json: bytes) -> Any:
+def json_deserialize(json: str) -> Any:
     """
     Deserializes a json into some valid type.
 
     :param json: A json that will be deserialized
-    :type json: bytes
+    :type json: str
     :return: The deserialized json
     :rtype: Any
 
-    :raise Exception: raised if json's deserialization is not valid.
+    :raise Exception: raised if jsons deserialization is not valid.
     """
     pass

--- a/boa3/builtin/nativecontract/stdlib.py
+++ b/boa3/builtin/nativecontract/stdlib.py
@@ -35,14 +35,14 @@ class StdLib:
         pass
 
     @classmethod
-    def json_serialize(cls, item: Any) -> bytes:
+    def json_serialize(cls, item: Any) -> str:
         """
         Serializes an item into a json.
 
         :param item: The item that will be serialized
         :type item: Any
         :return: The serialized item
-        :rtype: bytes
+        :rtype: str
 
         :raise Exception: raised if the item is an integer value out of the Neo's accepted range, is a dictionary with a
             bytearray key, or isn't serializable.
@@ -50,16 +50,16 @@ class StdLib:
         pass
 
     @classmethod
-    def json_deserialize(cls, json: bytes) -> Any:
+    def json_deserialize(cls, json: str) -> Any:
         """
         Deserializes a json into some valid type.
 
         :param json: A json that will be deserialized
-        :type json: bytes
+        :type json: str
         :return: The deserialized json
         :rtype: Any
 
-        :raise Exception: raised if json's deserialization is not valid.
+        :raise Exception: raised if jsons deserialization is not valid.
         """
         pass
 

--- a/boa3/model/builtin/interop/json/jsondeserializemethod.py
+++ b/boa3/model/builtin/interop/json/jsondeserializemethod.py
@@ -9,5 +9,5 @@ class JsonDeserializeMethod(StdLibMethod):
         from boa3.model.type.type import Type
         identifier = 'json_deserialize'
         native_identifier = 'jsonDeserialize'
-        args: Dict[str, Variable] = {'json': Variable(Type.bytes)}
+        args: Dict[str, Variable] = {'json': Variable(Type.str)}
         super().__init__(identifier, native_identifier, args, return_type=Type.any)

--- a/boa3/model/builtin/interop/json/jsonserializemethod.py
+++ b/boa3/model/builtin/interop/json/jsonserializemethod.py
@@ -10,4 +10,4 @@ class JsonSerializeMethod(StdLibMethod):
         identifier = 'json_serialize'
         native_identifier = 'jsonSerialize'
         args: Dict[str, Variable] = {'item': Variable(Type.any)}
-        super().__init__(identifier, native_identifier, args, return_type=Type.bytes)
+        super().__init__(identifier, native_identifier, args, return_type=Type.str)

--- a/boa3_test/test_sc/interop_test/json/JsonDeserialize.py
+++ b/boa3_test/test_sc/interop_test/json/JsonDeserialize.py
@@ -5,5 +5,5 @@ from boa3.builtin.interop.json import json_deserialize
 
 
 @public
-def main(json: bytes) -> Any:
+def main(json: str) -> Any:
     return json_deserialize(json)

--- a/boa3_test/test_sc/interop_test/json/JsonSerialize.py
+++ b/boa3_test/test_sc/interop_test/json/JsonSerialize.py
@@ -5,5 +5,5 @@ from boa3.builtin.interop.json import json_serialize
 
 
 @public
-def main(item: Any) -> bytes:
+def main(item: Any) -> str:
     return json_serialize(item)

--- a/boa3_test/test_sc/interop_test/json/JsonSerializeBool.py
+++ b/boa3_test/test_sc/interop_test/json/JsonSerializeBool.py
@@ -3,5 +3,5 @@ from boa3.builtin.interop.json import json_serialize
 
 
 @public
-def main() -> bytes:
+def main() -> str:
     return json_serialize(True)

--- a/boa3_test/test_sc/interop_test/json/JsonSerializeBytes.py
+++ b/boa3_test/test_sc/interop_test/json/JsonSerializeBytes.py
@@ -3,5 +3,5 @@ from boa3.builtin.interop.json import json_serialize
 
 
 @public
-def main() -> bytes:
+def main() -> str:
     return json_serialize(b'unit test')

--- a/boa3_test/test_sc/interop_test/json/JsonSerializeInt.py
+++ b/boa3_test/test_sc/interop_test/json/JsonSerializeInt.py
@@ -3,5 +3,5 @@ from boa3.builtin.interop.json import json_serialize
 
 
 @public
-def main() -> bytes:
+def main() -> str:
     return json_serialize(10)

--- a/boa3_test/test_sc/interop_test/json/JsonSerializeStr.py
+++ b/boa3_test/test_sc/interop_test/json/JsonSerializeStr.py
@@ -3,5 +3,5 @@ from boa3.builtin.interop.json import json_serialize
 
 
 @public
-def main() -> bytes:
+def main() -> str:
     return json_serialize('unit test')

--- a/boa3_test/test_sc/native_test/stdlib/JsonDeserialize.py
+++ b/boa3_test/test_sc/native_test/stdlib/JsonDeserialize.py
@@ -5,5 +5,5 @@ from boa3.builtin.nativecontract.stdlib import StdLib
 
 
 @public
-def main(json: bytes) -> Any:
+def main(json: str) -> Any:
     return StdLib.json_deserialize(json)

--- a/boa3_test/test_sc/native_test/stdlib/JsonSerialize.py
+++ b/boa3_test/test_sc/native_test/stdlib/JsonSerialize.py
@@ -5,5 +5,5 @@ from boa3.builtin.nativecontract.stdlib import StdLib
 
 
 @public
-def main(item: Any) -> bytes:
+def main(item: Any) -> str:
     return StdLib.json_serialize(item)

--- a/boa3_test/test_sc/native_test/stdlib/JsonSerializeBool.py
+++ b/boa3_test/test_sc/native_test/stdlib/JsonSerializeBool.py
@@ -3,5 +3,5 @@ from boa3.builtin.nativecontract.stdlib import StdLib
 
 
 @public
-def main() -> bytes:
+def main() -> str:
     return StdLib.json_serialize(True)

--- a/boa3_test/test_sc/native_test/stdlib/JsonSerializeBytes.py
+++ b/boa3_test/test_sc/native_test/stdlib/JsonSerializeBytes.py
@@ -3,5 +3,5 @@ from boa3.builtin.nativecontract.stdlib import StdLib
 
 
 @public
-def main() -> bytes:
+def main() -> str:
     return StdLib.json_serialize(b'unit test')

--- a/boa3_test/test_sc/native_test/stdlib/JsonSerializeInt.py
+++ b/boa3_test/test_sc/native_test/stdlib/JsonSerializeInt.py
@@ -3,5 +3,5 @@ from boa3.builtin.nativecontract.stdlib import StdLib
 
 
 @public
-def main() -> bytes:
+def main() -> str:
     return StdLib.json_serialize(10)

--- a/boa3_test/test_sc/native_test/stdlib/JsonSerializeStr.py
+++ b/boa3_test/test_sc/native_test/stdlib/JsonSerializeStr.py
@@ -3,5 +3,5 @@ from boa3.builtin.nativecontract.stdlib import StdLib
 
 
 @public
-def main() -> bytes:
+def main() -> str:
     return StdLib.json_serialize('unit test')

--- a/boa3_test/tests/compiler_tests/test_interop/test_json.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_json.py
@@ -14,62 +14,64 @@ class TestJsonInterop(BoaTest):
 
         engine = TestEngine()
         test_input = {"one": 1, "two": 2, "three": 3}
-        expected_result = String(json.dumps(test_input, separators=(',', ':'))).to_bytes()
+        expected_result = json.dumps(test_input, separators=(',', ':'))
         result = self.run_smart_contract(engine, path, 'main', test_input,
-                                         expected_result_type=bytes)
+                                         expected_result_type=str)
         self.assertEqual(expected_result, result)
 
     def test_json_serialize_int(self):
         path = self.get_contract_path('JsonSerializeInt.py')
 
         engine = TestEngine()
-        expected_result = String(json.dumps(10)).to_bytes()
+        expected_result = json.dumps(10)
         result = self.run_smart_contract(engine, path, 'main',
-                                         expected_result_type=bytes)
+                                         expected_result_type=str)
         self.assertEqual(expected_result, result)
 
     def test_json_serialize_bool(self):
         path = self.get_contract_path('JsonSerializeBool.py')
 
         engine = TestEngine()
-        expected_result = String(json.dumps(1)).to_bytes()
+        expected_result = json.dumps(1)
         result = self.run_smart_contract(engine, path, 'main',
-                                         expected_result_type=bytes)
+                                         expected_result_type=str)
         self.assertEqual(expected_result, result)
 
     def test_json_serialize_str(self):
         path = self.get_contract_path('JsonSerializeStr.py')
 
         engine = TestEngine()
-        expected_result = String(json.dumps('unit test')).to_bytes()
+        expected_result = json.dumps('unit test')
         result = self.run_smart_contract(engine, path, 'main',
-                                         expected_result_type=bytes)
+                                         expected_result_type=str)
         self.assertEqual(expected_result, result)
 
     def test_json_serialize_bytes(self):
         path = self.get_contract_path('JsonSerializeBytes.py')
 
         engine = TestEngine()
-        expected_result = b'"unit test"'
+        # Python does not accept bytes as parameter for json.dumps() method, since string and bytes ends up being the
+        # same on Neo, it's being converted to string, before using dumps
+        expected_result = json.dumps(String().from_bytes(b'unit test'))
         result = self.run_smart_contract(engine, path, 'main',
-                                         expected_result_type=bytes)
+                                         expected_result_type=str)
         self.assertEqual(expected_result, result)
 
     def test_json_deserialize(self):
         path = self.get_contract_path('JsonDeserialize.py')
 
         engine = TestEngine()
-        test_input = String(json.dumps(12345)).to_bytes()
+        test_input = json.dumps(12345)
         expected_result = json.loads(test_input)
         result = self.run_smart_contract(engine, path, 'main', test_input)
         self.assertEqual(expected_result, result)
 
-        test_input = String(json.dumps('unit test')).to_bytes()
+        test_input = json.dumps('unit test')
         expected_result = json.loads(test_input)
         result = self.run_smart_contract(engine, path, 'main', test_input)
         self.assertEqual(expected_result, result)
 
-        test_input = String(json.dumps(True)).to_bytes()
+        test_input = json.dumps(True)
         expected_result = json.loads(test_input)
         result = self.run_smart_contract(engine, path, 'main', test_input)
         self.assertEqual(expected_result, result)

--- a/boa3_test/tests/compiler_tests/test_interop/test_json.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_json.py
@@ -15,8 +15,7 @@ class TestJsonInterop(BoaTest):
         engine = TestEngine()
         test_input = {"one": 1, "two": 2, "three": 3}
         expected_result = json.dumps(test_input, separators=(',', ':'))
-        result = self.run_smart_contract(engine, path, 'main', test_input,
-                                         expected_result_type=str)
+        result = self.run_smart_contract(engine, path, 'main', test_input)
         self.assertEqual(expected_result, result)
 
     def test_json_serialize_int(self):
@@ -24,8 +23,7 @@ class TestJsonInterop(BoaTest):
 
         engine = TestEngine()
         expected_result = json.dumps(10)
-        result = self.run_smart_contract(engine, path, 'main',
-                                         expected_result_type=str)
+        result = self.run_smart_contract(engine, path, 'main')
         self.assertEqual(expected_result, result)
 
     def test_json_serialize_bool(self):
@@ -33,8 +31,7 @@ class TestJsonInterop(BoaTest):
 
         engine = TestEngine()
         expected_result = json.dumps(1)
-        result = self.run_smart_contract(engine, path, 'main',
-                                         expected_result_type=str)
+        result = self.run_smart_contract(engine, path, 'main')
         self.assertEqual(expected_result, result)
 
     def test_json_serialize_str(self):
@@ -42,8 +39,7 @@ class TestJsonInterop(BoaTest):
 
         engine = TestEngine()
         expected_result = json.dumps('unit test')
-        result = self.run_smart_contract(engine, path, 'main',
-                                         expected_result_type=str)
+        result = self.run_smart_contract(engine, path, 'main')
         self.assertEqual(expected_result, result)
 
     def test_json_serialize_bytes(self):
@@ -53,8 +49,7 @@ class TestJsonInterop(BoaTest):
         # Python does not accept bytes as parameter for json.dumps() method, since string and bytes ends up being the
         # same on Neo, it's being converted to string, before using dumps
         expected_result = json.dumps(String().from_bytes(b'unit test'))
-        result = self.run_smart_contract(engine, path, 'main',
-                                         expected_result_type=str)
+        result = self.run_smart_contract(engine, path, 'main')
         self.assertEqual(expected_result, result)
 
     def test_json_deserialize(self):

--- a/boa3_test/tests/compiler_tests/test_native/test_stdlib.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_stdlib.py
@@ -289,8 +289,7 @@ class TestStdlibClass(BoaTest):
         engine = TestEngine()
         test_input = {"one": 1, "two": 2, "three": 3}
         expected_result = json.dumps(test_input, separators=(',', ':'))
-        result = self.run_smart_contract(engine, path, 'main', test_input,
-                                         expected_result_type=str)
+        result = self.run_smart_contract(engine, path, 'main', test_input)
         self.assertEqual(expected_result, result)
 
     def test_json_serialize_int(self):
@@ -298,8 +297,7 @@ class TestStdlibClass(BoaTest):
 
         engine = TestEngine()
         expected_result = json.dumps(10)
-        result = self.run_smart_contract(engine, path, 'main',
-                                         expected_result_type=str)
+        result = self.run_smart_contract(engine, path, 'main')
         self.assertEqual(expected_result, result)
 
     def test_json_serialize_bool(self):
@@ -307,8 +305,7 @@ class TestStdlibClass(BoaTest):
 
         engine = TestEngine()
         expected_result = json.dumps(1)
-        result = self.run_smart_contract(engine, path, 'main',
-                                         expected_result_type=str)
+        result = self.run_smart_contract(engine, path, 'main')
         self.assertEqual(expected_result, result)
 
     def test_json_serialize_str(self):
@@ -316,8 +313,7 @@ class TestStdlibClass(BoaTest):
 
         engine = TestEngine()
         expected_result = json.dumps('unit test')
-        result = self.run_smart_contract(engine, path, 'main',
-                                         expected_result_type=str)
+        result = self.run_smart_contract(engine, path, 'main')
         self.assertEqual(expected_result, result)
 
     def test_json_serialize_bytes(self):
@@ -327,8 +323,7 @@ class TestStdlibClass(BoaTest):
         # Python does not accept bytes as parameter for json.dumps() method, since string and bytes ends up being the
         # same on Neo, it's being converted to string, before using dumps
         expected_result = json.dumps(String().from_bytes(b'unit test'))
-        result = self.run_smart_contract(engine, path, 'main',
-                                         expected_result_type=str)
+        result = self.run_smart_contract(engine, path, 'main')
         self.assertEqual(expected_result, result)
 
     def test_json_deserialize(self):

--- a/boa3_test/tests/compiler_tests/test_native/test_stdlib.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_stdlib.py
@@ -288,62 +288,64 @@ class TestStdlibClass(BoaTest):
 
         engine = TestEngine()
         test_input = {"one": 1, "two": 2, "three": 3}
-        expected_result = String(json.dumps(test_input, separators=(',', ':'))).to_bytes()
+        expected_result = json.dumps(test_input, separators=(',', ':'))
         result = self.run_smart_contract(engine, path, 'main', test_input,
-                                         expected_result_type=bytes)
+                                         expected_result_type=str)
         self.assertEqual(expected_result, result)
 
     def test_json_serialize_int(self):
         path = self.get_contract_path('JsonSerializeInt.py')
 
         engine = TestEngine()
-        expected_result = String(json.dumps(10)).to_bytes()
+        expected_result = json.dumps(10)
         result = self.run_smart_contract(engine, path, 'main',
-                                         expected_result_type=bytes)
+                                         expected_result_type=str)
         self.assertEqual(expected_result, result)
 
     def test_json_serialize_bool(self):
         path = self.get_contract_path('JsonSerializeBool.py')
 
         engine = TestEngine()
-        expected_result = String(json.dumps(1)).to_bytes()
+        expected_result = json.dumps(1)
         result = self.run_smart_contract(engine, path, 'main',
-                                         expected_result_type=bytes)
+                                         expected_result_type=str)
         self.assertEqual(expected_result, result)
 
     def test_json_serialize_str(self):
         path = self.get_contract_path('JsonSerializeStr.py')
 
         engine = TestEngine()
-        expected_result = String(json.dumps('unit test')).to_bytes()
+        expected_result = json.dumps('unit test')
         result = self.run_smart_contract(engine, path, 'main',
-                                         expected_result_type=bytes)
+                                         expected_result_type=str)
         self.assertEqual(expected_result, result)
 
     def test_json_serialize_bytes(self):
         path = self.get_contract_path('JsonSerializeBytes.py')
 
         engine = TestEngine()
-        expected_result = b'"unit test"'
+        # Python does not accept bytes as parameter for json.dumps() method, since string and bytes ends up being the
+        # same on Neo, it's being converted to string, before using dumps
+        expected_result = json.dumps(String().from_bytes(b'unit test'))
         result = self.run_smart_contract(engine, path, 'main',
-                                         expected_result_type=bytes)
+                                         expected_result_type=str)
         self.assertEqual(expected_result, result)
 
     def test_json_deserialize(self):
         path = self.get_contract_path('JsonDeserialize.py')
-        self.compile_and_save(path)
         engine = TestEngine()
-        test_input = String(json.dumps(12345)).to_bytes()
+
+        test_input = json.dumps(12345)
         expected_result = json.loads(test_input)
         result = self.run_smart_contract(engine, path, 'main', test_input)
         self.assertEqual(expected_result, result)
 
-        test_input = String(json.dumps('unit test')).to_bytes()
+        test_input = json.dumps('unit test')
         expected_result = json.loads(test_input)
         result = self.run_smart_contract(engine, path, 'main', test_input)
         self.assertEqual(expected_result, result)
 
-        test_input = String(json.dumps(True)).to_bytes()
+        test_input = json.dumps(True)
         expected_result = json.loads(test_input)
         result = self.run_smart_contract(engine, path, 'main', test_input)
         self.assertEqual(expected_result, result)


### PR DESCRIPTION
**Related issue**
#635 

**Summary or solution description**
Change `json_serialize` and `json_deserialize` to:
https://github.com/CityOfZion/neo3-boa/blob/3e974e715f6c17af9b4a2ec5f7273ec36917d039/boa3/builtin/interop/json/__init__.py#L4-L30

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/3e974e715f6c17af9b4a2ec5f7273ec36917d039/boa3_test/test_sc/interop_test/json/JsonSerialize.py#L7-L9
https://github.com/CityOfZion/neo3-boa/blob/3e974e715f6c17af9b4a2ec5f7273ec36917d039/boa3_test/test_sc/interop_test/json/JsonDeserialize.py#L7-L9

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/3e974e715f6c17af9b4a2ec5f7273ec36917d039/boa3_test/tests/compiler_tests/test_native/test_stdlib.py#L286-L352

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8
