### PR TITLE
Add support to String startswith method

### DIFF
--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -59,6 +59,7 @@ class Builtin:
     Exception = ExceptionMethod()
 
     # python class method
+    BytesStringStartswith = StartsWithMethod()
     BytesStringUpper = UpperMethod()
     BytesStringLower = LowerMethod()
     CountSequence = CountSequenceMethod()
@@ -90,6 +91,7 @@ class Builtin:
 
     _python_builtins: List[IdentifiedSymbol] = [Abs,
                                                 ByteArray,
+                                                BytesStringStartswith,
                                                 BytesStringUpper,
                                                 BytesStringLower,
                                                 ClassMethodDecorator,

--- a/boa3/model/builtin/classmethod/__init__.py
+++ b/boa3/model/builtin/classmethod/__init__.py
@@ -14,11 +14,13 @@ __all__ = ['AppendMethod',
            'PopSequenceMethod',
            'RemoveMethod',
            'ReverseMethod',
-           'UpperMethod',
+           'StartsWithMethod',
            'ToBoolMethod',
            'ToBytesMethod',
            'ToIntMethod',
-           'ToStrMethod']
+           'ToStrMethod',
+           'UpperMethod',
+           ]
 
 from boa3.model.builtin.classmethod.appendmethod import AppendMethod
 from boa3.model.builtin.classmethod.clearmethod import ClearMethod
@@ -36,6 +38,7 @@ from boa3.model.builtin.classmethod.popdictmethod import PopDictMethod
 from boa3.model.builtin.classmethod.popsequencemethod import PopSequenceMethod
 from boa3.model.builtin.classmethod.removemethod import RemoveMethod
 from boa3.model.builtin.classmethod.reversemethod import ReverseMethod
+from boa3.model.builtin.classmethod.startswithmethod import StartsWithMethod
 from boa3.model.builtin.classmethod.toboolmethod import ToBool as ToBoolMethod
 from boa3.model.builtin.classmethod.tobytesmethod import ToBytes as ToBytesMethod
 from boa3.model.builtin.classmethod.tointmethod import ToInt as ToIntMethod

