### PR TITLE
Support to super()

### DIFF
--- a/boa3/analyser/moduleanalyser.py
+++ b/boa3/analyser/moduleanalyser.py
@@ -186,7 +186,8 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
         :param callable_id: method id
         :param callable: method to be included
         """
-        if callable_id not in self._current_scope.symbols and hasattr(self._current_scope, 'include_callable'):
+        if ((self._current_scope is self._current_class or callable_id not in self._current_scope.symbols)
+                and hasattr(self._current_scope, 'include_callable')):
             self._current_scope.include_callable(callable_id, callable)
 
     def __include_class_variable(self, cl_var_id: str, cl_var: Variable):
@@ -796,7 +797,7 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
             fun_args.set_vararg(var_id, var)
 
         if arguments.kwarg is not None:
-            var_id, var = self.visit_arg(arguments.kwarg)   # Tuple[str, Variable]
+            var_id, var = self.visit_arg(arguments.kwarg)  # Tuple[str, Variable]
             fun_args.add_kwarg(var_id, var)
 
         return fun_args

--- a/boa3/compiler/codegenerator/codegeneratorvisitor.py
+++ b/boa3/compiler/codegenerator/codegeneratorvisitor.py
@@ -761,6 +761,9 @@ class VisitorCodeGenerator(IAstAnalyser):
 
         if self.is_exception_name(function_id):
             self.generator.convert_new_exception(len(call.args))
+        elif isinstance(symbol, type(Builtin.Super)) and len(args_to_generate) == 0:
+            self_or_cls_id = list(self.current_method.args)[0]
+            self.generator.convert_load_symbol(self_or_cls_id)
         elif isinstance(symbol, IBuiltinMethod):
             self.generator.convert_builtin_method_call(symbol, args_addresses)
         else:

--- a/boa3/exception/CompilerError.py
+++ b/boa3/exception/CompilerError.py
@@ -208,6 +208,19 @@ class MismatchedTypes(CompilerError):
         return "Expected type '%s', got '%s' instead" % (expected_types, actual_types)
 
 
+class MissingInitCall(CompilerError):
+    """
+    An error raised when a custom class is created with inheritance and it's missing the base __init__ call
+    """
+
+    def __init__(self, line: int, col: int):
+        super().__init__(line, col)
+
+    @property
+    def _error_message(self) -> Optional[str]:
+        return "Call to __init__ of super class is missed"
+
+
 class MissingReturnStatement(CompilerError):
     """
     An error raised when a function with a return value is missing a return statement

--- a/boa3/model/builtin/method/supermethod.py
+++ b/boa3/model/builtin/method/supermethod.py
@@ -1,19 +1,33 @@
-from typing import Optional
+from typing import Any, Optional, Sized
 
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.type.classes.classtype import ClassType
+from boa3.model.type.itype import IType
 
 
 class SuperMethod(IBuiltinMethod):
 
-    def __init__(self):
-        # TODO: Change when super() is implemented
+    def __init__(self, value_type: IType = None):
+        if isinstance(value_type, ClassType) and len(value_type.bases) > 0:
+            # TODO: change when inheritance with multiple bases is implemented
+            return_type = value_type.bases[0]
+        else:
+            from boa3.model.type.type import Type
+            return_type = Type.any
+
         identifier = 'super'
-        super().__init__(identifier)
+        self._super_type = value_type if isinstance(value_type, IType) else None
+        super().__init__(identifier, return_type=return_type)
+
+    @property
+    def identifier(self) -> str:
+        if self._super_type is None:
+            return self._identifier
+        return '-{0}_from_{1}'.format(self._identifier, self._super_type._identifier)
 
     @property
     def is_supported(self) -> bool:
-        # TODO: Change when super() is implemented
-        return False
+        return self._super_type is not None
 
     @property
     def _args_on_stack(self) -> int:
@@ -22,3 +36,12 @@ class SuperMethod(IBuiltinMethod):
     @property
     def _body(self) -> Optional[str]:
         return
+
+    def build(self, value: Any) -> IBuiltinMethod:
+        if isinstance(value, Sized) and len(value) > 0:
+            value = value[0]
+        if value == self._super_type:
+            return self
+        if isinstance(value, IType):
+            return SuperMethod(value)
+        return super().build(value)

--- a/boa3/model/callable.py
+++ b/boa3/model/callable.py
@@ -101,6 +101,13 @@ class Callable(IExpression, ABC):
         return any(decorator.has_cls_or_self for decorator in self.decorators)
 
     @property
+    def cls_or_self_type(self) -> Optional[IType]:
+        if not self.has_cls_or_self or len(self.args) == 0:
+            return None
+
+        return list(self.args.values())[0].type
+
+    @property
     def has_starred_argument(self) -> bool:
         return self._vararg is not None
 

--- a/boa3_test/test_sc/built_in_methods_test/SuperCallMethod.py
+++ b/boa3_test/test_sc/built_in_methods_test/SuperCallMethod.py
@@ -1,0 +1,22 @@
+from boa3.builtin import public
+
+
+class Foo:
+    def __init__(self, var_value: int):
+        self.bar = var_value
+
+    def test_method(self) -> int:
+        return -20
+
+
+class Example(Foo):
+    def test_method(self) -> int:
+        if self.bar > 30:
+            return super().test_method()
+        return self.bar
+
+
+@public
+def example_method(var_value: int) -> int:
+    foo = Example(var_value)
+    return foo.test_method()

