### PR TITLE
Fix issue with importing modules from different packages than current compiling file

### DIFF
--- a/boa3/analyser/analyser.py
+++ b/boa3/analyser/analyser.py
@@ -24,7 +24,7 @@ class Analyser:
     :ivar symbol_table: a dictionary used to store the identifiers
     """
 
-    def __init__(self, ast_tree: ast.AST, path: str = None, log: bool = False):
+    def __init__(self, ast_tree: ast.AST, path: str = None, project_root: str = None, log: bool = False):
         self.symbol_table: Dict[str, ISymbol] = {}
 
         self.ast_tree: ast.AST = ast_tree
@@ -39,9 +39,12 @@ class Analyser:
         import os
         self.path: str = path
         self.filename: str = path if path is None else os.path.realpath(path)
+        if os.path.isfile(project_root):
+            project_root = os.path.dirname(os.path.abspath(project_root))
+        self.root: str = os.path.realpath(project_root) if os.path.isdir(project_root) else path
 
     @staticmethod
-    def analyse(path: str, log: bool = False, analysed_files: Optional[List[str]] = None) -> Analyser:
+    def analyse(path: str, log: bool = False, analysed_files: Optional[List[str]] = None, root: str = None) -> Analyser:
         """
         Analyses the syntax of the Python code
 
@@ -55,7 +58,7 @@ class Analyser:
         with open(path, 'rb') as source:
             ast_tree = ast.parse(source.read())
 
-        analyser = Analyser(ast_tree, path, log)
+        analyser = Analyser(ast_tree, path, root if isinstance(root, str) else path, log)
         analyser.__pre_execute()
 
         # fill symbol table
@@ -106,6 +109,7 @@ class Analyser:
         module_analyser = ModuleAnalyser(self, self.symbol_table,
                                          log=self._log,
                                          filename=self.filename,
+                                         root_folder=self.root,
                                          analysed_files=analysed_files)
         self.symbol_table.update(module_analyser.global_symbols)
         self.ast_tree.body.extend(module_analyser.imported_nodes)

--- a/boa3/analyser/analyser.py
+++ b/boa3/analyser/analyser.py
@@ -39,9 +39,12 @@ class Analyser:
         import os
         self.path: str = path
         self.filename: str = path if path is None else os.path.realpath(path)
-        if os.path.isfile(project_root):
+
+        if project_root is not None and os.path.isfile(project_root):
             project_root = os.path.dirname(os.path.abspath(project_root))
-        self.root: str = os.path.realpath(project_root) if os.path.isdir(project_root) else path
+        self.root: str = (os.path.realpath(project_root)
+                          if project_root is not None and os.path.isdir(project_root)
+                          else path)
 
     @staticmethod
     def analyse(path: str, log: bool = False, analysed_files: Optional[List[str]] = None, root: str = None) -> Analyser:

--- a/boa3/analyser/moduleanalyser.py
+++ b/boa3/analyser/moduleanalyser.py
@@ -648,7 +648,6 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
             symbol = self.get_symbol(fun_rtype_symbol, origin_node=function.returns)
             fun_rtype_symbol = self.get_type(symbol)
 
