### PR TITLE
Change native types implementation to work with classes

### DIFF
--- a/boa3/analyser/astanalyser.py
+++ b/boa3/analyser/astanalyser.py
@@ -161,6 +161,15 @@ class IAstAnalyser(ABC, ast.NodeVisitor):
                 return True
         return False
 
+    def is_implemented_class_type(self, symbol) -> bool:
+        if not isinstance(symbol, ClassType):
+            return False
+
+        from boa3.model.type.classes.pythonclass import PythonClass
+        from boa3.model.builtin.interop.interopinterfacetype import InteropInterfaceType
+
+        return not isinstance(symbol, PythonClass) or isinstance(symbol, InteropInterfaceType)
+
     def parse_to_node(self, expression: str, origin: ast.AST = None) -> Union[ast.AST, Sequence[ast.AST]]:
         """
         Parses an expression to an ast.

--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -1458,7 +1458,7 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
 
         attr_type = value.type if isinstance(value, IExpression) else value
         # for checking during the code generation
-        if (isinstance(attr_type, ClassType) and
+        if (self.is_implemented_class_type(attr_type) and
                 not (isinstance(attribute.value, ast.Name) and attribute.value.id == attr_type.identifier) and
                 (not hasattr(attribute, 'generate_value') or not attribute.generate_value)):
             attribute.generate_value = True

--- a/boa3/model/builtin/classmethod/appendmethod.py
+++ b/boa3/model/builtin/classmethod/appendmethod.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Sized, Tuple
 
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.expression import IExpression
@@ -68,7 +68,9 @@ class AppendMethod(IBuiltinMethod):
         return None
 
     def build(self, value: Any) -> IBuiltinMethod:
-        if type(value) == type(self.args['self'].type):
+        if isinstance(value, Sized) and len(value) > 0:
+            value = value[0]
+        if value == self.args['self'].type:
             return self
         if isinstance(value, MutableSequenceType):
             return AppendMethod(value)

--- a/boa3/model/builtin/interop/contract/callflagstype.py
+++ b/boa3/model/builtin/interop/contract/callflagstype.py
@@ -39,7 +39,10 @@ class CallFlagsType(IntType):
         from boa3.builtin.interop.contract import CallFlags
         from boa3.model.variable import Variable
 
-        return {name: Variable(self) for name in CallFlags.__members__.keys()}
+        _symbols = super().symbols
+        _symbols.update({name: Variable(self) for name in CallFlags.__members__.keys()})
+
+        return _symbols
 
     def get_value(self, symbol_id) -> Any:
         """
@@ -47,8 +50,9 @@ class CallFlagsType(IntType):
 
         :return: the value if this type has this symbol. None otherwise.
         """
-        if symbol_id in self.symbols:
-            from boa3.builtin.interop.contract import CallFlags
+        from boa3.builtin.interop.contract import CallFlags
+
+        if symbol_id in self.symbols and symbol_id in CallFlags.__members__:
             return CallFlags.__members__[symbol_id]
 
         return None

--- a/boa3/model/builtin/interop/contract/contractmanifest/contractparametertype.py
+++ b/boa3/model/builtin/interop/contract/contractmanifest/contractparametertype.py
@@ -39,7 +39,10 @@ class ContractParameterType(IntType):
         from boa3.neo.vm.type.ContractParameterType import ContractParameterType as ContractParameter
         from boa3.model.variable import Variable
 
-        return {name: Variable(self) for name in ContractParameter.__members__.keys()}
+        _symbols = super().symbols
+        _symbols.update({name: Variable(self) for name in ContractParameter.__members__.keys()})
+
+        return _symbols
 
     def get_value(self, symbol_id) -> Any:
         """
@@ -47,8 +50,9 @@ class ContractParameterType(IntType):
 
         :return: the value if this type has this symbol. None otherwise.
         """
-        if symbol_id in self.symbols:
-            from boa3.neo.vm.type.ContractParameterType import ContractParameterType as ContractParameter
+        from boa3.neo.vm.type.ContractParameterType import ContractParameterType as ContractParameter
+
+        if symbol_id in self.symbols and symbol_id in ContractParameter.__members__:
             return ContractParameter.__members__[symbol_id]
 
         return None

--- a/boa3/model/builtin/interop/crypto/namedcurvetype.py
+++ b/boa3/model/builtin/interop/crypto/namedcurvetype.py
@@ -34,7 +34,10 @@ class NamedCurveType(IntType):
         from boa3.builtin.interop.crypto import NamedCurve
         from boa3.model.variable import Variable
 
-        return {name: Variable(self) for name in NamedCurve.__members__.keys()}
+        _symbols = super().symbols
+        _symbols.update({name: Variable(self) for name in NamedCurve.__members__.keys()})
+
+        return _symbols
 
     def get_value(self, symbol_id) -> Any:
         """
