### PR TITLE
Function with no return value does not compile

### DIFF
--- a/boa3/analyser/moduleanalyser.py
+++ b/boa3/analyser/moduleanalyser.py
@@ -642,10 +642,6 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
                 )
             )
 
-        if fun_rtype_symbol is None:
-            # it is a function with None return: Main(a: int) -> None:
-            raise NotImplementedError
-
         if isinstance(fun_rtype_symbol, str):
             symbol = self.get_symbol(fun_rtype_symbol, origin_node=function.returns)
             fun_rtype_symbol = self.get_type(symbol)

--- a/boa3_test/test_sc/function_test/NoneFunction.py
+++ b/boa3_test/test_sc/function_test/NoneFunction.py
@@ -1,2 +1,0 @@
-def Main(a: int) -> None:
-    pass

--- a/boa3_test/test_sc/function_test/NoneFunctionChangingValuesWithReturn.py
+++ b/boa3_test/test_sc/function_test/NoneFunctionChangingValuesWithReturn.py
@@ -1,0 +1,15 @@
+from typing import List
+
+from boa3.builtin import public
+
+
+def return_none(a: List[int]) -> None:
+    a.append(10)
+    return None
+
+
+@public
+def main() -> List[int]:
+    a = [2, 4, 6, 8]
+    return_none(a)
+    return a

--- a/boa3_test/test_sc/function_test/NoneFunctionChangingValuesWithoutReturn.py
+++ b/boa3_test/test_sc/function_test/NoneFunctionChangingValuesWithoutReturn.py
@@ -1,0 +1,14 @@
+from typing import List
+
+from boa3.builtin import public
+
+
+def return_none(a: List[int]) -> None:
+    a.append(10)
+
+
+@public
+def main() -> List[int]:
+    a = [2, 4, 6, 8]
+    return_none(a)
+    return a

--- a/boa3_test/test_sc/function_test/NoneFunctionPass.py
+++ b/boa3_test/test_sc/function_test/NoneFunctionPass.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main(a: int) -> None:
+    pass

--- a/boa3_test/test_sc/function_test/NoneFunctionReturnNone.py
+++ b/boa3_test/test_sc/function_test/NoneFunctionReturnNone.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main() -> None:
+    return None

--- a/boa3_test/tests/compiler_tests/test_function.py
+++ b/boa3_test/tests/compiler_tests/test_function.py
@@ -1,6 +1,7 @@
 from boa3 import constants
 from boa3.boa3 import Boa3
 from boa3.exception import CompilerError
+from boa3.neo.smart_contract.VoidType import VoidType
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3_test.tests.boa_test import BoaTest
@@ -61,9 +62,33 @@ class TestFunction(BoaTest):
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(1, result)
 
-    def test_none_function(self):
-        path = self.get_contract_path('NoneFunction.py')
-        self.assertCompilerLogs(CompilerError.InternalError, path)
+    def test_none_function_pass(self):
+        path = self.get_contract_path('NoneFunctionPass.py')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'main', 1)
+        self.assertEqual(VoidType, result)
+
+    def test_none_function_return_none(self):
+        path = self.get_contract_path('NoneFunctionReturnNone.py')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'main')
+        self.assertEqual(VoidType, result)
+
+    def test_none_function_changing_values_with_return(self):
+        path = self.get_contract_path('NoneFunctionChangingValuesWithReturn.py')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'main')
+        self.assertEqual([2, 4, 6, 8, 10], result)
+
+    def test_none_function_changing_values_without_return(self):
+        path = self.get_contract_path('NoneFunctionChangingValuesWithoutReturn.py')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'main')
+        self.assertEqual([2, 4, 6, 8, 10], result)
 
     def test_arg_without_type_hint(self):
         path = self.get_contract_path('ArgWithoutTypeHintFunction.py')

--- a/boa3_test/tests/compiler_tests/test_function.py
+++ b/boa3_test/tests/compiler_tests/test_function.py
@@ -1,7 +1,6 @@
 from boa3 import constants
 from boa3.boa3 import Boa3
 from boa3.exception import CompilerError
-from boa3.neo.smart_contract.VoidType import VoidType
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3_test.tests.boa_test import BoaTest
@@ -67,14 +66,14 @@ class TestFunction(BoaTest):
         engine = TestEngine()
 
         result = self.run_smart_contract(engine, path, 'main', 1)
-        self.assertEqual(VoidType, result)
+        self.assertIsVoid(result)
 
     def test_none_function_return_none(self):
         path = self.get_contract_path('NoneFunctionReturnNone.py')
         engine = TestEngine()
 
         result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(VoidType, result)
+        self.assertIsVoid(result)
 
     def test_none_function_changing_values_with_return(self):
         path = self.get_contract_path('NoneFunctionChangingValuesWithReturn.py')


### PR DESCRIPTION
**Related issue**
#736 

**Summary or solution description**
Removed a piece of code to let it be possible to compile a function returning `None` and added some more tests.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/d3aa84ddcd99f137c7e66055612fd0a77d672235/boa3_test/test_sc/function_test/NoneFunctionChangingValuesWithReturn.py#L1-L15

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/d3aa84ddcd99f137c7e66055612fd0a77d672235/boa3_test/tests/compiler_tests/test_function.py#L65-L91

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
