### PR TITLE
Add support to ceil

### DIFF
--- a/boa3/builtin/math.py
+++ b/boa3/builtin/math.py
@@ -1,3 +1,20 @@
+def ceil(x: int, decimals: int) -> int:
+    """
+    Return the ceiling of x given the amount of decimals.
+    This is the smallest integer >= x.
+
+    :param x: any integer number
+    :type x: int
+    :param decimals: number of decimals
+    :type decimals: int
+    :return: the ceiling of x
+    :rtype: int
+
+    :raise Exception: raised when decimals is negative.
+    """
+    pass
+
+
 def floor(x: int, decimals: int) -> int:
     """
     Return the floor of x given the amount of decimals.

--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -166,10 +166,12 @@ class Builtin:
 
     # region boa builtin modules
 
+    BuiltinMathCeil = DecimalCeilingMethod()
     BuiltinMathFloor = DecimalFloorMethod()
 
     MathModule = Package(identifier='math',
                          methods=[Math.Sqrt,
+                                  BuiltinMathCeil,
                                   BuiltinMathFloor])
 
     _modules = [MathModule]

--- a/boa3/model/builtin/math/__init__.py
+++ b/boa3/model/builtin/math/__init__.py
@@ -1,6 +1,8 @@
-__all__ = ['DecimalFloorMethod',
+__all__ = ['DecimalCeilingMethod',
+           'DecimalFloorMethod',
            'SqrtMethod',
            ]
 
+from boa3.model.builtin.math.decimalceil import DecimalCeilingMethod
 from boa3.model.builtin.math.decimalfloor import DecimalFloorMethod
 from boa3.model.builtin.math.sqrtmethod import SqrtMethod

--- a/boa3/model/builtin/math/decimalceil.py
+++ b/boa3/model/builtin/math/decimalceil.py
@@ -1,0 +1,73 @@
+from typing import Dict, List, Optional, Tuple
+
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class DecimalCeilingMethod(IBuiltinMethod):
+
+    def __init__(self):
+        from boa3.model.type.type import Type
+        identifier = 'ceil'
+        args: Dict[str, Variable] = {'x': Variable(Type.int),
+                                     'decimals': Variable(Type.int)}
+        super().__init__(identifier, args, return_type=Type.int)
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        from boa3.compiler.codegenerator import get_bytes_count
+        from boa3.neo.vm.type.Integer import Integer
+        from boa3.neo.vm.type.String import String
+
+        message = String("decimals cannot be negative").to_bytes()
+
+        if_negative_decimal = [
+            (Opcode.PUSHDATA1, Integer(len(message)).to_byte_array(signed=True, min_length=1) + message),
+            (Opcode.THROW, b''),
+        ]
+
+        decimals_unit = [
+            (Opcode.OVER, b''),
+            (Opcode.PUSH0, b''),
+            Opcode.get_jump_and_data(Opcode.JMPGE, get_bytes_count(if_negative_decimal), True),
+        ] + if_negative_decimal + [
+            (Opcode.DUP, b''),
+            (Opcode.REVERSE3, b''),
+            Opcode.get_push_and_data(10),
+            (Opcode.SWAP, b''),
+            (Opcode.POW, b''),
+            (Opcode.SWAP, b''),
+            (Opcode.NEGATE, b''),
+            (Opcode.OVER, b''),
+            (Opcode.MOD, b'')
+        ]
+
+        if_negative_mod = [
+            (Opcode.ADD, b''),
+            (Opcode.JMP, b'')
+        ]
+        else_negative_mod = [
+            (Opcode.NIP, b'')
+        ]
+        num_jmp_code = get_bytes_count(else_negative_mod)
+        if_negative_mod[-1] = Opcode.get_jump_and_data(Opcode.JMP, num_jmp_code, True)
+
+        num_jmp_code = get_bytes_count(if_negative_mod)
+        floor_computation = [
+            (Opcode.DUP, b''),
+            (Opcode.PUSH0, b''),
+            Opcode.get_jump_and_data(Opcode.JMPGE, num_jmp_code, True),
+        ] + if_negative_mod + else_negative_mod + [
+            (Opcode.ADD, b'')
+        ]
+
+        return decimals_unit + floor_computation
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> Optional[str]:
+        return

--- a/boa3_test/test_sc/boa_built_in_methods_test/DecimalCeiling.py
+++ b/boa3_test/test_sc/boa_built_in_methods_test/DecimalCeiling.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.math import ceil
+
+
+@public
+def main(x: int, decimals: int) -> int:
+    return ceil(x, decimals)

--- a/boa3_test/tests/compiler_tests/test_boa_builtin_method.py
+++ b/boa3_test/tests/compiler_tests/test_boa_builtin_method.py
@@ -89,7 +89,7 @@ class TestBuiltinMethod(BoaTest):
 
         multiplier = 10 ** decimals
         value_floor = int(floor(value)) * multiplier
-        integer_value = int(value) * multiplier
+        integer_value = int(value * multiplier)
         result = self.run_smart_contract(engine, path, 'main', integer_value, decimals)
         self.assertEqual(value_floor, result)
 
@@ -97,7 +97,7 @@ class TestBuiltinMethod(BoaTest):
 
         multiplier = 10 ** decimals
         value_floor = int(floor(value)) * multiplier
-        integer_value = int(value) * multiplier
+        integer_value = int(value * multiplier)
         result = self.run_smart_contract(engine, path, 'main', integer_value, decimals)
         self.assertEqual(value_floor, result)
 
@@ -108,6 +108,41 @@ class TestBuiltinMethod(BoaTest):
         integer_value = int(value * multiplier)
         result = self.run_smart_contract(engine, path, 'main', integer_value, decimals)
         self.assertEqual(value_floor, result)
+
+        # negative decimals will raise an exception
+        with self.assertRaises(TestExecutionException):
+            self.run_smart_contract(engine, path, 'main', integer_value, -1)
+
+    def test_decimal_ceil_method(self):
+        path = self.get_contract_path('DecimalCeiling.py')
+        engine = TestEngine()
+
+        from math import ceil
+
+        value = 4.2
+        decimals = 8
+
+        multiplier = 10 ** decimals
+        value_ceiling = int(ceil(value)) * multiplier
+        integer_value = int(value * multiplier)
+        result = self.run_smart_contract(engine, path, 'main', integer_value, decimals)
+        self.assertEqual(value_ceiling, result)
+
+        decimals = 12
+
+        multiplier = 10 ** decimals
+        value_ceiling = int(ceil(value)) * multiplier
+        integer_value = int(value * multiplier)
+        result = self.run_smart_contract(engine, path, 'main', integer_value, decimals)
+        self.assertEqual(value_ceiling, result)
+
+        value = -3.983541
+
+        multiplier = 10 ** decimals
+        value_ceiling = int(ceil(value) * multiplier)
+        integer_value = int(value * multiplier)
+        result = self.run_smart_contract(engine, path, 'main', integer_value, decimals)
+        self.assertEqual(value_ceiling, result)
 
         # negative decimals will raise an exception
         with self.assertRaises(TestExecutionException):

--- a/boa3_test/tests/compiler_tests/test_for.py
+++ b/boa3_test/tests/compiler_tests/test_for.py
@@ -244,7 +244,7 @@ class TestFor(BoaTest):
     def test_for_break(self):
         path = self.get_contract_path('ForBreak.py')
         engine = TestEngine()
-        
+
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(6, result)
 


### PR DESCRIPTION
**Related issue**
#661 

**Summary or solution description**
Implemented an integer alternative for `math.ceil` method. This method receives two int arguments, the first being the integer representation of a decimal number and the second the number of decimals to be considered. The number of decimals cannot be negative.
https://github.com/CityOfZion/neo3-boa/blob/fe26132b60d0e62f0375e40728a62d4e187c9151/boa3/builtin/math.py#L1-L15

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/fe26132b60d0e62f0375e40728a62d4e187c9151/boa3_test/test_sc/boa_built_in_methods_test/DecimalCeiling.py#L6-L7

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/fe26132b60d0e62f0375e40728a62d4e187c9151/boa3_test/tests/compiler_tests/test_boa_builtin_method.py#L116-L149

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
