### PR TITLE
UInt160, UInt256, ECPoint only accept int, not bytes

### DIFF
--- a/boa3/model/operation/binary/arithmetic/__init__.py
+++ b/boa3/model/operation/binary/arithmetic/__init__.py
@@ -5,7 +5,7 @@ __all__ = ['Addition',
            'Modulo',
            'Multiplication',
            'Power',
-           'StrMultiplication',
+           'StrBytesMultiplication',
            'Subtraction'
            ]
 
@@ -16,5 +16,5 @@ from boa3.model.operation.binary.arithmetic.floordivision import FloorDivision
 from boa3.model.operation.binary.arithmetic.modulo import Modulo
 from boa3.model.operation.binary.arithmetic.multiplication import Multiplication
 from boa3.model.operation.binary.arithmetic.power import Power
-from boa3.model.operation.binary.arithmetic.strmultiplication import StrMultiplication
+from boa3.model.operation.binary.arithmetic.strbytesmultiplication import StrBytesMultiplication
 from boa3.model.operation.binary.arithmetic.subtraction import Subtraction

--- a/boa3/model/operation/binary/arithmetic/strbytesmultiplication.py
+++ b/boa3/model/operation/binary/arithmetic/strbytesmultiplication.py
@@ -6,16 +6,16 @@ from boa3.model.type.type import IType, Type
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
-class StrMultiplication(BinaryOperation):
+class StrBytesMultiplication(BinaryOperation):
     """
-    A class used to represent a string concatenation operation
+    A class used to represent a string or bytes concatenation operation
 
     :ivar operator: the operator of the operation. Inherited from :class:`IOperation`
     :ivar left: the left operand type. Inherited from :class:`BinaryOperation`
     :ivar right: the left operand type. Inherited from :class:`BinaryOperation`
     :ivar result: the result type of the operation.  Inherited from :class:`IOperation`
     """
-    _valid_types: List[IType] = [Type.str]
+    _valid_types: List[IType] = [Type.str, Type.bytes]
 
     def __init__(self, left: IType = Type.str, right: IType = Type.int):
         self.operator: Operator = Operator.Mult

--- a/boa3/model/operation/binaryop.py
+++ b/boa3/model/operation/binaryop.py
@@ -22,7 +22,7 @@ class BinaryOp:
     Mod = Modulo()
     Pow = Power()
     Concat = Concat()
-    StrMul = StrMultiplication()
+    StrBytesMul = StrBytesMultiplication()
 
     # Relational operations
     NumEq = NumericEquality()

--- a/boa3_test/test_sc/arithmetic_test/BytesMultiplication.py
+++ b/boa3_test/test_sc/arithmetic_test/BytesMultiplication.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def bytes_mult(a: bytes, b: int) -> bytes:
+    return a * b

--- a/boa3_test/test_sc/arithmetic_test/BytesMultiplicationAugmentedAssignment.py
+++ b/boa3_test/test_sc/arithmetic_test/BytesMultiplicationAugmentedAssignment.py
@@ -2,6 +2,6 @@ from boa3.builtin import public
 
 
 @public
-def Main(a: str, b: int) -> str:
+def Main(a: bytes, b: int) -> bytes:
     a *= b
     return a

--- a/boa3_test/test_sc/arithmetic_test/BytesMultiplicationBuiltinType.py
+++ b/boa3_test/test_sc/arithmetic_test/BytesMultiplicationBuiltinType.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.interop.storage.findoptions import FindOptions
+
+
+@public
+def bytes_mult(a: bytes, b: FindOptions) -> bytes:
+    return a * b

--- a/boa3_test/tests/compiler_tests/test_arithmetic.py
+++ b/boa3_test/tests/compiler_tests/test_arithmetic.py
@@ -1,6 +1,5 @@
 from boa3.boa3 import Boa3
 from boa3.exception import CompilerError
-from boa3.model.operation.binary.arithmetic import StrBytesMultiplication
 from boa3.model.operation.binaryop import BinaryOp
 from boa3.model.type.type import Type
 from boa3.neo.vm.opcode.Opcode import Opcode
@@ -665,7 +664,7 @@ class TestArithmetic(BoaTest):
             + b'\x02'
             + Opcode.LDARG0
             + Opcode.LDARG1
-            + StrBytesMultiplication(Type.bytes).bytecode
+            + BinaryOp.StrBytesMul.build(Type.bytes).bytecode
             + Opcode.RET
         )
 
@@ -688,7 +687,7 @@ class TestArithmetic(BoaTest):
             + b'\x02'
             + Opcode.LDARG0
             + Opcode.LDARG1
-            + StrBytesMultiplication(Type.bytes).bytecode
+            + BinaryOp.StrBytesMul.build(Type.bytes).bytecode
             + Opcode.STARG0
             + Opcode.LDARG0
             + Opcode.RET


### PR DESCRIPTION
**Related issue**
#735 

**Summary or solution description**
Changed `strmultiplication.py` to also permit bytes multiplication.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/69b422e9ddd47e20872fa29fb29b9f77015b8891/boa3_test/test_sc/arithmetic_test/BytesMultiplication.py#L1-L6

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/69b422e9ddd47e20872fa29fb29b9f77015b8891/boa3_test/tests/compiler_tests/test_arithmetic.py#L661-L712

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
