### PR TITLE
Add support to Dict pop method

### DIFF
--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -66,10 +66,11 @@ class Builtin:
     SequenceClear = ClearMethod()
     SequenceExtend = ExtendMethod()
     SequenceInsert = InsertMethod()
-    SequencePop = PopMethod()
+    SequencePop = PopSequenceMethod()
     SequenceRemove = RemoveMethod()
     SequenceReverse = ReverseMethod()
     DictKeys = MapKeysMethod()
+    DictPop = PopDictMethod()
     DictValues = MapValuesMethod()
 
     # custom class methods

--- a/boa3/model/builtin/classmethod/__init__.py
+++ b/boa3/model/builtin/classmethod/__init__.py
@@ -6,7 +6,8 @@ __all__ = ['AppendMethod',
            'InsertMethod',
            'MapKeysMethod',
            'MapValuesMethod',
-           'PopMethod',
+           'PopDictMethod',
+           'PopSequenceMethod',
            'RemoveMethod',
            'ReverseMethod',
            'UpperMethod',
@@ -23,7 +24,8 @@ from boa3.model.builtin.classmethod.extendmethod import ExtendMethod
 from boa3.model.builtin.classmethod.insertmethod import InsertMethod
 from boa3.model.builtin.classmethod.mapkeysmethod import MapKeysMethod
 from boa3.model.builtin.classmethod.mapvaluesmethod import MapValuesMethod
-from boa3.model.builtin.classmethod.popmethod import PopMethod
+from boa3.model.builtin.classmethod.popdictmethod import PopDictMethod
+from boa3.model.builtin.classmethod.popsequencemethod import PopSequenceMethod
 from boa3.model.builtin.classmethod.removemethod import RemoveMethod
 from boa3.model.builtin.classmethod.reversemethod import ReverseMethod
 from boa3.model.builtin.classmethod.toboolmethod import ToBool as ToBoolMethod

--- a/boa3/model/builtin/classmethod/popdictmethod.py
+++ b/boa3/model/builtin/classmethod/popdictmethod.py
@@ -1,0 +1,22 @@
+from typing import Dict, Optional
+
+from boa3.model.builtin.classmethod.popmethod import PopMethod
+from boa3.model.type.itype import IType
+from boa3.model.variable import Variable
+
+
+class PopDictMethod(PopMethod):
+
+    def __init__(self, arg_value: Optional[IType] = None):
+        from boa3.model.type.type import Type
+
+        if not Type.dict.is_type_of(arg_value):
+            arg_value = Type.dict
+
+        args: Dict[str, Variable] = {
+            'self': Variable(arg_value),
+            'key': Variable(arg_value.valid_key)
+            # TODO: Add default parameter
+        }
+
+        super().__init__(args, return_type=arg_value.value_type)

--- a/boa3/model/builtin/classmethod/popsequencemethod.py
+++ b/boa3/model/builtin/classmethod/popsequencemethod.py
@@ -1,0 +1,25 @@
+import ast
+from typing import Dict, Optional
+
+from boa3.model.builtin.classmethod.popmethod import PopMethod
+from boa3.model.type.itype import IType
+from boa3.model.variable import Variable
+
+
+class PopSequenceMethod(PopMethod):
+
+    def __init__(self, arg_value: Optional[IType] = None):
+        from boa3.model.type.type import Type
+
+        if not Type.mutableSequence.is_type_of(arg_value):
+            arg_value = Type.mutableSequence
+
+        args: Dict[str, Variable] = {
+            'self': Variable(arg_value),
+            'index': Variable(arg_value.valid_key)
+        }
+
+        index_default = ast.parse("-1").body[0].value.operand
+        index_default.n = -1
+
+        super().__init__(args, defaults=[index_default], return_type=arg_value.value_type)

--- a/boa3_test/test_sc/dict_test/DictPop.py
+++ b/boa3_test/test_sc/dict_test/DictPop.py
@@ -1,0 +1,10 @@
+from typing import Dict, Any, Tuple
+
+from boa3.builtin import public
+
+
+@public
+def main(dict_: Dict[Any, Any], key: Any) -> Tuple[Dict[Any, Any], Any]:
+    value = dict_.pop(key)
+    new_dict_and_value = (dict_, value)
+    return new_dict_and_value

--- a/boa3_test/tests/compiler_tests/test_dict.py
+++ b/boa3_test/tests/compiler_tests/test_dict.py
@@ -518,3 +518,24 @@ class TestDict(BoaTest):
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'main')
         self.assertEqual(55, result)
+
+    def test_dict_pop(self):
+        path = self.get_contract_path('DictPop.py')
+        engine = TestEngine()
+
+        dict_ = {'a': 1, 'b': 2, 'c': 3, 'd': 4}
+        key = 'a'
+        result = self.run_smart_contract(engine, path, 'main', dict_, key)
+        value = dict_.pop(key)
+        self.assertEqual((dict_, value), tuple(result))
+
+        dict_ = {'a': 1, 'b': 2, 'c': 3, 'd': 4}
+        key = 'd'
+        result = self.run_smart_contract(engine, path, 'main', dict_, key)
+        value = dict_.pop(key)
+        self.assertEqual((dict_, value), tuple(result))
+
+        dict_ = {'a': 1, 'b': 2, 'c': 3, 'd': 4}
+        key = 'key not inside'
+        with self.assertRaises(TestExecutionException, msg=self.MAP_KEY_NOT_FOUND_ERROR_MSG):
+            self.run_smart_contract(engine, path, 'main', dict_, key)


### PR DESCRIPTION
**Related issue**
#686 

**Summary or solution description**
Added support to `dict.pop()` method, however, the `default` parameter was not implemented.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/d14c598600f29b26765b9b730c71d7dbf36bf354/boa3_test/test_sc/dict_test/DictPop.py#L1-L10

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/d14c598600f29b26765b9b730c71d7dbf36bf354/boa3_test/tests/compiler_tests/test_dict.py#L522-L541

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8
