### PR TITLE
Builtin missing imports are not being logged

### DIFF
--- a/boa3/analyser/model/functionarguments.py
+++ b/boa3/analyser/model/functionarguments.py
@@ -32,10 +32,12 @@ class FunctionArguments:
 
     @property
     def kwargs(self) -> Dict[str, Variable]:
-        return self._kwargs.copy()
+        return self._kwargs
 
     def add_kwarg(self, arg_id: str, arg: Variable) -> bool:
         if not isinstance(arg, Variable):
             return False
+        if self._kwargs is None:
+            self._kwargs: Dict[str, Variable] = {}
         self._kwargs[arg_id] = arg
         return True

--- a/boa3_test/test_sc/import_test/NotImportedBuiltinFromTypingInArgs.py
+++ b/boa3_test/test_sc/import_test/NotImportedBuiltinFromTypingInArgs.py
@@ -1,0 +1,2 @@
+def Main(a: Any):  # Any is not imported
+    b = a

--- a/boa3_test/test_sc/import_test/NotImportedBuiltinFromTypingInReturn.py
+++ b/boa3_test/test_sc/import_test/NotImportedBuiltinFromTypingInReturn.py
@@ -1,0 +1,2 @@
+def Main() -> Any:  # Any is not imported
+    return 10

--- a/boa3_test/test_sc/import_test/NotImportedBuiltinFromTypingInSubscript.py
+++ b/boa3_test/test_sc/import_test/NotImportedBuiltinFromTypingInSubscript.py
@@ -1,0 +1,5 @@
+from typing import Dict
+
+
+def Main(a: Dict[Any, Any]):  # Any is not imported
+    b = a

--- a/boa3_test/test_sc/import_test/NotImportedBuiltinFromTypingInVariable.py
+++ b/boa3_test/test_sc/import_test/NotImportedBuiltinFromTypingInVariable.py
@@ -1,0 +1,5 @@
+from typing import Any
+
+
+def Main(a: Any):
+    b: List[int] = a    # List is not imported

--- a/boa3_test/test_sc/import_test/NotImportedBuiltinPublic.py
+++ b/boa3_test/test_sc/import_test/NotImportedBuiltinPublic.py
@@ -1,0 +1,3 @@
+@public  # public is not imported
+def Main() -> int:
+    return 10

--- a/boa3_test/test_sc/logical_test/MismatchedOperandLogicNot.py
+++ b/boa3_test/test_sc/logical_test/MismatchedOperandLogicNot.py
@@ -1,2 +1,5 @@
+from typing import Any
+
+
 def Main(a: Any) -> Any:
     return ~a

--- a/boa3_test/test_sc/logical_test/MismatchedOperandLogicOr.py
+++ b/boa3_test/test_sc/logical_test/MismatchedOperandLogicOr.py
@@ -1,2 +1,5 @@
+from typing import Tuple
+
+
 def Main(a: bool, b: Tuple[str]) -> bool:
     return a | b

--- a/boa3_test/tests/compiler_tests/test_import.py
+++ b/boa3_test/tests/compiler_tests/test_import.py
@@ -311,3 +311,20 @@ class TestImport(BoaTest):
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'main')
         self.assertEqual(5, result)
+
+    def test_not_imported_builtin_public(self):
+        path = self.get_contract_path('NotImportedBuiltinPublic.py')
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+
+    def test_not_imported_builtin_from_typing(self):
+        path = self.get_contract_path('NotImportedBuiltinFromTypingInReturn.py')
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+
+        path = self.get_contract_path('NotImportedBuiltinFromTypingInArgs.py')
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+
+        path = self.get_contract_path('NotImportedBuiltinFromTypingInSubscript.py')
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+
+        path = self.get_contract_path('NotImportedBuiltinFromTypingInVariable.py')
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)


### PR DESCRIPTION
**Related issue**
#724 

**Summary or solution description**
Added the UnresolvedReference compiler error when trying to use builtins without importing them.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/35cd39747153836949fa83b6702732fb8341c95e/boa3_test/test_sc/import_test/NotImportedBuiltinPublic.py#L1-L3

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/35cd39747153836949fa83b6702732fb8341c95e/boa3_test/tests/compiler_tests/test_import.py#L319-L330

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7

**(Optional) Additional context**
Also changed a little bit of the kwargs on FunctionArguments.