@@ -42,8 +45,9 @@ class NamedCurveType(IntType):
 
         :return: the value if this type has this symbol. None otherwise.
         """
-        if symbol_id in self.symbols:
-            from boa3.builtin.interop.crypto import NamedCurve
+        from boa3.builtin.interop.crypto import NamedCurve
+
+        if symbol_id in self.symbols and symbol_id in NamedCurve.__members__:
             return NamedCurve.__members__[symbol_id]
 
         return None

--- a/boa3/model/builtin/interop/iterator/iteratortype.py
+++ b/boa3/model/builtin/interop/iterator/iteratortype.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any, List, Optional, Tuple
 
 from boa3.model.builtin.interop.interopinterfacetype import InteropInterfaceType
 from boa3.model.method import Method
-from boa3.model.property import Property
 from boa3.model.type.collection.icollection import ICollectionType
 from boa3.model.type.itype import IType
-from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
 
 
 class IteratorType(InteropInterfaceType, ICollectionType):
@@ -35,42 +34,6 @@ class IteratorType(InteropInterfaceType, ICollectionType):
     def identifier(self) -> str:
         return '{0}[{1}, {2}]'.format(self._identifier, self.valid_key.identifier, self.item_type.identifier)
 
-    @property
-    def class_variables(self) -> Dict[str, Variable]:
-        return {}
-
-    @property
-    def instance_variables(self) -> Dict[str, Variable]:
-        return {}
-
-    @property
-    def properties(self) -> Dict[str, Property]:
-        if self._properties is None:
-            from boa3.model.builtin.interop.iterator.getiteratorvalue import IteratorValueProperty
-            self._properties = {
-                'value': IteratorValueProperty(self)
-            }
-
-        return self._properties.copy()
-
-    @property
-    def static_methods(self) -> Dict[str, Method]:
-        return {}
-
-    @property
-    def class_methods(self) -> Dict[str, Method]:
-        return {}
-
-    @property
-    def instance_methods(self) -> Dict[str, Method]:
-        if self._methods is None:
-            from boa3.model.builtin.interop.iterator.iteratornextmethod import IteratorNextMethod
-
-            self._methods = {
-                'next': IteratorNextMethod()
-            }
-        return self._methods.copy()
-
     def constructor_method(self) -> Optional[Method]:
         return self._constructor
 
@@ -95,6 +58,20 @@ class IteratorType(InteropInterfaceType, ICollectionType):
     @classmethod
     def _is_type_of(cls, value: Any):
         return isinstance(value, IteratorType)
+
+    def _init_class_symbols(self):
+        super()._init_class_symbols()
+
+        from boa3.model.builtin.interop.iterator.iteratornextmethod import IteratorNextMethod
+        from boa3.model.builtin.interop.iterator.getiteratorvalue import IteratorValueProperty
+
+        self._instance_methods['next'] = IteratorNextMethod()
+
+        self._properties['value'] = IteratorValueProperty(self)
+
+    def is_instance_opcodes(self) -> List[Tuple[Opcode, bytes]]:
+        from boa3.model.type.classes.pythonclass import PythonClass
+        return super(PythonClass, self).is_instance_opcodes()
 
     def __eq__(self, other) -> bool:
         if not isinstance(other, IteratorType):

--- a/boa3/model/builtin/interop/oracle/oracleresponsecodetype.py
+++ b/boa3/model/builtin/interop/oracle/oracleresponsecodetype.py
@@ -34,7 +34,10 @@ class OracleResponseCodeType(IntType):
         from boa3.builtin.interop.role.roletype import Role
         from boa3.model.variable import Variable
 
-        return {name: Variable(self) for name in Role.__members__.keys()}
+        _symbols = super().symbols
+        _symbols.update({name: Variable(self) for name in Role.__members__.keys()})
+
+        return _symbols
 
     def get_value(self, symbol_id) -> Any:
         """
