### PR TITLE
Add support to Sequence index method

### DIFF
--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -66,6 +66,7 @@ class Builtin:
     SequenceAppend = AppendMethod()
     SequenceClear = ClearMethod()
     SequenceExtend = ExtendMethod()
+    SequenceIndex = IndexSequenceMethod()
     SequenceInsert = InsertMethod()
     SequencePop = PopSequenceMethod()
     SequenceRemove = RemoveMethod()
@@ -111,6 +112,7 @@ class Builtin:
                                                 SequenceAppend,
                                                 SequenceClear,
                                                 SequenceExtend,
+                                                SequenceIndex,
                                                 SequenceInsert,
                                                 SequencePop,
                                                 SequenceRemove,

--- a/boa3/model/builtin/classmethod/__init__.py
+++ b/boa3/model/builtin/classmethod/__init__.py
@@ -4,6 +4,7 @@ __all__ = ['AppendMethod',
            'CountSequenceMethod',
            'CountStrMethod',
            'ExtendMethod',
+           'IndexSequenceMethod',
            'InsertMethod',
            'MapKeysMethod',
            'MapValuesMethod',
@@ -23,6 +24,7 @@ from boa3.model.builtin.classmethod.copymethod import CopyMethod
 from boa3.model.builtin.classmethod.countsequencemethod import CountSequenceMethod
 from boa3.model.builtin.classmethod.countstrmethod import CountStrMethod
 from boa3.model.builtin.classmethod.extendmethod import ExtendMethod
+from boa3.model.builtin.classmethod.indexsequencemethod import IndexSequenceMethod
 from boa3.model.builtin.classmethod.insertmethod import InsertMethod
 from boa3.model.builtin.classmethod.mapkeysmethod import MapKeysMethod
 from boa3.model.builtin.classmethod.mapvaluesmethod import MapValuesMethod

--- a/boa3/model/builtin/classmethod/indexmethod.py
+++ b/boa3/model/builtin/classmethod/indexmethod.py
@@ -1,0 +1,72 @@
+import ast
+from typing import Any, Dict, List, Optional
+
+from boa3.model.type.itype import IType
+
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.variable import Variable
+
+
+class IndexMethod(IBuiltinMethod):
+
+    def __init__(self, args: Dict[str, Variable] = None, defaults: List[ast.AST] = None):
+        from boa3.model.type.type import Type
+        identifier = 'index'
+        super().__init__(identifier, args, defaults=defaults, return_type=Type.int)
+
+    @property
+    def identifier(self) -> str:
+        from boa3.model.type.type import Type
+
+        if self._arg_self.type is Type.sequence:    # IndexSequenceMethod default value for self
+            return self._identifier
+
+        if self._arg_self.type is Type.str:
+            return '-{0}_{1}'.format(self._identifier, Type.str.identifier)
+
+        if Type.sequence.is_type_of(self._arg_self.type):
+            return '-{0}_{1}'.format(self._identifier, Type.sequence.identifier)
+
+        return self._identifier
+
+    @property
+    def is_supported(self) -> bool:
+        # TODO: change when index() with only one argument is implemented for range
+        from boa3.model.type.type import Type
+        if Type.range.is_type_of(self._arg_self.type):
+            return False
+        return True
+
+    @property
+    def _arg_self(self) -> Variable:
+        return self.args['self']
+
+    @property
+    def _arg_value(self) -> Variable:
+        return self.args['value']
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> Optional[str]:
+        return
+
+    def build(self, value: Any) -> IBuiltinMethod:
+        if not isinstance(value, list):
+            value = [value]
+
+        from boa3.model.type.collection.sequence.mutable.listtype import ListType
+        from boa3.model.type.collection.sequence.tupletype import TupleType
+        from boa3.model.type.collection.sequence.rangetype import RangeType
+        if len(value) > 1 and isinstance(value[0], (ListType, TupleType, RangeType)):
+            from boa3.model.builtin.classmethod.indexsequencemethod import IndexSequenceMethod
+            return IndexSequenceMethod(value[0], value[1])
+
+        from boa3.model.type.type import Type
+        if len(value) > 0 and Type.str.is_type_of(value[0]):
+            from boa3.model.builtin.builtin import Builtin
+            return Builtin.CountStr
+
+        return super().build(value)

--- a/boa3/model/builtin/classmethod/indexsequencemethod.py
+++ b/boa3/model/builtin/classmethod/indexsequencemethod.py
@@ -1,0 +1,184 @@
+import ast
+from typing import Dict, List, Optional, Tuple
+
+from boa3.model.builtin.classmethod.indexmethod import IndexMethod
+from boa3.model.expression import IExpression
+from boa3.model.type.collection.sequence.sequencetype import SequenceType
+from boa3.model.type.itype import IType
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+from boa3.neo.vm.type.Integer import Integer
+from boa3.neo.vm.type.String import String
+
+
+class IndexSequenceMethod(IndexMethod):
+
+    def __init__(self, sequence_type: Optional[SequenceType] = None, arg_value: Optional[IType] = None):
+        from boa3.model.type.type import Type
+        if not isinstance(sequence_type, SequenceType):
+            sequence_type = Type.sequence
+        if not isinstance(arg_value, IType):
+            arg_value = Type.any
+
+        args: Dict[str, Variable] = {
+            'self': Variable(sequence_type),
+            'x': Variable(arg_value),
+            'start': Variable(Type.int),
+            'end': Variable(Type.int),
+        }
+
+        start_default = ast.parse("{0}".format(0)
+                                  ).body[0].value
+        end_default = ast.parse("-1").body[0].value.operand
+        end_default.n = -1
+
+        super().__init__(args, defaults=[start_default, end_default])
+
+    def validate_parameters(self, *params: IExpression) -> bool:
+        if 2 <= len(params) <= 4:
+            return False
+        if not all(isinstance(param, IExpression) for param in params):
+            return False
+
+        from boa3.model.type.itype import IType
+        sequence_type: IType = params[0].type
+
+        if not isinstance(sequence_type, SequenceType):
+            return False
+        from boa3.model.type.collection.sequence.mutable.listtype import ListType
+        from boa3.model.type.collection.sequence.tupletype import TupleType
+        from boa3.model.type.collection.sequence.rangetype import RangeType
+        if not isinstance(sequence_type, (ListType, TupleType, RangeType)):
+            return False
+        return True
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        from boa3.compiler.codegenerator import get_bytes_count
+
+        jmp_place_holder = (Opcode.JMP, b'\x01')
+        message = String("x not in sequence").to_bytes()
+
+        # receives: end, start, x, sequence
+        verify_negative_index = [           # verifies if index in a negative value
+            (Opcode.DUP, b''),
+            (Opcode.PUSHM1, b''),
+            jmp_place_holder                # if index >= 0, jump to verify_big_end or verify_big_start
+        ]
+
+        fix_negative_end = [                # gets the correspondent positive value of end
+            (Opcode.PUSH3, b''),
+            (Opcode.PICK, b''),
+            (Opcode.SIZE, b''),
+            (Opcode.ADD, b''),
+            (Opcode.INC, b''),              # end = end + len(sequence) + 1
+            (Opcode.DUP, b''),
+            (Opcode.PUSHM1, b''),
+            jmp_place_holder                # if end is not negative anymore, start verifying start
+        ]
+
+        fix_still_negative_index = [        # if index is still negative, consider it 0 then
+            (Opcode.DROP, b''),
+            (Opcode.PUSH0, b''),            # end = 0
+        ]
+
+        jmp_fix_negative_index = Opcode.get_jump_and_data(Opcode.JMPGT, get_bytes_count(fix_negative_end +
+                                                                                        fix_still_negative_index), True)
+        verify_negative_index[-1] = jmp_fix_negative_index
+
+        verify_big_end = [                  # verify if end is bigger then len(sequence)
+            (Opcode.DUP, b''),
+            (Opcode.PUSH4, b''),
+            (Opcode.PICK, b''),
+            (Opcode.SIZE, b''),
+            jmp_place_holder                # if end <= len(sequence), start verifying start
+        ]
+
+        fix_big_end = [                     # consider end as len(sequence)
+            (Opcode.DROP, b''),
+            (Opcode.PUSH2, b''),
+            (Opcode.PICK, b''),
+            (Opcode.SIZE, b''),             # end = len(sequence)
+        ]
+
+        jmp_other_verifies = Opcode.get_jump_and_data(Opcode.JMPGT, get_bytes_count(fix_still_negative_index +
+                                                                                    verify_big_end +
+                                                                                    fix_big_end), True)
+        fix_negative_end[-1] = jmp_other_verifies
+
+        jmp_fix_big_index = Opcode.get_jump_and_data(Opcode.JMPLE, get_bytes_count(fix_big_end), True)
+        verify_big_end[-1] = jmp_fix_big_index
+
+        verify_and_fix_end = [              # collection of Opcodes regarding verifying and fixing end index
+            (Opcode.REVERSE4, b''),
+        ]
+        verify_and_fix_end.extend(verify_negative_index)
+        verify_and_fix_end.extend(fix_negative_end)
+        verify_and_fix_end.extend(fix_still_negative_index)
+        verify_and_fix_end.extend(verify_big_end)
+        verify_and_fix_end.extend(fix_big_end)
+
+        verify_and_fix_start = [            # collection of Opcodes regarding verifying and fixing start index
+            (Opcode.SWAP, b'')
+        ]
+        verify_and_fix_start.extend(verify_negative_index)
+        verify_and_fix_start.extend(fix_negative_end)
+        verify_and_fix_start.extend(fix_still_negative_index)
+        verify_and_fix_start.extend(verify_big_end)
+        verify_and_fix_start.extend(fix_big_end)
+
+        verify_while = [                    # verify if already went through all items on the sequence[start:end]
+            (Opcode.OVER, b''),             # index = start
+            (Opcode.OVER, b''),
+            jmp_place_holder                # if index <= start, jump to not_inside_sequence
+        ]
+
+        compare_item = [                    # verifies if x is in sequence
+            (Opcode.PUSH3, b''),
+            (Opcode.PICK, b''),
+            (Opcode.OVER, b''),
+            (Opcode.PICKITEM, b''),
+            (Opcode.PUSH3, b''),
+            (Opcode.PICK, b''),
+            (Opcode.NUMEQUAL, b''),         # found_x = sequence[index] == x
+            jmp_place_holder                # if found_x, jump to return_index
+        ]
+
+        not_found = [                       # increments index and goes back to verify again
+            (Opcode.INC, b''),              # index++
+            # jump to verify_while
+        ]
+
+        jmp_back_to_verify = Opcode.get_jump_and_data(Opcode.JMP, -get_bytes_count(verify_while +
+                                                                                   compare_item +
+                                                                                   not_found), True)
+        not_found.append(jmp_back_to_verify)
+
+        jmp_to_error = Opcode.get_jump_and_data(Opcode.JMPLE, get_bytes_count(compare_item +
+                                                                              not_found), True)
+        verify_while[-1] = jmp_to_error
+
+        not_inside_sequence = [             # send error message saying that x is not in sequence
+            (Opcode.PUSHDATA1, Integer(len(message)).to_byte_array(signed=True, min_length=1) + message),
+            (Opcode.THROW, b''),
+        ]
+
+        jmp_to_return_index = Opcode.get_jump_and_data(Opcode.JMPIF, get_bytes_count(not_found +
+                                                                                     not_inside_sequence), True)
+        compare_item[-1] = jmp_to_return_index
+
+        return_index = [                    # removes all values in the stack but the index
+            (Opcode.NIP, b''),
+            (Opcode.NIP, b''),
+            (Opcode.NIP, b''),
+        ]
+
+        return (
+            verify_and_fix_end +
+            verify_and_fix_start +
+            verify_while +
+            compare_item +
+            not_found +
+            not_inside_sequence +
+            return_index
+        )

--- a/boa3_test/test_sc/list_test/IndexList.py
+++ b/boa3_test/test_sc/list_test/IndexList.py
@@ -1,0 +1,8 @@
+from typing import Any, List
+
+from boa3.builtin import public
+
+
+@public
+def main(a: List[Any], value: Any, start: int, end: int) -> int:
+    return a.index(value, start, end)

--- a/boa3_test/test_sc/list_test/IndexListBool.py
+++ b/boa3_test/test_sc/list_test/IndexListBool.py
@@ -1,0 +1,8 @@
+from typing import List
+
+from boa3.builtin import public
+
+
+@public
+def main(a: List[bool], value: bool) -> int:
+    return a.index(value)

--- a/boa3_test/test_sc/list_test/IndexListDefaults.py
+++ b/boa3_test/test_sc/list_test/IndexListDefaults.py
@@ -1,0 +1,8 @@
+from typing import Any, List
+
+from boa3.builtin import public
+
+
+@public
+def main(a: List[Any], value: Any) -> int:
+    return a.index(value)

--- a/boa3_test/test_sc/list_test/IndexListEndDefault.py
+++ b/boa3_test/test_sc/list_test/IndexListEndDefault.py
@@ -1,0 +1,8 @@
+from typing import Any, List
+
+from boa3.builtin import public
+
+
+@public
+def main(a: List[Any], value: Any, start: int) -> int:
+    return a.index(value, start)

--- a/boa3_test/test_sc/list_test/IndexListInt.py
+++ b/boa3_test/test_sc/list_test/IndexListInt.py
@@ -1,0 +1,8 @@
+from typing import List
+
+from boa3.builtin import public
+
+
+@public
+def main(a: List[int], value: int) -> int:
+    return a.index(value)

--- a/boa3_test/test_sc/list_test/IndexListStr.py
+++ b/boa3_test/test_sc/list_test/IndexListStr.py
@@ -1,0 +1,8 @@
+from typing import List
+
+from boa3.builtin import public
+
+
+@public
+def main(a: List[str], value: str) -> int:
+    return a.index(value)

--- a/boa3_test/test_sc/range_test/IndexRange.py
+++ b/boa3_test/test_sc/range_test/IndexRange.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main() -> int:
+    return range(1, 5).index(0)

--- a/boa3_test/test_sc/tuple_test/IndexTuple.py
+++ b/boa3_test/test_sc/tuple_test/IndexTuple.py
@@ -1,0 +1,8 @@
+from typing import Any, Tuple
+
+from boa3.builtin import public
+
+
+@public
+def main(a: Tuple[Any], value: Any, start: int, end: int) -> int:
+    return a.index(value, start, end)

--- a/boa3_test/test_sc/tuple_test/IndexTupleDefaults.py
+++ b/boa3_test/test_sc/tuple_test/IndexTupleDefaults.py
@@ -1,0 +1,8 @@
+from typing import Any, Tuple
+
+from boa3.builtin import public
+
+
+@public
+def main(a: Tuple[Any], value: Any) -> int:
+    return a.index(value)

--- a/boa3_test/test_sc/tuple_test/IndexTupleEndDefault.py
+++ b/boa3_test/test_sc/tuple_test/IndexTupleEndDefault.py
@@ -1,0 +1,8 @@
+from typing import Any, Tuple
+
+from boa3.builtin import public
+
+
+@public
+def main(a: Tuple[Any], value: Any, start: int) -> int:
+    return a.index(value, start)

--- a/boa3_test/tests/compiler_tests/test_list.py
+++ b/boa3_test/tests/compiler_tests/test_list.py
@@ -1258,3 +1258,111 @@ class TestList(BoaTest):
         self.assertEqual([True, False, True], result[1])
 
     # endregion
+
+    # region TestIndex
+
+    def test_list_index(self):
+        path = self.get_contract_path('IndexList.py')
+        engine = TestEngine()
+
+        list_ = [1, 2, 3, 4]
+        value = 3
+        start = 0
+        end = 4
+        result = self.run_smart_contract(engine, path, 'main', list_, value, start, end)
+        self.assertEqual(list_.index(value, start, end), result)
+
+        list_ = [1, 2, 3, 4]
+        value = 3
+        start = 2
+        end = 4
+        result = self.run_smart_contract(engine, path, 'main', list_, value, start, end)
+        self.assertEqual(list_.index(value, start, end), result)
+
+        with self.assertRaises(TestExecutionException):
+            self.run_smart_contract(engine, path, 'main', [1, 2, 3, 4], 3, 3, 4)
+
+        with self.assertRaises(TestExecutionException):
+            self.run_smart_contract(engine, path, 'main', [1, 2, 3, 4], 3, 4, -1)
+
+        with self.assertRaises(TestExecutionException):
+            self.run_smart_contract(engine, path, 'main', [1, 2, 3, 4], 3, 0, -99)
+
+        list_ = [1, 2, 3, 4]
+        value = 3
+        start = 0
+        end = -1
+        result = self.run_smart_contract(engine, path, 'main', list_, value, start, end)
+        self.assertEqual(list_.index(value, start, end), result)
+
+        list_ = [1, 2, 3, 4]
+        value = 2
+        start = 0
+        end = 99
+        result = self.run_smart_contract(engine, path, 'main', list_, value, start, end)
+        self.assertEqual(list_.index(value, start, end), result)
+
+    def test_list_index_end_default(self):
+        path = self.get_contract_path('IndexListEndDefault.py')
+        engine = TestEngine()
+
+        list_ = [1, 2, 3, 4]
+        value = 3
+        start = 0
+        result = self.run_smart_contract(engine, path, 'main', list_, value, start)
+        self.assertEqual(list_.index(value, start), result)
+
+        with self.assertRaises(TestExecutionException):
+            self.run_smart_contract(engine, path, 'main', [1, 2, 3, 4], 2, 99)
+
+        with self.assertRaises(TestExecutionException):
+            self.run_smart_contract(engine, path, 'main', [1, 2, 3, 4], 4, -1)
+
+        list_ = [1, 2, 3, 4]
+        value = 2
+        start = -10
+        result = self.run_smart_contract(engine, path, 'main', list_, value, start)
+        self.assertEqual(list_.index(value, start), result)
+
+    def test_list_index_defaults(self):
+        path = self.get_contract_path('IndexListDefaults.py')
+        engine = TestEngine()
+
+        list_ = [1, 2, 3, 4]
+        value = 3
+        result = self.run_smart_contract(engine, path, 'main', list_, value)
+        self.assertEqual(list_.index(value), result)
+
+        list_ = [1, 2, 3, 4]
+        value = 1
+        result = self.run_smart_contract(engine, path, 'main', list_, value)
+        self.assertEqual(list_.index(value), result)
+
+    def test_list_index_int(self):
+        path = self.get_contract_path('IndexListInt.py')
+        engine = TestEngine()
+
+        list_ = [1, 2, 3, 4]
+        value = 3
+        result = self.run_smart_contract(engine, path, 'main', list_, value)
+        self.assertEqual(list_.index(value), result)
+
+    def test_list_index_str(self):
+        path = self.get_contract_path('IndexListStr.py')
+        engine = TestEngine()
+
+        list_ = ['unit', 'test', 'neo3-boa']
+        value = 'test'
+        result = self.run_smart_contract(engine, path, 'main', list_, value)
+        self.assertEqual(list_.index(value), result)
+
+    def test_list_index_bool(self):
+        path = self.get_contract_path('IndexListBool.py')
+        engine = TestEngine()
+
+        list_ = [True, True, False]
+        value = False
+        result = self.run_smart_contract(engine, path, 'main', list_, value)
+        self.assertEqual(list_.index(value), result)
+
+    # endregion

--- a/boa3_test/tests/compiler_tests/test_range.py
+++ b/boa3_test/tests/compiler_tests/test_range.py
@@ -576,3 +576,10 @@ class TestRange(BoaTest):
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'main')
         self.assertEqual(list(range(100, 120)), result)
