### PR TITLE
Naming a variable as a package of a package

### DIFF
--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -1091,7 +1091,14 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
             while package_symbol is None and package.parent is not None:
                 package = package.parent
                 package_symbol = self.get_symbol(package.identifier, check_raw_id=True)
-            arg0_identifier = package_symbol if package_symbol else package.identifier
+
+            if package_symbol is None:
+                arg0_identifier = package.identifier
+            elif isinstance(package_symbol, Package):
+                arg0_identifier = package_symbol
+            else:
+                arg0_identifier = package
+
         elif isinstance(arg0, UserClass):
             arg0_identifier = arg0.identifier
         else:

--- a/boa3/compiler/codegenerator/codegeneratorvisitor.py
+++ b/boa3/compiler/codegenerator/codegeneratorvisitor.py
@@ -824,7 +824,7 @@ class VisitorCodeGenerator(IAstAnalyser):
                             if value_data.symbol is not None
                             else self.generator.get_symbol(value_id))
 
-            if isinstance(value_symbol, ClassType) and attribute.attr in value_symbol.symbols:
+            if hasattr(value_symbol, 'symbols') and attribute.attr in value_symbol.symbols:
                 attr = value_symbol.symbols[attribute.attr]
 
             if isinstance(value_symbol, UserClass):
@@ -839,10 +839,8 @@ class VisitorCodeGenerator(IAstAnalyser):
             self._remove_inserted_opcodes_since(last_address, last_stack)
 
         if attr is not Type.none and not hasattr(attribute, 'generate_value'):
-            attribute_id = (attribute.attr
-                            if not isinstance(value_symbol, ClassType)
-                            else f'{value_symbol.identifier}{constants.ATTRIBUTE_NAME_SEPARATOR}{attribute.attr}'
-                            )
+            value_symbol_id = value_symbol.identifier if isinstance(value_symbol, ClassType) else value_data.symbol_id
+            attribute_id = f'{value_symbol_id}{constants.ATTRIBUTE_NAME_SEPARATOR}{attribute.attr}'
             return self.build_data(attribute, symbol_id=attribute_id, symbol=attr)
 
         if isinstance(value, ast.Attribute):

--- a/boa3_test/test_sc/interop_test/role/ImportInteropRole.py
+++ b/boa3_test/test_sc/interop_test/role/ImportInteropRole.py
@@ -3,5 +3,5 @@ from boa3.builtin.type import ECPoint
 
 
 @public
-def main(role_: interop.role.Role, index: int) -> ECPoint:
-    return interop.role.get_designated_by_role(role_, index)
+def main(role: interop.role.Role, index: int) -> ECPoint:
+    return interop.role.get_designated_by_role(role, index)


### PR DESCRIPTION
**Related issue**
#572

**Summary or solution description**
Fixed the issue with variables named with the same id as boa3 built-in symbols. Also, fixed another issue with bytecode generation using attributes that were linked to the previous issue

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/2335f6fbd15a45ec02d246374aef6318ffa517e3/boa3_test/test_sc/interop_test/role/ImportInteropRole.py#L5-L7

**Tests**
Rerun the unit tests

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7