@@ -42,8 +45,9 @@ class OracleResponseCodeType(IntType):
 
         :return: the value if this type has this symbol. None otherwise
         """
-        if symbol_id in self.symbols:
-            from boa3.builtin.interop.oracle.oracleresponsecode import OracleResponseCode
+        from boa3.builtin.interop.oracle.oracleresponsecode import OracleResponseCode
+
+        if symbol_id in self.symbols and symbol_id in OracleResponseCode.__members__:
             return OracleResponseCode.__members__[symbol_id]
 
         return None

--- a/boa3/model/builtin/interop/role/roletype.py
+++ b/boa3/model/builtin/interop/role/roletype.py
@@ -34,7 +34,10 @@ class RoleType(IntType):
         from boa3.builtin.interop.role.roletype import Role
         from boa3.model.variable import Variable
 
-        return {name: Variable(self) for name in Role.__members__.keys()}
+        _symbols = super().symbols
+        _symbols.update({name: Variable(self) for name in Role.__members__.keys()})
+
+        return _symbols
 
     def get_value(self, symbol_id) -> Any:
         """
@@ -42,8 +45,9 @@ class RoleType(IntType):
 
         :return: the value if this type has this symbol. None otherwise
         """
-        if symbol_id in self.symbols:
-            from boa3.builtin.interop.role.roletype import Role
+        from boa3.builtin.interop.role.roletype import Role
+
+        if symbol_id in self.symbols and symbol_id in Role.__members__:
             return Role.__members__[symbol_id]
 
         return None

--- a/boa3/model/builtin/interop/runtime/triggertype.py
+++ b/boa3/model/builtin/interop/runtime/triggertype.py
@@ -40,7 +40,10 @@ class TriggerType(IntType):
         from boa3.builtin.interop.runtime import TriggerType as Trigger
         from boa3.model.variable import Variable
 
-        return {name: Variable(self) for name in Trigger.__members__.keys()}
+        _symbols = super().symbols
+        _symbols.update({name: Variable(self) for name in Trigger.__members__.keys()})
+
+        return _symbols
 
     def get_value(self, symbol_id) -> Any:
         """

--- a/boa3/model/builtin/interop/storage/findoptionstype.py
+++ b/boa3/model/builtin/interop/storage/findoptionstype.py
@@ -40,7 +40,10 @@ class FindOptionsType(IntType):
         from boa3.builtin.interop.storage import FindOptions
         from boa3.model.variable import Variable
 
-        return {name: Variable(self) for name in FindOptions.__members__.keys()}
+        _symbols = super().symbols
+        _symbols.update({name: Variable(self) for name in FindOptions.__members__.keys()})
+
+        return _symbols
 
     def get_value(self, symbol_id) -> Any:
         """
@@ -48,8 +51,9 @@ class FindOptionsType(IntType):
 
         :return: the value if this type has this symbol. None otherwise.
         """
-        if symbol_id in self.symbols:
-            from boa3.builtin.interop.storage import FindOptions
+        from boa3.builtin.interop.storage import FindOptions
+
+        if symbol_id in self.symbols and symbol_id in FindOptions.__members__:
             return FindOptions.__members__[symbol_id]
 
         return None

--- a/boa3/model/builtin/method/isinstancemethod.py
+++ b/boa3/model/builtin/method/isinstancemethod.py
@@ -96,7 +96,8 @@ class IsInstanceMethod(IBuiltinMethod):
             jmps = []
             for check_instance in types[:-1]:
                 opcodes.append((Opcode.DUP, b''))
-                opcodes.extend(check_instance.is_instance_opcodes())
+                is_instance_opcodes = check_instance.is_instance_opcodes()
+                opcodes.extend(is_instance_opcodes)
 
                 jmps.append(len(opcodes))
                 opcodes.append((Opcode.JMPIF, b''))

--- a/boa3/model/type/classes/classtype.py
+++ b/boa3/model/type/classes/classtype.py
@@ -1,12 +1,9 @@
 from abc import ABC, abstractmethod
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Tuple
 
 from boa3.compiler.codegenerator import get_bytes_count
-from boa3.model.method import Method
-from boa3.model.property import Property
 from boa3.model.symbol import ISymbol
 from boa3.model.type.itype import IType
-from boa3.model.variable import Variable
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.AbiType import AbiType
 from boa3.neo.vm.type.Integer import Integer
@@ -23,48 +20,74 @@ class ClassType(IType, ABC):
 
     @property
     @abstractmethod
-    def class_variables(self) -> Dict[str, Variable]:
+    def class_variables(self):
+        """
+        :rtype: Dict[str, boa3.model.variable.Variable]
+        """
         return {}
 
     @property
     @abstractmethod
-    def instance_variables(self) -> Dict[str, Variable]:
+    def instance_variables(self):
+        """
+        :rtype: Dict[str, boa3.model.variable.Variable]
+        """
         return {}
 
     @property
-    def variables(self) -> Dict[str, Variable]:
+    def variables(self):
+        """
+        :rtype: Dict[str, boa3.model.variable.Variable]
+        """
         variables = self.class_variables.copy()
         variables.update(self.instance_variables)
         return variables
 
     @property