+
+    def test_range_index(self):
+        path = self.get_contract_path('IndexRange.py')
+        engine = TestEngine()
+
+        # TODO: change when index() with only one argument is implemented for range
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)

--- a/boa3_test/tests/compiler_tests/test_tuple.py
+++ b/boa3_test/tests/compiler_tests/test_tuple.py
@@ -520,3 +520,80 @@ class TestTuple(BoaTest):
         expected_result = a[:999:-2]
         result = self.run_smart_contract(engine, path, 'really_high_end')
         self.assertEqual(expected_result, tuple(result))
+
+    def test_tuple_index(self):
+        path = self.get_contract_path('IndexTuple.py')
+        engine = TestEngine()
+
+        tuple_ = (1, 2, 3, 4)
+        value = 3
+        start = 0
+        end = 4
+        result = self.run_smart_contract(engine, path, 'main', tuple_, value, start, end)
+        self.assertEqual(tuple_.index(value, start, end), result)
+
+        tuple_ = (1, 2, 3, 4)
+        value = 3
+        start = 2
+        end = 4
+        result = self.run_smart_contract(engine, path, 'main', tuple_, value, start, end)
+        self.assertEqual(tuple_.index(value, start, end), result)
+
+        with self.assertRaises(TestExecutionException):
+            self.run_smart_contract(engine, path, 'main', (1, 2, 3, 4), 3, 3, 4)
+
+        with self.assertRaises(TestExecutionException):
+            self.run_smart_contract(engine, path, 'main', (1, 2, 3, 4), 3, 4, -1)
+
+        with self.assertRaises(TestExecutionException):
+            self.run_smart_contract(engine, path, 'main', (1, 2, 3, 4), 3, 0, -99)
+
+        tuple_ = (1, 2, 3, 4)
+        value = 3
+        start = 0
+        end = -1
+        result = self.run_smart_contract(engine, path, 'main', tuple_, value, start, end)
+        self.assertEqual(tuple_.index(value, start, end), result)
+
+        tuple_ = (1, 2, 3, 4)
+        value = 2
+        start = 0
+        end = 99
+        result = self.run_smart_contract(engine, path, 'main', tuple_, value, start, end)
+        self.assertEqual(tuple_.index(value, start, end), result)
+
+    def test_tuple_index_end_default(self):
+        path = self.get_contract_path('IndexTupleEndDefault.py')
+        engine = TestEngine()
+
+        tuple_ = (1, 2, 3, 4)
+        value = 3
+        start = 0
+        result = self.run_smart_contract(engine, path, 'main', tuple_, value, start)
+        self.assertEqual(tuple_.index(value, start), result)
+
+        with self.assertRaises(TestExecutionException):
+            self.run_smart_contract(engine, path, 'main', (1, 2, 3, 4), 2, 99)
+
+        with self.assertRaises(TestExecutionException):
+            self.run_smart_contract(engine, path, 'main', (1, 2, 3, 4), 4, -1)
+
+        tuple_ = (1, 2, 3, 4)
+        value = 2
+        start = -10
+        result = self.run_smart_contract(engine, path, 'main', tuple_, value, start)
+        self.assertEqual(tuple_.index(value, start), result)
+
+    def test_tuple_index_defaults(self):
+        path = self.get_contract_path('IndexTupleDefaults.py')
+        engine = TestEngine()
+
+        tuple_ = (1, 2, 3, 4)
+        value = 3
+        result = self.run_smart_contract(engine, path, 'main', tuple_, value)
+        self.assertEqual(tuple_.index(value), result)
+
+        tuple_ = (1, 2, 3, 4)
+        value = 1
+        result = self.run_smart_contract(engine, path, 'main', tuple_, value)
+        self.assertEqual(tuple_.index(value), result)


### PR DESCRIPTION
**Related issue**
#676 

**Summary or solution description**
Implemented `index(x, start, end)` for lists and tuples. 
The `index` method for str will be implemented in another issue, because Opcodes are different.
The `index` method for range will be implemented in another issue, because parameters are different.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/996211f17b40c0490b72d94e2d3e160e3623e72e/boa3_test/test_sc/list_test/IndexList.py#L1-L8

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/996211f17b40c0490b72d94e2d3e160e3623e72e/boa3_test/tests/compiler_tests/test_list.py#L1175-L1281

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8
