### PR TITLE
Update TestEngine to support different witness scopes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,10 @@ jobs:
             sudo apt update && \
               sudo apt-get install -y dotnet-sdk-5.0
 
-            git clone https://github.com/simplitech/neo-devpack-dotnet.git -b v3.0.2
+            git clone https://github.com/simplitech/neo-devpack-dotnet.git -b test-engine-executable --single-branch
+            cd ./neo-devpack-dotnet
+            git checkout c2dbad469d8f919c9058f2a148eee2b9efb2300f
+            cd ..
             dotnet build ./neo-devpack-dotnet/src/Neo.TestEngine/Neo.TestEngine.csproj -o ./Neo.TestEngine
             python -m unittest discover boa3_test
 

--- a/boa3_test/tests/test_classes/signer.py
+++ b/boa3_test/tests/test_classes/signer.py
@@ -4,26 +4,37 @@ from typing import Any, Dict
 
 from boa3.neo import from_hex_str
 from boa3.neo3.core.types import UInt160
+from boa3_test.tests.test_classes.witnessscope import WitnessScope
 
 
 class Signer:
-    def __init__(self, account: UInt160):
+    def __init__(self, account: UInt160, scopes: WitnessScope = WitnessScope.CalledByEntry):
         self._account: UInt160 = account
+        self._scopes: WitnessScope = scopes
 
     @property
     def account(self) -> UInt160:
         return self._account
 
+    @property
+    def scopes(self) -> WitnessScope:
+        return self._scopes
+
     def to_json(self) -> Dict[str, Any]:
         return {
-            'account': str(self._account)
+            'account': str(self._account),
+            'scopes': self._scopes.neo_name()
         }
 
     @classmethod
     def from_json(cls, json: Dict[str, Any]) -> Signer:
         account_hex = json['account']
         account = UInt160(from_hex_str(account_hex))
-        return cls(account)
+        scopes = WitnessScope.get_from_neo_name(json['scopes']) if 'scopes' in json else WitnessScope.CalledByEntry
+        return cls(account, scopes)
 
     def __str__(self) -> str:
         return self._account.__str__()
+
+    def __eq__(self, other) -> bool:
+        return isinstance(other, Signer) and self._account == other._account

--- a/boa3_test/tests/test_classes/witnessscope.py
+++ b/boa3_test/tests/test_classes/witnessscope.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import enum
+
+
+class WitnessScope(enum.IntEnum):
+    # Indicates that no contract was witnessed. Only sign the transaction.
+    _None = 0
+
+    # Indicates that the calling contract must be the entry contract. The witness/permission/signature
+    # given on first invocation will automatically expire if entering deeper internal
+    # invokes. This can be the default safe choice for native NEO/GAS (previously used
+    # on Neo 2 as "attach" mode).
+    CalledByEntry = 1
+
+    # Custom hash for contract-specific.
+    CustomContracts = 16
+
+    # Custom pubkey for group members.
+    CustomGroups = 32
+
+    # This allows the witness in all contexts (default Neo2 behavior).
+    Global = 128
+
+    def neo_name(self) -> str:
+        if self is WitnessScope._None:
+            return 'None'
+        else:
+            return self.name
+
+    @staticmethod
+    def get_from_neo_name(neo_name: str) -> WitnessScope:
+        if neo_name == 'None':
+            return WitnessScope._None
+        elif neo_name != WitnessScope._None.name:
+            return WitnessScope[neo_name]


### PR DESCRIPTION
**Related issue**
#642

**Summary or solution description**
Updated TestEngine interface to include signers with different witness scopes
https://github.com/CityOfZion/neo3-boa/blob/f265cdd91aa486b8bfaece2172d4925e4386f6cc/boa3_test/tests/test_classes/witnessscope.py#L6-L23

**How to Reproduce**
```python
from boa3_test.tests.test_classes.witnessscope import WitnessScope

engine = TestEngine()
engine.add_signer_account(account1, WitnessScope.CalledByEntry)
engine.add_signer_account(account2, WitnessScope.Global)

result = engine.run(path, 'Main', account)
```

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