-    def _all_variables(self) -> Dict[str, Variable]:
+    def _all_variables(self):
+        """
+        :rtype: Dict[str, boa3.model.variable.Variable]
+        """
         return self.variables
 
     @property
     @abstractmethod
-    def properties(self) -> Dict[str, Property]:
+    def properties(self):
+        """
+        :rtype: Dict[str, boa3.model.property.Property]
+        """
         return {}
 
     @property
     @abstractmethod
-    def static_methods(self) -> Dict[str, Method]:
+    def static_methods(self):
+        """
+        :rtype: Dict[str, boa3.model.method.Method]
+        """
         return {}
 
     @property
     @abstractmethod
-    def class_methods(self) -> Dict[str, Method]:
+    def class_methods(self):
+        """
+        :rtype: Dict[str, boa3.model.method.Method]
+        """
         return {}
 
     @property
     @abstractmethod
-    def instance_methods(self) -> Dict[str, Method]:
+    def instance_methods(self):
+        """
+        :rtype: Dict[str, boa3.model.method.Method]
+        """
         return {}
 
     @abstractmethod
-    def constructor_method(self) -> Optional[Method]:
+    def constructor_method(self):
         """
         If the class constructor is None, it mustn't allow instantiation of this class
+
+        :rtype: boa3.model.method.Method or None
         """
         pass
 

--- a/boa3/model/type/classes/pythonclass.py
+++ b/boa3/model/type/classes/pythonclass.py
@@ -1,0 +1,121 @@
+import abc
+from typing import List, Tuple
+
+from boa3 import constants
+from boa3.model.type.classes import classtype
+from boa3.neo.vm.opcode.Opcode import Opcode
+from boa3.neo.vm.type.AbiType import AbiType
+from boa3.neo.vm.type.StackItem import StackItemType
+
+
+class PythonClass(classtype.ClassType, abc.ABC):
+
+    def __init__(self, identifier: str,
+                 instance_variables: dict = None,
+                 instance_methods: dict = None,
+                 properties: dict = None,
+                 class_variables: dict = None,
+                 class_methods: dict = None,
+                 static_methods: dict = None):
+
+        self._instance_methods = instance_methods if isinstance(instance_methods, dict) else None
+        self._instance_variables = instance_variables if isinstance(instance_variables, dict) else None
+        self._properties = properties if isinstance(properties, dict) else None
+        self._class_variables = class_variables if isinstance(class_variables, dict) else None
+        self._class_methods = class_methods if isinstance(class_methods, dict) else None
+        self._static_methods = static_methods if isinstance(static_methods, dict) else None
+
+        is_init_defined = isinstance(instance_methods, dict) and constants.INIT_METHOD_ID in instance_methods
+        self._is_init_set = is_init_defined
+        self._constructor = (instance_methods[constants.INIT_METHOD_ID]
+                             if is_init_defined
+                             else None)
+
+        super().__init__(identifier)
+
+    def _init_class_symbols(self):
+        """
+        Overwrite this method to set variables and methods from this type.
+        Always call super()._init_class_symbols in the beginning
+        Used to avoid circular imports between the init classes
+        """
+        # TODO: May be removed when class inheritance is implemented
+        if not isinstance(self._instance_methods, dict):
+            self._instance_methods = {}
+        if not isinstance(self._instance_variables, dict):
+            self._instance_variables = {}
+        if not isinstance(self._properties, dict):
+            self._properties = {}
+        if not isinstance(self._class_variables, dict):
+            self._class_variables = {}
+        if not isinstance(self._class_methods, dict):
+            self._class_methods = {}
+        if not isinstance(self._static_methods, dict):
+            self._static_methods = {}
+
+    @property
+    def class_variables(self):
+        if not isinstance(self._class_variables, dict):
+            self._init_class_symbols()
+        return self._class_variables.copy()
+
+    @property
+    def instance_variables(self):
+        if not isinstance(self._instance_variables, dict):
+            self._init_class_symbols()
+        return self._instance_variables.copy()
+
+    @property
+    def properties(self):
+        if not isinstance(self._properties, dict):
+            self._init_class_symbols()
+        return self._properties.copy()
+
+    @property
+    def static_methods(self):
+        if not isinstance(self._static_methods, dict):
+            self._init_class_symbols()
+        return self._static_methods.copy()
+
+    @property
+    def class_methods(self):
+        if not isinstance(self._class_methods, dict):
+            self._init_class_symbols()
+        return self._class_methods.copy()
+
+    @property
+    def instance_methods(self):
+        if not isinstance(self._instance_methods, dict):
+            self._init_class_symbols()
+        return self._instance_methods.copy()
+
+    def constructor_method(self):
+        if not isinstance(self._instance_variables, dict):
+            self._init_class_symbols()
+        if not self._is_init_set:
+            self._constructor = (self._instance_methods[constants.INIT_METHOD_ID]
+                                 if constants.INIT_METHOD_ID in self._instance_methods
+                                 else None)
+            self._is_init_set = True
+        return self._constructor
+
+    @property
+    def abi_type(self) -> AbiType:
+        return super().abi_type
+
+    @property
+    def stack_item(self) -> StackItemType:
+        """
+        Get the Neo VM stack item type representation for this type
+
+        :return: the stack item type of this type. Any by default.
+        """
+        return super().stack_item
+
+    def is_instance_opcodes(self) -> List[Tuple[Opcode, bytes]]:
+        """
+        Get the list of opcodes to check if an value is of this type
+
+        :return: A list of opcodes to check a value type
+        """
+        return [(Opcode.ISTYPE, self.stack_item)]

