### PR TITLE
Change implementation of implicit class init

### DIFF
--- a/boa3/compiler/codegenerator/codegeneratorvisitor.py
+++ b/boa3/compiler/codegenerator/codegeneratorvisitor.py
@@ -232,6 +232,10 @@ class VisitorCodeGenerator(IAstAnalyser):
                 address = self.generator.bytecode_size
                 self.generator.convert_new_empty_array(len(class_symbol.class_variables), class_symbol)
                 self.generator.convert_store_variable(node.name, address)
+            else:
+                init_method = class_symbol.constructor_method()
+                if isinstance(init_method, Method) and init_method.start_address is None:
+                    self.generator.generate_implicit_init_user_class(init_method)
 
         for stmt in node.body:
             self.visit(stmt)

--- a/boa3/model/callable.py
+++ b/boa3/model/callable.py
@@ -143,3 +143,7 @@ class Callable(IExpression, ABC):
             signature = '({0})'.format(', '.join(args_types))
         public = 'public ' if self.is_public else ''
         return '{0}{1}'.format(public, signature)
+
+    def __repr__(self) -> str:
+        name = self.identifier if hasattr(self, 'identifier') else self.__class__.__name__
+        return f'{name}{str(self)}'

--- a/boa3/model/type/classes/classinitmethoddefault.py
+++ b/boa3/model/type/classes/classinitmethoddefault.py
@@ -1,13 +1,13 @@
-from typing import List, Optional, Tuple
+from typing import Optional
 
 from boa3 import constants
-from boa3.model.builtin.method import IBuiltinMethod
+from boa3.model.identifiedsymbol import IdentifiedSymbol
+from boa3.model.method import Method
 from boa3.model.type.classes.userclass import UserClass
 from boa3.model.variable import Variable
-from boa3.neo.vm.opcode.Opcode import Opcode
 
 
-class ClassInitMethod(IBuiltinMethod):
+class ClassInitMethod(IdentifiedSymbol, Method):
     def __init__(self, user_class: UserClass):
         self_var = Variable(user_class)
         args = {
@@ -20,9 +20,10 @@ class ClassInitMethod(IBuiltinMethod):
             # but change the self type
             args['self'] = self_var
 
-        super().__init__(identifier=constants.INIT_METHOD_ID,
-                         args=args,
-                         return_type=user_class)
+        Method.__init__(self, args=args, return_type=user_class)
+        IdentifiedSymbol.__init__(self, identifier=constants.INIT_METHOD_ID)
+
+        self.defined_by_entry = False
         self.is_init = True
         self.origin_class = user_class
         # __init__ method behave like class methods
@@ -36,35 +37,3 @@ class ClassInitMethod(IBuiltinMethod):
     @property
     def _body(self) -> Optional[str]:
         return None
-
-    @property
-    def opcode(self) -> List[Tuple[Opcode, bytes]]:
-        if self.origin_class is None or len(self.origin_class.bases) == 0:
-            return super().opcode
-
-        opcodes = []
-
-        for base in self.origin_class.bases:
-            base_constructor = base.constructor_method()
-            call_base_init = []
-            num_args = len(base_constructor.args)
-
-            opcode = Opcode.get_dup(num_args)
-            if opcode is Opcode.PICK:
-                load_arg = [
-                    Opcode.get_push_and_data(num_args - 1),
-                    (opcode, b'')
-                ]
-            else:
-                load_arg = [(opcode, b'')]
-
-            call_base_init.extend(load_arg * num_args)
-            call_base_init.append((Opcode.CALL, base_constructor))
-            call_base_init.append((Opcode.DROP, b''))
-
-            opcodes.extend(call_base_init)
-
-        additional_args = len(self.args) - 1  # num of arguments, not counting self
-        if additional_args > 0:
-            opcodes.extend([(Opcode.NIP, b'')] * additional_args)
-        return opcodes

--- a/boa3_test/test_sc/class_test/UserClassWithCascadeCreatedBase.py
+++ b/boa3_test/test_sc/class_test/UserClassWithCascadeCreatedBase.py
@@ -1,0 +1,24 @@
+from boa3.builtin import public
+
+
+class Foo:
+    def bar(self) -> int:
+        return 42
+
+
+class Zubs(Foo):
+    pass
+
+
+class Example(Zubs):
+    pass
+
+
+@public
+def implemented_method() -> int:
+    return Zubs().bar()
+
+
+@public
+def inherited_method() -> int:
+    return Example().bar()

--- a/boa3_test/tests/compiler_tests/test_class.py
+++ b/boa3_test/tests/compiler_tests/test_class.py
@@ -1,6 +1,7 @@
 from boa3.boa3 import Boa3
 from boa3.exception import CompilerError
 from boa3.neo.cryptography import hash160
+from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.String import String
 from boa3_test.tests.boa_test import BoaTest
 from boa3_test.tests.test_classes.testengine import TestEngine
@@ -91,10 +92,18 @@ class TestClass(BoaTest):
         self.assertEqual({}, result[4])
 
     def test_user_class_empty(self):
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x00'
+            + b'\x01'
+            + Opcode.LDARG0
+            + Opcode.RET
+        )
+
         path = self.get_contract_path('UserClassEmpty.py')
         output = Boa3.compile(path)
 
-        self.assertEqual(b'', output)
+        self.assertEqual(expected_output, output)
 
     def test_user_class_with_static_method_from_class(self):
         path = self.get_contract_path('UserClassWithStaticMethodFromClass.py')
@@ -293,6 +302,16 @@ class TestClass(BoaTest):
 
     def test_user_class_with_created_base(self):
         path = self.get_contract_path('UserClassWithCreatedBase.py')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'implemented_method')
+        self.assertEqual(42, result)
+
+        result = self.run_smart_contract(engine, path, 'inherited_method')
+        self.assertEqual(42, result)
+
+    def test_user_class_with_cascated_created_base(self):
+        path = self.get_contract_path('UserClassWithCascadeCreatedBase.py')
         engine = TestEngine()
 
         result = self.run_smart_contract(engine, path, 'implemented_method')


### PR DESCRIPTION
**Related issue**
#722

**Summary or solution description**
Changed the implementation of generated ``__init__`` methods for user-created classes. They were converted to inline assembly code in the same block they were called. Changed to be a separated method in the class block of assembly code.
It fixed the issue with inheritance using classes that inherit others.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/c9544fec36d58a72de3f44e356dcb333bb1ce424/boa3_test/test_sc/class_test/UserClassWithCascadeCreatedBase.py#L4-L24

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/c9544fec36d58a72de3f44e356dcb333bb1ce424/boa3_test/tests/compiler_tests/test_class.py#L303-L368

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
