### PR TITLE
Implicit cast does not work in different function scopes

### DIFF
--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -368,7 +368,9 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
         if self._current_scope is not None:
             if isinstance(node, ast.Name):
                 if node.id not in self._current_scope:
-                    if not isinstance(value_type, Collection):
+                    if implicit_cast:
+                        value_type = target_type
+                    elif not isinstance(value_type, Collection):
                         target_type = value_type
                     elif not (isinstance(type(value_type), type(target_type)) and
                               (value_type.value_type is Type.any or value_type.valid_key is Type.any)):

--- a/boa3_test/test_sc/typing_test/CastInsideIf.py
+++ b/boa3_test/test_sc/typing_test/CastInsideIf.py
@@ -1,0 +1,20 @@
+from typing import Any, Dict, cast
+
+from boa3.builtin import public
+from boa3.builtin.interop.json import json_deserialize
+
+
+@public
+def main() -> str:
+    # compilable
+    data_xy = '{"type":"skin"}'
+    data: Dict[str, Any] = json_deserialize(data_xy)
+    type_ = cast(str, data['type'])
+
+    # not compilable
+    if type_ == "skin":
+        data_xy = '{"type":"body"}'
+        data: Dict[str, Any] = json_deserialize(data_xy)
+        type_ = cast(str, data['type'])  # compile error on this line
+
+    return type_

--- a/boa3_test/tests/compiler_tests/test_typing.py
+++ b/boa3_test/tests/compiler_tests/test_typing.py
@@ -143,3 +143,10 @@ class TestTyping(BoaTest):
         path = self.get_contract_path('CastToTransaction.py')
         output = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
         self.assertEqual(expected_output, output)
+
+    def test_cast_inside_if(self):
+        path = self.get_contract_path('CastInsideIf.py')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'main')
+        self.assertEqual('body', result)


### PR DESCRIPTION
**Related issue**
#710

**Summary or solution description**
Fixed a bug when trying to implicit cast in different function scopes.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/76abce1ab05ef01247481879b93c8473d2d225f2/boa3_test/test_sc/typing_test/CastInsideIf.py#L1-L20

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/76abce1ab05ef01247481879b93c8473d2d225f2/boa3_test/tests/compiler_tests/test_typing.py#L147-L152

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8
 