--- a/boa3/model/type/collection/icollection.py
+++ b/boa3/model/type/collection/icollection.py
@@ -4,11 +4,12 @@ from abc import ABC, abstractmethod
 from typing import Any, Iterable, Set, Union
 
 from boa3.model.type.annotation.uniontype import UnionType
+from boa3.model.type.classes.pythonclass import PythonClass
 from boa3.model.type.itype import IType
 from boa3.model.type.primitive.primitivetype import PrimitiveType
 
 
-class ICollectionType(IType, ABC):
+class ICollectionType(PythonClass, ABC):
     """
     An interface used to represent Python mapping type
     """

--- a/boa3/model/type/collection/mapping/mutable/dicttype.py
+++ b/boa3/model/type/collection/mapping/mutable/dicttype.py
@@ -23,5 +23,18 @@ class DictType(MutableMappingType):
     def _is_type_of(cls, value: Any):
         return type(value) in [dict, DictType]
 
+    def _init_class_symbols(self):
+        super()._init_class_symbols()
+
+        from boa3.model.builtin.builtin import Builtin
+
+        instance_methods = [Builtin.DictKeys,
+                            Builtin.DictValues,
+                            Builtin.DictPop,
+                            ]
+
+        for instance_method in instance_methods:
+            self._instance_methods[instance_method.raw_identifier] = instance_method.build(self)
+
     def __hash__(self):
         return hash(self.identifier)

--- a/boa3/model/type/collection/sequence/ecpointtype.py
+++ b/boa3/model/type/collection/sequence/ecpointtype.py
@@ -1,16 +1,13 @@
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
 from boa3.model.method import Method
-from boa3.model.property import Property
-from boa3.model.type.classes.classtype import ClassType
 from boa3.model.type.itype import IType
 from boa3.model.type.primitive.bytestype import BytesType
-from boa3.model.variable import Variable
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.AbiType import AbiType
 
 
-class ECPointType(BytesType, ClassType):
+class ECPointType(BytesType):
     """
     A class used to represent Neo's UInt160 type
     """
@@ -29,30 +26,6 @@ class ECPointType(BytesType, ClassType):
     def abi_type(self) -> AbiType:
         return AbiType.PublicKey
 
-    @property
-    def instance_variables(self) -> Dict[str, Variable]:
-        return {}
-
-    @property
-    def class_variables(self) -> Dict[str, Variable]:
-        return {}
-
-    @property
-    def properties(self) -> Dict[str, Property]:
-        return {}
-
-    @property
-    def static_methods(self) -> Dict[str, Method]:
-        return {}
-
-    @property
-    def class_methods(self) -> Dict[str, Method]:
-        return {}
-
-    @property
-    def instance_methods(self) -> Dict[str, Method]:
-        return {}
-
     def constructor_method(self) -> Optional[Method]:
         return self._constructor
 
@@ -67,6 +40,10 @@ class ECPointType(BytesType, ClassType):
     @classmethod
     def _is_type_of(cls, value: Any):
         return isinstance(value, ECPointType)
+
+    def is_instance_opcodes(self) -> List[Tuple[Opcode, bytes]]:
+        from boa3.model.type.classes.pythonclass import PythonClass
+        return super(PythonClass, self).is_instance_opcodes()
 
     def _is_instance_inner_opcodes(self, jmp_to_if_false: int = 0) -> List[Tuple[Opcode, bytes]]:
         push_int_opcode, size_data = Opcode.get_push_and_data(33)

