### PR TITLE
Add support to String index method

### DIFF
--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -76,6 +76,7 @@ class Builtin:
     SequencePop = PopSequenceMethod()
     SequenceRemove = RemoveMethod()
     SequenceReverse = ReverseMethod()
+    StrIndex = IndexStrMethod()
     DictKeys = MapKeysMethod()
     DictPop = PopDictMethod()
     DictValues = MapValuesMethod()
@@ -131,6 +132,7 @@ class Builtin:
                                                 SequenceReverse,
                                                 Sqrt,
                                                 StaticMethodDecorator,
+                                                StrIndex,
                                                 StrSplit,
                                                 Sum
                                                 ]

--- a/boa3/model/builtin/classmethod/__init__.py
+++ b/boa3/model/builtin/classmethod/__init__.py
@@ -6,6 +6,7 @@ __all__ = ['AppendMethod',
            'CountStrMethod',
            'ExtendMethod',
            'IndexSequenceMethod',
+           'IndexStrMethod',
            'InsertMethod',
            'IsDigitMethod',
            'JoinMethod',
@@ -34,6 +35,7 @@ from boa3.model.builtin.classmethod.countsequencemethod import CountSequenceMeth
 from boa3.model.builtin.classmethod.countstrmethod import CountStrMethod
 from boa3.model.builtin.classmethod.extendmethod import ExtendMethod
 from boa3.model.builtin.classmethod.indexsequencemethod import IndexSequenceMethod
+from boa3.model.builtin.classmethod.indexstrmethod import IndexStrMethod
 from boa3.model.builtin.classmethod.insertmethod import InsertMethod
 from boa3.model.builtin.classmethod.isdigitmethod import IsDigitMethod
 from boa3.model.builtin.classmethod.joinmethod import JoinMethod

--- a/boa3/model/builtin/classmethod/indexmethod.py
+++ b/boa3/model/builtin/classmethod/indexmethod.py
@@ -64,7 +64,7 @@ class IndexMethod(IBuiltinMethod):
 
         from boa3.model.type.type import Type
         if len(value) > 0 and Type.str.is_type_of(value[0]):
-            from boa3.model.builtin.builtin import Builtin
-            return Builtin.CountStr
+            from boa3.model.builtin.classmethod.indexstrmethod import IndexStrMethod
+            return IndexStrMethod(value[0])
 
         return super().build(value)

--- a/boa3/model/builtin/classmethod/indexstrmethod.py
+++ b/boa3/model/builtin/classmethod/indexstrmethod.py
@@ -1,0 +1,197 @@
+import ast
+from typing import Dict, List, Optional, Tuple
+
+from boa3.model.builtin.classmethod.indexmethod import IndexMethod
+from boa3.model.expression import IExpression
+from boa3.model.type.primitive.strtype import StrType
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+from boa3.neo.vm.type.Integer import Integer
+from boa3.neo.vm.type.String import String
+
+
+class IndexStrMethod(IndexMethod):
+
+    def __init__(self, self_type: Optional[StrType] = None):
+        from boa3.model.type.type import Type
+        if not isinstance(self_type, StrType):
+            self_type = Type.str
+
+        args: Dict[str, Variable] = {
+            'self': Variable(self_type),
+            'x': Variable(self_type),
+            'start': Variable(Type.int),
+            'end': Variable(Type.int),
+        }
+
+        start_default = ast.parse("{0}".format(0)
+                                  ).body[0].value
+        end_default = ast.parse("-1").body[0].value.operand
+        end_default.n = -1
+
+        super().__init__(args, defaults=[start_default, end_default])
+
+    def validate_parameters(self, *params: IExpression) -> bool:
+        if 2 <= len(params) <= 4:
+            return False
+        if not all(isinstance(param, IExpression) for param in params):
+            return False
+
+        from boa3.model.type.itype import IType
+        self_type: IType = params[0].type
+
+        if not isinstance(self_type, StrType):
+            return False
+
+        if not self_type.is_type_of(params[1]):
+            return False
+
+        return True
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        from boa3.compiler.codegenerator import get_bytes_count
+        from boa3.neo.vm.type.StackItem import StackItemType
+
+        jmp_place_holder = (Opcode.JMP, b'\x01')
+        message = String("substring not found").to_bytes()
+
+        # receives: end, start, substr, str
+        verify_negative_index = [           # verifies if index in a negative value
+            (Opcode.DUP, b''),
+            (Opcode.PUSHM1, b''),
+            jmp_place_holder                # if index >= 0, jump to verify_big_end or verify_big_start
+        ]
+
+        fix_negative_end = [                # gets the correspondent positive value of end
+            (Opcode.PUSH3, b''),
+            (Opcode.PICK, b''),
+            (Opcode.SIZE, b''),
+            (Opcode.ADD, b''),
+            (Opcode.INC, b''),              # end = end + len(str) + 1
+            (Opcode.DUP, b''),
+            (Opcode.PUSHM1, b''),
+            jmp_place_holder                # if end is not negative anymore, start verifying start
+        ]
+
+        fix_still_negative_index = [        # if index is still negative, consider it 0 then
+            (Opcode.DROP, b''),
+            (Opcode.PUSH0, b''),            # end = 0
+        ]
+
+        jmp_fix_negative_index = Opcode.get_jump_and_data(Opcode.JMPGT, get_bytes_count(fix_negative_end +
+                                                                                        fix_still_negative_index), True)
+        verify_negative_index[-1] = jmp_fix_negative_index
+
+        verify_big_end = [                  # verify if end is bigger then len(str)
+            (Opcode.DUP, b''),
+            (Opcode.PUSH4, b''),
+            (Opcode.PICK, b''),
+            (Opcode.SIZE, b''),
+            jmp_place_holder                # if end <= len(str), start verifying start
+        ]
+
+        fix_big_end = [                     # consider end as len(str)
+            (Opcode.DROP, b''),
+            (Opcode.PUSH2, b''),
+            (Opcode.PICK, b''),
+            (Opcode.SIZE, b''),             # end = len(str)
+        ]
+
+        jmp_other_verifies = Opcode.get_jump_and_data(Opcode.JMPGT, get_bytes_count(fix_still_negative_index +
+                                                                                    verify_big_end +
+                                                                                    fix_big_end), True)
+        fix_negative_end[-1] = jmp_other_verifies
+
+        jmp_fix_big_index = Opcode.get_jump_and_data(Opcode.JMPLE, get_bytes_count(fix_big_end), True)
+        verify_big_end[-1] = jmp_fix_big_index
+
+        verify_and_fix_end = [              # collection of Opcodes regarding verifying and fixing end index
+            (Opcode.REVERSE4, b''),
+        ]
+        verify_and_fix_end.extend(verify_negative_index)
+        verify_and_fix_end.extend(fix_negative_end)
+        verify_and_fix_end.extend(fix_still_negative_index)
+        verify_and_fix_end.extend(verify_big_end)
+        verify_and_fix_end.extend(fix_big_end)
+
+        verify_and_fix_start = [            # collection of Opcodes regarding verifying and fixing start index
+            (Opcode.SWAP, b'')
+        ]
+        verify_and_fix_start.extend(verify_negative_index)
+        verify_and_fix_start.extend(fix_negative_end)
+        verify_and_fix_start.extend(fix_still_negative_index)
+        verify_and_fix_start.extend(verify_big_end)
+        verify_and_fix_start.extend(fix_big_end)
+
+        change_stack_order = [              # change order of items on the stack
+            (Opcode.PUSH2, b''),
+            (Opcode.PICK, b''),
+            (Opcode.SIZE, b''),             # size = len(substr)
+            (Opcode.ROT, b''),
+            (Opcode.ROT, b''),
+        ]
+
+        verify_while = [                    # verify already compared all that was need
+            (Opcode.OVER, b''),
+            (Opcode.OVER, b''),
+            (Opcode.SUB, b''),
+            (Opcode.PUSH3, b''),
+            (Opcode.PICK, b''),
+            jmp_place_holder                # if end - index >= size, jump to not_inside_sequence
+        ]
+
+        compare_item = [                    # compare str[index:index+size] with substr
+            (Opcode.PUSH4, b''),
+            (Opcode.PICK, b''),
+            (Opcode.OVER, b''),
+            (Opcode.PUSH4, b''),
+            (Opcode.PICK, b''),
+            (Opcode.SUBSTR, b''),
+            (Opcode.CONVERT, StackItemType.ByteString),
+            (Opcode.PUSH4, b''),
+            (Opcode.PICK, b''),
+            (Opcode.NUMEQUAL, b''),
+            jmp_place_holder                # if str[index:index+size] == substr, return index
+        ]
+
+        not_found = [                       # increments index and goes back to verify again
+            (Opcode.INC, b''),              # index++
+            # jump to verify_while
+        ]
+
+        jmp_back_to_verify = Opcode.get_jump_and_data(Opcode.JMP, -get_bytes_count(verify_while +
+                                                                                   compare_item +
+                                                                                   not_found), True)
+        not_found.append(jmp_back_to_verify)
+
+        jmp_to_error = Opcode.get_jump_and_data(Opcode.JMPLT, get_bytes_count(compare_item +
+                                                                              not_found), True)
+        verify_while[-1] = jmp_to_error
+
+        not_inside_sequence = [             # send error message saying that substring not found
+            (Opcode.PUSHDATA1, Integer(len(message)).to_byte_array(signed=True, min_length=1) + message),
+            (Opcode.THROW, b''),
+        ]
+
+        jmp_to_return_index = Opcode.get_jump_and_data(Opcode.JMPIF, get_bytes_count(not_found +
+                                                                                     not_inside_sequence), True)
+        compare_item[-1] = jmp_to_return_index
+
+        return_index = [                    # removes all values in the stack but the index
+            (Opcode.NIP, b''),
+            (Opcode.NIP, b''),
+            (Opcode.NIP, b''),
+            (Opcode.NIP, b''),
+        ]
+
+        return (
+            verify_and_fix_end +
+            verify_and_fix_start +
+            change_stack_order +
+            verify_while +
+            compare_item +
+            not_found +
+            not_inside_sequence +
+            return_index
+        )

--- a/boa3_test/test_sc/string_test/IndexString.py
+++ b/boa3_test/test_sc/string_test/IndexString.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main(a: str, value: str, start: int, end: int) -> int:
+    return a.index(value, start, end)

--- a/boa3_test/test_sc/string_test/IndexStringDefaults.py
+++ b/boa3_test/test_sc/string_test/IndexStringDefaults.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main(a: str, value: str) -> int:
+    return a.index(value)

--- a/boa3_test/test_sc/string_test/IndexStringEndDefault.py
+++ b/boa3_test/test_sc/string_test/IndexStringEndDefault.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main(a: str, value: str, start: int) -> int:
+    return a.index(value, start)

--- a/boa3_test/test_sc/string_test/IndexStringMismatchedType.py
+++ b/boa3_test/test_sc/string_test/IndexStringMismatchedType.py
@@ -1,0 +1,2 @@
+def main(a: str, value: int) -> int:
+    return a.index(value)

--- a/boa3_test/tests/compiler_tests/test_string.py
+++ b/boa3_test/tests/compiler_tests/test_string.py
@@ -601,7 +601,6 @@ class TestString(BoaTest):
     def test_isdigit_method(self):
         path = self.get_contract_path('IsdigitMethod.py')
         engine = TestEngine()
-        self.compile_and_save(path)
 
         string = '0123456789'
         result = self.run_smart_contract(engine, path, 'main', string)
@@ -662,3 +661,101 @@ class TestString(BoaTest):
         dictionary = {"UnitTest": 1}
         result = self.run_smart_contract(engine, path, 'main', string, dictionary)
         self.assertEqual(string.join(dictionary), result)
+
+    def test_string_index(self):
+        path = self.get_contract_path('IndexString.py')
+        engine = TestEngine()
+
+        string = 'unit test'
+        substring = 'i'
+        start = 0
+        end = 4
+        result = self.run_smart_contract(engine, path, 'main', string, substring, start, end)
+        self.assertEqual(string.index(substring, start, end), result)
+
+        string = 'unit test'
+        substring = 'i'
+        start = 2
+        end = 4
+        result = self.run_smart_contract(engine, path, 'main', string, substring, start, end)
+        self.assertEqual(string.index(substring, start, end), result)
+
+        with self.assertRaises(TestExecutionException):
+            self.run_smart_contract(engine, path, 'main', 'unit test', 'i', 3, 4)
+
+        with self.assertRaises(TestExecutionException):
+            self.run_smart_contract(engine, path, 'main', 'unit test', 'i', 4, -1)
+
+        with self.assertRaises(TestExecutionException):
+            self.run_smart_contract(engine, path, 'main', 'unit test', 'i', 0, -99)
+
+        string = 'unit test'
+        substring = 'i'
+        start = 0
+        end = -1
+        result = self.run_smart_contract(engine, path, 'main', string, substring, start, end)
+        self.assertEqual(string.index(substring, start, end), result)
+
+        string = 'unit test'
+        substring = 'n'
+        start = 0
+        end = 99
+        result = self.run_smart_contract(engine, path, 'main', string, substring, start, end)
+        self.assertEqual(string.index(substring, start, end), result)
+
+    def test_string_index_end_default(self):
+        path = self.get_contract_path('IndexStringEndDefault.py')
+        engine = TestEngine()
+
+        string = 'unit test'
+        substring = 't'
+        start = 0
+        result = self.run_smart_contract(engine, path, 'main', string, substring, start)
+        self.assertEqual(string.index(substring, start), result)
+
+        string = 'unit test'
+        substring = 't'
+        start = 4
+        result = self.run_smart_contract(engine, path, 'main', string, substring, start)
+        self.assertEqual(string.index(substring, start), result)
+
+        string = 'unit test'
+        substring = 't'
+        start = 6
+        result = self.run_smart_contract(engine, path, 'main', string, substring, start)
+        self.assertEqual(string.index(substring, start), result)
+
+        with self.assertRaises(TestExecutionException):
+            self.run_smart_contract(engine, path, 'main', 'unit test', 'i', 99)
+
+        with self.assertRaises(TestExecutionException):
+            self.run_smart_contract(engine, path, 'main', 'unit test', 't', -1)
+
+        string = 'unit test'
+        substring = 'i'
+        start = -10
+        result = self.run_smart_contract(engine, path, 'main', string, substring, start)
+        self.assertEqual(string.index(substring, start), result)
+
+    def test_string_index_defaults(self):
+        path = self.get_contract_path('IndexStringDefaults.py')
+        engine = TestEngine()
+
+        string = 'unit test'
+        substring = 'u'
+        result = self.run_smart_contract(engine, path, 'main', string, substring)
+        self.assertEqual(string.index(substring), result)
+
+        string = 'unit test'
+        substring = 't'
+        result = self.run_smart_contract(engine, path, 'main', string, substring)
+        self.assertEqual(string.index(substring), result)
+
+        string = 'unit test'
+        substring = ' '
+        result = self.run_smart_contract(engine, path, 'main', string, substring)
+        self.assertEqual(string.index(substring), result)
+
+    def test_string_index_mismatched_type(self):
+        path = self.get_contract_path('IndexStringMismatchedType.py')
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)


### PR DESCRIPTION
**Related issue**
#677 

**Summary or solution description**
Implemented `string.index()`.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/8d7e478125562c1cd82d8b502244ec2c7451328c/boa3_test/test_sc/string_test/IndexString.py#L1-L6

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/8d7e478125562c1cd82d8b502244ec2c7451328c/boa3_test/tests/compiler_tests/test_string.py#L665-L761

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8
