### PR TITLE
Call methods does not work with variable objects

### DIFF
--- a/boa3/compiler/codegenerator/codegeneratorvisitor.py
+++ b/boa3/compiler/codegenerator/codegeneratorvisitor.py
@@ -713,7 +713,11 @@ class VisitorCodeGenerator(IAstAnalyser):
             self._remove_inserted_opcodes_since(last_address, last_stack)
 
         if isinstance(symbol, Method):
-            args_to_generate = [arg for index, arg in enumerate(call.args) if index in symbol.args_to_be_generated()]
+            # self or cls is already generated
+            call_args = (call.args[1:]
+                         if has_cls_or_self_argument and len(call.args) == len(symbol.args)
+                         else call.args)
+            args_to_generate = [arg for index, arg in enumerate(call_args) if index in symbol.args_to_be_generated()]
             keywords_dict = {keyword.arg: keyword.value for keyword in call.keywords}
             keywords_with_index = {index: keywords_dict[arg_name] for index, arg_name in enumerate(symbol.args) if arg_name in keywords_dict}
 

--- a/boa3_test/test_sc/class_test/UserClassWithClassMethodFromVariable.py
+++ b/boa3_test/test_sc/class_test/UserClassWithClassMethodFromVariable.py
@@ -1,0 +1,13 @@
+from boa3.builtin import public
+
+
+class Example:
+    @classmethod
+    def some_method(cls) -> int:
+        return 42
+
+
+@public
+def call_by_class_name() -> int:
+    example = Example()
+    return example.some_method()

--- a/boa3_test/test_sc/class_test/UserClassWithClassVariableFromVariable.py
+++ b/boa3_test/test_sc/class_test/UserClassWithClassVariableFromVariable.py
@@ -1,0 +1,22 @@
+from boa3.builtin import public
+
+
+class Example:
+    val1 = 1
+    val2 = 2
+
+    @classmethod
+    def foo(cls) -> int:
+        return cls.val1
+
+
+@public
+def get_val1() -> int:
+    example = Example()
+    return example.val1
+
+
+@public
+def get_val2() -> int:
+    example = Example()
+    return example.val2

--- a/boa3_test/test_sc/class_test/UserClassWithInstanceMethodFromVariable.py
+++ b/boa3_test/test_sc/class_test/UserClassWithInstanceMethodFromVariable.py
@@ -1,0 +1,12 @@
+from boa3.builtin import public
+
+
+class Example:
+    def some_method(self) -> int:
+        return 42
+
+
+@public
+def call_by_class_name() -> int:
+    example = Example()
+    return example.some_method()

--- a/boa3_test/test_sc/class_test/UserClassWithInstanceVariableFromVariable.py
+++ b/boa3_test/test_sc/class_test/UserClassWithInstanceVariableFromVariable.py
@@ -1,0 +1,19 @@
+from boa3.builtin import public
+
+
+class Example:
+    def __init__(self):
+        self.val1 = 1
+        self.val2 = 2
+
+
+@public
+def get_val1() -> int:
+    example = Example()
+    return example.val1
+
+
+@public
+def get_val2() -> int:
+    example = Example()
+    return example.val2

--- a/boa3_test/tests/compiler_tests/test_class.py
+++ b/boa3_test/tests/compiler_tests/test_class.py
@@ -172,6 +172,13 @@ class TestClass(BoaTest):
         result = self.run_smart_contract(engine, path, 'call_by_class_name')
         self.assertEqual(42, result)
 
+    def test_user_class_with_class_method_called_from_variable(self):
+        path = self.get_contract_path('UserClassWithClassMethodFromVariable.py')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'call_by_class_name')
+        self.assertEqual(42, result)
+
     def test_user_class_with_class_method_with_args(self):
         path = self.get_contract_path('UserClassWithClassMethodWithArgs.py')
         engine = TestEngine()
@@ -220,6 +227,16 @@ class TestClass(BoaTest):
         result = self.run_smart_contract(engine, path, 'get_val2')
         self.assertEqual(2, result)
 
+    def test_user_class_with_class_variable_from_variable(self):
+        path = self.get_contract_path('UserClassWithClassVariableFromVariable.py')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'get_val1')
+        self.assertEqual(1, result)
+
+        result = self.run_smart_contract(engine, path, 'get_val2')
+        self.assertEqual(2, result)
+
     def test_user_class_update_class_variable(self):
         path = self.get_contract_path('UserClassUpdateClassVariable.py')
         self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
@@ -255,12 +272,31 @@ class TestClass(BoaTest):
         result = self.run_smart_contract(engine, path, 'call_by_class_name')
         self.assertEqual(42, result)
 
+    def test_user_class_with_instance_method_from_variable(self):
+        path = self.get_contract_path('UserClassWithInstanceMethodFromVariable.py')
+        from boa3.compiler.codegenerator.vmcodemapping import VMCodeMapping
+        self.compile_and_save(path)
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'call_by_class_name')
+        self.assertEqual(42, result)
+
     def test_user_class_with_instance_variable_from_class(self):
         path = self.get_contract_path('UserClassWithInstanceVariableFromClass.py')
         self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
 
     def test_user_class_with_instance_variable_from_object(self):
         path = self.get_contract_path('UserClassWithInstanceVariableFromObject.py')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'get_val1')
+        self.assertEqual(1, result)
+
+        result = self.run_smart_contract(engine, path, 'get_val2')
+        self.assertEqual(2, result)
+
+    def test_user_class_with_instance_variable_from_variable(self):
+        path = self.get_contract_path('UserClassWithInstanceVariableFromVariable.py')
         engine = TestEngine()
 
         result = self.run_smart_contract(engine, path, 'get_val1')


### PR DESCRIPTION
**Related issue**
#719

**Summary or solution description**
Fixed bug with methods called from an user-defined class object stored in a variable

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/19b42533508dff31d27ff71f42256d664c6ff275/boa3_test/test_sc/class_test/UserClassWithInstanceMethodFromVariable.py#L4-L12

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/19b42533508dff31d27ff71f42256d664c6ff275/boa3_test/tests/compiler_tests/test_class.py#L175-L181
https://github.com/CityOfZion/neo3-boa/blob/19b42533508dff31d27ff71f42256d664c6ff275/boa3_test/tests/compiler_tests/test_class.py#L275-L307

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7