-
         fun_return: IType = self.get_type(fun_rtype_symbol)
 
         method = Method(args=fun_args.args, defaults=function.args.defaults, return_type=fun_return,

--- a/boa3/analyser/moduleanalyser.py
+++ b/boa3/analyser/moduleanalyser.py
@@ -49,9 +49,10 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
     :ivar symbols: a dictionary that maps the global symbols.
     """
 
-    def __init__(self, analyser, symbol_table: Dict[str, ISymbol], filename: str = None,
+    def __init__(self, analyser, symbol_table: Dict[str, ISymbol],
+                 filename: str = None, root_folder: str = None,
                  analysed_files: Optional[List[str]] = None, log: bool = False):
-        super().__init__(analyser.ast_tree, filename, log)
+        super().__init__(analyser.ast_tree, filename, root_folder, log)
         self.modules: Dict[str, Module] = {}
         self.symbols: Dict[str, ISymbol] = symbol_table
 
@@ -234,7 +235,7 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
 
     def _log_import(self, import_from: str):
         if self._log:
-            logging.info("Importing '{0}'".format(import_from))
+            logging.info("Importing '{0}'\t <{1}>".format(import_from, self.filename))
 
     def _log_unresolved_import(self, origin_node: ast.AST, import_id: str):
         if self._log:
@@ -399,6 +400,7 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
             already_imported = already_imported.union(self._analysed_files)
 
         analyser = ImportAnalyser(import_target=target,
+                                  root_folder=self.root_folder,
                                   importer_file=self.filename,
                                   already_imported_modules=list(already_imported),
                                   log=self._log)

--- a/boa3/analyser/supportedstandard/standardanalyser.py
+++ b/boa3/analyser/supportedstandard/standardanalyser.py
@@ -19,7 +19,7 @@ class StandardAnalyser(IAstAnalyser):
     def __init__(self, analyser, symbol_table: Dict[str, ISymbol], log: bool = False):
         from boa3.builtin import NeoMetadata
 
-        super().__init__(analyser.ast_tree, log=log)
+        super().__init__(analyser.ast_tree, analyser.filename, log=log)
 
         self.symbols: Dict[str, ISymbol] = symbol_table
 

--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -46,7 +46,7 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
     """
 
     def __init__(self, analyser, symbol_table: Dict[str, ISymbol], log: bool = False):
-        super().__init__(analyser.ast_tree, log=log)
+        super().__init__(analyser.ast_tree, analyser.filename, log=log)
         self.type_errors: List[Exception] = []
         self.modules: Dict[str, Module] = {}
         self.symbols: Dict[str, ISymbol] = symbol_table

--- a/boa3/exception/CompilerError.py
+++ b/boa3/exception/CompilerError.py
@@ -14,10 +14,13 @@ class CompilerError(ABC, BaseException):
     def __init__(self, line: int, col: int):
         self.line: int = line
         self.col: int = col
+        self.filepath: Optional[str] = None
 
     @property
     def message(self) -> str:
         message = '' if self._error_message is None else ' - ' + self._error_message
+        if isinstance(self.filepath, str):
+            message += f'\t <{self.filepath}>'
         return '{0}:{1}{2}'.format(self.line, self.col, message)
 
     @property
@@ -236,10 +239,6 @@ class MissingStandardDefinition(CompilerError):
                                                                   self.symbol_id,
                                                                   self.symbol.shadowing_name,
                                                                   self.symbol)
-
-    @property
-    def message(self) -> str:
-        return self._error_message
 
 
 class NotSupportedOperation(CompilerError):

--- a/boa3/exception/CompilerWarning.py
+++ b/boa3/exception/CompilerWarning.py
@@ -6,10 +6,13 @@ class CompilerWarning(ABC, BaseException):
     def __init__(self, line: int, col: int):
         self.line: int = line
         self.col: int = col
+        self.filepath: Optional[str] = None
 
     @property
     def message(self) -> str:
         message = '' if self._warning_message is None else ' - ' + self._warning_message
+        if isinstance(self.filepath, str):
+            message += f'\t <{self.filepath}>'
         return '{0}:{1}{2}'.format(self.line, self.col, message)
 
     @property

--- a/boa3_test/tests/compiler_tests/test_class.py
+++ b/boa3_test/tests/compiler_tests/test_class.py
@@ -274,7 +274,6 @@ class TestClass(BoaTest):
 
     def test_user_class_with_instance_method_from_variable(self):
         path = self.get_contract_path('UserClassWithInstanceMethodFromVariable.py')
-        self.compile_and_save(path)
         engine = TestEngine()
 
         result = self.run_smart_contract(engine, path, 'call_by_class_name')


### PR DESCRIPTION
**Related issue**
#734

**Summary or solution description**
Fixed the import from packages outside `boa3` package

**How to Reproduce**
```python
from objects.example import Example


@public
def new_example() -> Example:
    return Example()
```

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
