### PR TITLE
Add support to floor

### DIFF
--- a/boa3/builtin/math.py
+++ b/boa3/builtin/math.py
@@ -1,0 +1,29 @@
+def floor(x: int, decimals: int) -> int:
+    """
+    Return the floor of x given the amount of decimals.
+    This is the largest integer <= x.
+
+    :param x: any integer number
+    :type x: int
+    :param decimals: number of decimals
+    :type decimals: int
+    :return: the floor of x
+    :rtype: int
+
+    :raise Exception: raised when decimals is negative.
+    """
+    pass
+
+
+def sqrt(x: int) -> int:
+    """
+    Gets the square root of a number.
+
+    :param x: a non-negative number
+    :type x: int
+    :return: the square root of a number
+    :rtype: int
+
+    :raise Exception: raised when number is negative.
+    """
+    pass

--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -7,14 +7,17 @@ from boa3.model.builtin.contract import *
 from boa3.model.builtin.decorator import *
 from boa3.model.builtin.internal.innerdeploymethod import InnerDeployMethod
 from boa3.model.builtin.interop.interop import Interop
+from boa3.model.builtin.math import *
 from boa3.model.builtin.method import *
 from boa3.model.builtin.neometadatatype import MetadataTypeSingleton as NeoMetadataType
 from boa3.model.callable import Callable
 from boa3.model.identifiedsymbol import IdentifiedSymbol
+from boa3.model.imports.package import Package
 from boa3.model.type.collection.sequence.ecpointtype import ECPointType
 from boa3.model.type.collection.sequence.uint160type import UInt160Type
 from boa3.model.type.collection.sequence.uint256type import UInt256Type
 from boa3.model.type.itype import IType
+from boa3.model.type.math import Math
 
 
 class BoaPackage(str, Enum):
@@ -161,6 +164,18 @@ class Builtin:
     # boa smart contract methods
     Abort = AbortMethod()
 