--- a/boa3_test/test_sc/built_in_methods_test/SuperWithArgs.py
+++ b/boa3_test/test_sc/built_in_methods_test/SuperWithArgs.py
@@ -1,0 +1,22 @@
+from boa3.builtin import public
+
+
+class Foo:
+    def __init__(self, var_value: int):
+        self.bar = var_value
+
+    def test_method(self) -> int:
+        return -20
+
+
+class Example(Foo):
+    def test_method(self) -> int:
+        if self.bar > 30:
+            return super(Example, self).test_method()  # super with args is not implemented yet
+        return self.bar
+
+
+@public
+def example_method(var_value: int) -> int:
+    foo = Example(var_value)
+    return foo.test_method()

--- a/boa3_test/test_sc/class_test/UserClassWithCreatedBaseWithInitWithArgs.py
+++ b/boa3_test/test_sc/class_test/UserClassWithCreatedBaseWithInitWithArgs.py
@@ -2,13 +2,13 @@ from boa3.builtin import public
 
 
 class Foo:
-    def __init__(self):
-        self.bar = 42
+    def __init__(self, init_value: int):
+        self.bar = init_value
 
 
 class Example(Foo):
     def __init__(self):
-        super().__init__()
+        super().__init__(-10)
 
 
 @public

--- a/boa3_test/test_sc/class_test/UserClassWithCreatedBaseWithMoreVariables.py
+++ b/boa3_test/test_sc/class_test/UserClassWithCreatedBaseWithMoreVariables.py
@@ -9,9 +9,10 @@ class Foo:
 class Example(Foo):
     def __init__(self):
         super().__init__()
+        self.var_1 = 10
+        self.var_2 = 20
 
 
 @public
-def inherited_var() -> int:
-    foo = Example()
-    return foo.bar
+def get_full_object() -> Example:
+    return Example()

--- a/boa3_test/test_sc/class_test/UserClassWithCreatedBaseWithMoreVariablesWithoutSuperInit.py
+++ b/boa3_test/test_sc/class_test/UserClassWithCreatedBaseWithMoreVariablesWithoutSuperInit.py
@@ -8,10 +8,10 @@ class Foo:
 
 class Example(Foo):
     def __init__(self):
-        super().__init__()
+        self.var_1 = 10
+        self.var_2 = 20
 
 
 @public
-def inherited_var() -> int:
-    foo = Example()
-    return foo.bar
+def get_full_object() -> Example:
+    return Example()

--- a/boa3_test/tests/compiler_tests/test_builtin_method.py
+++ b/boa3_test/tests/compiler_tests/test_builtin_method.py
@@ -1415,3 +1415,29 @@ class TestBuiltinMethod(BoaTest):
         self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
 
     # endregion
+
+    # region super test
+
+    def test_super_with_args(self):
+        # TODO: Change when super with args is implemented
+        path = self.get_contract_path('SuperWithArgs.py')
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+
+    def test_super_call_method(self):
+        path = self.get_contract_path('SuperCallMethod.py')
+        engine = TestEngine()
+
+        super_method_expected_result = -20
+        arg = 20
+        result = self.run_smart_contract(engine, path, 'example_method', arg)
+        self.assertEqual(arg, result)
+
+        arg = 30
+        result = self.run_smart_contract(engine, path, 'example_method', arg)
+        self.assertEqual(arg, result)
+
+        arg = 40
+        result = self.run_smart_contract(engine, path, 'example_method', arg)
+        self.assertEqual(super_method_expected_result, result)
+
+    # endregion

--- a/boa3_test/tests/compiler_tests/test_class.py
+++ b/boa3_test/tests/compiler_tests/test_class.py
@@ -403,7 +403,31 @@ class TestClass(BoaTest):
 
     def test_user_class_with_created_base_with_init(self):
         path = self.get_contract_path('UserClassWithCreatedBaseWithInit.py')
-        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+        engine = TestEngine()
+
+        expected_result = 42
+        result = self.run_smart_contract(engine, path, 'inherited_var')
+        self.assertEqual(expected_result, result)
+
+    def test_user_class_with_created_base_with_init_with_args(self):
+        path = self.get_contract_path('UserClassWithCreatedBaseWithInitWithArgs.py')
+        engine = TestEngine()
+
+        expected_result = -10
+        result = self.run_smart_contract(engine, path, 'inherited_var')
+        self.assertEqual(expected_result, result)
+
+    def test_user_class_with_created_base_with_more_variables(self):
+        path = self.get_contract_path('UserClassWithCreatedBaseWithMoreVariables.py')
+        engine = TestEngine()
+
+        expected_result = [42, 10, 20]
+        result = self.run_smart_contract(engine, path, 'get_full_object')
+        self.assertEqual(expected_result, result)
+
+    def test_user_class_with_created_base_with_more_variables_without_super_init(self):
+        path = self.get_contract_path('UserClassWithCreatedBaseWithMoreVariablesWithoutSuperInit.py')
+        self.assertCompilerLogs(CompilerError.MissingInitCall, path)
 
     def test_user_class_with_multiple_bases(self):
         path = self.get_contract_path('UserClassWithMultipleBases.py')


### PR DESCRIPTION
**Related issue**
#723

**Summary or solution description**
Implemented `super()` calls to support more usages of inheritance. Only `super()` call without arguments is implemented

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/95095ff6a2278d2e80fce42d71a782db3e67fdc2/boa3_test/test_sc/class_test/UserClassWithCreatedBaseWithInitWithArgs.py#L4-L11
https://github.com/CityOfZion/neo3-boa/blob/95095ff6a2278d2e80fce42d71a782db3e67fdc2/boa3_test/test_sc/built_in_methods_test/SuperCallMethod.py#L12-L16

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/95095ff6a2278d2e80fce42d71a782db3e67fdc2/boa3_test/tests/compiler_tests/test_class.py#L404-L430
https://github.com/CityOfZion/neo3-boa/blob/95095ff6a2278d2e80fce42d71a782db3e67fdc2/boa3_test/tests/compiler_tests/test_builtin_method.py#L1421-L1441

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