--- a/boa3/model/builtin/classmethod/startswithmethod.py
+++ b/boa3/model/builtin/classmethod/startswithmethod.py
@@ -1,0 +1,192 @@
+import ast
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.type.primitive.bytestype import BytesType
+from boa3.model.type.primitive.strtype import StrType
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class StartsWithMethod(IBuiltinMethod):
+    def __init__(self, self_type: Union[StrType, BytesType] = None):
+        from boa3.model.type.type import Type
+
+        if not isinstance(self_type, (StrType, BytesType)):
+            self_type = Type.str
+
+        identifier = 'startswith'
+        args: Dict[str, Variable] = {
+            'self': Variable(self_type),
+            'value': Variable(self_type),
+            'start': Variable(Type.int),
+            'end': Variable(Type.int),
+        }
+
+        start_default = ast.parse("{0}".format(0)
+                                  ).body[0].value
+        end_default = ast.parse("-1").body[0].value.operand
+        end_default.n = -1
+
+        super().__init__(identifier, args, defaults=[start_default, end_default], return_type=Type.bool)
+
+    @property
+    def _arg_self(self) -> Variable:
+        return self.args['self']
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        from boa3.compiler.codegenerator import get_bytes_count
+        from boa3.neo.vm.type.StackItem import StackItemType
+
+        jmp_place_holder = (Opcode.JMP, b'\x01')
+        # string, end, start, substring
+
+        verify_negative_index = [           # verify if index is negative value
+            (Opcode.DUP, b''),
+            (Opcode.PUSHM1, b''),
+            jmp_place_holder                # if not index < 0, jump to verify_big_end
+        ]
+
+        fix_negative_end = [                # fix negative value to a positive equivalent
+            (Opcode.PUSH3, b''),
+            (Opcode.PICK, b''),
+            (Opcode.SIZE, b''),
+            (Opcode.ADD, b''),
+            (Opcode.INC, b''),              # end = end + len(string) + 1
+            (Opcode.DUP, b''),
+            (Opcode.PUSHM1, b''),
+            jmp_place_holder                # if not end < 0, jump to verify_and_fix_start
+        ]
+
+        fix_still_negative_index = [        # if end still is less than 0, then it should be 0
+            (Opcode.DROP, b''),
+            (Opcode.PUSH0, b''),            # end = 0
+        ]
+
+        jmp_fix_negative_index = Opcode.get_jump_and_data(Opcode.JMPGT, get_bytes_count(fix_negative_end +
+                                                                                        fix_still_negative_index), True)
+        verify_negative_index[-1] = jmp_fix_negative_index
+
+        verify_big_end = [                  # verify if end is greater or equals to len(string)
+            (Opcode.DUP, b''),
+            (Opcode.PUSH4, b''),
+            (Opcode.PICK, b''),
+            (Opcode.SIZE, b''),
+            jmp_place_holder                # if not end >= len(string), jump to verify_and_fix_start
+        ]
+
+        fix_big_end = [                     # fix end value to a positive equivalent
+            (Opcode.DROP, b''),
+            (Opcode.PUSH2, b''),
+            (Opcode.PICK, b''),
+            (Opcode.SIZE, b''),             # end = len(string)
+        ]
+
+        jmp_other_verifies = Opcode.get_jump_and_data(Opcode.JMPGT, get_bytes_count(fix_still_negative_index +
+                                                                                    verify_big_end +
+                                                                                    fix_big_end), True)
+        fix_negative_end[-1] = jmp_other_verifies
+
+        jmp_fix_big_index = Opcode.get_jump_and_data(Opcode.JMPLE, get_bytes_count(fix_big_end), True)
+        verify_big_end[-1] = jmp_fix_big_index
+
+        verify_and_fix_end = [              # verify and fix end index
+            (Opcode.REVERSE3, b''),         # change positions on stack
+        ]
+        verify_and_fix_end.extend(verify_negative_index)
+        verify_and_fix_end.extend(fix_negative_end)
+        verify_and_fix_end.extend(fix_still_negative_index)
+        verify_and_fix_end.extend(verify_big_end)
+        verify_and_fix_end.extend(fix_big_end)
+
+        verify_and_fix_start = [            # verify and fix end index
+            (Opcode.SWAP, b''),             # change positions on stack
+        ]
+
+        # fix_negative_start is the same as fix_negative_end, but jump is different
+        fix_negative_start = fix_negative_end.copy()
+        verify_big_start = [                # verify if start is greater or equals to len(string)
+            (Opcode.DUP, b''),
+            (Opcode.PUSH4, b''),
+            (Opcode.PICK, b''),
+            (Opcode.SIZE, b''),
+            jmp_place_holder                # if start >= len(string), return False
+        ]
+
+        jmp_other_verifies = Opcode.get_jump_and_data(Opcode.JMPGT, get_bytes_count(fix_still_negative_index +
+                                                                                    verify_big_start), True)
+        fix_negative_end[-1] = jmp_other_verifies
+
+        verify_size = [                     # verify if len(string[start:end]) > len(substring)
+            (Opcode.REVERSE3, b''),
+            (Opcode.REVERSE4, b''),
+            (Opcode.REVERSE3, b''),
+            (Opcode.OVER, b''),
+            (Opcode.SUB, b''),
+            (Opcode.SUBSTR, b''),
+
+            (Opcode.PUSH0, b''),
+            (Opcode.PUSH2, b''),
+            (Opcode.PICK, b''),
+            (Opcode.SIZE, b''),
+            (Opcode.DUP, b''),
+            (Opcode.PUSH3, b''),
+            (Opcode.PICK, b''),
+            (Opcode.SIZE, b''),
+            jmp_place_holder                # if len(string[start:end]) > len(substring), return False
+        ]
+
+        compare_starts = [                  # string.startswith(substring)
+            (Opcode.SUBSTR, b''),
+            (Opcode.CONVERT, StackItemType.ByteString),
+            (Opcode.NUMEQUAL, b''),         # return string[start:end][0:len(substring)] == substring
+            jmp_place_holder                # jumps other opcodes
+        ]
+
+        jmp_compare_starts = Opcode.get_jump_and_data(Opcode.JMPGT, get_bytes_count(compare_starts), True)
+        verify_size[-1] = jmp_compare_starts
+
+        jmp_to_false = Opcode.get_jump_and_data(Opcode.JMPGE, get_bytes_count(verify_size +
+                                                                              compare_starts), True)
+        verify_big_start[-1] = jmp_to_false
+
+        verify_and_fix_start.extend(verify_negative_index)
+        verify_and_fix_start.extend(fix_negative_start)
+        verify_and_fix_start.extend(fix_still_negative_index)
+        verify_and_fix_start.extend(verify_big_start)
+
+        return_false = [                    # remove all values from stack and put False
+            (Opcode.DROP, b''),
+            (Opcode.DROP, b''),
+            (Opcode.DROP, b''),
+            (Opcode.DROP, b''),
+            (Opcode.PUSH0, b''),            # return False
+        ]
+
+        jmp_bigger_substr = Opcode.get_jump_and_data(Opcode.JMP, get_bytes_count(return_false), True)
+        compare_starts[-1] = jmp_bigger_substr
+
+        return (
+            verify_and_fix_end +
+            verify_and_fix_start +
+            verify_size +
+            compare_starts +
+            return_false
+        )
+
+    def push_self_first(self) -> bool:
+        return self.has_self_argument
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> Optional[str]:
+        return None
+
+    def build(self, value: Any) -> IBuiltinMethod:
+        if isinstance(value, (StrType, BytesType)):
+            return StartsWithMethod(value)
+        return super().build(value)