+    # region boa builtin modules
+
+    BuiltinMathFloor = DecimalFloorMethod()
+
+    MathModule = Package(identifier='math',
+                         methods=[Math.Sqrt,
+                                  BuiltinMathFloor])
+
+    _modules = [MathModule]
+
+    # endregion
+
     boa_builtins: List[IdentifiedSymbol] = [ContractInterface,
                                             Event,
                                             Metadata,
@@ -168,7 +183,7 @@ class Builtin:
                                             NewEvent,
                                             Public,
                                             ScriptHash
-                                            ]
+                                            ] + _modules
 
     metadata_fields: Dict[str, Union[type, Tuple[type]]] = {
         'supported_standards': list,

--- a/boa3/model/builtin/math/__init__.py
+++ b/boa3/model/builtin/math/__init__.py
@@ -1,4 +1,6 @@
-__all__ = ['SqrtMethod',
+__all__ = ['DecimalFloorMethod',
+           'SqrtMethod',
            ]
 
+from boa3.model.builtin.math.decimalfloor import DecimalFloorMethod
 from boa3.model.builtin.math.sqrtmethod import SqrtMethod

--- a/boa3/model/builtin/math/decimalfloor.py
+++ b/boa3/model/builtin/math/decimalfloor.py
@@ -1,0 +1,72 @@
+from typing import Dict, List, Optional, Tuple
+
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class DecimalFloorMethod(IBuiltinMethod):
+
+    def __init__(self):
+        from boa3.model.type.type import Type
+        identifier = 'floor'
+        args: Dict[str, Variable] = {'x': Variable(Type.int),
+                                     'decimals': Variable(Type.int)}
+        super().__init__(identifier, args, return_type=Type.int)
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        from boa3.compiler.codegenerator import get_bytes_count
+        from boa3.neo.vm.type.Integer import Integer
+        from boa3.neo.vm.type.String import String
+
+        message = String("decimals cannot be negative").to_bytes()
+
+        if_negative_decimal = [
+            (Opcode.PUSHDATA1, Integer(len(message)).to_byte_array(signed=True, min_length=1) + message),
+            (Opcode.THROW, b''),
+        ]
+
+        decimals_unit = [
+            (Opcode.OVER, b''),
+            (Opcode.PUSH0, b''),
+            Opcode.get_jump_and_data(Opcode.JMPGE, get_bytes_count(if_negative_decimal), True),
+        ] + if_negative_decimal + [
+            (Opcode.DUP, b''),
+            (Opcode.REVERSE3, b''),
+            Opcode.get_push_and_data(10),
+            (Opcode.SWAP, b''),
+            (Opcode.POW, b''),
+            (Opcode.SWAP, b''),
+            (Opcode.OVER, b''),
+            (Opcode.MOD, b'')
+        ]
+
+        if_negative_mod = [
+            (Opcode.ADD, b''),
+            (Opcode.JMP, b'')
+        ]
+        else_negative_mod = [
+            (Opcode.NIP, b'')
+        ]
+        num_jmp_code = get_bytes_count(else_negative_mod)
+        if_negative_mod[-1] = Opcode.get_jump_and_data(Opcode.JMP, num_jmp_code, True)
+
+        num_jmp_code = get_bytes_count(if_negative_mod)
+        floor_computation = [
+            (Opcode.DUP, b''),
+            (Opcode.PUSH0, b''),
+            Opcode.get_jump_and_data(Opcode.JMPGE, num_jmp_code, True),
+        ] + if_negative_mod + else_negative_mod + [
+            (Opcode.SUB, b'')
+        ]
+
+        return decimals_unit + floor_computation
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> Optional[str]:
+        return

--- a/boa3/model/type/math.py
+++ b/boa3/model/type/math.py
@@ -7,7 +7,7 @@ from boa3.model.symbol import ISymbol
 
 class Math:
 
-    # neo3-boa math methods
+    # python math methods
     Sqrt = SqrtMethod()
 
     @classmethod

--- a/boa3_test/test_sc/arithmetic_test/ModuloAugmentedAssignment.py
+++ b/boa3_test/test_sc/arithmetic_test/ModuloAugmentedAssignment.py
@@ -1,2 +1,7 @@
-def Main(a: int, b: int):
+from boa3.builtin import public
+
+
+@public
+def mod(a: int, b: int) -> int:
     a %= b
+    return a

--- a/boa3_test/test_sc/boa_built_in_methods_test/DecimalFloor.py
+++ b/boa3_test/test_sc/boa_built_in_methods_test/DecimalFloor.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.math import floor
+
+
+@public
+def main(x: int, decimals: int) -> int:
+    return floor(x, decimals)

--- a/boa3_test/test_sc/boa_built_in_methods_test/Sqrt.py
+++ b/boa3_test/test_sc/boa_built_in_methods_test/Sqrt.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.math import sqrt
+
+
+@public
+def main(x: int) -> int:
+    return sqrt(x)

--- a/boa3_test/test_sc/boa_built_in_methods_test/SqrtFromMath.py
+++ b/boa3_test/test_sc/boa_built_in_methods_test/SqrtFromMath.py
@@ -1,0 +1,6 @@
+from boa3.builtin import math, public
+
+
+@public
+def main(x: int) -> int:
+    return math.sqrt(x)

--- a/boa3_test/tests/compiler_tests/test_arithmetic.py
+++ b/boa3_test/tests/compiler_tests/test_arithmetic.py
@@ -456,44 +456,60 @@ class TestArithmetic(BoaTest):
     # region Modulo
 
     def test_modulo_operation(self):
-        expected_output = (
-            Opcode.INITSLOT
-            + b'\x00'
-            + b'\x02'
-            + Opcode.LDARG0
-            + Opcode.LDARG1
-            + Opcode.MOD
-            + Opcode.RET
-        )
-
         path = self.get_contract_path('Modulo.py')
-        output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
-
         engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'mod', 10, 3)
-        self.assertEqual(1, result)
-        result = self.run_smart_contract(engine, path, 'mod', -42, -9)
-        self.assertEqual(-6, result)
-        result = self.run_smart_contract(engine, path, 'mod', -100, 3)
-        self.assertEqual(-1, result)
+
+        op1 = 10
+        op2 = 3
+        expected_output = op1 % op2
+        result = self.run_smart_contract(engine, path, 'mod', op1, op2)
+        self.assertEqual(expected_output, result)
+
+        op1 = -42
+        op2 = -9
+        expected_output = op1 % op2
+        result = self.run_smart_contract(engine, path, 'mod', op1, op2)
+        self.assertEqual(expected_output, result)
+
+        op1 = -100
+        op2 = 3
+        expected_output = op1 % op2
+        result = self.run_smart_contract(engine, path, 'mod', op1, op2)
+        self.assertEqual(expected_output, result)
+
+        op1 = 100
+        op2 = -3
+        expected_output = op1 % op2
+        result = self.run_smart_contract(engine, path, 'mod', op1, op2)
+        self.assertEqual(expected_output, result)
 
     def test_modulo_augmented_assignment(self):
-        expected_output = (
-            Opcode.INITSLOT
-            + b'\x00'
-            + b'\x02'
-            + Opcode.LDARG0
-            + Opcode.LDARG1
-            + Opcode.MOD
-            + Opcode.STARG0
-            + Opcode.RET
-        )
-
         path = self.get_contract_path('ModuloAugmentedAssignment.py')
-        output = Boa3.compile(path)
+        engine = TestEngine()
 
-        self.assertEqual(expected_output, output)
+        op1 = 10
+        op2 = 3
+        expected_output = op1 % op2
+        result = self.run_smart_contract(engine, path, 'mod', op1, op2)
+        self.assertEqual(expected_output, result)
+
+        op1 = -42
+        op2 = -9
+        expected_output = op1 % op2
+        result = self.run_smart_contract(engine, path, 'mod', op1, op2)
+        self.assertEqual(expected_output, result)
+
+        op1 = -100
+        op2 = 3
+        expected_output = op1 % op2
+        result = self.run_smart_contract(engine, path, 'mod', op1, op2)
+        self.assertEqual(expected_output, result)
+
+        op1 = 100
+        op2 = -3
+        expected_output = op1 % op2
+        result = self.run_smart_contract(engine, path, 'mod', op1, op2)
+        self.assertEqual(expected_output, result)
 
     def test_modulo_builtin_type(self):
         path = self.get_contract_path('ModuloBuiltinType.py')

--- a/boa3_test/tests/compiler_tests/test_boa_builtin_method.py
+++ b/boa3_test/tests/compiler_tests/test_boa_builtin_method.py
@@ -31,3 +31,86 @@ class TestBuiltinMethod(BoaTest):
     def test_will_not_compile(self):
         path = self.get_contract_path('WillNotCompile.py')
         self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+
+    # region math builtins
+
+    def test_sqrt_method(self):
+        path = self.get_contract_path('Sqrt.py')
+        engine = TestEngine()
+
+        from math import sqrt
+
+        expected_result = int(sqrt(0))
+        result = self.run_smart_contract(engine, path, 'main', 0)
+        self.assertEqual(expected_result, result)
+        expected_result = int(sqrt(1))
+        result = self.run_smart_contract(engine, path, 'main', 1)
+        self.assertEqual(expected_result, result)
+        expected_result = int(sqrt(3))
+        result = self.run_smart_contract(engine, path, 'main', 3)
+        self.assertEqual(expected_result, result)
+        expected_result = int(sqrt(4))
+        result = self.run_smart_contract(engine, path, 'main', 4)
+        self.assertEqual(expected_result, result)
+        expected_result = int(sqrt(8))
+        result = self.run_smart_contract(engine, path, 'main', 8)
+        self.assertEqual(expected_result, result)
+        expected_result = int(sqrt(10))
+        result = self.run_smart_contract(engine, path, 'main', 10)
+        self.assertEqual(expected_result, result)
+
+        with self.assertRaises(TestExecutionException):
+            self.run_smart_contract(engine, path, 'main', -1)
+
+        val = 25
+        expected_result = int(sqrt(val))
+        result = self.run_smart_contract(engine, path, 'main', val)
+        self.assertEqual(expected_result, result)
+
+    def test_sqrt_method_from_math(self):
+        path = self.get_contract_path('SqrtFromMath.py')
+        engine = TestEngine()
+
+        from math import sqrt
+
+        val = 25
+        expected_result = int(sqrt(val))
+        result = self.run_smart_contract(engine, path, 'main', val)
+        self.assertEqual(expected_result, result)
+
+    def test_decimal_floor_method(self):
+        path = self.get_contract_path('DecimalFloor.py')
+        engine = TestEngine()
+
+        from math import floor
+
+        value = 4.2
+        decimals = 8
+
+        multiplier = 10 ** decimals
+        value_floor = int(floor(value)) * multiplier
+        integer_value = int(value) * multiplier
+        result = self.run_smart_contract(engine, path, 'main', integer_value, decimals)
+        self.assertEqual(value_floor, result)
+
+        decimals = 12
+
+        multiplier = 10 ** decimals
+        value_floor = int(floor(value)) * multiplier
+        integer_value = int(value) * multiplier
+        result = self.run_smart_contract(engine, path, 'main', integer_value, decimals)
+        self.assertEqual(value_floor, result)
+
+        value = -3.983541
+
+        multiplier = 10 ** decimals
+        value_floor = int(floor(value) * multiplier)
+        integer_value = int(value * multiplier)
+        result = self.run_smart_contract(engine, path, 'main', integer_value, decimals)
+        self.assertEqual(value_floor, result)
+
+        # negative decimals will raise an exception
+        with self.assertRaises(TestExecutionException):
+            self.run_smart_contract(engine, path, 'main', integer_value, -1)
+
+    # endregion

--- a/boa3_test/tests/compiler_tests/test_for.py
+++ b/boa3_test/tests/compiler_tests/test_for.py
@@ -235,217 +235,23 @@ class TestFor(BoaTest):
         self.assertEqual(24, result)
 
     def test_for_continue(self):
-        jmpif_address = Integer(28).to_byte_array(min_length=1, signed=True)
-        jmp_address = Integer(-31).to_byte_array(min_length=1, signed=True)
-
-        expected_output = (
-            Opcode.INITSLOT
-            + b'\x03'
-            + b'\x00'
-            + Opcode.PUSH0      # a = 0
-            + Opcode.STLOC0
-            + Opcode.PUSH15     # sequence = (3, 5, 15)
-            + Opcode.PUSH5
-            + Opcode.PUSH3
-            + Opcode.PUSH3
-            + Opcode.PACK
-            + Opcode.STLOC1
-            + Opcode.LDLOC1     # for_sequence = sequence
-            + Opcode.PUSH0      # for_index = 0
-            + Opcode.JMP
-            + jmpif_address
-            + Opcode.OVER           # x = for_sequence[for_index]
-            + Opcode.OVER
-            + Opcode.DUP
-            + Opcode.SIGN
-            + Opcode.PUSHM1
-            + Opcode.JMPNE
-            + Integer(5).to_byte_array(min_length=1, signed=True)
-            + Opcode.OVER
-            + Opcode.SIZE
-            + Opcode.ADD
-            + Opcode.PICKITEM
-            + Opcode.STLOC2
-            + Opcode.LDLOC2         # if x % 5 != 0
-            + Opcode.PUSH5
-            + Opcode.MOD
-            + Opcode.PUSH0
-            + Opcode.NUMNOTEQUAL
-            + Opcode.JMPIFNOT
-            + Integer(4).to_byte_array(min_length=1, signed=True)
-            + Opcode.JMP                # continue
-            + Integer(6).to_byte_array(min_length=1, signed=True)
-            + Opcode.LDLOC0         # a = a + x
-            + Opcode.LDLOC2
-            + Opcode.ADD
-            + Opcode.STLOC0
-            + Opcode.INC            # for_index = for_index + 1
-            + Opcode.DUP        # if for_index < len(for_sequence)
-            + Opcode.PUSH2
-            + Opcode.PICK
-            + Opcode.SIZE
-            + Opcode.LT
-            + Opcode.JMPIF      # end for
-            + jmp_address
-            + Opcode.DROP
-            + Opcode.DROP
-            + Opcode.LDLOC0     # return a
-            + Opcode.RET
-        )
-
         path = self.get_contract_path('ForContinue.py')
-        output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
-
         engine = TestEngine()
+
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(20, result)
 
     def test_for_break(self):
-        jmpif_address = Integer(32).to_byte_array(min_length=1, signed=True)
-        jmp_address = Integer(-35).to_byte_array(min_length=1, signed=True)
-
-        expected_output = (
-            Opcode.INITSLOT
-            + b'\x03'
-            + b'\x00'
-            + Opcode.PUSH0      # a = 0
-            + Opcode.STLOC0
-            + Opcode.PUSH15     # sequence = (3, 5, 15)
-            + Opcode.PUSH5
-            + Opcode.PUSH3
-            + Opcode.PUSH3
-            + Opcode.PACK
-            + Opcode.STLOC1
-            + Opcode.LDLOC1     # for_sequence = sequence
-            + Opcode.PUSH0      # for_index = 0
-            + Opcode.JMP
-            + jmpif_address
-            + Opcode.OVER           # x = for_sequence[for_index]
-            + Opcode.OVER
-            + Opcode.DUP
-            + Opcode.SIGN
-            + Opcode.PUSHM1
-            + Opcode.JMPNE
-            + Integer(5).to_byte_array(min_length=1, signed=True)
-            + Opcode.OVER
-            + Opcode.SIZE
-            + Opcode.ADD
-            + Opcode.PICKITEM
-            + Opcode.STLOC2
-            + Opcode.LDLOC2         # if x % 5 != 0
-            + Opcode.PUSH5
-            + Opcode.MOD
-            + Opcode.PUSH0
-            + Opcode.NUMEQUAL
-            + Opcode.JMPIFNOT
-            + Integer(8).to_byte_array(min_length=1, signed=True)
-            + Opcode.LDLOC0             # a += x
-            + Opcode.LDLOC2
-            + Opcode.ADD
-            + Opcode.STLOC0
-            + Opcode.JMP                # break
-            + Integer(14).to_byte_array(min_length=1, signed=True)
-            + Opcode.LDLOC0         # a += 1
-            + Opcode.PUSH1
-            + Opcode.ADD
-            + Opcode.STLOC0
-            + Opcode.INC            # for_index = for_index + 1
-            + Opcode.DUP        # if for_index < len(for_sequence)
-            + Opcode.PUSH2
-            + Opcode.PICK
-            + Opcode.SIZE
-            + Opcode.LT
-            + Opcode.JMPIF      # end for
-            + jmp_address
-            + Opcode.DROP
-            + Opcode.DROP
-            + Opcode.LDLOC0     # return a
-            + Opcode.RET
-        )
         path = self.get_contract_path('ForBreak.py')
-        output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
-
         engine = TestEngine()
+        
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(6, result)
 
     def test_for_break_else(self):
-        jmpif_address = Integer(33).to_byte_array(min_length=1, signed=True)
-        jmp_address = Integer(-36).to_byte_array(min_length=1, signed=True)
-
-        expected_output = (
-            Opcode.INITSLOT
-            + b'\x03'
-            + b'\x00'
-            + Opcode.PUSH0      # a = 0
-            + Opcode.STLOC0
-            + Opcode.PUSH15     # sequence = (3, 5, 15)
-            + Opcode.PUSH5
-            + Opcode.PUSH3
-            + Opcode.PUSH3
-            + Opcode.PACK
-            + Opcode.STLOC1
-            + Opcode.LDLOC1     # for_sequence = sequence
-            + Opcode.PUSH0      # for_index = 0
-            + Opcode.JMP
-            + jmpif_address
-            + Opcode.OVER           # x = for_sequence[for_index]
-            + Opcode.OVER
-            + Opcode.DUP
-            + Opcode.SIGN
-            + Opcode.PUSHM1
-            + Opcode.JMPNE
-            + Integer(5).to_byte_array(min_length=1, signed=True)
-            + Opcode.OVER
-            + Opcode.SIZE
-            + Opcode.ADD
-            + Opcode.PICKITEM
-            + Opcode.STLOC2
-            + Opcode.LDLOC2         # if x % 5 == 0
-            + Opcode.PUSH5
-            + Opcode.MOD
-            + Opcode.PUSH0
-            + Opcode.NUMEQUAL
-            + Opcode.JMPIFNOT
-            + Integer(9).to_byte_array(min_length=1, signed=True)
-            + Opcode.LDLOC0             # a += x
-            + Opcode.LDLOC2
-            + Opcode.ADD
-            + Opcode.STLOC0
-            + Opcode.PUSH1
-            + Opcode.JMP                # break
-            + Integer(15).to_byte_array(min_length=1, signed=True)
-            + Opcode.LDLOC0         # a += 1
-            + Opcode.PUSH1
-            + Opcode.ADD
-            + Opcode.STLOC0
-            + Opcode.INC            # for_index = for_index + 1
-            + Opcode.DUP        # if for_index < len(for_sequence)
-            + Opcode.PUSH2
-            + Opcode.PICK
-            + Opcode.SIZE
-            + Opcode.LT
-            + Opcode.JMPIF      # end for
-            + jmp_address
-            + Opcode.PUSH0
-            + Opcode.REVERSE3
-            + Opcode.DROP
-            + Opcode.DROP
-            + Opcode.JMPIF
-            + Integer(4).to_byte_array(signed=True)
-            + Opcode.PUSHM1         # a = -1
-            + Opcode.STLOC0
-            + Opcode.LDLOC0     # return a
-            + Opcode.RET
-        )
-
         path = self.get_contract_path('ForBreakElse.py')
-        output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
-
         engine = TestEngine()
+
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(6, result)
 

--- a/boa3_test/tests/compiler_tests/test_function.py
+++ b/boa3_test/tests/compiler_tests/test_function.py
@@ -110,28 +110,9 @@ class TestFunction(BoaTest):
         self.assertIsVoid(result)
 
     def test_no_return_hint_function_with_condition_empty_return_statement(self):
-        expected_output = (
-            Opcode.INITSLOT  # function signature
-            + b'\x01'
-            + b'\x01'
-            + Opcode.LDARG0  # if a > 10
-            + Opcode.PUSH10
-            + Opcode.GT
-            + Opcode.JMPIFNOT
-            + Integer(3).to_byte_array()
-            + Opcode.RET  # return
-            + Opcode.LDARG0
-            + Opcode.PUSH10
-            + Opcode.MOD
-            + Opcode.STLOC0
-            + Opcode.RET  # return
-        )
-
         path = self.get_contract_path('ConditionEmptyReturnFunction.py')
-        output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
-
         engine = TestEngine()
+
         result = self.run_smart_contract(engine, path, 'Main', 5)
         self.assertIsVoid(result)
 
@@ -139,30 +120,9 @@ class TestFunction(BoaTest):
         self.assertIsVoid(result)
 
     def test_empty_return_with_optional_return_type(self):
-        expected_output = (
-            Opcode.INITSLOT  # function signature
-            + b'\x00'
-            + b'\x01'
-            + Opcode.LDARG0  # if a % 2 == 1
-            + Opcode.PUSH2
-            + Opcode.MOD
-            + Opcode.PUSH1
-            + Opcode.NUMEQUAL
-            + Opcode.JMPIFNOT
-            + Integer(4).to_byte_array()
-            + Opcode.PUSHNULL  # return
-            + Opcode.RET
-            + Opcode.LDARG0  # return a // 2
-            + Opcode.PUSH2
-            + Opcode.DIV
-            + Opcode.RET
-        )
-
         path = self.get_contract_path('EmptyReturnWithOptionalReturnType.py')
-        output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
-
         engine = TestEngine()
+
         result = self.run_smart_contract(engine, path, 'Main', 5)
         self.assertIsNone(result)
 
@@ -538,41 +498,9 @@ class TestFunction(BoaTest):
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_return_inside_if(self):
-        expected_output = (
-            Opcode.INITSLOT  # Main
-            + b'\x00'
-            + b'\x01'
-            + Opcode.LDARG0  # if arg0 % 3 == 1
-            + Opcode.PUSH3
-            + Opcode.MOD
-            + Opcode.PUSH1
-            + Opcode.NUMEQUAL
-            + Opcode.JMPIFNOT
-            + Integer(6).to_byte_array(min_length=1, signed=True)
-            + Opcode.LDARG0  # return arg0 - 1
-            + Opcode.PUSH1
-            + Opcode.SUB
-            + Opcode.RET
-            + Opcode.LDARG0  # elif arg0 % 3 == 2
-            + Opcode.PUSH3
-            + Opcode.MOD
-            + Opcode.PUSH2
-            + Opcode.NUMEQUAL
-            + Opcode.JMPIFNOT
-            + Integer(6).to_byte_array(min_length=1, signed=True)
-            + Opcode.LDARG0  # return arg0 + 1
-            + Opcode.PUSH1
-            + Opcode.ADD
-            + Opcode.RET
-            + Opcode.LDARG0  # else
-            + Opcode.RET  # return arg0
-        )
-
         path = self.get_contract_path('ReturnIf.py')
-        output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
-
         engine = TestEngine()
+
         result = self.run_smart_contract(engine, path, 'Main', 4)
         self.assertEqual(3, result)
         result = self.run_smart_contract(engine, path, 'Main', 5)

--- a/boa3_test/tests/compiler_tests/test_while.py
+++ b/boa3_test/tests/compiler_tests/test_while.py
@@ -99,59 +99,9 @@ class TestWhile(BoaTest):
             output = Boa3.compile(path)
 
     def test_nested_while(self):
-        outer_jmpif_address = Integer(23).to_byte_array(min_length=1, signed=True)
-        outer_jmp_address = Integer(-26).to_byte_array(min_length=1, signed=True)
-
-        inner_jmpif_address = Integer(6).to_byte_array(min_length=1, signed=True)
-        inner_jmp_address = Integer(-9).to_byte_array(min_length=1, signed=True)
-
-        expected_output = (
-            Opcode.INITSLOT
-            + b'\x02'
-            + b'\x00'
-            + Opcode.PUSH0      # c = 0
-            + Opcode.STLOC0
-            + Opcode.PUSH0      # d = c
-            + Opcode.STLOC1
-            + Opcode.JMP        # begin outer while
-            + outer_jmpif_address
-            + Opcode.LDLOC0     # c = c + 2
-            + Opcode.PUSH2
-            + Opcode.ADD
-            + Opcode.STLOC0
-            + Opcode.JMP        # begin inner while
-            + inner_jmpif_address
-            + Opcode.LDLOC1     # d = d + 3
-            + Opcode.PUSH3
-            + Opcode.ADD
-            + Opcode.STLOC1
-            + Opcode.LDLOC1     # while d % 10 < 5
-            + Opcode.PUSH10
-            + Opcode.MOD
-            + Opcode.PUSH5
-            + Opcode.LT
-            + Opcode.JMPIF      # end inner while arg1
-            + inner_jmp_address
-            + Opcode.LDLOC0     # c = c + d
-            + Opcode.LDLOC1
-            + Opcode.ADD
-            + Opcode.STLOC0
-            + Opcode.LDLOC0     # while c % 3 < 2
-            + Opcode.PUSH3
-            + Opcode.MOD
-            + Opcode.PUSH2
-            + Opcode.LT
-            + Opcode.JMPIF      # end outer while arg0
-            + outer_jmp_address
-            + Opcode.LDLOC0     # return c
-            + Opcode.RET
-        )
-
         path = self.get_contract_path('NestedWhile.py')
-        output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
-
         engine = TestEngine()
+
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(8, result)
 
@@ -277,140 +227,16 @@ class TestWhile(BoaTest):
         self.assertEqual(20, result)
 
     def test_while_continue(self):
-        jmpif_address = Integer(31).to_byte_array(min_length=1, signed=True)
-        jmp_address = Integer(-33).to_byte_array(min_length=1, signed=True)
-
-        expected_output = (
-            Opcode.INITSLOT
-            + b'\x04'
-            + b'\x00'
-            + Opcode.PUSH0      # a = 0
-            + Opcode.STLOC0
-            + Opcode.PUSH0      # b = 0
-            + Opcode.STLOC1
-            + Opcode.PUSH15     # sequence = (3, 5, 15)
-            + Opcode.PUSH5
-            + Opcode.PUSH3
-            + Opcode.PUSH3
-            + Opcode.PACK
-            + Opcode.STLOC2
-            + Opcode.JMP        # begin while
-            + jmpif_address
-            + Opcode.LDLOC2     # x = sequence[a]
-            + Opcode.LDLOC0
-            + Opcode.DUP
-            + Opcode.SIGN
-            + Opcode.PUSHM1
-            + Opcode.JMPNE
-            + Integer(5).to_byte_array(min_length=1, signed=True)
-            + Opcode.OVER
-            + Opcode.SIZE
-            + Opcode.ADD
-            + Opcode.PICKITEM
-            + Opcode.STLOC3
-            + Opcode.LDLOC0     # a += 1
-            + Opcode.PUSH1
-            + Opcode.ADD
-            + Opcode.STLOC0
-            + Opcode.LDLOC3     # if x % 5 != 0
-            + Opcode.PUSH5
-            + Opcode.MOD
-            + Opcode.PUSH0
-            + Opcode.NUMNOTEQUAL
-            + Opcode.JMPIFNOT
-            + Integer(4).to_byte_array(min_length=1, signed=True)
-            + Opcode.JMP        # continue
-            + Integer(6).to_byte_array(min_length=1, signed=True)
-            + Opcode.LDLOC1     # b += x
-            + Opcode.LDLOC3
-            + Opcode.ADD
-            + Opcode.STLOC1
-            + Opcode.LDLOC0
-            + Opcode.LDLOC2
-            + Opcode.SIZE
-            + Opcode.LT
-            + Opcode.JMPIF      # end while a < len(sequence)
-            + jmp_address
-            + Opcode.LDLOC1     # return b
-            + Opcode.RET
-        )
-
         path = self.get_contract_path('WhileContinue.py')
-        output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
-
         engine = TestEngine()
+
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(20, result)
 
     def test_while_break(self):
-        jmpif_address = Integer(35).to_byte_array(min_length=1, signed=True)
-        jmp_address = Integer(-37).to_byte_array(min_length=1, signed=True)
-
-        expected_output = (
-            Opcode.INITSLOT
-            + b'\x04'
-            + b'\x00'
-            + Opcode.PUSH0      # a = 0
-            + Opcode.STLOC0
-            + Opcode.PUSH0      # b = 0
-            + Opcode.STLOC1
-            + Opcode.PUSH15     # sequence = (3, 5, 15)
-            + Opcode.PUSH5
-            + Opcode.PUSH3
-            + Opcode.PUSH3
-            + Opcode.PACK
-            + Opcode.STLOC2
-            + Opcode.JMP        # begin while
-            + jmpif_address
-            + Opcode.LDLOC2         # x = sequence[a]
-            + Opcode.LDLOC0
-            + Opcode.DUP
-            + Opcode.SIGN
-            + Opcode.PUSHM1
-            + Opcode.JMPNE
-            + Integer(5).to_byte_array(min_length=1, signed=True)
-            + Opcode.OVER
-            + Opcode.SIZE
-            + Opcode.ADD
-            + Opcode.PICKITEM
-            + Opcode.STLOC3
-            + Opcode.LDLOC0         # a += 1
-            + Opcode.PUSH1
-            + Opcode.ADD
-            + Opcode.STLOC0
-            + Opcode.LDLOC3         # if x % 5 == 0
-            + Opcode.PUSH5
-            + Opcode.MOD
-            + Opcode.PUSH0
-            + Opcode.NUMEQUAL
-            + Opcode.JMPIFNOT
-            + Integer(8).to_byte_array(min_length=1, signed=True)
-            + Opcode.LDLOC1             # b += x
-            + Opcode.LDLOC3
-            + Opcode.ADD
-            + Opcode.STLOC1
-            + Opcode.JMP                # break
-            + Integer(12).to_byte_array(min_length=1, signed=True)
-            + Opcode.LDLOC1         # b += 1
-            + Opcode.PUSH1
-            + Opcode.ADD
-            + Opcode.STLOC1
-            + Opcode.LDLOC0
-            + Opcode.LDLOC2
-            + Opcode.SIZE
-            + Opcode.LT
-            + Opcode.JMPIF      # end while a < len(sequence)
-            + jmp_address
-            + Opcode.LDLOC1     # return b
-            + Opcode.RET
-        )
-
         path = self.get_contract_path('WhileBreak.py')
-        output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
-
         engine = TestEngine()
+
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(6, result)
 

--- a/docs/source/boa3/builtin/boa3-builtin-math.rst
+++ b/docs/source/boa3/builtin/boa3-builtin-math.rst
@@ -1,0 +1,4 @@
+math
+====
+
+.. automodule:: boa3.builtin.math

--- a/docs/source/boa3/builtin/boa3-builtins.rst
+++ b/docs/source/boa3/builtin/boa3-builtins.rst
@@ -10,3 +10,8 @@ boa3.builtin package
    interop/boa3-builtin-interop
    nativecontract/boa3-builtin-nativecontract
    type/boa3-builtin-type
+
+.. toctree::
+   :caption: Modules:
+
+   boa3-builtin-math


### PR DESCRIPTION
**Related issue**
#663

**Summary or solution description**
Implemented an integer alternative for `math.floor` method. This method receives two int arguments, the first being the integer representation of a decimal number and the second the number of decimals to be considered. The number of decimals cannot be negative.
https://github.com/CityOfZion/neo3-boa/blob/f6487a2fafa6218f8363ebaaf048ff3664eb8af5/boa3/builtin/math.py#L1-L14

Also fixed the modulo operation (`%`) which results were different from Python depending on the signs of the operands.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/f6487a2fafa6218f8363ebaaf048ff3664eb8af5/boa3_test/test_sc/boa_built_in_methods_test/DecimalFloor.py#L6-L7

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/f6487a2fafa6218f8363ebaaf048ff3664eb8af5/boa3_test/tests/compiler_tests/test_boa_builtin_method.py#L81-L114

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