--- a/boa3/model/type/collection/sequence/mutable/mutablesequencetype.py
+++ b/boa3/model/type/collection/sequence/mutable/mutablesequencetype.py
@@ -13,6 +13,22 @@ class MutableSequenceType(SequenceType, ABC):
     def __init__(self, identifier: str, values_type: Set[IType]):
         super().__init__(identifier, values_type)
 
+    def _init_class_symbols(self):
+        super()._init_class_symbols()
+
+        from boa3.model.builtin.builtin import Builtin
+
+        instance_methods = [Builtin.SequenceAppend,
+                            Builtin.SequenceClear,
+                            Builtin.SequenceInsert,
+                            Builtin.SequenceExtend,
+                            Builtin.SequenceReverse,
+                            Builtin.SequenceRemove,
+                            ]
+
+        for instance_method in instance_methods:
+            self._instance_methods[instance_method.raw_identifier] = instance_method.build(self)
+
     def is_type_of(self, value: Any) -> bool:
         if self._is_type_of(value):
             if isinstance(value, MutableSequenceType):

--- a/boa3/model/type/collection/sequence/uint160type.py
+++ b/boa3/model/type/collection/sequence/uint160type.py
@@ -1,17 +1,13 @@
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
 from boa3.model.method import Method
-from boa3.model.property import Property
-from boa3.model.type.classes.classtype import ClassType
 from boa3.model.type.itype import IType
 from boa3.model.type.primitive.bytestype import BytesType
-from boa3.model.variable import Variable
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.AbiType import AbiType
-from boa3.neo.vm.type.StackItem import StackItemType
 
 
-class UInt160Type(BytesType, ClassType):
+class UInt160Type(BytesType):
     """
     A class used to represent Neo's UInt160 type
     """
@@ -30,34 +26,6 @@ class UInt160Type(BytesType, ClassType):
     def abi_type(self) -> AbiType:
         return AbiType.Hash160
 
-    @property
-    def stack_item(self) -> StackItemType:
-        return StackItemType.ByteString
-
-    @property
-    def instance_variables(self) -> Dict[str, Variable]:
-        return {}
-
-    @property
-    def class_variables(self) -> Dict[str, Variable]:
-        return {}
-
-    @property
-    def properties(self) -> Dict[str, Property]:
-        return {}
-
-    @property
-    def static_methods(self) -> Dict[str, Method]:
-        return {}
-
-    @property
-    def class_methods(self) -> Dict[str, Method]:
-        return {}
-
-    @property
-    def instance_methods(self) -> Dict[str, Method]:
-        return {}
-
     def constructor_method(self) -> Optional[Method]:
         return self._constructor
 
@@ -72,6 +40,10 @@ class UInt160Type(BytesType, ClassType):
     @classmethod
     def _is_type_of(cls, value: Any):
         return isinstance(value, UInt160Type)
+
+    def is_instance_opcodes(self) -> List[Tuple[Opcode, bytes]]:
+        from boa3.model.type.classes.pythonclass import PythonClass
+        return super(PythonClass, self).is_instance_opcodes()
 
     def _is_instance_inner_opcodes(self, jmp_to_if_false: int = 0) -> List[Tuple[Opcode, bytes]]:
         push_int_opcode, size_data = Opcode.get_push_and_data(20)

--- a/boa3/model/type/collection/sequence/uint256type.py
+++ b/boa3/model/type/collection/sequence/uint256type.py
@@ -1,14 +1,11 @@
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
 from boa3.model.method import Method
-from boa3.model.property import Property
 from boa3.model.type.classes.classtype import ClassType
 from boa3.model.type.itype import IType
 from boa3.model.type.primitive.bytestype import BytesType
-from boa3.model.variable import Variable
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.AbiType import AbiType
-from boa3.neo.vm.type.StackItem import StackItemType
 
 
 class UInt256Type(BytesType, ClassType):
@@ -30,34 +27,6 @@ class UInt256Type(BytesType, ClassType):
     def abi_type(self) -> AbiType:
         return AbiType.Hash256
 
-    @property
-    def stack_item(self) -> StackItemType:
-        return StackItemType.ByteString
-
-    @property
-    def instance_variables(self) -> Dict[str, Variable]:
-        return {}
-
-    @property
-    def class_variables(self) -> Dict[str, Variable]:
-        return {}
-
-    @property
-    def properties(self) -> Dict[str, Property]:
-        return {}
-
-    @property
-    def static_methods(self) -> Dict[str, Method]:
-        return {}
-
-    @property
-    def class_methods(self) -> Dict[str, Method]:
-        return {}
-
-    @property
-    def instance_methods(self) -> Dict[str, Method]:
-        return {}
-
     def constructor_method(self) -> Optional[Method]:
         return self._constructor
 
