### PR TITLE
Add support to String isdigit method for ASCII symbols

### DIFF
--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -59,9 +59,10 @@ class Builtin:
     Exception = ExceptionMethod()
 
     # python class method
+    BytesStringIsdigit = IsDigitMethod()
+    BytesStringLower = LowerMethod()
     BytesStringStartswith = StartsWithMethod()
     BytesStringUpper = UpperMethod()
-    BytesStringLower = LowerMethod()
     CountSequence = CountSequenceMethod()
     CountStr = CountStrMethod()
     Copy = CopyListMethod()
@@ -91,9 +92,10 @@ class Builtin:
 
     _python_builtins: List[IdentifiedSymbol] = [Abs,
                                                 ByteArray,
+                                                BytesStringIsdigit,
+                                                BytesStringLower,
                                                 BytesStringStartswith,
                                                 BytesStringUpper,
-                                                BytesStringLower,
                                                 ClassMethodDecorator,
                                                 ConvertToBool,
                                                 ConvertToBytes,

--- a/boa3/model/builtin/classmethod/__init__.py
+++ b/boa3/model/builtin/classmethod/__init__.py
@@ -7,6 +7,7 @@ __all__ = ['AppendMethod',
            'ExtendMethod',
            'IndexSequenceMethod',
            'InsertMethod',
+           'IsDigitMethod',
            'LowerMethod',
            'MapKeysMethod',
            'MapValuesMethod',
@@ -31,6 +32,7 @@ from boa3.model.builtin.classmethod.countstrmethod import CountStrMethod
 from boa3.model.builtin.classmethod.extendmethod import ExtendMethod
 from boa3.model.builtin.classmethod.indexsequencemethod import IndexSequenceMethod
 from boa3.model.builtin.classmethod.insertmethod import InsertMethod
+from boa3.model.builtin.classmethod.isdigitmethod import IsDigitMethod
 from boa3.model.builtin.classmethod.lowermethod import LowerMethod
 from boa3.model.builtin.classmethod.mapkeysmethod import MapKeysMethod
 from boa3.model.builtin.classmethod.mapvaluesmethod import MapValuesMethod

--- a/boa3/model/builtin/classmethod/isdigitmethod.py
+++ b/boa3/model/builtin/classmethod/isdigitmethod.py
@@ -1,0 +1,157 @@
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.type.primitive.bytestype import BytesType
+from boa3.model.type.primitive.strtype import StrType
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class IsDigitMethod(IBuiltinMethod):
+    def __init__(self, self_type: Union[StrType, BytesType] = None):
+        from boa3.model.type.type import Type
+
+        if not isinstance(self_type, (StrType, BytesType)):
+            self_type = Type.str
+
+        identifier = 'isdigit'
+        args: Dict[str, Variable] = {'self': Variable(self_type)}
+
+        super().__init__(identifier, args, return_type=Type.bool)
+
+    @property
+    def _arg_self(self) -> Variable:
+        return self.args['self']
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        from boa3.compiler.codegenerator import get_bytes_count
+        from boa3.neo.vm.type.Integer import Integer
+        from boa3.neo.vm.type.StackItem import StackItemType
+
+        number0 = Integer(ord('0')).to_byte_array()
+        number9 = Integer(ord('9')).to_byte_array()
+        jmp_place_holder = (Opcode.JMP, b'\x01')
+
+        initializing = [                    # initialize auxiliary values
+            (Opcode.DUP, b''),
+            (Opcode.SIZE, b''),
+            (Opcode.DEC, b''),              # index = len(string) - 1
+            (Opcode.PUSH1, b''),            # isdigit = True
+        ]
+
+        verify_empty_string = [             # verifies if string is empty
+            (Opcode.OVER, b''),
+            (Opcode.PUSHM1, b''),
+            jmp_place_holder,               # jump to change_to_false if index == -1
+        ]
+
+        skip_first_verify_while = [         # skips the first while verification, since string is not empty
+            jmp_place_holder
+        ]
+
+        verify_while = [                    # verifies if while is over
+            (Opcode.OVER, b''),
+            (Opcode.PUSH0, b''),
+            jmp_place_holder,               # jump to return_bool if index >= len(string)
+        ]
+
+        jmp_verify_while = Opcode.get_jump_and_data(Opcode.JMP, get_bytes_count(verify_while), True)
+        skip_first_verify_while[-1] = jmp_verify_while
+
+        while_verify_lt_0 = [               # verifies if ord(string[index]) is < ord('0')
+            (Opcode.PUSH2, b''),
+            (Opcode.PICK, b''),
+            (Opcode.PUSH2, b''),
+            (Opcode.PICK, b''),
+            (Opcode.PUSH1, b''),
+            (Opcode.SUBSTR, b''),
+            (Opcode.CONVERT, StackItemType.ByteString),
+            (Opcode.DUP, b''),
+            (Opcode.PUSHDATA1, Integer(len(number0)).to_byte_array() + number0),
+            jmp_place_holder,               # if ord(string[index]) < ord('0'), return False
+        ]
+
+        while_verify_gt_9 = [               # verifies if ord(string[index]) is > ord('9')
+            (Opcode.PUSHDATA1, Integer(len(number9)).to_byte_array() + number9),
+            jmp_place_holder,               # if ord(string[index]) > ord('9'), return False
+        ]
+
+        while_go_to_verify = [              # decreases index and goes back to verify if there all characters were visited already
+            (Opcode.SWAP, b''),
+            (Opcode.DEC, b''),              # index--
+            (Opcode.SWAP, b''),
+            # jump back to verify_while
+        ]
+
+        jmp_back_to_verify = Opcode.get_jump_and_data(Opcode.JMP, -get_bytes_count(verify_while +
+                                                                                   while_verify_lt_0 +
+                                                                                   while_verify_gt_9 +
+                                                                                   while_go_to_verify))
+        while_go_to_verify.append(jmp_back_to_verify)
+
+        jmp_out_of_while = Opcode.get_jump_and_data(Opcode.JMPLT, get_bytes_count(while_verify_gt_9 +
+                                                                                  while_go_to_verify), True)
+        while_verify_lt_0[-1] = jmp_out_of_while
+
+        drop_char = [                       # remove extra char from stack
+            (Opcode.DROP, b'')
+        ]
+
+        jmp_to_change_to_false = Opcode.get_jump_and_data(Opcode.JMPGT, get_bytes_count(while_go_to_verify +
+                                                                                        drop_char), True)
+        while_verify_gt_9[-1] = jmp_to_change_to_false
+
+        change_to_false = [                 # remove True on top of stack and put False
+            (Opcode.DROP, b''),
+            (Opcode.PUSH0, b''),
+        ]
+
+        jmp_to_return = Opcode.get_jump_and_data(Opcode.JMPEQ, get_bytes_count(skip_first_verify_while +
+                                                                               verify_while +
+                                                                               while_verify_lt_0 +
+                                                                               while_verify_gt_9 +
+                                                                               while_go_to_verify +
+                                                                               drop_char), True)
+        verify_empty_string[-1] = jmp_to_return
+
+        jmp_to_return = Opcode.get_jump_and_data(Opcode.JMPLT, get_bytes_count(while_verify_lt_0 +
+                                                                               while_verify_gt_9 +
+                                                                               while_go_to_verify +
+                                                                               drop_char +
+                                                                               change_to_false), True)
+        verify_while[-1] = jmp_to_return
+
+        clean_and_return_bool = [           # remove extra values from stack
+            (Opcode.NIP, b''),
+            (Opcode.NIP, b'')
+        ]
+
+        return (
+            initializing +
+            verify_empty_string +
+            skip_first_verify_while +
+            verify_while +
+            while_verify_lt_0 +
+            while_verify_gt_9 +
+            while_go_to_verify +
+            drop_char +
+            change_to_false +
+            clean_and_return_bool
+        )
+
+    def push_self_first(self) -> bool:
+        return self.has_self_argument
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> Optional[str]:
+        return None
+
+    def build(self, value: Any) -> IBuiltinMethod:
+        if isinstance(value, (StrType, BytesType)):
+            return IsDigitMethod(value)
+        return super().build(value)

--- a/boa3_test/test_sc/bytes_test/IsdigitMethod.py
+++ b/boa3_test/test_sc/bytes_test/IsdigitMethod.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main(b_value: bytes) -> bool:
+    return b_value.isdigit()

--- a/boa3_test/test_sc/string_test/IsdigitMethod.py
+++ b/boa3_test/test_sc/string_test/IsdigitMethod.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main(string: str) -> bool:
+    return string.isdigit()

--- a/boa3_test/tests/compiler_tests/test_bytes.py
+++ b/boa3_test/tests/compiler_tests/test_bytes.py
@@ -974,3 +974,23 @@ class TestBytes(BoaTest):
         subbytes_value = b'bigger subbytes_value'
         result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value)
         self.assertEqual(bytes_value.startswith(subbytes_value), result)
+
+    def test_isdigit_method(self):
+        path = self.get_contract_path('IsdigitMethod.py')
+        engine = TestEngine()
+
+        bytes_value = b'0123456789'
+        result = self.run_smart_contract(engine, path, 'main', bytes_value)
+        self.assertEqual(bytes_value.isdigit(), result)
+
+        bytes_value = b'23mixed01'
+        result = self.run_smart_contract(engine, path, 'main', bytes_value)
+        self.assertEqual(bytes_value.isdigit(), result)
+
+        bytes_value = b'no digits here'
+        result = self.run_smart_contract(engine, path, 'main', bytes_value)
+        self.assertEqual(bytes_value.isdigit(), result)
+
+        bytes_value = b''
+        result = self.run_smart_contract(engine, path, 'main', bytes_value)
+        self.assertEqual(bytes_value.isdigit(), result)

--- a/boa3_test/tests/compiler_tests/test_string.py
+++ b/boa3_test/tests/compiler_tests/test_string.py
@@ -558,3 +558,30 @@ class TestString(BoaTest):
         substring = 'bigger substring'
         result = self.run_smart_contract(engine, path, 'main', string, substring)
         self.assertEqual(string.startswith(substring), result)
+
+    def test_isdigit_method(self):
+        path = self.get_contract_path('IsdigitMethod.py')
+        engine = TestEngine()
+        self.compile_and_save(path)
+
+        string = '0123456789'
+        result = self.run_smart_contract(engine, path, 'main', string)
+        self.assertEqual(string.isdigit(), result)
+
+        string = '23mixed01'
+        result = self.run_smart_contract(engine, path, 'main', string)
+        self.assertEqual(string.isdigit(), result)
+
+        string = 'no digits here'
+        result = self.run_smart_contract(engine, path, 'main', string)
+        self.assertEqual(string.isdigit(), result)
+
+        string = ''
+        result = self.run_smart_contract(engine, path, 'main', string)
+        self.assertEqual(string.isdigit(), result)
+
+        string = '¹²³'
+        result = self.run_smart_contract(engine, path, 'main', string)
+        with self.assertRaises(AssertionError):
+            # neo3-boas isdigit implementation does not verify values that are not from the ASCII
+            self.assertEqual(string.isdigit(), result)


### PR DESCRIPTION
**Related issue**
#672 

**Summary or solution description**
 Implemented `string.isdigit()` and `bytes.isdigit()`.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/f08b936dcf9b6c78a9a42acc116c992a6af3c909/boa3_test/test_sc/string_test/IsdigitMethod.py#L1-L6

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/f08b936dcf9b6c78a9a42acc116c992a6af3c909/boa3_test/tests/compiler_tests/test_string.py#L562-L587

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8