### PR TITLE
Fix issue related to class variables

### DIFF
--- a/boa3/analyser/astanalyser.py
+++ b/boa3/analyser/astanalyser.py
@@ -89,11 +89,12 @@ class IAstAnalyser(ABC, ast.NodeVisitor):
             else:
                 value = fun_rtype_id
 
-        if (isinstance(value, Attribute) and
-                ((isinstance(value.attr_symbol, IExpression) and isinstance(value.attr_symbol.type, ClassType))
-                 or (isinstance(value.attr_symbol, IType))
-                 )):
-            value = value.attr_symbol
+        if isinstance(value, Attribute):
+            if ((isinstance(value.attr_symbol, IExpression) and isinstance(value.attr_symbol.type, ClassType))
+                    or (isinstance(value.attr_symbol, IType))):
+                value = value.attr_symbol
+            elif isinstance(value.type, IType):
+                value = value.type
 
         if isinstance(value, IType):
             final_type = value

--- a/boa3/compiler/codegenerator/codegenerator.py
+++ b/boa3/compiler/codegenerator/codegenerator.py
@@ -1458,11 +1458,17 @@ class CodeGenerator:
             inner_index = list(user_class.variables).index(var_id)
 
         if isinstance(inner_index, int):
-            # it's a class variable
+            # it's a variable from a class
             self.convert_literal(inner_index)
             index_address = self.bytecode_size
-            self.convert_load_variable(user_class.identifier, Variable(user_class))
-            no_stack_items_to_swap = 3 if var_id in user_class.class_variables else 2
+
+            if var_id in user_class.class_variables:
+                # it's a class variable
+                self.convert_load_variable(user_class.identifier, Variable(user_class))
+                no_stack_items_to_swap = 3
+            else:
+                no_stack_items_to_swap = 2
+
             self.swap_reverse_stack_items(no_stack_items_to_swap)
             self.convert_set_item(index_address)
             return

--- a/boa3_test/test_sc/class_test/UserClassAccessInstanceVariableOnInit.py
+++ b/boa3_test/test_sc/class_test/UserClassAccessInstanceVariableOnInit.py
@@ -1,0 +1,12 @@
+from boa3.builtin import public
+
+
+class Example:
+    def __init__(self):
+        self.val1 = 2
+        self.val2 = self.val1 * 2
+
+
+@public
+def get_obj() -> Example:
+    return Example()

--- a/boa3_test/test_sc/class_test/UserClassAccessInstanceVariableOnMethod.py
+++ b/boa3_test/test_sc/class_test/UserClassAccessInstanceVariableOnMethod.py
@@ -1,0 +1,23 @@
+from boa3.builtin import public
+
+
+class Example:
+    def __init__(self):
+        self.val1 = 1
+        self.val2 = 4
+
+    def get_val1(self) -> int:
+        return self.val1
+
+    def get_val2(self) -> int:
+        return self.val2
+
+
+@public
+def get_val1() -> int:
+    return Example().get_val1()
+
+
+@public
+def get_val2() -> int:
+    return Example().get_val2()

--- a/boa3_test/test_sc/class_test/UserClassUpdateInstanceVariable.py
+++ b/boa3_test/test_sc/class_test/UserClassUpdateInstanceVariable.py
@@ -6,7 +6,7 @@ class Example:
 
     def __init__(self):
         self.val1 = 1
-        self.val2 = 2
+        self.val2 = self.val1 + 1
 
 
 @public

--- a/boa3_test/test_sc/class_test/UserClassUpdateInstanceVariable.py
+++ b/boa3_test/test_sc/class_test/UserClassUpdateInstanceVariable.py
@@ -2,6 +2,8 @@ from boa3.builtin import public
 
 
 class Example:
+    class_val = 10
+
     def __init__(self):
         self.val1 = 1
         self.val2 = 2

--- a/boa3_test/test_sc/class_test/UserClassUpdateInstanceVariable.py
+++ b/boa3_test/test_sc/class_test/UserClassUpdateInstanceVariable.py
@@ -6,7 +6,7 @@ class Example:
 
     def __init__(self):
         self.val1 = 1
-        self.val2 = self.val1 + 1
+        self.val2 = 2
 
 
 @public

--- a/boa3_test/tests/compiler_tests/test_class.py
+++ b/boa3_test/tests/compiler_tests/test_class.py
@@ -266,7 +266,6 @@ class TestClass(BoaTest):
 
     def test_user_class_update_instance_variable(self):
         path = self.get_contract_path('UserClassUpdateInstanceVariable.py')
-        self.compile_and_save(path)
         engine = TestEngine()
 
         result = self.run_smart_contract(engine, path, 'get_val', 10)
@@ -274,6 +273,23 @@ class TestClass(BoaTest):
 
         result = self.run_smart_contract(engine, path, 'get_val', 40)
         self.assertEqual([10, 40, 2], result)
+
+    def test_user_class_access_variable_on_init(self):
+        path = self.get_contract_path('UserClassAccessInstanceVariableOnInit.py')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'get_obj')
+        self.assertEqual([2, 4], result)
+
+    def test_user_class_access_variable_on_method(self):
+        path = self.get_contract_path('UserClassAccessInstanceVariableOnMethod.py')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'get_val1')
+        self.assertEqual(1, result)
+
+        result = self.run_smart_contract(engine, path, 'get_val2')
+        self.assertEqual(4, result)
 
     def test_user_class_with_base(self):
         path = self.get_contract_path('UserClassWithBase.py')

--- a/boa3_test/tests/compiler_tests/test_class.py
+++ b/boa3_test/tests/compiler_tests/test_class.py
@@ -270,10 +270,10 @@ class TestClass(BoaTest):
         engine = TestEngine()
 
         result = self.run_smart_contract(engine, path, 'get_val', 10)
-        self.assertEqual([10, 2], result)
+        self.assertEqual([10, 10, 2], result)
 
         result = self.run_smart_contract(engine, path, 'get_val', 40)
-        self.assertEqual([40, 2], result)
+        self.assertEqual([10, 40, 2], result)
 
     def test_user_class_with_base(self):
         path = self.get_contract_path('UserClassWithBase.py')


### PR DESCRIPTION

**Summary or solution description**
Fixed error that was raised when using both class and instance variables in the same class.
The same modification fixed a bug with the access of instance variables inside the `__init__`

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/98d431cf3e908150a0c7811de8cd7cc1794ef3af/boa3_test/test_sc/class_test/UserClassUpdateInstanceVariable.py#L4-L16

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/98d431cf3e908150a0c7811de8cd7cc1794ef3af/boa3_test/tests/compiler_tests/test_class.py#L267-L292

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7