### PR TITLE
Add support to String join method

### DIFF
--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -59,9 +59,10 @@ class Builtin:
     Exception = ExceptionMethod()
 
     # python class method
+    BytesStringJoin = JoinMethod()
+    BytesStringLower = LowerMethod()
     BytesStringStartswith = StartsWithMethod()
     BytesStringUpper = UpperMethod()
-    BytesStringLower = LowerMethod()
     CountSequence = CountSequenceMethod()
     CountStr = CountStrMethod()
     Copy = CopyListMethod()
@@ -91,9 +92,10 @@ class Builtin:
 
     _python_builtins: List[IdentifiedSymbol] = [Abs,
                                                 ByteArray,
+                                                BytesStringJoin,
+                                                BytesStringLower,
                                                 BytesStringStartswith,
                                                 BytesStringUpper,
-                                                BytesStringLower,
                                                 ClassMethodDecorator,
                                                 ConvertToBool,
                                                 ConvertToBytes,

--- a/boa3/model/builtin/classmethod/__init__.py
+++ b/boa3/model/builtin/classmethod/__init__.py
@@ -7,6 +7,7 @@ __all__ = ['AppendMethod',
            'ExtendMethod',
            'IndexSequenceMethod',
            'InsertMethod',
+           'JoinMethod',
            'LowerMethod',
            'MapKeysMethod',
            'MapValuesMethod',
@@ -31,6 +32,7 @@ from boa3.model.builtin.classmethod.countstrmethod import CountStrMethod
 from boa3.model.builtin.classmethod.extendmethod import ExtendMethod
 from boa3.model.builtin.classmethod.indexsequencemethod import IndexSequenceMethod
 from boa3.model.builtin.classmethod.insertmethod import InsertMethod
+from boa3.model.builtin.classmethod.joinmethod import JoinMethod
 from boa3.model.builtin.classmethod.lowermethod import LowerMethod
 from boa3.model.builtin.classmethod.mapkeysmethod import MapKeysMethod
 from boa3.model.builtin.classmethod.mapvaluesmethod import MapValuesMethod

--- a/boa3/model/builtin/classmethod/joinmethod.py
+++ b/boa3/model/builtin/classmethod/joinmethod.py
@@ -1,0 +1,155 @@
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.type.collection.mapping.mutable.dicttype import DictType
+from boa3.model.type.collection.sequence.sequencetype import SequenceType
+from boa3.model.type.primitive.bytestype import BytesType
+from boa3.model.type.primitive.strtype import StrType
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class JoinMethod(IBuiltinMethod):
+    def __init__(self, self_type: Union[StrType, BytesType] = None, iterable_type: Union[SequenceType, DictType] = None):
+        from boa3.model.type.type import Type
+
+        if not isinstance(self_type, (StrType, BytesType)):
+            self_type = Type.str
+
+        if not isinstance(iterable_type, (SequenceType, DictType)):
+            iterable_type = Type.sequence.build_collection([self_type])
+
+        identifier = 'join'
+        args: Dict[str, Variable] = {
+            'self': Variable(self_type),
+            'iterable': Variable(iterable_type),
+        }
+
+        super().__init__(identifier, args, return_type=self_type)
+
+    @property
+    def identifier(self) -> str:
+        from boa3.model.type.type import Type
+
+        if Type.dict.is_type_of(self._arg_iterable.type):
+            return '-{0}_{1}'.format(self._identifier, Type.dict.identifier)
+
+        return self._identifier                             # JoinMethod default value for self
+
+    @property
+    def _arg_self(self) -> Variable:
+        return self.args['self']
+
+    @property
+    def _arg_iterable(self) -> Variable:
+        return self.args['iterable']
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        from boa3.compiler.codegenerator import get_bytes_count
+
+        jmp_place_holder = (Opcode.JMP, b'\x01')
+
+        # Receives: string, iterable
+        verify_empty_string = [         # verify if string is empty
+            (Opcode.DUP, b''),
+            (Opcode.SIZE, b''),         # iterable_size = len(iterable)
+            (Opcode.PUSH0, b''),        # index = 0
+            (Opcode.OVER, b''),
+            (Opcode.OVER, b''),
+            jmp_place_holder            # if iterable_size is less than or equals to 0, return empty string
+        ]
+
+        initialize_string = [           # initializes the return value
+            (Opcode.PUSH2, b''),
+            (Opcode.PICK, b''),
+            (Opcode.OVER, b''),
+            (Opcode.PICKITEM, b''),     # joined = iterable[0]
+            (Opcode.SWAP, b''),
+            (Opcode.INC, b''),          # index++
+            (Opcode.SWAP, b''),
+        ]
+
+        from boa3.model.type.type import Type
+        if Type.dict.is_type_of(self._arg_iterable.type):
+            get_dict_keys = [           # get dictionary keys as an array
+                (Opcode.REVERSE3, b''),
+                (Opcode.KEYS, b''),
+                (Opcode.REVERSE3, b''),
+            ]
+            initialize_string = get_dict_keys + initialize_string
+
+        verify_index = [                # verify if all items on the iterable were visited
+            (Opcode.OVER, b''),
+            (Opcode.PUSH3, b''),
+            (Opcode.PICK, b''),
+            jmp_place_holder            # jump to remove_extra_values if every item was already visited
+        ]
+
+        concat_strings = [              # concatenate the items inside de interable
+            (Opcode.PUSH4, b''),
+            (Opcode.PICK, b''),
+            (Opcode.CAT, b''),          # joined = joined + string
+            (Opcode.PUSH3, b''),
+            (Opcode.PICK, b''),
+            (Opcode.PUSH2, b''),
+            (Opcode.PICK, b''),
+            (Opcode.PICKITEM, b''),
+            (Opcode.CAT, b''),          # joined = joined + iterable[index]
+            (Opcode.SWAP, b''),
+            (Opcode.INC, b''),          # index++
+            (Opcode.SWAP, b''),
+            # jump back to verify_index
+        ]
+
+        jmp_back_to_verify = Opcode.get_jump_and_data(Opcode.JMP, -get_bytes_count(verify_index +
+                                                                                   concat_strings))
+        concat_strings.append(jmp_back_to_verify)
+
+        jmp_concatenation = Opcode.get_jump_and_data(Opcode.JMPLE, get_bytes_count(initialize_string +
+                                                                                   verify_index +
+                                                                                   concat_strings), True)
+        verify_empty_string[-1] = jmp_concatenation
+
+        add_empty_string = [            # add a empty string at the top of the stack
+            (Opcode.PUSHDATA1, b'\x00')
+        ]
+
+        jmp_concatenation = Opcode.get_jump_and_data(Opcode.JMPGE, get_bytes_count(concat_strings +
+                                                                                   add_empty_string), True)
+        verify_index[-1] = jmp_concatenation
+
+        remove_extra_values = [         # remove all values from stack except the joined string
+            (Opcode.NIP, b''),
+            (Opcode.NIP, b''),
+            (Opcode.NIP, b''),
+            (Opcode.NIP, b''),
+        ]
+
+        return (
+            verify_empty_string +
+            initialize_string +
+            verify_index +
+            concat_strings +
+            add_empty_string +
+            remove_extra_values
+        )
+
+    def push_self_first(self) -> bool:
+        return self.has_self_argument
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> Optional[str]:
+        return None
+
+    def build(self, value: Any) -> IBuiltinMethod:
+        if isinstance(value, list) and len(value) <= 2:
+            if isinstance(value[0], StrType) and isinstance(value[1], SequenceType):
+                return self
+            else:
+                return JoinMethod(value[0], value[1])
+        return super().build(value)

--- a/boa3_test/test_sc/bytes_test/JoinBytesMethodWithDictionary.py
+++ b/boa3_test/test_sc/bytes_test/JoinBytesMethodWithDictionary.py
@@ -1,0 +1,8 @@
+from typing import Any, Dict
+
+from boa3.builtin import public
+
+
+@public
+def main(string: bytes, dictionary: Dict[bytes, Any]) -> bytes:
+    return string.join(dictionary)

--- a/boa3_test/test_sc/bytes_test/JoinBytesMethodWithSequence.py
+++ b/boa3_test/test_sc/bytes_test/JoinBytesMethodWithSequence.py
@@ -1,0 +1,8 @@
+from typing import Sequence
+
+from boa3.builtin import public
+
+
+@public
+def main(string: bytes, sequence: Sequence[bytes]) -> bytes:
+    return string.join(sequence)

--- a/boa3_test/test_sc/string_test/JoinStringMethodWithDictionary.py
+++ b/boa3_test/test_sc/string_test/JoinStringMethodWithDictionary.py
@@ -1,0 +1,8 @@
+from typing import Any, Dict
+
+from boa3.builtin import public
+
+
+@public
+def main(string: str, dictionary: Dict[str, Any]) -> str:
+    return string.join(dictionary)

--- a/boa3_test/test_sc/string_test/JoinStringMethodWithSequence.py
+++ b/boa3_test/test_sc/string_test/JoinStringMethodWithSequence.py
@@ -1,0 +1,8 @@
+from typing import Sequence
+
+from boa3.builtin import public
+
+
+@public
+def main(string: str, sequence: Sequence[str]) -> str:
+    return string.join(sequence)

--- a/boa3_test/tests/compiler_tests/test_bytes.py
+++ b/boa3_test/tests/compiler_tests/test_bytes.py
@@ -974,3 +974,47 @@ class TestBytes(BoaTest):
         subbytes_value = b'bigger subbytes_value'
         result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value)
         self.assertEqual(bytes_value.startswith(subbytes_value), result)
+
+    def test_bytes_join_with_sequence(self):
+        path = self.get_contract_path('JoinBytesMethodWithSequence.py')
+        engine = TestEngine()
+
+        bytes_value = b' '
+        sequence = [b"Unit", b"Test", b"Neo3-boa"]
+        result = self.run_smart_contract(engine, path, 'main', bytes_value, sequence,
+                                         expected_result_type=bytes)
+        self.assertEqual(bytes_value.join(sequence), result)
+
+        bytes_value = b' '
+        sequence = []
+        result = self.run_smart_contract(engine, path, 'main', bytes_value, sequence,
+                                         expected_result_type=bytes)
+        self.assertEqual(bytes_value.join(sequence), result)
+
+        bytes_value = b' '
+        sequence = [b"UnitTest"]
+        result = self.run_smart_contract(engine, path, 'main', bytes_value, sequence,
+                                         expected_result_type=bytes)
+        self.assertEqual(bytes_value.join(sequence), result)
+
+    def test_bytes_join_with_dictionary(self):
+        path = self.get_contract_path('JoinBytesMethodWithDictionary.py')
+        engine = TestEngine()
+
+        bytes_value = b' '
+        dictionary = {b"Unit": 1, b"Test": 2, b"Neo3-boa": 3}
+        result = self.run_smart_contract(engine, path, 'main', bytes_value, dictionary,
+                                         expected_result_type=bytes)
+        self.assertEqual(bytes_value.join(dictionary), result)
+
+        bytes_value = b' '
+        dictionary = {}
+        result = self.run_smart_contract(engine, path, 'main', bytes_value, dictionary,
+                                         expected_result_type=bytes)
+        self.assertEqual(bytes_value.join(dictionary), result)
+
+        bytes_value = b' '
+        dictionary = {b"UnitTest": 1}
+        result = self.run_smart_contract(engine, path, 'main', bytes_value, dictionary,
+                                         expected_result_type=bytes)
+        self.assertEqual(bytes_value.join(dictionary), result)

--- a/boa3_test/tests/compiler_tests/test_string.py
+++ b/boa3_test/tests/compiler_tests/test_string.py
@@ -558,3 +558,41 @@ class TestString(BoaTest):
         substring = 'bigger substring'
         result = self.run_smart_contract(engine, path, 'main', string, substring)
         self.assertEqual(string.startswith(substring), result)
+
+    def test_string_join_with_sequence(self):
+        path = self.get_contract_path('JoinStringMethodWithSequence.py')
+        engine = TestEngine()
+
+        string = ' '
+        sequence = ["Unit", "Test", "Neo3-boa"]
+        result = self.run_smart_contract(engine, path, 'main', string, sequence)
+        self.assertEqual(string.join(sequence), result)
+
+        string = ' '
+        sequence = []
+        result = self.run_smart_contract(engine, path, 'main', string, sequence)
+        self.assertEqual(string.join(sequence), result)
+
+        string = ' '
+        sequence = ["UnitTest"]
+        result = self.run_smart_contract(engine, path, 'main', string, sequence)
+        self.assertEqual(string.join(sequence), result)
+
+    def test_string_join_with_dictionary(self):
+        path = self.get_contract_path('JoinStringMethodWithDictionary.py')
+        engine = TestEngine()
+
+        string = ' '
+        dictionary = {"Unit": 1, "Test": 2, "Neo3-boa": 3}
+        result = self.run_smart_contract(engine, path, 'main', string, dictionary)
+        self.assertEqual(string.join(dictionary), result)
+
+        string = ' '
+        dictionary = {}
+        result = self.run_smart_contract(engine, path, 'main', string, dictionary)
+        self.assertEqual(string.join(dictionary), result)
+
+        string = ' '
+        dictionary = {"UnitTest": 1}
+        result = self.run_smart_contract(engine, path, 'main', string, dictionary)
+        self.assertEqual(string.join(dictionary), result)


### PR DESCRIPTION
**Related issue**
#675 

**Summary or solution description**
 Implemented `string.join()` and `bytes.join()`.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/21a51e4337b587e1c29cd2e07a1ff31b5815d0d5/boa3_test/test_sc/string_test/JoinStringMethodWithSequence.py#L1-L8
https://github.com/CityOfZion/neo3-boa/blob/21a51e4337b587e1c29cd2e07a1ff31b5815d0d5/boa3_test/test_sc/string_test/JoinStringMethodWithDictionary.py#L1-L8

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/21a51e4337b587e1c29cd2e07a1ff31b5815d0d5/boa3_test/tests/compiler_tests/test_string.py#L562-L598

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8