### PR TITLE
Support to Python 3.9 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,9 @@ executors:
   python38-executor:
     docker:
       - image: circleci/python:3.8.0
+  python39-executor:
+    docker:
+      - image: circleci/python:3.9.0
 
 orbs:
   python: circleci/python@0.2.1
@@ -35,16 +38,17 @@ jobs:
             sudo apt update && \
               sudo apt-get install -y dotnet-sdk-5.0
 
-            git clone https://github.com/simplitech/neo-devpack-dotnet.git -b test-engine-executable --single-branch
-            cd ./neo-devpack-dotnet
-            git checkout c2dbad469d8f919c9058f2a148eee2b9efb2300f
-            cd ..
+            git clone https://github.com/simplitech/neo-devpack-dotnet.git -b v3.0.3
             dotnet build ./neo-devpack-dotnet/src/Neo.TestEngine/Neo.TestEngine.csproj -o ./Neo.TestEngine
             python -m unittest discover boa3_test
 
   unit-test-38:
     <<: *unit-test
     executor: python38-executor
+
+  unit-test-39:
+    <<: *unit-test
+    executor: python39-executor
 
   build_deploy: &build_deploy
     working_directory: ~/neo3-boa
@@ -121,11 +125,16 @@ workflows:
          filters:
            tags:
              only: /.*/
+      - unit-test-39:
+         filters:
+           tags:
+             only: /.*/
       - build_deploy_test:
          context: pypi_test
          requires:
            - unit-test-37
            - unit-test-38
+           - unit-test-39
          filters:
            tags:
              only: /^v.*/

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Clone neo-devpack-dotnet project and compile the TestEngine.
 > Note: Until [neo-devpack-dotnet#365](https://github.com/neo-project/neo-devpack-dotnet/pull/365) is approved by Neo, you need to clone neo-devpack-dotnet from [simplitech:test-engine-executable](https://github.com/simplitech/neo-devpack-dotnet/tree/test-engine-executable) branch 
 
 ```shell
-$ git clone https://github.com/simplitech/neo-devpack-dotnet.git -b v3.0.2
+$ git clone https://github.com/simplitech/neo-devpack-dotnet.git -b v3.0.3
 $ dotnet build ./neo-devpack-dotnet/src/Neo.TestEngine/Neo.TestEngine.csproj
 ```
 

--- a/boa3/compiler/codegenerator/codegeneratorvisitor.py
+++ b/boa3/compiler/codegenerator/codegeneratorvisitor.py
@@ -413,7 +413,7 @@ class VisitorCodeGenerator(IAstAnalyser):
             # set item
             var_data = self.visit(subscript.value)
 
-            index = subscript.slice.value
+            index = subscript.slice.value if isinstance(subscript.slice, ast.Index) else subscript.slice
             symbol_id = var_data.symbol_id
             value_type = var_data.type
 

--- a/boa3/compiler/compiler.py
+++ b/boa3/compiler/compiler.py
@@ -1,6 +1,7 @@
 import logging
 import os
 
+from boa3 import constants
 from boa3.analyser.analyser import Analyser
 from boa3.compiler.codegenerator.codegenerator import CodeGenerator
 from boa3.compiler.filegenerator import FileGenerator
@@ -30,7 +31,8 @@ class Compiler:
         fullpath = os.path.realpath(path)
         filepath, filename = os.path.split(fullpath)
 
-        logging.info('Started compiling\t{0}'.format(filename))
+        logging.info(f'neo3-boa v{constants.BOA_VERSION}\tPython {constants.SYS_VERSION}')
+        logging.info(f'Started compiling\t{filename}')
         self._entry_smart_contract = os.path.splitext(filename)[0]
         self._analyse(fullpath, log)
         return self._compile()

--- a/boa3/constants.py
+++ b/boa3/constants.py
@@ -1,8 +1,12 @@
+import platform
 import sys
 
+from boa3 import __version__ as boa_version
 from boa3.neo import from_hex_str
 
 SYS_VERSION_INFO = sys.version_info
+SYS_VERSION = platform.python_version()
+BOA_VERSION = boa_version
 
 ONE_BYTE_MAX_VALUE = 255
 TWO_BYTES_MAX_VALUE = 256 ** 2 - 1

--- a/boa3/model/builtin/classmethod/copydictmethod.py
+++ b/boa3/model/builtin/classmethod/copydictmethod.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Tuple
+from typing import List, Optional, Tuple
 
 from boa3.model.builtin.classmethod.copymethod import CopyMethod
 from boa3.model.type.itype import IType

--- a/boa3/model/builtin/classmethod/indexmethod.py
+++ b/boa3/model/builtin/classmethod/indexmethod.py
@@ -1,8 +1,6 @@
 import ast
 from typing import Any, Dict, List, Optional
 
-from boa3.model.type.itype import IType
-
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.variable import Variable
 

--- a/boa3_test/test_sc/class_test/UserClassWithPropertyUsingInstanceVariablesFromObject.py
+++ b/boa3_test/test_sc/class_test/UserClassWithPropertyUsingInstanceVariablesFromObject.py
@@ -9,6 +9,7 @@ class Example:
     def some_property(self) -> int:
         return self._ivar
 
+
 @public
 def get_property() -> int:
     return Example().some_property

--- a/boa3_test/test_sc/dict_test/DictCopy.py
+++ b/boa3_test/test_sc/dict_test/DictCopy.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, List
+
 from boa3.builtin import public
 
 

--- a/boa3_test/test_sc/dict_test/DictPop.py
+++ b/boa3_test/test_sc/dict_test/DictPop.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, Tuple
+from typing import Any, Dict, Tuple
 
 from boa3.builtin import public
 

--- a/boa3_test/test_sc/list_test/Copy.py
+++ b/boa3_test/test_sc/list_test/Copy.py
@@ -1,4 +1,5 @@
 from typing import Any, List
+
 from boa3.builtin import public
 
 

--- a/boa3_test/test_sc/list_test/CopyBool.py
+++ b/boa3_test/test_sc/list_test/CopyBool.py
@@ -1,4 +1,5 @@
 from typing import List
+
 from boa3.builtin import public
 
 

--- a/boa3_test/test_sc/list_test/CopyBytes.py
+++ b/boa3_test/test_sc/list_test/CopyBytes.py
@@ -1,4 +1,5 @@
 from typing import List
+
 from boa3.builtin import public
 
 

--- a/boa3_test/test_sc/list_test/CopyInt.py
+++ b/boa3_test/test_sc/list_test/CopyInt.py
@@ -1,4 +1,5 @@
 from typing import List
+
 from boa3.builtin import public
 
 

--- a/boa3_test/test_sc/list_test/CopyStr.py
+++ b/boa3_test/test_sc/list_test/CopyStr.py
@@ -1,4 +1,5 @@
 from typing import List
+
 from boa3.builtin import public
 
 

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -120,7 +120,7 @@ Clone neo-devpack-dotnet project and compile the TestEngine.
 
 ::
     
-    $ git clone https://github.com/simplitech/neo-devpack-dotnet.git -b v3.0.2
+    $ git clone https://github.com/simplitech/neo-devpack-dotnet.git -b v3.0.3
     $ dotnet build ./neo-devpack-dotnet/src/Neo.TestEngine/Neo.TestEngine.csproj
 
 


### PR DESCRIPTION
**Related issue**
#697

**Summary or solution description**
Fixed issues that happened when running boa with Python 3.9.0 and included running the unit tests with Python 3.9.0 in the CircleCI workflow. Also included the current Python and Boa versions in the log for better validation.

**How to Reproduce**
Run the unit tests using Python 3.9.0

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.9.0