### PR TITLE
Using a property with the same as a variable doesn't run

### DIFF
--- a/boa3/analyser/astoptimizer.py
+++ b/boa3/analyser/astoptimizer.py
@@ -155,7 +155,7 @@ class AstOptimizer(IAstAnalyser, ast.NodeTransformer):
                     and self.is_symmetric_operation(bin_op.op, bin_op.left.op)):
                 left_value, right_value = self.reorder_operations(bin_op, bin_op.left)
             elif (right_value is Undefined and isinstance(bin_op.right, ast.BinOp)
-                    and self.is_symmetric_operation(bin_op.op, bin_op.right.op)):
+                  and self.is_symmetric_operation(bin_op.op, bin_op.right.op)):
                 left_value, right_value = self.reorder_operations(bin_op, bin_op.right)
 
             value = self._evaluate_binary_operation(left_value, right_value, bin_op.op)

--- a/boa3/analyser/constructanalyser.py
+++ b/boa3/analyser/constructanalyser.py
@@ -48,8 +48,8 @@ class ConstructAnalyser(IAstAnalyser, ast.NodeTransformer):
                     value = ast.literal_eval(call.func.value)
                     if not isinstance(value, tuple(types.values())):
                         return call
-                elif (isinstance(call.func.value, ast.Name)     # checks if is the name of a type
-                      and call.func.value.id in types        # and if the arguments is from the same type
+                elif (isinstance(call.func.value, ast.Name)  # checks if is the name of a type
+                      and call.func.value.id in types  # and if the arguments is from the same type
                       and len(call.args) == 1
                       and isinstance(call.args[0], literal)):
                     value = ast.literal_eval(call.args[0])

--- a/boa3/analyser/importanalyser.py
+++ b/boa3/analyser/importanalyser.py
@@ -63,7 +63,7 @@ class ImportAnalyser(IAstAnalyser):
             self.is_builtin_import = True
             return
 
-        if not('boa3' in path and '/'.join(path[path.index('boa3'):]).startswith('boa3/builtin')):
+        if not ('boa3' in path and '/'.join(path[path.index('boa3'):]).startswith('boa3/builtin')):
             # doesn't analyse boa3.builtin packages that aren't included in the imports.builtin as an user module
             # TODO: refactor when importing from user modules is accepted
             import re

--- a/boa3/analyser/supportedstandard/standardanalyser.py
+++ b/boa3/analyser/supportedstandard/standardanalyser.py
@@ -57,8 +57,8 @@ class StandardAnalyser(IAstAnalyser):
 
                 # validade standard's methods
                 for method_id, standard_method in current_standard.methods.items():
-                    if (method_id not in self.symbols or 
-                            not isinstance(self.symbols[method_id], Method) or 
+                    if (method_id not in self.symbols or
+                            not isinstance(self.symbols[method_id], Method) or
                             not current_standard.match_definition(method_id, self.symbols[method_id])):
                         self._log_error(
                             CompilerError.MissingStandardDefinition(standard, method_id, standard_method)
@@ -72,7 +72,6 @@ class StandardAnalyser(IAstAnalyser):
                             all(not current_standard.match_definition(event.name, event)
                                 for event in events_with_same_name
                                 )):
-
                         self._log_error(
                             CompilerError.MissingStandardDefinition(standard,
                                                                     standard_event.name,

--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -1220,7 +1220,6 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
 
             if (len(call.args) >= len(callable_target.args)
                     and (len(call.args) == 0 or not isinstance(call.args[0], ast.Starred))):
-
                 # starred argument is always the last argument
                 len_args_without_starred = len(callable_target.args) - 1
                 args = self.parse_to_node(str(Type.tuple.default_value), call)

--- a/boa3/builtin/__init__.py
+++ b/boa3/builtin/__init__.py
@@ -5,8 +5,10 @@ def public(*args):
     """
     This decorator identifies which methods should be included in the abi file.
     """
+
     def public_wrapper():
         pass
+
     return public_wrapper
 
 
@@ -15,8 +17,10 @@ def metadata(*args):
     This decorator identifies the function that returns the metadata object of the smart contract.
     This can be used to only one function. Using this decorator in multiple functions will raise a compiler error.
     """
+
     def metadata_wrapper():
         pass
+
     return metadata_wrapper
 
 

--- a/boa3/builtin/interop/blockchain/__init__.py
+++ b/boa3/builtin/interop/blockchain/__init__.py
@@ -74,7 +74,6 @@ Gets the hash of the current block.
 :meta hide-value:
 """
 
-
 current_index: int = 0
 """
 Gets the index of the current block.

--- a/boa3/compiler/codegenerator/codegenerator.py
+++ b/boa3/compiler/codegenerator/codegenerator.py
@@ -1384,7 +1384,7 @@ class CodeGenerator:
 
         symbol = self.get_symbol(symbol_id, is_internal=is_internal)
 
-        if symbol is Type.none and class_type is not None and symbol_id in class_type.symbols:
+        if class_type is not None and symbol_id in class_type.symbols:
             symbol = class_type.symbols[symbol_id]
 
         if symbol is not Type.none:

--- a/boa3/compiler/codegenerator/codegeneratorvisitor.py
+++ b/boa3/compiler/codegenerator/codegeneratorvisitor.py
@@ -723,7 +723,9 @@ class VisitorCodeGenerator(IAstAnalyser):
                          else call.args)
             args_to_generate = [arg for index, arg in enumerate(call_args) if index in symbol.args_to_be_generated()]
             keywords_dict = {keyword.arg: keyword.value for keyword in call.keywords}
-            keywords_with_index = {index: keywords_dict[arg_name] for index, arg_name in enumerate(symbol.args) if arg_name in keywords_dict}
+            keywords_with_index = {index: keywords_dict[arg_name]
+                                   for index, arg_name in enumerate(symbol.args)
+                                   if arg_name in keywords_dict}
 
             for index in keywords_with_index:
                 if index < len(args_to_generate):
@@ -916,7 +918,9 @@ class VisitorCodeGenerator(IAstAnalyser):
                     symbol_id = attribute.attr if isinstance(generation_result, Variable) else class_attr_id
                     result_type = result
                 else:
-                    index = self.generator.convert_class_symbol(result, attribute.attr, isinstance(attribute.ctx, ast.Load))
+                    index = self.generator.convert_class_symbol(result,
+                                                                attribute.attr,
+                                                                isinstance(attribute.ctx, ast.Load))
                     generated = True
                     symbol = result
                     if not isinstance(result, UserClass):

--- a/boa3/model/builtin/classmethod/countmethod.py
+++ b/boa3/model/builtin/classmethod/countmethod.py
@@ -16,7 +16,7 @@ class CountMethod(IBuiltinMethod):
     def identifier(self) -> str:
         from boa3.model.type.type import Type
 
-        if self._arg_self.type is Type.sequence:    # CountSequenceMethod default value for self
+        if self._arg_self.type is Type.sequence:  # CountSequenceMethod default value for self
             return self._identifier
 
         if self._arg_self.type is Type.str:

--- a/boa3/model/builtin/classmethod/indexmethod.py
+++ b/boa3/model/builtin/classmethod/indexmethod.py
@@ -16,7 +16,7 @@ class IndexMethod(IBuiltinMethod):
     def identifier(self) -> str:
         from boa3.model.type.type import Type
 
-        if self._arg_self.type is Type.sequence:    # IndexSequenceMethod default value for self
+        if self._arg_self.type is Type.sequence:  # IndexSequenceMethod default value for self
             return self._identifier
 
         if self._arg_self.type is Type.str:

--- a/boa3/model/builtin/classmethod/joinmethod.py
+++ b/boa3/model/builtin/classmethod/joinmethod.py
@@ -34,7 +34,7 @@ class JoinMethod(IBuiltinMethod):
         if Type.dict.is_type_of(self._arg_iterable.type):
             return '-{0}_{1}'.format(self._identifier, Type.dict.identifier)
 
-        return self._identifier                             # JoinMethod default value for self
+        return self._identifier  # JoinMethod default value for self
 
     @property
     def _arg_self(self) -> Variable:

--- a/boa3/model/builtin/contract/neoaccountstatetype.py
+++ b/boa3/model/builtin/contract/neoaccountstatetype.py
@@ -83,9 +83,8 @@ class NeoAccountStateMethod(IBuiltinMethod):
 
     @property
     def opcode(self) -> List[Tuple[Opcode, bytes]]:
-
         return [
-            Opcode.get_pushdata_and_data(bytes(33)),    # vote_to
+            Opcode.get_pushdata_and_data(bytes(33)),  # vote_to
             (Opcode.PUSH0, b''),  # height
             (Opcode.PUSH0, b''),  # balance
             (Opcode.PUSH3, b''),

--- a/boa3/model/builtin/internal/internalmethod.py
+++ b/boa3/model/builtin/internal/internalmethod.py
@@ -15,7 +15,6 @@ class IInternalMethod(IBuiltinMethod, abc.ABC):
     def __init__(self, identifier: str, args: Dict[str, Variable] = None,
                  defaults: List[ast.AST] = None, return_type: IType = None,
                  vararg: Optional[Tuple[str, Variable]] = None):
-
         super().__init__(identifier, args, defaults, return_type, vararg)
 
     @classmethod

--- a/boa3/model/builtin/interop/nativecontract/Neo/getneoscripthashmethod.py
+++ b/boa3/model/builtin/interop/nativecontract/Neo/getneoscripthashmethod.py
@@ -24,7 +24,6 @@ class GetNeoScriptHashMethod(IBuiltinMethod):
 
     @property
     def opcode(self) -> List[Tuple[Opcode, bytes]]:
-
         value = NEO_SCRIPT
         return [
             Opcode.get_pushdata_and_data(value)

--- a/boa3/model/builtin/interop/oracle/__init__.py
+++ b/boa3/model/builtin/interop/oracle/__init__.py
@@ -2,6 +2,5 @@ __all__ = ['OracleResponseCodeType',
            'OracleType',
            ]
 
-
 from boa3.model.builtin.interop.oracle.oracleresponsecodetype import OracleResponseCodeType
 from boa3.model.builtin.interop.oracle.oracletype import OracleType

--- a/boa3/model/builtin/interop/stdlib/memorysearchmethod.py
+++ b/boa3/model/builtin/interop/stdlib/memorysearchmethod.py
@@ -24,4 +24,6 @@ class MemorySearchMethod(StdLibMethod):
         backward_default = set_internal_call(ast.parse("{0}".format(Type.bool.default_value)
                                                        ).body[0].value)
 
-        super().__init__(identifier, native_identifier, args, defaults=[start_default, backward_default], return_type=Type.int)
+        super().__init__(identifier, native_identifier, args,
+                         defaults=[start_default, backward_default],
+                         return_type=Type.int)

--- a/boa3/model/builtin/interop/storage/storagecontext/storagecontexttype.py
+++ b/boa3/model/builtin/interop/storage/storagecontext/storagecontexttype.py
@@ -46,7 +46,8 @@ class StorageContextType(InteropInterfaceType):
         if len(self._instance_methods) == 0:
             from boa3.model.builtin.interop.storage.storagecontext.storagecontextcreatemapmethod import \
                 StorageContextCreateMapMethod
-            from boa3.model.builtin.interop.storage.storagecontext.storagecontextasreadonlymethod import StorageContextAsReadOnlyMethod
+            from boa3.model.builtin.interop.storage.storagecontext.storagecontextasreadonlymethod import \
+                StorageContextAsReadOnlyMethod
 
             self._instance_methods = {
                 'create_map': StorageContextCreateMapMethod(),

--- a/boa3/model/builtin/interop/storage/storagemap/storagemaptype.py
+++ b/boa3/model/builtin/interop/storage/storagemap/storagemaptype.py
@@ -33,7 +33,8 @@ class StorageMapType(ClassArrayType):
 
     @property
     def _all_variables(self) -> Dict[str, Variable]:
-        from boa3.model.builtin.interop.storage.storagecontext.storagecontexttype import _StorageContext as StorageContextType
+        from boa3.model.builtin.interop.storage.storagecontext.storagecontexttype import \
+            _StorageContext as StorageContextType
         from boa3.model.type.type import Type
 
         private_variables = {
@@ -96,7 +97,8 @@ class StorageMapMethod(IBuiltinMethod):
 
     def __init__(self, return_type: StorageMapType):
         from boa3.model.type.type import Type
-        from boa3.model.builtin.interop.storage.storagecontext.storagecontexttype import _StorageContext as StorageContextType
+        from boa3.model.builtin.interop.storage.storagecontext.storagecontexttype import \
+            _StorageContext as StorageContextType
 
         identifier = '-StorageMap__init__'
         args: Dict[str, Variable] = {

--- a/boa3/model/builtin/native/nativecontract.py
+++ b/boa3/model/builtin/native/nativecontract.py
@@ -8,7 +8,6 @@ from boa3.model.imports.package import Package
 
 
 class NativeContract:
-
     # Class Interfaces
     ContractManagement = ContractManagementClass()
     CryptoLib = CryptoLibClass()

--- a/boa3/model/imports/builtin.py
+++ b/boa3/model/imports/builtin.py
@@ -8,8 +8,8 @@ from boa3.model.builtin.native.nativecontract import NativeContract
 from boa3.model.identifiedsymbol import IdentifiedSymbol
 from boa3.model.imports.package import Package
 from boa3.model.symbol import ISymbol
-from boa3.model.type.typeutils import TypeUtils
 from boa3.model.type.math import Math
+from boa3.model.type.typeutils import TypeUtils
 
 __all__ = ['get_package',
            'get_internal_symbol'
@@ -25,7 +25,6 @@ def get_internal_symbol(symbol_id: str) -> Optional[ISymbol]:
 
 
 class CompilerBuiltin:
-
     _instance = None
 
     @classmethod

--- a/boa3/model/method.py
+++ b/boa3/model/method.py
@@ -111,7 +111,7 @@ class Method(Callable):
         """
         if not any((info.start_line == instr_info.start_line and info.start_col == instr_info.start_col
                     for info in self._debug_map)):
-            existing_instr_info: Optional[DebugInstruction] =\
+            existing_instr_info: Optional[DebugInstruction] = \
                 next((info for info in self._debug_map if info.code == instr_info.code), None)
             if existing_instr_info is not None:
                 self._debug_map.remove(existing_instr_info)

--- a/boa3/model/symbol.py
+++ b/boa3/model/symbol.py
@@ -2,7 +2,6 @@ from abc import ABC, abstractmethod
 
 
 class ISymbol(ABC):
-
     defined_by_entry: bool = False
 
     @property

--- a/boa3/model/type/collection/mapping/mappingtype.py
+++ b/boa3/model/type/collection/mapping/mappingtype.py
@@ -62,7 +62,7 @@ class MappingType(ICollectionType, ABC):
 
         if len(values_type) > 1 and all(isinstance(x, MappingType) for x in values_type):
             first_item: MappingType = list(values_type)[0]
-            mapping_type = type(first_item)          # first mapping type
+            mapping_type = type(first_item)  # first mapping type
 
             k_types = set(value.key_type for value in values_type)
             v_types = set(value.value_type for value in values_type)

--- a/boa3/neo/contracts/__init__.py
+++ b/boa3/neo/contracts/__init__.py
@@ -2,4 +2,5 @@ __all__ = [
     'NEF',
     'Version'
 ]
+
 from boa3.neo3.contracts.nef import NEF, Version

--- a/boa3/neo/core/__init__.py
+++ b/boa3/neo/core/__init__.py
@@ -2,4 +2,5 @@ __all__ = [
     'BinaryReader',
     'BinaryWriter'
 ]
+
 from boa3.neo3.core.serialization import BinaryReader, BinaryWriter

--- a/boa3/neo/vm/opcode/Opcode.py
+++ b/boa3/neo/vm/opcode/Opcode.py
@@ -9,7 +9,6 @@ from boa3.neo.vm.type.String import String
 
 
 class Opcode(bytes, Enum):
-
     # region Constants
 
     # Pushes a 1-byte signed integer onto the stack.

--- a/boa3/neo3/contracts/native/__init__.py
+++ b/boa3/neo3/contracts/native/__init__.py
@@ -1,4 +1,3 @@
 from boa3.neo3.contracts.native.nativetypes import Role
 
-
 __all__ = ['Role']

--- a/boa3/neo3/contracts/nef.py
+++ b/boa3/neo3/contracts/nef.py
@@ -129,9 +129,9 @@ class NEF(serialization.ISerializable):
             s.uint32  # magic
             + 32  # compiler
             + (s.uint64 * 4)  # version
-            + 2   # reserve
-            + utils.get_var_size(bytes())   # TODO: method tokens
-            + 2   # reserve
+            + 2  # reserve
+            + utils.get_var_size(bytes())  # TODO: method tokens
+            + 2  # reserve
             + utils.get_var_size(self.script)
             + s.uint32)  # checksum
 

--- a/boa3/neo3/core/serialization.py
+++ b/boa3/neo3/core/serialization.py
@@ -15,6 +15,7 @@ class ISerializable(abc.ABC):
     """
     An interface like class supporting NEO's network serialization protocol.
     """
+
     @abc.abstractmethod
     def serialize(self, writer: BinaryWriter) -> None:
         """

--- a/boa3_test/test_sc/arithmetic_test/ListAddition.py
+++ b/boa3_test/test_sc/arithmetic_test/ListAddition.py
@@ -1,4 +1,4 @@
-from typing import List, Any
+from typing import Any, List
 
 from boa3.builtin import public
 

--- a/boa3_test/test_sc/variable_test/DifferentScopesWithSameName.py
+++ b/boa3_test/test_sc/variable_test/DifferentScopesWithSameName.py
@@ -1,0 +1,17 @@
+from boa3.builtin import public
+
+
+class Example:
+    def __init__(self):
+        self._num = 1_000
+
+    @property
+    def number(self) -> int:
+        return self._num
+
+
+@public
+def test() -> int:
+    number = 10
+    x = Example()
+    return x.number

--- a/boa3_test/tests/compiler_tests/test_any.py
+++ b/boa3_test/tests/compiler_tests/test_any.py
@@ -7,7 +7,6 @@ from boa3_test.tests.boa_test import BoaTest
 
 
 class TestAny(BoaTest):
-
     default_folder: str = 'test_sc/any_test'
 
     def test_any_variable_assignments(self):

--- a/boa3_test/tests/compiler_tests/test_arithmetic.py
+++ b/boa3_test/tests/compiler_tests/test_arithmetic.py
@@ -11,7 +11,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestArithmetic(BoaTest):
-
     default_folder: str = 'test_sc/arithmetic_test'
 
     # region Addition

--- a/boa3_test/tests/compiler_tests/test_assert.py
+++ b/boa3_test/tests/compiler_tests/test_assert.py
@@ -9,7 +9,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestAssert(BoaTest):
-
     default_folder: str = 'test_sc/assert_test'
 
     def test_assert_unary_boolean_operation(self):

--- a/boa3_test/tests/compiler_tests/test_boa_builtin_method.py
+++ b/boa3_test/tests/compiler_tests/test_boa_builtin_method.py
@@ -5,7 +5,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestBuiltinMethod(BoaTest):
-
     default_folder: str = 'test_sc/boa_built_in_methods_test'
 
     def test_abort(self):

--- a/boa3_test/tests/compiler_tests/test_builtin_method.py
+++ b/boa3_test/tests/compiler_tests/test_builtin_method.py
@@ -12,7 +12,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestBuiltinMethod(BoaTest):
-
     default_folder: str = 'test_sc/built_in_methods_test'
 
     # region len test

--- a/boa3_test/tests/compiler_tests/test_bytes.py
+++ b/boa3_test/tests/compiler_tests/test_bytes.py
@@ -10,7 +10,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestBytes(BoaTest):
-
     default_folder: str = 'test_sc/bytes_test'
 
     def test_bytes_literal_value(self):

--- a/boa3_test/tests/compiler_tests/test_class.py
+++ b/boa3_test/tests/compiler_tests/test_class.py
@@ -8,7 +8,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestClass(BoaTest):
-
     default_folder: str = 'test_sc/class_test'
 
     def test_notification_get_variables(self):

--- a/boa3_test/tests/compiler_tests/test_contract_interface.py
+++ b/boa3_test/tests/compiler_tests/test_contract_interface.py
@@ -5,7 +5,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestContractInterface(BoaTest):
-
     default_folder: str = 'test_sc/contract_interface_test'
 
     def test_contract_interface_decorator_literal_hash_str(self):

--- a/boa3_test/tests/compiler_tests/test_dict.py
+++ b/boa3_test/tests/compiler_tests/test_dict.py
@@ -9,7 +9,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestDict(BoaTest):
-
     default_folder: str = 'test_sc/dict_test'
 
     def test_dict_int_keys(self):

--- a/boa3_test/tests/compiler_tests/test_event.py
+++ b/boa3_test/tests/compiler_tests/test_event.py
@@ -9,7 +9,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestEvent(BoaTest):
-
     default_folder: str = 'test_sc/event_test'
 
     def test_event_without_arguments(self):

--- a/boa3_test/tests/compiler_tests/test_exception.py
+++ b/boa3_test/tests/compiler_tests/test_exception.py
@@ -10,7 +10,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestException(BoaTest):
-
     default_folder: str = 'test_sc/exception_test'
 
     EXCEPTION_EMPTY_MESSAGE = String(Builtin.Exception.default_message).to_bytes()

--- a/boa3_test/tests/compiler_tests/test_file_generation.py
+++ b/boa3_test/tests/compiler_tests/test_file_generation.py
@@ -14,7 +14,6 @@ from boa3_test.tests.boa_test import BoaTest
 
 
 class TestFileGeneration(BoaTest):
-
     default_folder: str = 'test_sc/generation_test'
 
     def test_generate_files(self):

--- a/boa3_test/tests/compiler_tests/test_for.py
+++ b/boa3_test/tests/compiler_tests/test_for.py
@@ -7,7 +7,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestFor(BoaTest):
-
     default_folder: str = 'test_sc/for_test'
 
     def test_for_tuple_condition(self):

--- a/boa3_test/tests/compiler_tests/test_if.py
+++ b/boa3_test/tests/compiler_tests/test_if.py
@@ -8,7 +8,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestIf(BoaTest):
-
     default_folder: str = 'test_sc/if_test'
 
     def test_if_constant_condition(self):

--- a/boa3_test/tests/compiler_tests/test_import.py
+++ b/boa3_test/tests/compiler_tests/test_import.py
@@ -9,7 +9,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestImport(BoaTest):
-
     default_folder: str = 'test_sc/import_test'
 
     def test_import_typing(self):

--- a/boa3_test/tests/compiler_tests/test_interop/test_blockchain.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_blockchain.py
@@ -14,7 +14,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestBlockchainInterop(BoaTest):
-
     default_folder: str = 'test_sc/interop_test/blockchain'
 
     def test_block_constructor(self):
@@ -27,16 +26,16 @@ class TestBlockchainInterop(BoaTest):
         for k in range(len(result)):
             if isinstance(result[k], str):
                 result[k] = String(result[k]).to_bytes()
-        self.assertEqual(UInt256(), UInt256(result[0]))   # hash
-        self.assertEqual(0, result[1])   # version
-        self.assertEqual(UInt256(), UInt256(result[2]))   # previous_hash
-        self.assertEqual(UInt256(), UInt256(result[3]))   # merkle_root
-        self.assertEqual(0, result[4])   # timestamp
-        self.assertEqual(0, result[5])   # nonce
-        self.assertEqual(0, result[6])   # index
-        self.assertEqual(0, result[7])   # primary_index
-        self.assertEqual(UInt160(), UInt160(result[8]))   # next_consensus
-        self.assertEqual(0, result[9])   # transaction_count
+        self.assertEqual(UInt256(), UInt256(result[0]))  # hash
+        self.assertEqual(0, result[1])  # version
+        self.assertEqual(UInt256(), UInt256(result[2]))  # previous_hash
+        self.assertEqual(UInt256(), UInt256(result[3]))  # merkle_root
+        self.assertEqual(0, result[4])  # timestamp
+        self.assertEqual(0, result[5])  # nonce
+        self.assertEqual(0, result[6])  # index
+        self.assertEqual(0, result[7])  # primary_index
+        self.assertEqual(UInt160(), UInt160(result[8]))  # next_consensus
+        self.assertEqual(0, result[9])  # transaction_count
 
     def test_get_contract(self):
         path = self.get_contract_path('GetContract.py')
@@ -112,18 +111,18 @@ class TestBlockchainInterop(BoaTest):
         self.assertEqual(8, len(result))
         if isinstance(result[0], str):
             result[0] = String(result[0]).to_bytes()
-        self.assertEqual(UInt256(), UInt256(result[0]))   # hash
-        self.assertEqual(0, result[1])   # version
-        self.assertEqual(0, result[2])   # nonce
+        self.assertEqual(UInt256(), UInt256(result[0]))  # hash
+        self.assertEqual(0, result[1])  # version
+        self.assertEqual(0, result[2])  # nonce
         if isinstance(result[3], str):
             result[3] = String(result[3]).to_bytes()
-        self.assertEqual(UInt160(), UInt160(result[3]))   # sender
-        self.assertEqual(0, result[4])   # system_fee
-        self.assertEqual(0, result[5])   # network_fee
-        self.assertEqual(0, result[6])   # valid_until_block
+        self.assertEqual(UInt160(), UInt160(result[3]))  # sender
+        self.assertEqual(0, result[4])  # system_fee
+        self.assertEqual(0, result[5])  # network_fee
+        self.assertEqual(0, result[6])  # valid_until_block
         if isinstance(result[7], str):
             result[7] = String(result[7]).to_bytes()
-        self.assertEqual(b'', result[7])   # script
+        self.assertEqual(b'', result[7])  # script
 
     def test_get_transaction(self):
         call_flags = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
@@ -168,18 +167,18 @@ class TestBlockchainInterop(BoaTest):
         self.assertEqual(8, len(result))
         if isinstance(result[0], str):
             result[0] = String(result[0]).to_bytes()
-        self.assertEqual(UInt256(hash_), UInt256(result[0]))   # hash
-        self.assertIsInstance(result[1], int)   # version
-        self.assertIsInstance(result[2], int)   # nonce
+        self.assertEqual(UInt256(hash_), UInt256(result[0]))  # hash
+        self.assertIsInstance(result[1], int)  # version
+        self.assertIsInstance(result[2], int)  # nonce
         if isinstance(result[3], str):
             result[3] = String(result[3]).to_bytes()
-        self.assertEqual(UInt160(sender), UInt160(result[3]))   # sender
-        self.assertIsInstance(result[4], int)   # system_fee
-        self.assertIsInstance(result[5], int)   # network_fee
-        self.assertIsInstance(result[6], int)   # valid_until_block
+        self.assertEqual(UInt160(sender), UInt160(result[3]))  # sender
+        self.assertIsInstance(result[4], int)  # system_fee
+        self.assertIsInstance(result[5], int)  # network_fee
+        self.assertIsInstance(result[6], int)  # valid_until_block
         if isinstance(result[7], str):
             result[7] = String(result[7]).to_bytes()
-        self.assertEqual(script, result[7])   # script
+        self.assertEqual(script, result[7])  # script
 
     def test_get_transaction_mismatched_type(self):
         path = self.get_contract_path('GetTransactionMismatchedType.py')

--- a/boa3_test/tests/compiler_tests/test_interop/test_contract.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_contract.py
@@ -15,7 +15,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestContractInterop(BoaTest):
-
     default_folder: str = 'test_sc/interop_test/contract'
 
     def test_call_contract(self):
@@ -169,8 +168,8 @@ class TestContractInterop(BoaTest):
 
         notifies = engine.get_events('notify')
         self.assertEqual(2, len(notifies))
-        self.assertEqual(False, notifies[0].arguments[0])   # not updated
-        self.assertEqual(data, notifies[1].arguments[0])    # data
+        self.assertEqual(False, notifies[0].arguments[0])  # not updated
+        self.assertEqual(data, notifies[1].arguments[0])  # data
         result = self.run_smart_contract(engine, call_contract_path, 'main')
         self.assertEqual(data, result)
 
@@ -439,7 +438,7 @@ class TestContractInterop(BoaTest):
         path = self.get_contract_path('GetMinimumDeploymentFee.py')
         engine = TestEngine()
 
-        minimum_cost = 10 * 10**8   # minimum deployment cost is 10 GAS right now
+        minimum_cost = 10 * 10 ** 8  # minimum deployment cost is 10 GAS right now
         result = self.run_smart_contract(engine, path, 'main')
         self.assertEqual(minimum_cost, result)
 

--- a/boa3_test/tests/compiler_tests/test_interop/test_crypto.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_crypto.py
@@ -15,7 +15,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestCryptoInterop(BoaTest):
-
     default_folder: str = 'test_sc/interop_test/crypto'
     ecpoint_init = (
         Opcode.CONVERT + Type.bytes.stack_item

--- a/boa3_test/tests/compiler_tests/test_interop/test_iterator.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_iterator.py
@@ -4,7 +4,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestIteratorInterop(BoaTest):
-
     default_folder: str = 'test_sc/interop_test/iterator'
 
     def test_iterator_create(self):

--- a/boa3_test/tests/compiler_tests/test_interop/test_json.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_json.py
@@ -6,7 +6,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestJsonInterop(BoaTest):
-
     default_folder: str = 'test_sc/interop_test/json'
 
     def test_json_serialize(self):

--- a/boa3_test/tests/compiler_tests/test_interop/test_oracle.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_oracle.py
@@ -130,7 +130,6 @@ class TestNativeContracts(BoaTest):
             self.run_oracle_response(engine, request_id, OracleResponseCode.Success, b'12345')
 
     def test_oracle_get_price(self):
-
         from boa3.model.builtin.interop.interop import Interop
         from boa3.neo3.contracts import CallFlags
         from boa3.model.builtin.interop.oracle.oraclegetpricemethod import OracleGetPriceMethod

--- a/boa3_test/tests/compiler_tests/test_interop/test_policy.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_policy.py
@@ -4,7 +4,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestPolicyInterop(BoaTest):
-
     default_folder: str = 'test_sc/interop_test/policy'
 
     def test_get_exec_fee_factor(self):

--- a/boa3_test/tests/compiler_tests/test_interop/test_role.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_role.py
@@ -10,7 +10,6 @@ from boa3_test.tests.boa_test import BoaTest
 
 
 class TestRoleInterop(BoaTest):
-
     default_folder: str = 'test_sc/interop_test/role'
 
     def test_get_designated_by_role(self):

--- a/boa3_test/tests/compiler_tests/test_interop/test_runtime.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_runtime.py
@@ -14,7 +14,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestRuntimeInterop(BoaTest):
-
     default_folder: str = 'test_sc/interop_test/runtime'
 
     def test_check_witness(self):
@@ -526,11 +525,11 @@ class TestRuntimeInterop(BoaTest):
         path = self.get_contract_path('BurnGas.py')
         engine = TestEngine()
 
-        burn_gas_cost = 2460    # 2460 * 10^-8 GAS
+        burn_gas_cost = 2460  # 2460 * 10^-8 GAS
 
         # can not burn negative GAS
         with self.assertRaises(TestExecutionException):
-            self.run_smart_contract(engine, path, 'main', -10**8)
+            self.run_smart_contract(engine, path, 'main', -10 ** 8)
         self.assertEqual(engine.gas_consumed - burn_gas_cost, 0)
 
         # can not burn no GAS
@@ -538,12 +537,12 @@ class TestRuntimeInterop(BoaTest):
             self.run_smart_contract(engine, path, 'main', 0)
         self.assertEqual(engine.gas_consumed - burn_gas_cost, 0)
 
-        burned_gas = 1 * 10**8  # 1 GAS
+        burned_gas = 1 * 10 ** 8  # 1 GAS
         result = self.run_smart_contract(engine, path, 'main', burned_gas)
         self.assertIsVoid(result)
         self.assertEqual(engine.gas_consumed - burn_gas_cost, burned_gas)
 
-        burned_gas = 123 * 10**5   # 0.123 GAS
+        burned_gas = 123 * 10 ** 5  # 0.123 GAS
         result = self.run_smart_contract(engine, path, 'main', burned_gas)
         self.assertIsVoid(result)
         self.assertEqual(engine.gas_consumed - burn_gas_cost, burned_gas)
@@ -623,7 +622,7 @@ class TestRuntimeInterop(BoaTest):
         engine = TestEngine()
 
         result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(0x334F454E, result)   # Neo3 main net's magic number
+        self.assertEqual(0x334F454E, result)  # Neo3 main net's magic number
 
     def test_get_network_too_many_parameters(self):
         path = self.get_contract_path('GetNetworkTooManyArguments.py')

--- a/boa3_test/tests/compiler_tests/test_interop/test_stdlib.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_stdlib.py
@@ -7,7 +7,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestStdlibInterop(BoaTest):
-
     default_folder: str = 'test_sc/interop_test/stdlib'
 
     def test_base64_encode(self):

--- a/boa3_test/tests/compiler_tests/test_interop/test_storage.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_storage.py
@@ -12,7 +12,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestStorageInterop(BoaTest):
-
     default_folder: str = 'test_sc/interop_test/storage'
 
     def test_storage_get_bytes_key(self):

--- a/boa3_test/tests/compiler_tests/test_list.py
+++ b/boa3_test/tests/compiler_tests/test_list.py
@@ -12,7 +12,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestList(BoaTest):
-
     default_folder: str = 'test_sc/list_test'
 
     def test_list_int_values(self):

--- a/boa3_test/tests/compiler_tests/test_logical.py
+++ b/boa3_test/tests/compiler_tests/test_logical.py
@@ -7,7 +7,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestLogical(BoaTest):
-
     default_folder: str = 'test_sc/logical_test'
 
     # region BoolAnd

--- a/boa3_test/tests/compiler_tests/test_metadata.py
+++ b/boa3_test/tests/compiler_tests/test_metadata.py
@@ -4,12 +4,11 @@ from boa3_test.tests.boa_test import BoaTest
 
 
 class TestMetadata(BoaTest):
-
     default_folder: str = 'test_sc/metadata_test'
 
     def test_metadata_info_method(self):
         expected_output = (
-            Opcode.PUSH5        # return 5
+            Opcode.PUSH5  # return 5
             + Opcode.RET
         )
 
@@ -31,7 +30,7 @@ class TestMetadata(BoaTest):
 
     def test_metadata_info_multiple_method(self):
         expected_output = (
-            Opcode.PUSH5        # return 5
+            Opcode.PUSH5  # return 5
             + Opcode.RET
         )
 
@@ -64,7 +63,7 @@ class TestMetadata(BoaTest):
 
     def test_metadata_info_author(self):
         expected_output = (
-            Opcode.PUSH5        # return 5
+            Opcode.PUSH5  # return 5
             + Opcode.RET
         )
 
@@ -83,7 +82,7 @@ class TestMetadata(BoaTest):
 
     def test_metadata_info_email(self):
         expected_output = (
-            Opcode.PUSH5        # return 5
+            Opcode.PUSH5  # return 5
             + Opcode.RET
         )
 
@@ -102,7 +101,7 @@ class TestMetadata(BoaTest):
 
     def test_metadata_info_description(self):
         expected_output = (
-            Opcode.PUSH5        # return 5
+            Opcode.PUSH5  # return 5
             + Opcode.RET
         )
 
@@ -121,7 +120,7 @@ class TestMetadata(BoaTest):
 
     def test_metadata_info_extras(self):
         expected_output = (
-            Opcode.PUSH5        # return 5
+            Opcode.PUSH5  # return 5
             + Opcode.RET
         )
 
@@ -140,7 +139,7 @@ class TestMetadata(BoaTest):
 
     def test_metadata_info_new_extras(self):
         expected_output = (
-            Opcode.PUSH5        # return 5
+            Opcode.PUSH5  # return 5
             + Opcode.RET
         )
 

--- a/boa3_test/tests/compiler_tests/test_multiple_expressions.py
+++ b/boa3_test/tests/compiler_tests/test_multiple_expressions.py
@@ -7,7 +7,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestMultipleExpressions(BoaTest):
-
     default_folder: str = 'test_sc'
 
     def test_multiple_arithmetic_expressions(self):

--- a/boa3_test/tests/compiler_tests/test_native/test_contract_management.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_contract_management.py
@@ -11,14 +11,13 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestContractManagementContract(BoaTest):
-
     default_folder: str = 'test_sc/native_test/contractmanagement'
 
     def test_get_minimum_deployment_fee(self):
         path = self.get_contract_path('GetMinimumDeploymentFee.py')
         engine = TestEngine()
 
-        minimum_cost = 10 * 10**8   # minimum deployment cost is 10 GAS right now
+        minimum_cost = 10 * 10 ** 8  # minimum deployment cost is 10 GAS right now
         result = self.run_smart_contract(engine, path, 'main')
         self.assertEqual(minimum_cost, result)
 
@@ -84,8 +83,8 @@ class TestContractManagementContract(BoaTest):
 
         notifies = engine.get_events('notify')
         self.assertEqual(2, len(notifies))
-        self.assertEqual(False, notifies[0].arguments[0])   # not updated
-        self.assertEqual(data, notifies[1].arguments[0])    # data
+        self.assertEqual(False, notifies[0].arguments[0])  # not updated
+        self.assertEqual(data, notifies[1].arguments[0])   # data
         result = self.run_smart_contract(engine, call_contract_path, 'main')
         self.assertEqual(data, result)
 

--- a/boa3_test/tests/compiler_tests/test_native/test_cryptolib.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_cryptolib.py
@@ -15,7 +15,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestCryptoLibClass(BoaTest):
-
     default_folder: str = 'test_sc/native_test/cryptolib'
     ecpoint_init = (
         Opcode.CONVERT + Type.bytes.stack_item

--- a/boa3_test/tests/compiler_tests/test_native/test_gas.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_gas.py
@@ -4,7 +4,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestGasClass(BoaTest):
-
     default_folder: str = 'test_sc/native_test/gas'
 
     def test_symbol(self):

--- a/boa3_test/tests/compiler_tests/test_native/test_ledger.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_ledger.py
@@ -12,7 +12,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestLedgerContract(BoaTest):
-
     default_folder: str = 'test_sc/native_test/ledger'
 
     def test_get_block_by_hash(self):
@@ -100,18 +99,18 @@ class TestLedgerContract(BoaTest):
         self.assertEqual(8, len(result))
         if isinstance(result[0], str):
             result[0] = String(result[0]).to_bytes()
-        self.assertEqual(UInt256(hash_), UInt256(result[0]))   # hash
-        self.assertIsInstance(result[1], int)   # version
-        self.assertIsInstance(result[2], int)   # nonce
+        self.assertEqual(UInt256(hash_), UInt256(result[0]))  # hash
+        self.assertIsInstance(result[1], int)  # version
+        self.assertIsInstance(result[2], int)  # nonce
         if isinstance(result[3], str):
             result[3] = String(result[3]).to_bytes()
-        self.assertEqual(UInt160(sender), UInt160(result[3]))   # sender
-        self.assertIsInstance(result[4], int)   # system_fee
-        self.assertIsInstance(result[5], int)   # network_fee
-        self.assertIsInstance(result[6], int)   # valid_until_block
+        self.assertEqual(UInt160(sender), UInt160(result[3]))  # sender
+        self.assertIsInstance(result[4], int)  # system_fee
+        self.assertIsInstance(result[5], int)  # network_fee
+        self.assertIsInstance(result[6], int)  # valid_until_block
         if isinstance(result[7], str):
             result[7] = String(result[7]).to_bytes()
-        self.assertEqual(script, result[7])   # script
+        self.assertEqual(script, result[7])  # script
 
     def test_get_transaction_mismatched_type(self):
         path = self.get_contract_path('GetTransactionMismatchedType.py')

--- a/boa3_test/tests/compiler_tests/test_native/test_neo.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_neo.py
@@ -5,7 +5,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestNeoClass(BoaTest):
-
     default_folder: str = 'test_sc/native_test/neo'
 
     def test_symbol(self):

--- a/boa3_test/tests/compiler_tests/test_native/test_policy.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_policy.py
@@ -4,7 +4,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestPolicyContract(BoaTest):
-
     default_folder: str = 'test_sc/native_test/policy'
 
     def test_get_exec_fee_factor(self):

--- a/boa3_test/tests/compiler_tests/test_native/test_rolemanagement.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_rolemanagement.py
@@ -10,7 +10,6 @@ from boa3_test.tests.boa_test import BoaTest
 
 
 class TestRoleManagementClass(BoaTest):
-
     default_folder: str = 'test_sc/native_test/rolemanagement'
 
     def test_get_designated_by_role(self):

--- a/boa3_test/tests/compiler_tests/test_native/test_stdlib.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_stdlib.py
@@ -9,7 +9,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestStdlibClass(BoaTest):
-
     default_folder: str = 'test_sc/native_test/stdlib'
 
     def test_base64_encode(self):

--- a/boa3_test/tests/compiler_tests/test_neo_types.py
+++ b/boa3_test/tests/compiler_tests/test_neo_types.py
@@ -6,7 +6,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestNeoTypes(BoaTest):
-
     default_folder: str = 'test_sc/neo_type_test'
 
     # region UInt160

--- a/boa3_test/tests/compiler_tests/test_none.py
+++ b/boa3_test/tests/compiler_tests/test_none.py
@@ -6,7 +6,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestNone(BoaTest):
-
     default_folder: str = 'test_sc/none_test'
 
     def test_variable_none(self):

--- a/boa3_test/tests/compiler_tests/test_optional.py
+++ b/boa3_test/tests/compiler_tests/test_optional.py
@@ -5,7 +5,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestOptional(BoaTest):
-
     default_folder: str = 'test_sc/optional_test'
 
     def test_optional_return(self):

--- a/boa3_test/tests/compiler_tests/test_python_operation.py
+++ b/boa3_test/tests/compiler_tests/test_python_operation.py
@@ -5,7 +5,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestPythonOperation(BoaTest):
-
     default_folder: str = 'test_sc/python_operation_test'
 
     # region Membership

--- a/boa3_test/tests/compiler_tests/test_range.py
+++ b/boa3_test/tests/compiler_tests/test_range.py
@@ -9,7 +9,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestRange(BoaTest):
-
     default_folder: str = 'test_sc/range_test'
 
     RANGE_ERROR_MESSAGE = String('range() arg 3 must not be zero').to_bytes()

--- a/boa3_test/tests/compiler_tests/test_relational.py
+++ b/boa3_test/tests/compiler_tests/test_relational.py
@@ -9,7 +9,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestRelational(BoaTest):
-
     default_folder: str = 'test_sc/relational_test'
 
     # region GreaterThan

--- a/boa3_test/tests/compiler_tests/test_reversed.py
+++ b/boa3_test/tests/compiler_tests/test_reversed.py
@@ -5,7 +5,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestReversed(BoaTest):
-
     default_folder: str = 'test_sc/reversed_test'
 
     def test_reversed_list_bool(self):

--- a/boa3_test/tests/compiler_tests/test_string.py
+++ b/boa3_test/tests/compiler_tests/test_string.py
@@ -9,7 +9,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestString(BoaTest):
-
     default_folder: str = 'test_sc/string_test'
 
     def test_string_get_value(self):

--- a/boa3_test/tests/compiler_tests/test_tuple.py
+++ b/boa3_test/tests/compiler_tests/test_tuple.py
@@ -11,7 +11,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestTuple(BoaTest):
-
     default_folder: str = 'test_sc/tuple_test'
 
     def test_tuple_int_values(self):

--- a/boa3_test/tests/compiler_tests/test_typing.py
+++ b/boa3_test/tests/compiler_tests/test_typing.py
@@ -7,7 +7,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestTyping(BoaTest):
-
     default_folder: str = 'test_sc/typing_test'
 
     def test_cast_to_int(self):

--- a/boa3_test/tests/compiler_tests/test_union.py
+++ b/boa3_test/tests/compiler_tests/test_union.py
@@ -8,7 +8,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestUnion(BoaTest):
-
     default_folder: str = 'test_sc/union_test'
 
     def test_union_return(self):

--- a/boa3_test/tests/compiler_tests/test_variable.py
+++ b/boa3_test/tests/compiler_tests/test_variable.py
@@ -14,7 +14,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestVariable(BoaTest):
-
     default_folder: str = 'test_sc/variable_test'
 
     def test_declaration_with_type(self):
@@ -320,7 +319,7 @@ class TestVariable(BoaTest):
             Opcode.INITSLOT
             + b'\x01'
             + b'\x00'
-            + Opcode.PUSHDATA1    # a = '1'
+            + Opcode.PUSHDATA1  # a = '1'
             + Integer(len(byte_input)).to_byte_array()
             + byte_input
             + Opcode.STLOC0
@@ -336,7 +335,7 @@ class TestVariable(BoaTest):
             Opcode.INITSLOT
             + b'\x01'
             + b'\x00'
-            + Opcode.PUSH3    # a = 1 + 2
+            + Opcode.PUSH3  # a = 1 + 2
             + Opcode.STLOC0
             + Opcode.RET
         )
@@ -350,7 +349,7 @@ class TestVariable(BoaTest):
             Opcode.INITSLOT
             + b'\x01'
             + b'\x00'
-            + Opcode.PUSH5    # a = -5
+            + Opcode.PUSH5  # a = -5
             + Opcode.NEGATE
             + Opcode.STLOC0
             + Opcode.RET
@@ -365,7 +364,7 @@ class TestVariable(BoaTest):
             Opcode.INITSLOT
             + b'\x01'
             + b'\x03'
-            + Opcode.LDARG1     # b = min <= a - 2 <= max
+            + Opcode.LDARG1  # b = min <= a - 2 <= max
             + Opcode.LDARG0
             + Opcode.PUSH2
             + Opcode.SUB
@@ -389,7 +388,7 @@ class TestVariable(BoaTest):
             Opcode.INITSLOT
             + b'\x01'
             + b'\x01'
-            + Opcode.LDARG0     # b = a[0]
+            + Opcode.LDARG0  # b = a[0]
             + Opcode.PUSH0
             + Opcode.DUP
             + Opcode.SIGN
@@ -671,3 +670,9 @@ class TestVariable(BoaTest):
     def test_assign_starred_variable(self):
         path = self.get_contract_path('AssignStarredVariable.py')
         self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+
+    def test_variables_in_different_scope_with_same_name(self):
+        path = self.get_contract_path('DifferentScopesWithSameName.py')
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'test')
+        self.assertEqual(1_000, result)

--- a/boa3_test/tests/compiler_tests/test_while.py
+++ b/boa3_test/tests/compiler_tests/test_while.py
@@ -10,7 +10,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestWhile(BoaTest):
-
     default_folder: str = 'test_sc/while_test'
 
     def test_while_constant_condition(self):

--- a/boa3_test/tests/examples_tests/test_amm.py
+++ b/boa3_test/tests/examples_tests/test_amm.py
@@ -9,7 +9,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestTemplate(BoaTest):
-
     default_folder: str = 'examples'
 
     OWNER_SCRIPT_HASH = bytes(20)

--- a/boa3_test/tests/examples_tests/test_hello_world.py
+++ b/boa3_test/tests/examples_tests/test_hello_world.py
@@ -4,7 +4,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestTemplate(BoaTest):
-
     default_folder: str = 'examples'
 
     def test_hello_world_compile(self):

--- a/boa3_test/tests/examples_tests/test_htlc.py
+++ b/boa3_test/tests/examples_tests/test_htlc.py
@@ -12,7 +12,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestHTLCTemplate(BoaTest):
-
     default_folder: str = 'examples'
 
     OWNER_SCRIPT_HASH = bytes(20)
@@ -44,8 +43,10 @@ class TestHTLCTemplate(BoaTest):
         engine = TestEngine()
 
         # can not atomic_swap() without deploying first
-        result = self.run_smart_contract(engine, path, 'atomic_swap', self.OWNER_SCRIPT_HASH, constants.NEO_SCRIPT, 10 * 10**8,
-                                         self.OTHER_ACCOUNT_1, constants.GAS_SCRIPT, 10000 * 10**8, hash160(String('unit test').to_bytes()),
+        result = self.run_smart_contract(engine, path, 'atomic_swap',
+                                         self.OWNER_SCRIPT_HASH, constants.NEO_SCRIPT, 10 * 10 ** 8,
+                                         self.OTHER_ACCOUNT_1, constants.GAS_SCRIPT, 10000 * 10 ** 8,
+                                         hash160(String('unit test').to_bytes()),
                                          signer_accounts=[self.OWNER_SCRIPT_HASH],
                                          expected_result_type=bool)
         self.assertEqual(False, result)
@@ -57,8 +58,10 @@ class TestHTLCTemplate(BoaTest):
         self.assertEqual(True, result)
 
         # starting atomic swap by using the atomic_swap method
-        result = self.run_smart_contract(engine, path, 'atomic_swap', self.OWNER_SCRIPT_HASH, constants.NEO_SCRIPT, 10 * 10 ** 8,
-                                         self.OTHER_ACCOUNT_1, constants.GAS_SCRIPT, 10000 * 10 ** 8, hash160(String('unit test').to_bytes()),
+        result = self.run_smart_contract(engine, path, 'atomic_swap',
+                                         self.OWNER_SCRIPT_HASH, constants.NEO_SCRIPT, 10 * 10 ** 8,
+                                         self.OTHER_ACCOUNT_1, constants.GAS_SCRIPT, 10000 * 10 ** 8,
+                                         hash160(String('unit test').to_bytes()),
                                          signer_accounts=[self.OWNER_SCRIPT_HASH],
                                          expected_result_type=bool)
         self.assertEqual(True, result)
@@ -66,8 +69,8 @@ class TestHTLCTemplate(BoaTest):
     def test_HTLC_onNEP17Payment(self):
         path = self.get_contract_path('htlc.py')
         engine = TestEngine()
-        transferred_amount_neo = 10 * 10**8
-        transferred_amount_gas = 10000 * 10**8
+        transferred_amount_neo = 10 * 10 ** 8
+        transferred_amount_gas = 10000 * 10 ** 8
 
         output, manifest = self.compile_and_save(path)
         htlc_address = hash160(output)
@@ -100,7 +103,8 @@ class TestHTLCTemplate(BoaTest):
 
         # transfer wil be aborted at onPayment if the transfer is not valid
         with self.assertRaises(TestExecutionException, msg=self.ABORTED_CONTRACT_MSG):
-            self.run_smart_contract(engine, aux_path, 'calling_transfer', constants.NEO_SCRIPT, aux_address, htlc_address,
+            self.run_smart_contract(engine, aux_path, 'calling_transfer',
+                                    constants.NEO_SCRIPT, aux_address, htlc_address,
                                     transferred_amount_neo - 100, None,
                                     signer_accounts=[self.OWNER_SCRIPT_HASH],
                                     expected_result_type=bool)
@@ -145,7 +149,8 @@ class TestHTLCTemplate(BoaTest):
         # transfer won't be accepted, because amount is wrong
         with self.assertRaises(TestExecutionException, msg=self.ABORTED_CONTRACT_MSG):
             self.run_smart_contract(engine, aux_path2, 'calling_transfer',
-                                    constants.GAS_SCRIPT, aux_address2, htlc_address, transferred_amount_gas - 100, None,
+                                    constants.GAS_SCRIPT, aux_address2, htlc_address,
+                                    transferred_amount_gas - 100, None,
                                     signer_accounts=[aux_address2],
                                     expected_result_type=bool)
 
@@ -189,8 +194,8 @@ class TestHTLCTemplate(BoaTest):
     def test_HTLC_withdraw(self):
         path = self.get_contract_path('htlc.py')
         engine = TestEngine()
-        transferred_amount_neo = 10 * 10**8
-        transferred_amount_gas = 10000 * 10**8
+        transferred_amount_neo = 10 * 10 ** 8
+        transferred_amount_gas = 10000 * 10 ** 8
 
         output, manifest = self.compile_and_save(path)
         htlc_address = hash160(output)
@@ -312,8 +317,8 @@ class TestHTLCTemplate(BoaTest):
     def test_HTLC_refund(self):
         path = self.get_contract_path('htlc.py')
         engine = TestEngine()
-        transferred_amount_neo = 10 * 10**8
-        transferred_amount_gas = 10000 * 10**8
+        transferred_amount_neo = 10 * 10 ** 8
+        transferred_amount_gas = 10000 * 10 ** 8
 
         output, manifest = self.compile_and_save(path)
         htlc_address = hash160(output)

--- a/boa3_test/tests/examples_tests/test_ico.py
+++ b/boa3_test/tests/examples_tests/test_ico.py
@@ -6,7 +6,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestTemplate(BoaTest):
-
     default_folder: str = 'examples'
 
     OWNER_SCRIPT_HASH = bytes(20)
@@ -361,7 +360,7 @@ class TestTemplate(BoaTest):
 
         # should fail if amount is a negative number
         with self.assertRaises(TestExecutionException, msg=self.ASSERT_RESULTED_FALSE_MSG):
-            self.run_smart_contract(engine, path, 'mint', -10 * 10**8)
+            self.run_smart_contract(engine, path, 'mint', -10 * 10 ** 8)
 
         minted_amount = 10_000 * 10 ** 8
         # should fail if not signed by the administrator

--- a/boa3_test/tests/examples_tests/test_nep17.py
+++ b/boa3_test/tests/examples_tests/test_nep17.py
@@ -8,7 +8,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestNEP17Template(BoaTest):
-
     default_folder: str = 'examples'
 
     OWNER_SCRIPT_HASH = bytes(20)

--- a/boa3_test/tests/examples_tests/test_nep5.py
+++ b/boa3_test/tests/examples_tests/test_nep5.py
@@ -7,7 +7,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestTemplate(BoaTest):
-
     default_folder: str = 'examples'
 
     OWNER_SCRIPT_HASH = bytes(20)

--- a/boa3_test/tests/examples_tests/test_update_contract.py
+++ b/boa3_test/tests/examples_tests/test_update_contract.py
@@ -8,7 +8,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestUpdateContractTemplate(BoaTest):
-
     default_folder: str = 'examples'
 
     OWNER_SCRIPT_HASH = bytes(20)

--- a/boa3_test/tests/examples_tests/test_wrapped_neo.py
+++ b/boa3_test/tests/examples_tests/test_wrapped_neo.py
@@ -9,7 +9,6 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestTemplate(BoaTest):
-
     default_folder: str = 'examples'
 
     OWNER_SCRIPT_HASH = bytes(20)
@@ -231,8 +230,8 @@ class TestTemplate(BoaTest):
         output, manifest = self.compile_and_save(path)
         wrapped_neo_address = hash160(output)
 
-        engine.add_neo(wrapped_neo_address, 10_000_000 * 10**8)
-        burned_amount = 100 * 10**8
+        engine.add_neo(wrapped_neo_address, 10_000_000 * 10 ** 8)
+        burned_amount = 100 * 10 ** 8
 
         # deploying this smart contract will give 10m total supply * 10^8 zNEOs to OWNER
         result = self.run_smart_contract(engine, path, 'deploy',

--- a/boa3_test/tests/test_classes/contract/neoeventstruct.py
+++ b/boa3_test/tests/test_classes/contract/neoeventstruct.py
@@ -6,7 +6,6 @@ from boa3_test.tests.test_classes.contract.neostruct import NeoStruct
 
 
 class NeoEventStruct(NeoStruct):
-
     _name_field = 'name'
     _parameters_field = 'parameters'
 

--- a/boa3_test/tests/test_classes/contract/neomanifeststruct.py
+++ b/boa3_test/tests/test_classes/contract/neomanifeststruct.py
@@ -33,7 +33,7 @@ class NeoManifestStruct(NeoStruct):
         struct = cls()
         struct.append(json[cls._name_field])
         struct.append(json[cls._groups_field])  # TODO: groups aren't implemented yet
-        struct.append({})   # TODO: features aren't implemented yet
+        struct.append({})  # TODO: features aren't implemented yet
         struct.append(json[cls._supported_standards_field])  # TODO: supported standards aren't implemented
         struct.append(NeoAbiStruct.from_json(json[cls._abi_field]))
         struct.append([NeoPermissionsStruct.from_json(permission) for permission in json[cls._permissions_field]])

--- a/boa3_test/tests/test_classes/contract/neomethodstruct.py
+++ b/boa3_test/tests/test_classes/contract/neomethodstruct.py
@@ -7,7 +7,6 @@ from boa3_test.tests.test_classes.contract.neostruct import NeoStruct
 
 
 class NeoMethodStruct(NeoStruct):
-
     _name_field = 'name'
     _parameters_field = 'parameters'
     _return_type_field = 'returntype'

--- a/boa3_test/tests/test_classes/contract/neopermissionsstruct.py
+++ b/boa3_test/tests/test_classes/contract/neopermissionsstruct.py
@@ -7,7 +7,6 @@ from boa3_test.tests.test_classes.contract.neostruct import NeoStruct
 
 
 class NeoPermissionsStruct(NeoStruct):
-
     _contract_fields = 'contract'
     _methods_fields = 'methods'
 


### PR DESCRIPTION
**Related issue**
#762

**Summary or solution description**
There was a bug during Neo assembly code generation that converted methods and variables from classes incorrectly if there were any variable or method with the same name in a different scope.

**How to Reproduce**
```python
@public
def test() -> int:
    number = 10
    x = Example()
    return x.number  # the code generated accessed the local variable instead of the class variable
```

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/c3849aa17ed981c22ef8bf4f9e46c6cc59f54119/boa3_test/test_sc/variable_test/DifferentScopesWithSameName.py#L4-L17
https://github.com/CityOfZion/neo3-boa/blob/c3849aa17ed981c22ef8bf4f9e46c6cc59f54119/boa3_test/tests/compiler_tests/test_variable.py#L674-L678

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
