### PR TITLE
Implement kwargs

### DIFF
--- a/boa3/analyser/model/functionarguments.py
+++ b/boa3/analyser/model/functionarguments.py
@@ -8,6 +8,7 @@ class FunctionArguments:
     def __init__(self):
         self._args: Dict[str, Variable] = {}
         self._vararg: Optional[Tuple[str, Variable]] = None
+        self._kwargs: Optional[Dict[str, Variable]] = None
 
     @property
     def args(self) -> Dict[str, Variable]:
@@ -27,4 +28,14 @@ class FunctionArguments:
         if not isinstance(arg, Variable):
             return False
         self._vararg = (arg_id, arg)
+        return True
+
+    @property
+    def kwargs(self) -> Dict[str, Variable]:
+        return self._kwargs.copy()
+
+    def add_kwarg(self, arg_id: str, arg: Variable) -> bool:
+        if not isinstance(arg, Variable):
+            return False
+        self._kwargs[arg_id] = arg
         return True

--- a/boa3/analyser/moduleanalyser.py
+++ b/boa3/analyser/moduleanalyser.py
@@ -27,6 +27,7 @@ from boa3.model.type.classes.classscope import ClassScope
 from boa3.model.type.classes.classtype import ClassType
 from boa3.model.type.classes.userclass import UserClass
 from boa3.model.type.collection.icollection import ICollectionType as Collection
+from boa3.model.type.collection.mapping.mutable.dicttype import DictType
 from boa3.model.type.collection.sequence.sequencetype import SequenceType
 from boa3.model.type.type import IType, Type
 from boa3.model.variable import Variable
@@ -573,6 +574,15 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
         fun_args: FunctionArguments = self.visit(function.args)
         fun_rtype_symbol = self.visit(function.returns) if function.returns is not None else Type.none
 
+        # TODO: remove when dictionary unpacking operator is implemented
+        if hasattr(function.args, 'kwarg') and function.args.kwarg is not None:
+            self._log_error(
+                CompilerError.NotSupportedOperation(
+                    function.lineno, function.col_offset,
+                    symbol_id='** variables'
+                )
+            )
+
         if fun_rtype_symbol is None:
             # it is a function with None return: Main(a: int) -> None:
             raise NotImplementedError
@@ -673,6 +683,10 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
         if arguments.vararg is not None:
             var_id, var = self.visit_arg(arguments.vararg)  # Tuple[str, Variable]
             fun_args.set_vararg(var_id, var)
+
+        if arguments.kwarg is not None:
+            var_id, var = self.visit_arg(arguments.kwarg)   # Tuple[str, Variable]
+            fun_args.add_kwarg(var_id, var)
 
         return fun_args
 
@@ -928,7 +942,7 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
             return None
 
         if not isinstance(func_symbol, Callable):
-            # verifiy if it is a builtin method with its name shadowed
+            # verify if it is a builtin method with its name shadowed
             func = Builtin.get_symbol(func_id)
             func_symbol = func if func is not None else func_symbol
 

--- a/boa3/compiler/codegenerator/codegeneratorvisitor.py
+++ b/boa3/compiler/codegenerator/codegeneratorvisitor.py
@@ -702,6 +702,17 @@ class VisitorCodeGenerator(IAstAnalyser):
 
         if isinstance(symbol, Method):
             args_to_generate = [arg for index, arg in enumerate(call.args) if index in symbol.args_to_be_generated()]
+            keywords_dict = {keyword.arg: keyword.value for keyword in call.keywords}
+            keywords_with_index = {index: keywords_dict[arg_name] for index, arg_name in enumerate(symbol.args) if arg_name in keywords_dict}
+
+            for index in keywords_with_index:
+                if index < len(args_to_generate):
+                    # override default values
+                    args_to_generate[index] = keywords_with_index[index]
+                else:
+                    # put keywords
+                    args_to_generate.append(keywords_with_index[index])
+
         else:
             args_to_generate = call.args
 

--- a/boa3/model/builtin/builtincallable.py
+++ b/boa3/model/builtin/builtincallable.py
@@ -12,8 +12,9 @@ from boa3.neo.vm.opcode.Opcode import Opcode
 class IBuiltinCallable(Callable, IdentifiedSymbol, ABC):
     def __init__(self, identifier: str, args: Dict[str, Variable] = None,
                  vararg: Optional[Tuple[str, Variable]] = None,
+                 kwargs: Optional[Dict[str, Variable]] = None,
                  defaults: List[ast.AST] = None, return_type: IType = None):
-        super().__init__(args, vararg, defaults, return_type)
+        super().__init__(args, vararg, kwargs, defaults, return_type)
         self._identifier = identifier
         self.defined_by_entry = False  # every builtin symbol must have this variable set as False
 

--- a/boa3/model/builtin/method/builtinevent.py
+++ b/boa3/model/builtin/method/builtinevent.py
@@ -10,9 +10,10 @@ from boa3.model.variable import Variable
 class IBuiltinEvent(IBuiltinCallable, Event, ABC):
     def __init__(self, identifier: str, args: Dict[str, Variable] = None,
                  defaults: List[ast.AST] = None,
-                 vararg: Optional[Tuple[str, Variable]] = None):
+                 vararg: Optional[Tuple[str, Variable]] = None,
+                 kwargs: Optional[Dict[str, Variable]] = None):
         from boa3.model.type.type import Type
-        super().__init__(identifier, args, vararg, defaults, Type.none)
+        super().__init__(identifier, args, vararg, kwargs, defaults, Type.none)
 
         # constructor of IBuiltinCallable and Event classes are conflicting
         self._identifier = identifier

--- a/boa3/model/builtin/method/builtinmethod.py
+++ b/boa3/model/builtin/method/builtinmethod.py
@@ -13,8 +13,9 @@ from boa3.model.variable import Variable
 class IBuiltinMethod(IBuiltinCallable, Method, ABC):
     def __init__(self, identifier: str, args: Dict[str, Variable] = None,
                  defaults: List[ast.AST] = None, return_type: IType = None,
-                 vararg: Optional[Tuple[str, Variable]] = None):
-        super().__init__(identifier, args, vararg, defaults, return_type)
+                 vararg: Optional[Tuple[str, Variable]] = None,
+                 kwargs: Optional[Dict[str, Variable]] = None):
+        super().__init__(identifier, args, vararg, kwargs, defaults, return_type)
 
     @property
     def is_supported(self) -> bool:

--- a/boa3/model/callable.py
+++ b/boa3/model/callable.py
@@ -22,6 +22,7 @@ class Callable(IExpression, ABC):
 
     def __init__(self, args: Dict[str, Variable] = None,
                  vararg: Optional[Tuple[str, Variable]] = None,
+                 kwargs: Optional[Dict[str, Variable]] = None,
                  defaults: List[ast.AST] = None,
                  return_type: IType = Type.none, is_public: bool = False,
                  decorators: List[Callable] = None,
@@ -54,6 +55,10 @@ class Callable(IExpression, ABC):
             self.args[vararg_id] = Variable(Type.tuple.build_collection([vararg_var.type]))
             self.defaults.append(default_value)
             self._vararg = vararg
+
+        if kwargs is None:
+            kwargs = {}
+        self._kwargs: Dict[str, Variable] = kwargs.copy()
 
         self.return_type: IType = return_type
         self.is_public: bool = is_public

--- a/boa3/model/event.py
+++ b/boa3/model/event.py
@@ -9,9 +9,11 @@ from boa3.model.variable import Variable
 
 class Event(Callable, IdentifiedSymbol):
     def __init__(self, event_id: str, args: Dict[str, Variable] = None,
-                 vararg: Optional[Tuple[str, Variable]] = None, defaults: List[ast.AST] = None,
+                 vararg: Optional[Tuple[str, Variable]] = None,
+                 kwargs: Optional[Dict[str, Variable]] = None,
+                 defaults: List[ast.AST] = None,
                  origin_node: Optional[ast.AST] = None):
-        super().__init__(args, vararg, defaults, Type.none, True, origin_node)
+        super().__init__(args, vararg, kwargs, defaults, Type.none, True, origin_node)
 
         self.name: str = event_id
         self._identifier: str = self.name

--- a/boa3/model/method.py
+++ b/boa3/model/method.py
@@ -21,12 +21,13 @@ class Method(Callable):
 
     def __init__(self, args: Dict[str, Variable] = None,
                  vararg: Optional[Tuple[str, Variable]] = None,
+                 kwargs: Optional[Dict[str, Variable]] = None,
                  defaults: List[ast.AST] = None,
                  return_type: IType = Type.none, is_public: bool = False,
                  decorators: List[Callable] = None,
                  is_init: bool = False,
                  origin_node: Optional[ast.AST] = None):
-        super().__init__(args, vararg, defaults, return_type, is_public, decorators, origin_node)
+        super().__init__(args, vararg, kwargs, defaults, return_type, is_public, decorators, origin_node)
 
         self.imported_symbols = {}
         self._symbols = {}

--- a/boa3_test/test_sc/function_test/CallFunctionWIthKwargsOnly.py
+++ b/boa3_test/test_sc/function_test/CallFunctionWIthKwargsOnly.py
@@ -1,0 +1,10 @@
+from boa3.builtin import public
+
+
+@public
+def main() -> int:
+    return calc(x1=1, x2=2, x3=3, x4=4)
+
+
+def calc(*, x1: int = 1, x2: int = 2, x3: int = 3, x4: int = 4) -> int:
+    return x1 * 1000 + x2 * 100 + x3 * 10 + x4

--- a/boa3_test/test_sc/function_test/CallFunctionWithKwarg.py
+++ b/boa3_test/test_sc/function_test/CallFunctionWithKwarg.py
@@ -1,0 +1,10 @@
+from boa3.builtin import public
+
+
+@public
+def Main(n: int) -> int:
+    return negate(number=n)
+
+
+def negate(number: int) -> int:
+    return -number

--- a/boa3_test/test_sc/function_test/CallFunctionWithKwargsSelf.py
+++ b/boa3_test/test_sc/function_test/CallFunctionWithKwargsSelf.py
@@ -1,0 +1,16 @@
+from boa3.builtin import public
+
+
+class Example:
+    def __init__(self):
+        self.val1 = 1
+        self.val2 = 2
+
+    def func(self, value1: int, value2: int) -> int:
+        return self.val1 + self.val2 + value1 + value2
+
+
+@public
+def get_val() -> int:
+    obj = Example()
+    return Example.func(value2=10, value1=5, self=obj)

--- a/boa3_test/test_sc/function_test/CallFunctionWithKwargsTooFewArguments.py
+++ b/boa3_test/test_sc/function_test/CallFunctionWithKwargsTooFewArguments.py
@@ -1,0 +1,6 @@
+def Main() -> int:
+    return calc(10, c=9, d=12)
+
+
+def calc(a: int, b: int, c: int = 0, d: int = 0) -> int:
+    return -a + b - c + d

--- a/boa3_test/test_sc/function_test/CallFunctionWithKwargsTooManyArguments.py
+++ b/boa3_test/test_sc/function_test/CallFunctionWithKwargsTooManyArguments.py
@@ -1,0 +1,6 @@
+def Main() -> int:
+    return calc(2, a=10, b=20)
+
+
+def calc(a: int, b: int, c: int = 0, d: int = 0) -> int:
+    return -a + b - c + d

--- a/boa3_test/test_sc/function_test/CallFunctionWithKwargsTooManyKwArguments.py
+++ b/boa3_test/test_sc/function_test/CallFunctionWithKwargsTooManyKwArguments.py
@@ -1,0 +1,6 @@
+def Main() -> int:
+    return calc(a=10, b=20, another_kwarg=999, c=30, d=40)
+
+
+def calc(a: int, b: int, c: int = 0, d: int = 0) -> int:
+    return -a + b - c + d

--- a/boa3_test/test_sc/function_test/CallFunctionWithKwargsWithDefaultValues.py
+++ b/boa3_test/test_sc/function_test/CallFunctionWithKwargsWithDefaultValues.py
@@ -21,5 +21,15 @@ def mixed_out_of_order() -> int:
     return calc(5, 6, x4=1, x3=2)
 
 
-def calc(x1: int, x2: int, x3: int, x4: int) -> int:
+@public
+def default_values() -> int:
+    return calc(1, x3=3, x4=4)
+
+
+@public
+def only_default_values_and_kwargs() -> int:
+    return calc(x4=4, x2=2)
+
+
+def calc(x1: int = 0, x2: int = 0, x3: int = 0, x4: int = 0) -> int:
     return x1 * 1000 + x2 * 100 + x3 * 10 + x4

--- a/boa3_test/test_sc/function_test/CallFunctionWithKwargsWrongType.py
+++ b/boa3_test/test_sc/function_test/CallFunctionWithKwargsWrongType.py
@@ -1,0 +1,6 @@
+def Main() -> int:
+    return calc(a='unit', b='test')
+
+
+def calc(a: int, b: int) -> int:
+    return -a + b

--- a/boa3_test/test_sc/function_test/FunctionWithDictionaryUnpackingOperator.py
+++ b/boa3_test/test_sc/function_test/FunctionWithDictionaryUnpackingOperator.py
@@ -1,0 +1,13 @@
+from typing import Any, Dict
+
+from boa3.builtin import public
+
+
+@public
+def function_with_unpacking(**kwargs: Dict[Any, Any]) -> int:  # not sure if Dict is the best type
+    return len(kwargs)
+
+
+@public
+def main(dictionary: Dict[str, int]) -> int:
+    return function_with_unpacking(**dictionary)

--- a/boa3_test/tests/compiler_tests/test_function.py
+++ b/boa3_test/tests/compiler_tests/test_function.py
@@ -1,3 +1,5 @@
+import unittest
+
 from boa3 import constants
 from boa3.boa3 import Boa3
 from boa3.exception import CompilerError
@@ -8,16 +10,15 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestFunction(BoaTest):
-
     default_folder: str = 'test_sc/function_test'
 
     def test_integer_function(self):
         expected_output = (
-            Opcode.INITSLOT     # function signature
-            + b'\x00'           # num local variables
-            + b'\x01'           # num arguments
-            + Opcode.PUSH10     # body
-            + Opcode.RET        # return
+                Opcode.INITSLOT  # function signature
+                + b'\x00'  # num local variables
+                + b'\x01'  # num arguments
+                + Opcode.PUSH10  # body
+                + Opcode.RET  # return
         )
 
         path = self.get_contract_path('IntegerFunction.py')
@@ -33,10 +34,10 @@ class TestFunction(BoaTest):
     def test_string_function(self):
         expected_output = (
             # functions without arguments and local variables don't need initslot
-            Opcode.PUSHDATA1        # body
-            + bytes([len('42')])
-            + bytes('42', constants.ENCODING)
-            + Opcode.RET            # return
+                Opcode.PUSHDATA1  # body
+                + bytes([len('42')])
+                + bytes('42', constants.ENCODING)
+                + Opcode.RET  # return
         )
 
         path = self.get_contract_path('StringFunction.py')
@@ -50,8 +51,8 @@ class TestFunction(BoaTest):
     def test_bool_function(self):
         expected_output = (
             # functions without arguments and local variables don't need initslot
-            Opcode.PUSH1      # body
-            + Opcode.RET        # return
+                Opcode.PUSH1  # body
+                + Opcode.RET  # return
         )
 
         path = self.get_contract_path('BoolFunction.py')
@@ -72,10 +73,10 @@ class TestFunction(BoaTest):
 
     def test_no_return_hint_function_with_empty_return_statement(self):
         expected_output = (
-            Opcode.INITSLOT     # function signature
-            + b'\x00'           # num local variables
-            + b'\x01'           # num arguments
-            + Opcode.RET        # return
+                Opcode.INITSLOT  # function signature
+                + b'\x00'  # num local variables
+                + b'\x01'  # num arguments
+                + Opcode.RET  # return
         )
 
         path = self.get_contract_path('EmptyReturnFunction.py')
@@ -88,20 +89,20 @@ class TestFunction(BoaTest):
 
     def test_no_return_hint_function_with_condition_empty_return_statement(self):
         expected_output = (
-            Opcode.INITSLOT     # function signature
-            + b'\x01'
-            + b'\x01'
-            + Opcode.LDARG0     # if a > 10
-            + Opcode.PUSH10
-            + Opcode.GT
-            + Opcode.JMPIFNOT
-            + Integer(3).to_byte_array()
-            + Opcode.RET            # return
-            + Opcode.LDARG0
-            + Opcode.PUSH10
-            + Opcode.MOD
-            + Opcode.STLOC0
-            + Opcode.RET        # return
+                Opcode.INITSLOT  # function signature
+                + b'\x01'
+                + b'\x01'
+                + Opcode.LDARG0  # if a > 10
+                + Opcode.PUSH10
+                + Opcode.GT
+                + Opcode.JMPIFNOT
+                + Integer(3).to_byte_array()
+                + Opcode.RET  # return
+                + Opcode.LDARG0
+                + Opcode.PUSH10
+                + Opcode.MOD
+                + Opcode.STLOC0
+                + Opcode.RET  # return
         )
 
         path = self.get_contract_path('ConditionEmptyReturnFunction.py')
@@ -117,22 +118,22 @@ class TestFunction(BoaTest):
 
     def test_empty_return_with_optional_return_type(self):
         expected_output = (
-            Opcode.INITSLOT     # function signature
-            + b'\x00'
-            + b'\x01'
-            + Opcode.LDARG0     # if a % 2 == 1
-            + Opcode.PUSH2
-            + Opcode.MOD
-            + Opcode.PUSH1
-            + Opcode.NUMEQUAL
-            + Opcode.JMPIFNOT
-            + Integer(4).to_byte_array()
-            + Opcode.PUSHNULL       # return
-            + Opcode.RET
-            + Opcode.LDARG0     # return a // 2
-            + Opcode.PUSH2
-            + Opcode.DIV
-            + Opcode.RET
+                Opcode.INITSLOT  # function signature
+                + b'\x00'
+                + b'\x01'
+                + Opcode.LDARG0  # if a % 2 == 1
+                + Opcode.PUSH2
+                + Opcode.MOD
+                + Opcode.PUSH1
+                + Opcode.NUMEQUAL
+                + Opcode.JMPIFNOT
+                + Integer(4).to_byte_array()
+                + Opcode.PUSHNULL  # return
+                + Opcode.RET
+                + Opcode.LDARG0  # return a // 2
+                + Opcode.PUSH2
+                + Opcode.DIV
+                + Opcode.RET
         )
 
         path = self.get_contract_path('EmptyReturnWithOptionalReturnType.py')
@@ -148,10 +149,10 @@ class TestFunction(BoaTest):
 
     def test_no_return_hint_function_without_return_statement(self):
         expected_output = (
-            Opcode.INITSLOT     # function signature
-            + b'\x00'           # num local variables
-            + b'\x01'           # num arguments
-            + Opcode.RET        # return
+                Opcode.INITSLOT  # function signature
+                + b'\x00'  # num local variables
+                + b'\x01'  # num arguments
+                + Opcode.RET  # return
         )
 
         path = self.get_contract_path('NoReturnFunction.py')
@@ -180,8 +181,8 @@ class TestFunction(BoaTest):
 
     def test_empty_list_return(self):
         expected_output = (
-            Opcode.NEWARRAY0
-            + Opcode.RET
+                Opcode.NEWARRAY0
+                + Opcode.RET
         )
 
         path = self.get_contract_path('EmptyListReturn.py')
@@ -204,16 +205,16 @@ class TestFunction(BoaTest):
         called_function_address = Integer(4).to_byte_array(min_length=1, signed=True)
 
         expected_output = (
-            Opcode.CALL             # TestFunction()
-            + called_function_address
-            + Opcode.PUSH1          # return True
-            + Opcode.RET
-            + Opcode.INITSLOT   # TestFunction
-            + b'\x01'
-            + b'\x00'
-            + Opcode.PUSH1          # a = 1
-            + Opcode.STLOC0
-            + Opcode.RET            # return
+                Opcode.CALL  # TestFunction()
+                + called_function_address
+                + Opcode.PUSH1  # return True
+                + Opcode.RET
+                + Opcode.INITSLOT  # TestFunction
+                + b'\x01'
+                + b'\x00'
+                + Opcode.PUSH1  # a = 1
+                + Opcode.STLOC0
+                + Opcode.RET  # return
         )
 
         path = self.get_contract_path('CallVoidFunctionWithoutArgs.py')
@@ -228,16 +229,16 @@ class TestFunction(BoaTest):
         called_function_address = Integer(5).to_byte_array(min_length=1, signed=True)
 
         expected_output = (
-            Opcode.INITSLOT     # Main
-            + b'\x01'
-            + b'\x00'
-            + Opcode.CALL           # a = TestFunction()
-            + called_function_address
-            + Opcode.STLOC0
-            + Opcode.LDLOC0         # return a
-            + Opcode.RET
-            + Opcode.PUSH1      # TestFunction
-            + Opcode.RET            # return 1
+                Opcode.INITSLOT  # Main
+                + b'\x01'
+                + b'\x00'
+                + Opcode.CALL  # a = TestFunction()
+                + called_function_address
+                + Opcode.STLOC0
+                + Opcode.LDLOC0  # return a
+                + Opcode.RET
+                + Opcode.PUSH1  # TestFunction
+                + Opcode.RET  # return 1
         )
 
         path = self.get_contract_path('CallReturnFunctionWithoutArgs.py')
@@ -252,20 +253,20 @@ class TestFunction(BoaTest):
         called_function_address = Integer(4).to_byte_array(min_length=1, signed=True)
 
         expected_output = (
-            Opcode.PUSH2            # TestAdd(1, 2)
-            + Opcode.PUSH1
-            + Opcode.CALL
-            + called_function_address
-            + Opcode.PUSH1          # return True
-            + Opcode.RET
-            + Opcode.INITSLOT   # TestFunction
-            + b'\x01'
-            + b'\x02'
-            + Opcode.LDARG0         # c = a + b
-            + Opcode.LDARG1
-            + Opcode.ADD
-            + Opcode.STLOC0
-            + Opcode.RET            # return
+                Opcode.PUSH2  # TestAdd(1, 2)
+                + Opcode.PUSH1
+                + Opcode.CALL
+                + called_function_address
+                + Opcode.PUSH1  # return True
+                + Opcode.RET
+                + Opcode.INITSLOT  # TestFunction
+                + b'\x01'
+                + b'\x02'
+                + Opcode.LDARG0  # c = a + b
+                + Opcode.LDARG1
+                + Opcode.ADD
+                + Opcode.STLOC0
+                + Opcode.RET  # return
         )
 
         path = self.get_contract_path('CallVoidFunctionWithLiteralArgs.py')
@@ -280,23 +281,23 @@ class TestFunction(BoaTest):
         called_function_address = Integer(5).to_byte_array(min_length=1, signed=True)
 
         expected_output = (
-            Opcode.INITSLOT     # Main
-            + b'\x01'
-            + b'\x00'
-            + Opcode.PUSH2          # a = TestAdd(1, 2)
-            + Opcode.PUSH1
-            + Opcode.CALL
-            + called_function_address
-            + Opcode.STLOC0
-            + Opcode.LDLOC0         # return a
-            + Opcode.RET
-            + Opcode.INITSLOT   # TestFunction
-            + b'\x00'
-            + b'\x02'
-            + Opcode.LDARG0         # return a + b
-            + Opcode.LDARG1
-            + Opcode.ADD
-            + Opcode.RET            # return
+                Opcode.INITSLOT  # Main
+                + b'\x01'
+                + b'\x00'
+                + Opcode.PUSH2  # a = TestAdd(1, 2)
+                + Opcode.PUSH1
+                + Opcode.CALL
+                + called_function_address
+                + Opcode.STLOC0
+                + Opcode.LDLOC0  # return a
+                + Opcode.RET
+                + Opcode.INITSLOT  # TestFunction
+                + b'\x00'
+                + b'\x02'
+                + Opcode.LDARG0  # return a + b
+                + Opcode.LDARG1
+                + Opcode.ADD
+                + Opcode.RET  # return
         )
 
         path = self.get_contract_path('CallReturnFunctionWithLiteralArgs.py')
@@ -311,27 +312,27 @@ class TestFunction(BoaTest):
         called_function_address = Integer(4).to_byte_array(min_length=1, signed=True)
 
         expected_output = (
-            Opcode.INITSLOT     # Main
-            + b'\x02'
-            + b'\x00'
-            + Opcode.PUSH1          # a = 1
-            + Opcode.STLOC0
-            + Opcode.PUSH2          # b = 2
-            + Opcode.STLOC1
-            + Opcode.PUSH2          # TestAdd(a, b)
-            + Opcode.PUSH1
-            + Opcode.CALL
-            + called_function_address
-            + Opcode.PUSH1          # return True
-            + Opcode.RET
-            + Opcode.INITSLOT   # TestFunction
-            + b'\x01'
-            + b'\x02'
-            + Opcode.LDARG0         # c = a + b
-            + Opcode.LDARG1
-            + Opcode.ADD
-            + Opcode.STLOC0
-            + Opcode.RET            # return
+                Opcode.INITSLOT  # Main
+                + b'\x02'
+                + b'\x00'
+                + Opcode.PUSH1  # a = 1
+                + Opcode.STLOC0
+                + Opcode.PUSH2  # b = 2
+                + Opcode.STLOC1
+                + Opcode.PUSH2  # TestAdd(a, b)
+                + Opcode.PUSH1
+                + Opcode.CALL
+                + called_function_address
+                + Opcode.PUSH1  # return True
+                + Opcode.RET
+                + Opcode.INITSLOT  # TestFunction
+                + b'\x01'
+                + b'\x02'
+                + Opcode.LDARG0  # c = a + b
+                + Opcode.LDARG1
+                + Opcode.ADD
+                + Opcode.STLOC0
+                + Opcode.RET  # return
         )
 
         path = self.get_contract_path('CallVoidFunctionWithVariableArgs.py')
@@ -346,27 +347,27 @@ class TestFunction(BoaTest):
         called_function_address = Integer(5).to_byte_array(min_length=1, signed=True)
 
         expected_output = (
-            Opcode.INITSLOT     # Main
-            + b'\x03'
-            + b'\x02'
-            + Opcode.PUSH1          # a = 1
-            + Opcode.STLOC0
-            + Opcode.PUSH2          # b = 2
-            + Opcode.STLOC1
-            + Opcode.PUSH2          # c = TestAdd(a, b)
-            + Opcode.PUSH1
-            + Opcode.CALL
-            + called_function_address
-            + Opcode.STLOC2
-            + Opcode.LDLOC2         # return c
-            + Opcode.RET
-            + Opcode.INITSLOT   # TestFunction
-            + b'\x00'
-            + b'\x02'
-            + Opcode.LDARG0         # return a + b
-            + Opcode.LDARG1
-            + Opcode.ADD
-            + Opcode.RET            # return
+                Opcode.INITSLOT  # Main
+                + b'\x03'
+                + b'\x02'
+                + Opcode.PUSH1  # a = 1
+                + Opcode.STLOC0
+                + Opcode.PUSH2  # b = 2
+                + Opcode.STLOC1
+                + Opcode.PUSH2  # c = TestAdd(a, b)
+                + Opcode.PUSH1
+                + Opcode.CALL
+                + called_function_address
+                + Opcode.STLOC2
+                + Opcode.LDLOC2  # return c
+                + Opcode.RET
+                + Opcode.INITSLOT  # TestFunction
+                + b'\x00'
+                + b'\x02'
+                + Opcode.LDARG0  # return a + b
+                + Opcode.LDARG1
+                + Opcode.ADD
+                + Opcode.RET  # return
         )
 
         path = self.get_contract_path('CallReturnFunctionWithVariableArgs.py')
@@ -382,25 +383,25 @@ class TestFunction(BoaTest):
         called_function_address = Integer(3).to_byte_array(min_length=1, signed=True)
 
         expected_output = (
-            Opcode.INITSLOT     # Main
-            + b'\x02'
-            + b'\x00'
-            + Opcode.PUSH1          # a = 1
-            + Opcode.STLOC0
-            + Opcode.PUSH2          # b = 2
-            + Opcode.STLOC1
-            + Opcode.PUSH2          # return TestAdd(a, b)
-            + Opcode.PUSH1
-            + Opcode.CALL
-            + called_function_address
-            + Opcode.RET
-            + Opcode.INITSLOT   # TestFunction
-            + b'\x00'
-            + b'\x02'
-            + Opcode.LDARG0         # return a + b
-            + Opcode.LDARG1
-            + Opcode.ADD
-            + Opcode.RET            # return
+                Opcode.INITSLOT  # Main
+                + b'\x02'
+                + b'\x00'
+                + Opcode.PUSH1  # a = 1
+                + Opcode.STLOC0
+                + Opcode.PUSH2  # b = 2
+                + Opcode.STLOC1
+                + Opcode.PUSH2  # return TestAdd(a, b)
+                + Opcode.PUSH1
+                + Opcode.CALL
+                + called_function_address
+                + Opcode.RET
+                + Opcode.INITSLOT  # TestFunction
+                + b'\x00'
+                + b'\x02'
+                + Opcode.LDARG0  # return a + b
+                + Opcode.LDARG1
+                + Opcode.ADD
+                + Opcode.RET  # return
         )
 
         path = self.get_contract_path('CallReturnFunctionOnReturn.py')
@@ -418,34 +419,34 @@ class TestFunction(BoaTest):
         end_if = Integer(5).to_byte_array(min_length=1, signed=True)
 
         expected_output = (
-            Opcode.PUSH1        # One
-            + Opcode.RET            # return 1
-            + Opcode.INITSLOT   # Main
-            + b'\x00'
-            + b'\x01'
-            + Opcode.LDARG0         # if arg0 == 1
-            + Opcode.PUSH1
-            + Opcode.NUMEQUAL
-            + Opcode.JMPIFNOT
-            + end_if
-            + Opcode.CALL           # return One()
-            + main_to_one_address
-            + Opcode.RET
-            + Opcode.LDARG0         # elif arg0 == 2
-            + Opcode.PUSH2
-            + Opcode.NUMEQUAL
-            + Opcode.JMPIFNOT
-            + end_if
-            + Opcode.CALL           # return Two()
-            + main_to_two_address
-            + Opcode.RET
-            + Opcode.PUSH0          # default return
-            + Opcode.RET
-            + Opcode.PUSH1     # Two
-            + Opcode.CALL           # return 1 + One()
-            + two_to_one_address
-            + Opcode.ADD
-            + Opcode.RET
+                Opcode.PUSH1  # One
+                + Opcode.RET  # return 1
+                + Opcode.INITSLOT  # Main
+                + b'\x00'
+                + b'\x01'
+                + Opcode.LDARG0  # if arg0 == 1
+                + Opcode.PUSH1
+                + Opcode.NUMEQUAL
+                + Opcode.JMPIFNOT
+                + end_if
+                + Opcode.CALL  # return One()
+                + main_to_one_address
+                + Opcode.RET
+                + Opcode.LDARG0  # elif arg0 == 2
+                + Opcode.PUSH2
+                + Opcode.NUMEQUAL
+                + Opcode.JMPIFNOT
+                + end_if
+                + Opcode.CALL  # return Two()
+                + main_to_two_address
+                + Opcode.RET
+                + Opcode.PUSH0  # default return
+                + Opcode.RET
+                + Opcode.PUSH1  # Two
+                + Opcode.CALL  # return 1 + One()
+                + two_to_one_address
+                + Opcode.ADD
+                + Opcode.RET
         )
 
         path = self.get_contract_path('CallFunctionWithoutVariables.py')
@@ -464,18 +465,18 @@ class TestFunction(BoaTest):
         call_address = Integer(-9).to_byte_array(min_length=1, signed=True)
 
         expected_output = (
-            Opcode.INITSLOT     # TestFunction
-            + b'\x00'
-            + b'\x02'
-            + Opcode.LDARG0         # return a + b
-            + Opcode.LDARG1
-            + Opcode.ADD
-            + Opcode.RET
-            + Opcode.PUSH2          # return TestAdd(a, b)
-            + Opcode.PUSH1
-            + Opcode.CALL
-            + call_address
-            + Opcode.RET
+                Opcode.INITSLOT  # TestFunction
+                + b'\x00'
+                + b'\x02'
+                + Opcode.LDARG0  # return a + b
+                + Opcode.LDARG1
+                + Opcode.ADD
+                + Opcode.RET
+                + Opcode.PUSH2  # return TestAdd(a, b)
+                + Opcode.PUSH1
+                + Opcode.CALL
+                + call_address
+                + Opcode.RET
         )
 
         path = self.get_contract_path('CallFunctionWrittenBefore.py')
@@ -490,16 +491,16 @@ class TestFunction(BoaTest):
         called_function_address = Integer(4).to_byte_array(min_length=1, signed=True)
 
         expected_output = (
-            Opcode.CALL         # Main
-            + called_function_address  # return TestFunction()
-            + Opcode.PUSHNULL
-            + Opcode.RET
-            + Opcode.INITSLOT   # TestFunction
-            + b'\x01'
-            + b'\x00'
-            + Opcode.PUSH1          # a = 1
-            + Opcode.STLOC0
-            + Opcode.RET            # return
+                Opcode.CALL  # Main
+                + called_function_address  # return TestFunction()
+                + Opcode.PUSHNULL
+                + Opcode.RET
+                + Opcode.INITSLOT  # TestFunction
+                + b'\x01'
+                + b'\x00'
+                + Opcode.PUSH1  # a = 1
+                + Opcode.STLOC0
+                + Opcode.RET  # return
         )
 
         path = self.get_contract_path('ReturnVoidFunction.py')
@@ -516,33 +517,33 @@ class TestFunction(BoaTest):
 
     def test_return_inside_if(self):
         expected_output = (
-            Opcode.INITSLOT     # Main
-            + b'\x00'
-            + b'\x01'
-            + Opcode.LDARG0     # if arg0 % 3 == 1
-            + Opcode.PUSH3
-            + Opcode.MOD
-            + Opcode.PUSH1
-            + Opcode.NUMEQUAL
-            + Opcode.JMPIFNOT
-            + Integer(6).to_byte_array(min_length=1, signed=True)
-            + Opcode.LDARG0     # return arg0 - 1
-            + Opcode.PUSH1
-            + Opcode.SUB
-            + Opcode.RET
-            + Opcode.LDARG0     # elif arg0 % 3 == 2
-            + Opcode.PUSH3
-            + Opcode.MOD
-            + Opcode.PUSH2
-            + Opcode.NUMEQUAL
-            + Opcode.JMPIFNOT
-            + Integer(6).to_byte_array(min_length=1, signed=True)
-            + Opcode.LDARG0     # return arg0 + 1
-            + Opcode.PUSH1
-            + Opcode.ADD
-            + Opcode.RET
-            + Opcode.LDARG0     # else
-            + Opcode.RET            # return arg0
+                Opcode.INITSLOT  # Main
+                + b'\x00'
+                + b'\x01'
+                + Opcode.LDARG0  # if arg0 % 3 == 1
+                + Opcode.PUSH3
+                + Opcode.MOD
+                + Opcode.PUSH1
+                + Opcode.NUMEQUAL
+                + Opcode.JMPIFNOT
+                + Integer(6).to_byte_array(min_length=1, signed=True)
+                + Opcode.LDARG0  # return arg0 - 1
+                + Opcode.PUSH1
+                + Opcode.SUB
+                + Opcode.RET
+                + Opcode.LDARG0  # elif arg0 % 3 == 2
+                + Opcode.PUSH3
+                + Opcode.MOD
+                + Opcode.PUSH2
+                + Opcode.NUMEQUAL
+                + Opcode.JMPIFNOT
+                + Integer(6).to_byte_array(min_length=1, signed=True)
+                + Opcode.LDARG0  # return arg0 + 1
+                + Opcode.PUSH1
+                + Opcode.ADD
+                + Opcode.RET
+                + Opcode.LDARG0  # else
+                + Opcode.RET  # return arg0
         )
 
         path = self.get_contract_path('ReturnIf.py')
@@ -584,17 +585,17 @@ class TestFunction(BoaTest):
 
     def test_return_if_expression(self):
         expected_output = (
-            Opcode.INITSLOT     # Main
-            + b'\x00'
-            + b'\x01'
-            + Opcode.LDARG0     # return 5 if condition else 10
-            + Opcode.JMPIFNOT
-            + Integer(5).to_byte_array(min_length=1, signed=True)
-            + Opcode.PUSH5      # 5
-            + Opcode.JMP        # else
-            + Integer(3).to_byte_array(min_length=1, signed=True)
-            + Opcode.PUSH10     # 10
-            + Opcode.RET        # return
+                Opcode.INITSLOT  # Main
+                + b'\x00'
+                + b'\x01'
+                + Opcode.LDARG0  # return 5 if condition else 10
+                + Opcode.JMPIFNOT
+                + Integer(5).to_byte_array(min_length=1, signed=True)
+                + Opcode.PUSH5  # 5
+                + Opcode.JMP  # else
+                + Integer(3).to_byte_array(min_length=1, signed=True)
+                + Opcode.PUSH10  # 10
+                + Opcode.RET  # return
         )
 
         path = self.get_contract_path('ReturnIfExpression.py')
@@ -613,40 +614,40 @@ class TestFunction(BoaTest):
 
     def test_return_inside_for(self):
         expected_output = (
-            Opcode.INITSLOT     # Main
-            + b'\x01'
-            + b'\x01'
-            + Opcode.LDARG0     # for_sequence = arg0
-            + Opcode.PUSH0      # for_index = 0
-            + Opcode.JMP        # begin for
-            + Integer(18).to_byte_array(min_length=1, signed=True)
-            + Opcode.OVER     # value = for_sequence[for_index]
-            + Opcode.OVER
-            + Opcode.DUP
-            + Opcode.SIGN
-            + Opcode.PUSHM1
-            + Opcode.JMPNE
-            + Integer(5).to_byte_array(min_length=1, signed=True)
-            + Opcode.OVER
-            + Opcode.SIZE
-            + Opcode.ADD
-            + Opcode.PICKITEM
-            + Opcode.STLOC0
-            + Opcode.CLEAR
-            + Opcode.LDLOC0     # return value
-            + Opcode.RET
-            + Opcode.INC     # for_index = for_index + 1
-            + Opcode.DUP        # if for_index < len(for_sequence)
-            + Opcode.PUSH2
-            + Opcode.PICK
-            + Opcode.SIZE
-            + Opcode.LT
-            + Opcode.JMPIF
-            + Integer(-21).to_byte_array(min_length=1, signed=True)
-            + Opcode.DROP
-            + Opcode.DROP
-            + Opcode.PUSH5      # else
-            + Opcode.RET          # return 5
+                Opcode.INITSLOT  # Main
+                + b'\x01'
+                + b'\x01'
+                + Opcode.LDARG0  # for_sequence = arg0
+                + Opcode.PUSH0  # for_index = 0
+                + Opcode.JMP  # begin for
+                + Integer(18).to_byte_array(min_length=1, signed=True)
+                + Opcode.OVER  # value = for_sequence[for_index]
+                + Opcode.OVER
+                + Opcode.DUP
+                + Opcode.SIGN
+                + Opcode.PUSHM1
+                + Opcode.JMPNE
+                + Integer(5).to_byte_array(min_length=1, signed=True)
+                + Opcode.OVER
+                + Opcode.SIZE
+                + Opcode.ADD
+                + Opcode.PICKITEM
+                + Opcode.STLOC0
+                + Opcode.CLEAR
+                + Opcode.LDLOC0  # return value
+                + Opcode.RET
+                + Opcode.INC  # for_index = for_index + 1
+                + Opcode.DUP  # if for_index < len(for_sequence)
+                + Opcode.PUSH2
+                + Opcode.PICK
+                + Opcode.SIZE
+                + Opcode.LT
+                + Opcode.JMPIF
+                + Integer(-21).to_byte_array(min_length=1, signed=True)
+                + Opcode.DROP
+                + Opcode.DROP
+                + Opcode.PUSH5  # else
+                + Opcode.RET  # return 5
         )
 
         path = self.get_contract_path('ReturnFor.py')
@@ -663,43 +664,43 @@ class TestFunction(BoaTest):
 
     def test_missing_return_inside_for(self):
         expected_output = (
-            Opcode.INITSLOT     # Main
-            + b'\x02'
-            + b'\x01'
-            + Opcode.PUSH0      # x = 0
-            + Opcode.STLOC0
-            + Opcode.LDARG0     # for_sequence = arg0
-            + Opcode.PUSH0      # for_index = 0
-            + Opcode.JMP        # begin for
-            + Integer(19).to_byte_array(min_length=1, signed=True)
-            + Opcode.OVER       # value = for_sequence[for_index]
-            + Opcode.OVER
-            + Opcode.DUP
-            + Opcode.SIGN
-            + Opcode.PUSHM1
-            + Opcode.JMPNE
-            + Integer(5).to_byte_array(min_length=1, signed=True)
-            + Opcode.OVER
-            + Opcode.SIZE
-            + Opcode.ADD
-            + Opcode.PICKITEM
-            + Opcode.STLOC1
-            + Opcode.LDLOC0     # x += value
-            + Opcode.LDLOC1
-            + Opcode.ADD
-            + Opcode.STLOC0
-            + Opcode.INC        # for_index = for_index + 1
-            + Opcode.DUP        # if for_index < len(for_sequence)
-            + Opcode.PUSH2
-            + Opcode.PICK
-            + Opcode.SIZE
-            + Opcode.LT
-            + Opcode.JMPIF
-            + Integer(-22).to_byte_array(min_length=1, signed=True)
-            + Opcode.DROP
-            + Opcode.DROP
-            + Opcode.LDLOC0     # else
-            + Opcode.RET          # return x
+                Opcode.INITSLOT  # Main
+                + b'\x02'
+                + b'\x01'
+                + Opcode.PUSH0  # x = 0
+                + Opcode.STLOC0
+                + Opcode.LDARG0  # for_sequence = arg0
+                + Opcode.PUSH0  # for_index = 0
+                + Opcode.JMP  # begin for
+                + Integer(19).to_byte_array(min_length=1, signed=True)
+                + Opcode.OVER  # value = for_sequence[for_index]
+                + Opcode.OVER
+                + Opcode.DUP
+                + Opcode.SIGN
+                + Opcode.PUSHM1
+                + Opcode.JMPNE
+                + Integer(5).to_byte_array(min_length=1, signed=True)
+                + Opcode.OVER
+                + Opcode.SIZE
+                + Opcode.ADD
+                + Opcode.PICKITEM
+                + Opcode.STLOC1
+                + Opcode.LDLOC0  # x += value
+                + Opcode.LDLOC1
+                + Opcode.ADD
+                + Opcode.STLOC0
+                + Opcode.INC  # for_index = for_index + 1
+                + Opcode.DUP  # if for_index < len(for_sequence)
+                + Opcode.PUSH2
+                + Opcode.PICK
+                + Opcode.SIZE
+                + Opcode.LT
+                + Opcode.JMPIF
+                + Integer(-22).to_byte_array(min_length=1, signed=True)
+                + Opcode.DROP
+                + Opcode.DROP
+                + Opcode.LDLOC0  # else
+                + Opcode.RET  # return x
         )
 
         path = self.get_contract_path('ReturnForOnlyOnElse.py')
@@ -720,26 +721,26 @@ class TestFunction(BoaTest):
 
     def test_return_inside_while(self):
         expected_output = (
-            Opcode.INITSLOT     # Main
-            + b'\x01'
-            + b'\x01'
-            + Opcode.LDARG0     # x = arg0
-            + Opcode.STLOC0
-            + Opcode.JMP        # begin while
-            + Integer(8).to_byte_array(min_length=1, signed=True)
-            + Opcode.LDLOC0     # x += 1
-            + Opcode.PUSH1
-            + Opcode.ADD
-            + Opcode.STLOC0
-            + Opcode.LDLOC0     # return x
-            + Opcode.RET
-            + Opcode.LDLOC0
-            + Opcode.PUSH10
-            + Opcode.LT
-            + Opcode.JMPIF      # end while x < 10
-            + Integer(-9).to_byte_array(min_length=1, signed=True)
-            + Opcode.LDLOC0     # else
-            + Opcode.RET            # return x
+                Opcode.INITSLOT  # Main
+                + b'\x01'
+                + b'\x01'
+                + Opcode.LDARG0  # x = arg0
+                + Opcode.STLOC0
+                + Opcode.JMP  # begin while
+                + Integer(8).to_byte_array(min_length=1, signed=True)
+                + Opcode.LDLOC0  # x += 1
+                + Opcode.PUSH1
+                + Opcode.ADD
+                + Opcode.STLOC0
+                + Opcode.LDLOC0  # return x
+                + Opcode.RET
+                + Opcode.LDLOC0
+                + Opcode.PUSH10
+                + Opcode.LT
+                + Opcode.JMPIF  # end while x < 10
+                + Integer(-9).to_byte_array(min_length=1, signed=True)
+                + Opcode.LDLOC0  # else
+                + Opcode.RET  # return x
         )
 
         path = self.get_contract_path('ReturnWhile.py')
@@ -758,24 +759,24 @@ class TestFunction(BoaTest):
 
     def test_missing_return_inside_while(self):
         expected_output = (
-            Opcode.INITSLOT     # Main
-            + b'\x01'
-            + b'\x01'
-            + Opcode.LDARG0     # x = arg0
-            + Opcode.STLOC0
-            + Opcode.JMP        # begin while
-            + Integer(6).to_byte_array(min_length=1, signed=True)
-            + Opcode.LDLOC0     # x += 1
-            + Opcode.PUSH1
-            + Opcode.ADD
-            + Opcode.STLOC0
-            + Opcode.LDLOC0
-            + Opcode.PUSH10
-            + Opcode.LT
-            + Opcode.JMPIF      # end while x < 10
-            + Integer(-7).to_byte_array(min_length=1, signed=True)
-            + Opcode.LDLOC0     # else
-            + Opcode.RET            # return x
+                Opcode.INITSLOT  # Main
+                + b'\x01'
+                + b'\x01'
+                + Opcode.LDARG0  # x = arg0
+                + Opcode.STLOC0
+                + Opcode.JMP  # begin while
+                + Integer(6).to_byte_array(min_length=1, signed=True)
+                + Opcode.LDLOC0  # x += 1
+                + Opcode.PUSH1
+                + Opcode.ADD
+                + Opcode.STLOC0
+                + Opcode.LDLOC0
+                + Opcode.PUSH10
+                + Opcode.LT
+                + Opcode.JMPIF  # end while x < 10
+                + Integer(-7).to_byte_array(min_length=1, signed=True)
+                + Opcode.LDLOC0  # else
+                + Opcode.RET  # return x
         )
 
         path = self.get_contract_path('ReturnWhileOnlyOnElse.py')
@@ -833,34 +834,34 @@ class TestFunction(BoaTest):
 
     def test_function_with_default_argument(self):
         expected_output = (
-            Opcode.INITSLOT
-            + b'\x02'
-            + b'\x00'
-            + Opcode.PUSH3  # x = add(1, 2, 3)
-            + Opcode.PUSH2
-            + Opcode.PUSH1
-            + Opcode.CALL
-            + Integer(14).to_byte_array(signed=True, min_length=1)
-            + Opcode.STLOC0
-            + Opcode.PUSH0
-            + Opcode.PUSH6  # y = add(5, 6)
-            + Opcode.PUSH5
-            + Opcode.CALL
-            + Integer(8).to_byte_array(signed=True, min_length=1)
-            + Opcode.STLOC1
-            + Opcode.LDLOC1
-            + Opcode.LDLOC0
-            + Opcode.PUSH2
-            + Opcode.PACK
-            + Opcode.RET
-            + Opcode.INITSLOT   # def add(a: int, b: int, c: int = 0)
-            + b'\x00\x03'
-            + Opcode.LDARG0     # return a + b + c
-            + Opcode.LDARG1
-            + Opcode.ADD
-            + Opcode.LDARG2
-            + Opcode.ADD
-            + Opcode.RET
+                Opcode.INITSLOT
+                + b'\x02'
+                + b'\x00'
+                + Opcode.PUSH3  # x = add(1, 2, 3)
+                + Opcode.PUSH2
+                + Opcode.PUSH1
+                + Opcode.CALL
+                + Integer(14).to_byte_array(signed=True, min_length=1)
+                + Opcode.STLOC0
+                + Opcode.PUSH0
+                + Opcode.PUSH6  # y = add(5, 6)
+                + Opcode.PUSH5
+                + Opcode.CALL
+                + Integer(8).to_byte_array(signed=True, min_length=1)
+                + Opcode.STLOC1
+                + Opcode.LDLOC1
+                + Opcode.LDLOC0
+                + Opcode.PUSH2
+                + Opcode.PACK
+                + Opcode.RET
+                + Opcode.INITSLOT  # def add(a: int, b: int, c: int = 0)
+                + b'\x00\x03'
+                + Opcode.LDARG0  # return a + b + c
+                + Opcode.LDARG1
+                + Opcode.ADD
+                + Opcode.LDARG2
+                + Opcode.ADD
+                + Opcode.RET
         )
 
         path = self.get_contract_path('FunctionWithDefaultArgument.py')
@@ -873,37 +874,37 @@ class TestFunction(BoaTest):
 
     def test_function_with_only_default_arguments(self):
         expected_output = (
-            Opcode.PUSH0        # defaults
-            + Opcode.PUSH0
-            + Opcode.PUSH0
-            + Opcode.CALL   # add()
-            + Integer(20).to_byte_array(signed=True, min_length=1)
-            + Opcode.PUSH0      # defaults
-            + Opcode.PUSH6      # add(5, 6)
-            + Opcode.PUSH5
-            + Opcode.CALL
-            + Integer(15).to_byte_array(signed=True, min_length=1)
-            + Opcode.PUSH0      # defaults
-            + Opcode.PUSH0
-            + Opcode.PUSH9      # add(9)
-            + Opcode.CALL
-            + Integer(10).to_byte_array(signed=True, min_length=1)
-            + Opcode.PUSH3      # add(1, 2, 3)
-            + Opcode.PUSH2
-            + Opcode.PUSH1
-            + Opcode.CALL
-            + Integer(5).to_byte_array(signed=True, min_length=1)
-            + Opcode.PUSH4
-            + Opcode.PACK
-            + Opcode.RET
-            + Opcode.INITSLOT   # def add(a: int, b: int, c: int)
-            + b'\x00\x03'
-            + Opcode.LDARG0     # return a + b + c
-            + Opcode.LDARG1
-            + Opcode.ADD
-            + Opcode.LDARG2
-            + Opcode.ADD
-            + Opcode.RET
+                Opcode.PUSH0  # defaults
+                + Opcode.PUSH0
+                + Opcode.PUSH0
+                + Opcode.CALL  # add()
+                + Integer(20).to_byte_array(signed=True, min_length=1)
+                + Opcode.PUSH0  # defaults
+                + Opcode.PUSH6  # add(5, 6)
+                + Opcode.PUSH5
+                + Opcode.CALL
+                + Integer(15).to_byte_array(signed=True, min_length=1)
+                + Opcode.PUSH0  # defaults
+                + Opcode.PUSH0
+                + Opcode.PUSH9  # add(9)
+                + Opcode.CALL
+                + Integer(10).to_byte_array(signed=True, min_length=1)
+                + Opcode.PUSH3  # add(1, 2, 3)
+                + Opcode.PUSH2
+                + Opcode.PUSH1
+                + Opcode.CALL
+                + Integer(5).to_byte_array(signed=True, min_length=1)
+                + Opcode.PUSH4
+                + Opcode.PACK
+                + Opcode.RET
+                + Opcode.INITSLOT  # def add(a: int, b: int, c: int)
+                + b'\x00\x03'
+                + Opcode.LDARG0  # return a + b + c
+                + Opcode.LDARG1
+                + Opcode.ADD
+                + Opcode.LDARG2
+                + Opcode.ADD
+                + Opcode.RET
         )
 
         path = self.get_contract_path('FunctionWithOnlyDefaultArguments.py')
@@ -918,11 +919,84 @@ class TestFunction(BoaTest):
         path = self.get_contract_path('FunctionWithDefaultArgumentBetweenArgs.py')
 
         with self.assertRaises(SyntaxError):
-            output = Boa3.compile(path)
+            Boa3.compile(path)
+
+    def test_call_function_with_kwarg(self):
+        path = self.get_contract_path('CallFunctionWithKwarg.py')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'Main', 10)
+        self.assertEqual(-10, result)
 
     def test_call_function_with_kwargs(self):
         path = self.get_contract_path('CallFunctionWithKwargs.py')
