### PR TITLE
Add support to the + operator using lists

### DIFF
--- a/boa3/model/operation/binary/arithmetic/__init__.py
+++ b/boa3/model/operation/binary/arithmetic/__init__.py
@@ -2,6 +2,7 @@ __all__ = ['Addition',
            'Concat',
            'Division',
            'FloorDivision',
+           'ListAddition',
            'Modulo',
            'Multiplication',
            'Power',
@@ -13,6 +14,7 @@ from boa3.model.operation.binary.arithmetic.addition import Addition
 from boa3.model.operation.binary.arithmetic.concat import Concat
 from boa3.model.operation.binary.arithmetic.division import Division
 from boa3.model.operation.binary.arithmetic.floordivision import FloorDivision
+from boa3.model.operation.binary.arithmetic.listaddition import ListAddition
 from boa3.model.operation.binary.arithmetic.modulo import Modulo
 from boa3.model.operation.binary.arithmetic.multiplication import Multiplication
 from boa3.model.operation.binary.arithmetic.power import Power

--- a/boa3/model/operation/binary/arithmetic/listaddition.py
+++ b/boa3/model/operation/binary/arithmetic/listaddition.py
@@ -1,0 +1,64 @@
+from typing import List, Tuple
+
+from boa3.model.operation.binary.binaryoperation import BinaryOperation
+from boa3.model.operation.operator import Operator
+from boa3.model.type.type import IType, Type
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class ListAddition(BinaryOperation):
+    """
+    A class used to represent a list addition operation
+
+    :ivar operator: the operator of the operation. Inherited from :class:`IOperation`
+    :ivar left: the left operand type. Inherited from :class:`BinaryOperation`
+    :ivar right: the left operand type. Inherited from :class:`BinaryOperation`
+    :ivar result: the result type of the operation.  Inherited from :class:`IOperation`
+    """
+    _valid_types: List[IType] = [Type.list]
+
+    def __init__(self, left: IType = Type.list, right: IType = None):
+        self.operator: Operator = Operator.Plus
+        super().__init__(left, right)
+
+    @property
+    def is_symmetric(self) -> bool:
+        return True
+
+    def validate_type(self, *types: IType) -> bool:
+        if len(types) != self.number_of_operands:
+            return False
+        left: IType = types[0]
+        right: IType = types[1]
+
+        return left == right and any(_type.is_type_of(left) for _type in self._valid_types)
+
+    def _get_result(self, left: IType, right: IType) -> IType:
+        if self.validate_type(left, right):
+            return left
+        else:
+            return Type.none
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        from boa3.neo.vm.type.Integer import Integer
+        from boa3.neo.vm.type.StackItem import StackItemType
+        return [
+            (Opcode.OVER, b''),
+            (Opcode.ISTYPE, StackItemType.Array),
+            (Opcode.JMPIF, Integer(5).to_byte_array(signed=True, min_length=1)),
+            (Opcode.CAT, b''),
+            (Opcode.JMP, Integer(18).to_byte_array(signed=True, min_length=1)),
+            (Opcode.UNPACK, b''),       # get the values, top of stack will be the array size
+            (Opcode.JMP, Integer(9).to_byte_array(signed=True, min_length=1)),  # begin while
+            (Opcode.DUP, b''),
+            (Opcode.INC, b''),          # push the array to the top of the stack
+            (Opcode.PICK, b''),
+            (Opcode.PUSH2, b''),
+            (Opcode.ROLL, b''),         # get the first value that wasn't appended yet
+            (Opcode.APPEND, b''),       # append the value to the array
+            (Opcode.DEC, b''),
+            (Opcode.DUP, b''),          # when the array is empty, stop the loop
+            (Opcode.JMPIF, Integer(-8).to_byte_array(signed=True, min_length=1)),
+            (Opcode.DROP, b''),         # the top items in the stack will be the extended array
+        ]

--- a/boa3/model/operation/binary/arithmetic/listaddition.py
+++ b/boa3/model/operation/binary/arithmetic/listaddition.py
@@ -21,10 +21,6 @@ class ListAddition(BinaryOperation):
         self.operator: Operator = Operator.Plus
         super().__init__(left, right)
 
-    @property
-    def is_symmetric(self) -> bool:
-        return True
-
     def validate_type(self, *types: IType) -> bool:
         if len(types) != self.number_of_operands:
             return False

--- a/boa3/model/operation/binaryop.py
+++ b/boa3/model/operation/binaryop.py
@@ -19,6 +19,7 @@ class BinaryOp:
     Mul = Multiplication()
     Div = Division()
     IntDiv = FloorDivision()
+    ListAdd = ListAddition()
     Mod = Modulo()
     Pow = Power()
     Concat = Concat()

--- a/boa3_test/test_sc/arithmetic_test/ListAddition.py
+++ b/boa3_test/test_sc/arithmetic_test/ListAddition.py
@@ -1,0 +1,23 @@
+from typing import List, Any
+
+from boa3.builtin import public
+
+
+@public
+def add_any(a: List[Any], b: List[Any]) -> List[Any]:
+    return a + b
+
+
+@public
+def add_int(a: List[int], b: List[int]) -> List[int]:
+    return a + b
+
+
+@public
+def add_bool(a: List[bool], b: List[bool]) -> List[bool]:
+    return a + b
+
+
+@public
+def add_str(a: List[str], b: List[str]) -> List[str]:
+    return a + b

--- a/boa3_test/tests/compiler_tests/test_arithmetic.py
+++ b/boa3_test/tests/compiler_tests/test_arithmetic.py
@@ -369,6 +369,23 @@ class TestArithmetic(BoaTest):
 
     # endregion
 
+    # region ListAddition
+
+    def test_list_addition(self):
+        path = self.get_contract_path('ListAddition.py')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'add_any', [1, 'str', '123'], [2, True, False])
+        self.assertEqual([1, 'str', '123'] + [2, True, False], result)
+        result = self.run_smart_contract(engine, path, 'add_int', [1, 3], [2, 5])
+        self.assertEqual([1, 3] + [2, 5], result)
+        result = self.run_smart_contract(engine, path, 'add_bool', [True], [False, True])
+        self.assertEqual([True] + [False, True], result)
+        result = self.run_smart_contract(engine, path, 'add_str', ['unit', ' '], ['test', '.'])
+        self.assertEqual(['unit', ' '] + ['test', '.'], result)
+
+    # endregion
+
     # region Mismatched
 
     def test_mismatched_type_binary_operation(self):


### PR DESCRIPTION
**Related issue**
#685 

**Summary or solution description**
Added another binary operation to make list addition possible.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/f3cfbf84fec477197508bbfd45e9d468f111897d/boa3_test/test_sc/arithmetic_test/ListAddition.py#L1-L23

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/f3cfbf84fec477197508bbfd45e9d468f111897d/boa3_test/tests/compiler_tests/test_arithmetic.py#L374-L385

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