--- a/boa3_test/test_sc/bytes_test/StartswithBytesMethod.py
+++ b/boa3_test/test_sc/bytes_test/StartswithBytesMethod.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main(bytes_value: bytes, subbytes_value: bytes, start: int, end: int) -> bool:
+    return bytes_value.startswith(subbytes_value, start, end)

--- a/boa3_test/test_sc/bytes_test/StartswithBytesMethodDefaultEnd.py
+++ b/boa3_test/test_sc/bytes_test/StartswithBytesMethodDefaultEnd.py
@@ -1,0 +1,7 @@
+
+from boa3.builtin import public
+
+
+@public
+def main(bytes_value: bytes, subbytes_value: bytes, start: int) -> bool:
+    return bytes_value.startswith(subbytes_value, start)

--- a/boa3_test/test_sc/bytes_test/StartswithBytesMethodDefaults.py
+++ b/boa3_test/test_sc/bytes_test/StartswithBytesMethodDefaults.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main(bytes_value: bytes, subbytes_value: bytes) -> bool:
+    return bytes_value.startswith(subbytes_value)

--- a/boa3_test/test_sc/string_test/StartswithStringMethod.py
+++ b/boa3_test/test_sc/string_test/StartswithStringMethod.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main(string: str, substr: str, start: int, end: int) -> bool:
+    return string.startswith(substr, start, end)

--- a/boa3_test/test_sc/string_test/StartswithStringMethodDefaultEnd.py
+++ b/boa3_test/test_sc/string_test/StartswithStringMethodDefaultEnd.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main(string: str, substr: str, start: int) -> bool:
+    return string.startswith(substr, start)

--- a/boa3_test/test_sc/string_test/StartswithStringMethodDefaults.py
+++ b/boa3_test/test_sc/string_test/StartswithStringMethodDefaults.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main(string: str, substr: str) -> bool:
+    return string.startswith(substr)

--- a/boa3_test/tests/compiler_tests/test_bytes.py
+++ b/boa3_test/tests/compiler_tests/test_bytes.py
@@ -840,3 +840,137 @@ class TestBytes(BoaTest):
         bytes_value = b'!@#$%123*-/'
         result = self.run_smart_contract(engine, path, 'main', bytes_value, expected_result_type=bytes)
         self.assertEqual(bytes_value.lower(), result)