@@ -72,6 +41,10 @@ class UInt256Type(BytesType, ClassType):
     @classmethod
     def _is_type_of(cls, value: Any):
         return isinstance(value, UInt256Type)
+
+    def is_instance_opcodes(self) -> List[Tuple[Opcode, bytes]]:
+        from boa3.model.type.classes.pythonclass import PythonClass
+        return super(PythonClass, self).is_instance_opcodes()
 
     def _is_instance_inner_opcodes(self, jmp_to_if_false: int = 0) -> List[Tuple[Opcode, bytes]]:
         push_int_opcode, size_data = Opcode.get_push_and_data(32)

--- a/boa3/model/type/primitive/bytestringtype.py
+++ b/boa3/model/type/primitive/bytestringtype.py
@@ -1,0 +1,49 @@
+import abc
+from typing import List
+
+from boa3.model.type.collection.sequence.sequencetype import SequenceType
+from boa3.model.type.itype import IType
+from boa3.model.type.primitive.primitivetype import PrimitiveType
+from boa3.neo.vm.type.StackItem import StackItemType
+
+
+class ByteStringType(SequenceType, PrimitiveType, abc.ABC):
+    """
+    A class used to represent Neo ByteString type
+    """
+
+    def __init__(self, identifier: str, values_type: List[IType]):
+        super().__init__(identifier, values_type)
+
+    @property
+    def identifier(self) -> str:
+        return self._identifier
+
+    @property
+    def stack_item(self) -> StackItemType:
+        return StackItemType.ByteString
+
+    def _init_class_symbols(self):
+        super()._init_class_symbols()
+
+        from boa3.model.builtin.builtin import Builtin
+
+        bytestring_instance_methods = [Builtin.BytesStringLower,
+                                       Builtin.BytesStringUpper,
+                                       Builtin.BytesStringStartswith,
+                                       ]
+
+        for instance_method in bytestring_instance_methods:
+            self._instance_methods[instance_method.raw_identifier] = instance_method.build(self)
+
+    def is_valid_key(self, key_type: IType) -> bool:
+        return key_type == self.valid_key
+
+    @property
+    def valid_key(self) -> IType:
+        from boa3.model.type.type import Type
+        return Type.int
+
+    @property
+    def can_reassign_values(self) -> bool:
+        return False

--- a/boa3/model/type/primitive/bytestype.py
+++ b/boa3/model/type/primitive/bytestype.py
@@ -1,13 +1,11 @@
 from typing import Any
 
-from boa3.model.type.collection.sequence.sequencetype import SequenceType
 from boa3.model.type.itype import IType
-from boa3.model.type.primitive.primitivetype import PrimitiveType
+from boa3.model.type.primitive.bytestringtype import ByteStringType
 from boa3.neo.vm.type.AbiType import AbiType
-from boa3.neo.vm.type.StackItem import StackItemType
 
 
-class BytesType(SequenceType, PrimitiveType):
+class BytesType(ByteStringType):
     """
     A class used to represent Python bytes type
     """
@@ -19,28 +17,12 @@ class BytesType(SequenceType, PrimitiveType):
         super().__init__(identifier, values_type)
 
     @property
-    def identifier(self) -> str:
-        return self._identifier
-
-    @property
     def abi_type(self) -> AbiType:
         return AbiType.ByteArray
 
     @property
-    def stack_item(self) -> StackItemType:
-        return StackItemType.ByteString
-
-    @property
     def default_value(self) -> Any:
         return bytes()
-
-    def is_valid_key(self, key_type: IType) -> bool:
-        return key_type == self.valid_key
-
-    @property
-    def valid_key(self) -> IType:
-        from boa3.model.type.type import Type
-        return Type.int
 
     @classmethod
     def build(cls, value: Any) -> IType:
@@ -55,6 +37,15 @@ class BytesType(SequenceType, PrimitiveType):
     def _is_type_of(cls, value: Any):
         return type(value) is bytes or isinstance(value, BytesType)
 
-    @property
-    def can_reassign_values(self) -> bool:
-        return False
+    def _init_class_symbols(self):
+        super()._init_class_symbols()
+
+        from boa3.model.builtin.builtin import Builtin
+
+        instance_methods = [Builtin.ConvertToBool,
+                            Builtin.ConvertToInt,
+                            Builtin.ConvertToStr,
+                            ]
+
+        for instance_method in instance_methods:
+            self._instance_methods[instance_method.raw_identifier] = instance_method.build(self)