-        self.assertCompilerLogs(CompilerError.InternalError, path)
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'positional_order')
+        self.assertEqual(1234, result)
+
+        result = self.run_smart_contract(engine, path, 'out_of_order')
+        self.assertEqual(2413, result)
+
+        result = self.run_smart_contract(engine, path, 'mixed_in_order')
+        self.assertEqual(5612, result)
+
+        result = self.run_smart_contract(engine, path, 'mixed_out_of_order')
+        self.assertEqual(5621, result)
+
+    def test_call_function_with_kwargs_with_default_values(self):
+        path = self.get_contract_path('CallFunctionWithKwargsWithDefaultValues.py')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'positional_order')
+        self.assertEqual(1234, result)
+
+        result = self.run_smart_contract(engine, path, 'out_of_order')
+        self.assertEqual(2413, result)
+
+        result = self.run_smart_contract(engine, path, 'mixed_in_order')
+        self.assertEqual(5612, result)
+
+        result = self.run_smart_contract(engine, path, 'mixed_out_of_order')
+        self.assertEqual(5621, result)
+
+        result = self.run_smart_contract(engine, path, 'default_values')
+        self.assertEqual(1034, result)
+
+        result = self.run_smart_contract(engine, path, 'only_default_values_and_kwargs')
+        self.assertEqual(204, result)
+
+    @unittest.skip("using asterisk as the first parameter is not implemented yet")
+    def test_call_function_with_kwargs_only(self):
+        path = self.get_contract_path('CallFunctionWithKwargsOnly.py')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'main')
+        self.assertEqual(1234, result)
+
+    @unittest.skip("calling a class method using the class and passing the object is not implemented yet")
+    def test_call_function_with_kwargs_self(self):
+        path = self.get_contract_path('CallFunctionWithKwargsSelf.py')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'get_val')
+        self.assertEqual(18, result)
+
+    def test_call_function_with_kwargs_wrong_type(self):
+        path = self.get_contract_path('CallFunctionWithKwargsWrongType.py')
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+
+    def test_call_function_with_kwargs_too_few_parameters(self):
+        path = self.get_contract_path('CallFunctionWithKwargsTooFewArguments.py')
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+
+    def test_call_function_with_kwargs_too_many_parameters(self):
+        path = self.get_contract_path('CallFunctionWithKwargsTooManyArguments.py')
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+
+    def test_call_function_with_kwargs_too_many_kw_parameters(self):
+        path = self.get_contract_path('CallFunctionWithKwargsTooManyKwArguments.py')
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
 
     def test_boa2_fibonacci_test(self):
         path = self.get_contract_path('FibonacciBoa2Test.py')
@@ -1034,3 +1108,7 @@ class TestFunction(BoaTest):
 
         result = self.run_smart_contract(engine, path, 'result')
         self.assertEqual([10, 20], result)
+
+    def test_function_with_dictionary_unpacking_operator(self):
+        path = self.get_contract_path('FunctionWithDictionaryUnpackingOperator.py')
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)


### PR DESCRIPTION
**Related issue**
#246 

**Summary or solution description**
Implemented a way to let the user use kwargs.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/cf438565a9803af3e0ba409e8559ec518633d6e6/boa3_test/test_sc/function_test/CallFunctionWithKwarg.py#L1-L10

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/cf438565a9803af3e0ba409e8559ec518633d6e6/boa3_test/tests/compiler_tests/test_function.py#L924-L999

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8

**(Optional) Additional context**
Trying to create a function without positional arguments and with only keyword arguments was not implemented in this issue, e.g. `def function(*, kwarg1, kwarg2)`.

The dictionary unpacking operator will be implemented in another issue, e.g. `def function(**kwargs)`.

It's not possible to use `self` as a keyword right now, since trying to call a class function with a class and passing the object is not working right now.