+
+    def test_bytes_startswith_method(self):
+        path = self.get_contract_path('StartswithBytesMethod.py')
+        engine = TestEngine()
+
+        bytes_value = b'unit_test'
+        subbytes_value = b'unit'
+        start = 0
+        end = len(bytes_value)
+        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value, start, end)
+        self.assertEqual(bytes_value.startswith(subbytes_value, start, end), result)
+
+        bytes_value = b'unit_test'
+        subbytes_value = b'unit'
+        start = 2
+        end = 6
+        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value, start, end)
+        self.assertEqual(bytes_value.startswith(subbytes_value, start, end), result)
+
+        bytes_value = b'unit_test'
+        subbytes_value = b'it'
+        start = 2
+        end = 6
+        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value, start, end)
+        self.assertEqual(bytes_value.startswith(subbytes_value, start, end), result)
+
+        bytes_value = b'unit_test'
+        subbytes_value = b'it'
+        start = 2
+        end = 3
+        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value, start, end)
+        self.assertEqual(bytes_value.startswith(subbytes_value, start, end), result)
+
+        bytes_value = b'unit_test'
+        subbytes_value = b'unit_tes'
+        start = -99
+        end = -1
+        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value, start, end)
+        self.assertEqual(bytes_value.startswith(subbytes_value, start, end), result)
+
+        bytes_value = b'unit_test'
+        subbytes_value = b''
+        start = 0
+        end = 0
+        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value, start, end)
+        self.assertEqual(bytes_value.startswith(subbytes_value, start, end), result)
+
+        bytes_value = b'unit_test'
+        subbytes_value = b'unit_test'
+        start = 0
+        end = 99
+        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value, start, end)
+        self.assertEqual(bytes_value.startswith(subbytes_value, start, end), result)
+
+    def test_bytes_startswith_method_default_end(self):
+        path = self.get_contract_path('StartswithBytesMethodDefaultEnd.py')
+        engine = TestEngine()
+
+        bytes_value = b'unit_test'
+        subbytes_value = b'unit'
+        start = 0
+        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value, start)
+        self.assertEqual(bytes_value.startswith(subbytes_value, start), result)
+
+        bytes_value = b'unit_test'
+        subbytes_value = b'unit'
+        start = 2
+        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value, start)
+        self.assertEqual(bytes_value.startswith(subbytes_value, start), result)
+
+        bytes_value = b'unit_test'
+        subbytes_value = b'it'
+        start = 2
+        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value, start)
+        self.assertEqual(bytes_value.startswith(subbytes_value, start), result)
+
+        bytes_value = b'unit_test'
+        subbytes_value = b'it'
+        start = 3
+        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value, start)
+        self.assertEqual(bytes_value.startswith(subbytes_value, start), result)
+
+        bytes_value = b'unit_test'
+        subbytes_value = b'unit_tes'
+        start = -99
+        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value, start)
+        self.assertEqual(bytes_value.startswith(subbytes_value, start), result)
+
+        bytes_value = b'unit_test'
+        subbytes_value = b''
+        start = 0
+        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value, start)
+        self.assertEqual(bytes_value.startswith(subbytes_value, start), result)
+
+        bytes_value = b'unit_test'
+        subbytes_value = b''
+        start = 99
+        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value, start)
+        self.assertEqual(bytes_value.startswith(subbytes_value, start), result)
+
+        bytes_value = b'unit_test'
+        subbytes_value = b'unit_test'
+        start = 0
+        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value, start)
+        self.assertEqual(bytes_value.startswith(subbytes_value, start), result)
+
+    def test_bytes_startswith_method_defaults(self):
+        path = self.get_contract_path('StartswithBytesMethodDefaults.py')
+        engine = TestEngine()
+
+        bytes_value = b'unit_test'
+        subbytes_value = b'unit'
+        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value)
+        self.assertEqual(bytes_value.startswith(subbytes_value), result)
+
+        bytes_value = b'unit_test'
+        subbytes_value = b'unit_test'
+        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value)
+        self.assertEqual(bytes_value.startswith(subbytes_value), result)
+
+        bytes_value = b'unit_test'
+        subbytes_value = b''
+        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value)
+        self.assertEqual(bytes_value.startswith(subbytes_value), result)
+
+        bytes_value = b'unit_test'
+        subbytes_value = b'12345'
+        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value)
+        self.assertEqual(bytes_value.startswith(subbytes_value), result)
+
+        bytes_value = b'unit_test'
+        subbytes_value = b'bigger subbytes_value'
+        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value)
+        self.assertEqual(bytes_value.startswith(subbytes_value), result)

--- a/boa3_test/tests/compiler_tests/test_string.py
+++ b/boa3_test/tests/compiler_tests/test_string.py
@@ -417,3 +417,144 @@ class TestString(BoaTest):
         with self.assertRaises(AssertionError):
             # TODO: upper was implemented for ASCII characters only
             self.assertEqual(string.lower(), result)