--- a/boa3/model/type/primitive/inttype.py
+++ b/boa3/model/type/primitive/inttype.py
@@ -27,6 +27,17 @@ class IntType(PrimitiveType):
     def stack_item(self) -> StackItemType:
         return StackItemType.Integer
 
+    def _init_class_symbols(self):
+        super()._init_class_symbols()
+
+        from boa3.model.builtin.builtin import Builtin
+
+        instance_methods = [Builtin.ConvertToBytes
+                            ]
+
+        for instance_method in instance_methods:
+            self._instance_methods[instance_method.raw_identifier] = instance_method.build(self)
+
     @classmethod
     def build(cls, value: Any) -> IType:
         if cls._is_type_of(value):

--- a/boa3/model/type/primitive/nonetype.py
+++ b/boa3/model/type/primitive/nonetype.py
@@ -1,11 +1,12 @@
 from typing import Any, List, Tuple
 
+from boa3.model.type.classes.pythonclass import PythonClass
 from boa3.model.type.itype import IType
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.AbiType import AbiType
 
 
-class NoneType(IType):
+class NoneType(PythonClass):
     """
     A class used to represent Python None value
     """

--- a/boa3/model/type/primitive/primitivetype.py
+++ b/boa3/model/type/primitive/primitivetype.py
@@ -1,12 +1,10 @@
 from abc import ABC
 
-from boa3.model.type.itype import IType
+from boa3.model.type.classes.pythonclass import PythonClass
 
 
-class PrimitiveType(IType, ABC):
+class PrimitiveType(PythonClass, ABC):
     """
     An interface for primitive types
     """
-
-    def __init__(self, identifier: str):
-        super().__init__(identifier)
+    pass

--- a/boa3/model/type/primitive/strtype.py
+++ b/boa3/model/type/primitive/strtype.py
@@ -1,13 +1,11 @@
 from typing import Any
 
-from boa3.model.type.collection.sequence.sequencetype import SequenceType
 from boa3.model.type.itype import IType
-from boa3.model.type.primitive.primitivetype import PrimitiveType
+from boa3.model.type.primitive.bytestringtype import ByteStringType
 from boa3.neo.vm.type.AbiType import AbiType
-from boa3.neo.vm.type.StackItem import StackItemType
 
 
-class StrType(SequenceType, PrimitiveType):
+class StrType(ByteStringType):
     """
     A class used to represent Python str type
     """
@@ -17,10 +15,6 @@ class StrType(SequenceType, PrimitiveType):
         super().__init__(identifier, [self])
 
     @property
-    def identifier(self) -> str:
-        return self._identifier
-
-    @property
     def default_value(self) -> Any:
         return str()
 
@@ -28,9 +22,17 @@ class StrType(SequenceType, PrimitiveType):
     def abi_type(self) -> AbiType:
         return AbiType.String
 
-    @property
-    def stack_item(self) -> StackItemType:
-        return StackItemType.ByteString
+    def _init_class_symbols(self):
+        super()._init_class_symbols()
+
+        from boa3.model.builtin.builtin import Builtin
+
+        instance_methods = [Builtin.StrSplit,
+                            Builtin.ConvertToBytes
+                            ]
+
+        for instance_method in instance_methods:
+            self._instance_methods[instance_method.raw_identifier] = instance_method.build(self)
 
     @classmethod
     def build(cls, value: Any) -> IType:
@@ -49,15 +51,3 @@ class StrType(SequenceType, PrimitiveType):
 
     def is_type_of(self, value: Any) -> bool:
         return self._is_type_of(value)
-
-    def is_valid_key(self, key_type: IType) -> bool:
-        return key_type == self.valid_key
-
-    @property
-    def valid_key(self) -> IType:
-        from boa3.model.type.type import Type
-        return Type.int
-
-    @property
-    def can_reassign_values(self) -> bool:
-        return False

--- a/boa3_test/tests/compiler_tests/test_builtin_method.py
+++ b/boa3_test/tests/compiler_tests/test_builtin_method.py
@@ -563,8 +563,6 @@ class TestBuiltinMethod(BoaTest):
             Opcode.PUSHDATA1        # str.to_bytes('123')
             + Integer(len(value)).to_byte_array(min_length=1)
             + value
-            + Opcode.CONVERT
-            + Type.bytes.stack_item
             + Opcode.RET
         )
 


### PR DESCRIPTION
**Related issue**
#700

**Summary or solution description**
Refactored the native Python types implementations to compile the same way as other classes.
Blocker for class inheritance feature

**Tests**
Rerun the existing unit tests

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7+