### PR TITLE
Verify support to user-defined class serialization

### DIFF
--- a/boa3_test/test_sc/interop_test/stdlib/SerializationUserClass.py
+++ b/boa3_test/test_sc/interop_test/stdlib/SerializationUserClass.py
@@ -1,0 +1,37 @@
+from typing import cast
+
+from boa3.builtin import public
+from boa3.builtin.interop.stdlib import deserialize, serialize
+
+
+class Example:
+    def __init__(self):
+        self.val1 = 2
+        self.val2 = self.val1 * 2
+
+    def some_method(self) -> int:
+        return 42
+
+
+@public
+def serialize_user_class() -> bytes:
+    user_class = Example()
+    return serialize(user_class)
+
+
+@public
+def deserialize_user_class(arg: bytes) -> Example:
+    user_class = cast(Example, deserialize(arg))
+    return user_class
+
+
+@public
+def get_variable_from_deserialized(arg: bytes) -> int:
+    user_class = deserialize_user_class(arg)
+    return user_class.val1
+
+
+@public
+def call_method_from_deserialized(arg: bytes) -> int:
+    user_class = deserialize_user_class(arg)
+    return user_class.some_method()

--- a/boa3_test/tests/compiler_tests/test_class.py
+++ b/boa3_test/tests/compiler_tests/test_class.py
@@ -274,7 +274,6 @@ class TestClass(BoaTest):
 
     def test_user_class_with_instance_method_from_variable(self):
         path = self.get_contract_path('UserClassWithInstanceMethodFromVariable.py')
-        from boa3.compiler.codegenerator.vmcodemapping import VMCodeMapping
         self.compile_and_save(path)
         engine = TestEngine()
 

--- a/boa3_test/tests/compiler_tests/test_interop/test_stdlib.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_stdlib.py
@@ -307,6 +307,26 @@ class TestStdlibInterop(BoaTest):
         result = self.run_smart_contract(engine, path, 'main', 4)
         self.assertEqual(['j', 3, 5], result)
 
+    def test_user_class_serialization(self):
+        path = self.get_contract_path('SerializationUserClass.py')
+        engine = TestEngine()
+
+        expected_class = [2, 4]
+        serialized = self.run_smart_contract(engine, path, 'serialize_user_class',
+                                             expected_result_type=bytes)
+        expected_result = serialize(expected_class)
+        self.assertEqual(expected_result, serialized)
+
+        result = self.run_smart_contract(engine, path, 'deserialize_user_class', serialized,
+                                         expected_result_type=list)
+        self.assertEqual(expected_class, result)
+
+        result = self.run_smart_contract(engine, path, 'get_variable_from_deserialized', serialized)
+        self.assertEqual(2, result)
+
+        result = self.run_smart_contract(engine, path, 'call_method_from_deserialized', serialized)
+        self.assertEqual(42, result)
+
     def test_atoi(self):
         path = self.get_contract_path('Atoi.py')
         engine = TestEngine()


### PR DESCRIPTION
**Related issue**
#727

**Summary or solution description**
Included unit tests to test `serialize` and `deserialize` objects from user-defined classes.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/534690bebf2441cc0503d38207e0883f76b5b29c/boa3_test/test_sc/interop_test/stdlib/SerializationUserClass.py#L4-L37

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/534690bebf2441cc0503d38207e0883f76b5b29c/boa3_test/tests/compiler_tests/test_interop/test_stdlib.py#L310-L328

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7