+
+    def test_string_startswith_method(self):
+        path = self.get_contract_path('StartswithStringMethod.py')
+        engine = TestEngine()
+
+        string = 'unit_test'
+        substring = 'unit'
+        start = 0
+        end = len(string)
+        result = self.run_smart_contract(engine, path, 'main', string, substring, start, end)
+        self.assertEqual(string.startswith(substring, start, end), result)
+
+        string = 'unit_test'
+        substring = 'unit'
+        start = 2
+        end = 6
+        result = self.run_smart_contract(engine, path, 'main', string, substring, start, end)
+        self.assertEqual(string.startswith(substring, start, end), result)
+
+        string = 'unit_test'
+        substring = 'it'
+        start = 2
+        end = 6
+        result = self.run_smart_contract(engine, path, 'main', string, substring, start, end)
+        self.assertEqual(string.startswith(substring, start, end), result)
+
+        string = 'unit_test'
+        substring = 'it'
+        start = 2
+        end = 3
+        result = self.run_smart_contract(engine, path, 'main', string, substring, start, end)
+        self.assertEqual(string.startswith(substring, start, end), result)
+
+        string = 'unit_test'
+        substring = 'unit_tes'
+        start = -99
+        end = -1
+        result = self.run_smart_contract(engine, path, 'main', string, substring, start, end)
+        self.assertEqual(string.startswith(substring, start, end), result)
+
+        string = 'unit_test'
+        substring = ''
+        start = 0
+        end = 0
+        result = self.run_smart_contract(engine, path, 'main', string, substring, start, end)
+        self.assertEqual(string.startswith(substring, start, end), result)
+
+        string = 'unit_test'
+        substring = 'unit_test'
+        start = 0
+        end = 99
+        result = self.run_smart_contract(engine, path, 'main', string, substring, start, end)
+        self.assertEqual(string.startswith(substring, start, end), result)
+
+        string = 'unit_test'
+        substring = 'unit_test'
+        start = 100
+        end = 99
+        result = self.run_smart_contract(engine, path, 'main', string, substring, start, end)
+        self.assertEqual(string.startswith(substring, start, end), result)
+
+    def test_string_startswith_method_default_end(self):
+        path = self.get_contract_path('StartswithStringMethodDefaultEnd.py')
+        engine = TestEngine()
+
+        string = 'unit_test'
+        substring = 'unit'
+        start = 0
+        result = self.run_smart_contract(engine, path, 'main', string, substring, start)
+        self.assertEqual(string.startswith(substring, start), result)
+
+        string = 'unit_test'
+        substring = 'unit'
+        start = 2
+        result = self.run_smart_contract(engine, path, 'main', string, substring, start)
+        self.assertEqual(string.startswith(substring, start), result)
+
+        string = 'unit_test'
+        substring = 'it'
+        start = 2
+        result = self.run_smart_contract(engine, path, 'main', string, substring, start)
+        self.assertEqual(string.startswith(substring, start), result)
+
+        string = 'unit_test'
+        substring = 'it'
+        start = 3
+        result = self.run_smart_contract(engine, path, 'main', string, substring, start)
+        self.assertEqual(string.startswith(substring, start), result)
+
+        string = 'unit_test'
+        substring = 'unit_tes'
+        start = -99
+        result = self.run_smart_contract(engine, path, 'main', string, substring, start)
+        self.assertEqual(string.startswith(substring, start), result)
+
+        string = 'unit_test'
+        substring = ''
+        start = 0
+        result = self.run_smart_contract(engine, path, 'main', string, substring, start)
+        self.assertEqual(string.startswith(substring, start), result)
+
+        string = 'unit_test'
+        substring = ''
+        start = 99
+        result = self.run_smart_contract(engine, path, 'main', string, substring, start)
+        self.assertEqual(string.startswith(substring, start), result)
+
+        string = 'unit_test'
+        substring = 'unit_test'
+        start = 0
+        result = self.run_smart_contract(engine, path, 'main', string, substring, start)
+        self.assertEqual(string.startswith(substring, start), result)
+
+    def test_string_startswith_method_defaults(self):
+        path = self.get_contract_path('StartswithStringMethodDefaults.py')
+        engine = TestEngine()
+
+        string = 'unit_test'
+        substring = 'unit'
+        result = self.run_smart_contract(engine, path, 'main', string, substring)
+        self.assertEqual(string.startswith(substring), result)
+
+        string = 'unit_test'
+        substring = 'unit_test'
+        result = self.run_smart_contract(engine, path, 'main', string, substring)
+        self.assertEqual(string.startswith(substring), result)
+
+        string = 'unit_test'
+        substring = ''
+        result = self.run_smart_contract(engine, path, 'main', string, substring)
+        self.assertEqual(string.startswith(substring), result)
+
+        string = 'unit_test'
+        substring = '12345'
+        result = self.run_smart_contract(engine, path, 'main', string, substring)
+        self.assertEqual(string.startswith(substring), result)
+
+        string = 'unit_test'
+        substring = 'bigger substring'
+        result = self.run_smart_contract(engine, path, 'main', string, substring)
+        self.assertEqual(string.startswith(substring), result)


### PR DESCRIPTION
**Related issue**
#673 

**Summary or solution description**
Implemented `string.startswith()` and `bytes.startswith()`.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/f8e2e3b497ca3f2045a80ef49f772377cf25eb29/boa3_test/test_sc/string_test/StartswithStringMethod.py#L1-L6
The `start` and `end` parameters are optionals.

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/f8e2e3b497ca3f2045a80ef49f772377cf25eb29/boa3_test/tests/compiler_tests/test_string.py#L421-L560

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8
