### PR TITLE
Add support to int constructor with integer values

### DIFF
--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -54,6 +54,8 @@ class Builtin:
     # python builtin class constructor
     ByteArray = ByteArrayMethod()
     Exception = ExceptionMethod()
+    IntByteString = IntByteStringMethod()
+    IntInt = IntIntMethod()
     Range = RangeMethod()
     Reversed = ReversedMethod()
     Super = SuperMethod()

--- a/boa3/model/builtin/method/__init__.py
+++ b/boa3/model/builtin/method/__init__.py
@@ -5,6 +5,8 @@ __all__ = ['AbsMethod',
            'EventType',
            'ExceptionMethod',
            'ExitMethod',
+           'IntByteStringMethod',
+           'IntIntMethod',
            'IsInstanceMethod',
            'LenMethod',
            'MaxIntMethod',
@@ -26,6 +28,8 @@ from boa3.model.builtin.method.bytearraymethod import ByteArrayMethod
 from boa3.model.builtin.method.createeventmethod import CreateEventMethod, EventType
 from boa3.model.builtin.method.exceptionmethod import ExceptionMethod
 from boa3.model.builtin.method.exitmethod import ExitMethod
+from boa3.model.builtin.method.intbytestringmethod import IntByteStringMethod
+from boa3.model.builtin.method.intintmethod import IntIntMethod
 from boa3.model.builtin.method.isinstancemethod import IsInstanceMethod
 from boa3.model.builtin.method.lenmethod import LenMethod
 from boa3.model.builtin.method.maxbytestringmethod import MaxByteStringMethod

--- a/boa3/model/builtin/method/intbytestringmethod.py
+++ b/boa3/model/builtin/method/intbytestringmethod.py
@@ -1,0 +1,486 @@
+import ast
+from typing import Dict, List, Tuple
+
+from boa3.model.builtin.method.intmethod import IntMethod
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class IntByteStringMethod(IntMethod):
+
+    def __init__(self):
+        from boa3.model.type.type import Type
+
+        args: Dict[str, Variable] = {
+            'value': Variable(Type.union.build([
+                Type.bytes,
+                Type.str
+            ])),
+            'base': Variable(Type.int)
+        }
+
+        value_default = ast.parse("{0}".format(Type.int.default_value)
+                                  ).body[0].value
+
+        base_default = ast.parse("{0}".format(10)
+                                 ).body[0].value
+
+        super().__init__(args, [value_default, base_default])
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        from boa3.compiler.codegenerator import get_bytes_count
+        from boa3.neo.vm.type.StackItem import StackItemType
+        jmp_place_holder = (Opcode.JMP, b'\x01')
+        a_lower = ord('a')
+        a_upper = ord('A')
+        zero = ord('0')
+
+        # region verify_base
+
+        verify_base_ge37 = [    # verifies if base >= 37, base greater than 36 shouldn't be accepted
+            (Opcode.OVER, b''),
+            Opcode.get_push_and_data(37),
+            jmp_place_holder,   # jumps to an assertion error
+        ]
+
+        verify_base_equal1 = [  # verifies if base == 1, base equals 1 shouldn't be accepted
+            (Opcode.OVER, b''),
+            (Opcode.PUSH1, b''),
+            jmp_place_holder    # jumps to an assertion error
+        ]
+
+        verify_base_le_minus1 = [   # verifies if base <= -1, base less than 0 shouldn't be accepted
+            (Opcode.OVER, b''),
+            (Opcode.PUSHM1, b''),
+            jmp_place_holder,       # jumps to an assertion error
+        ]
+
+        verify_base_jump_error = [  # jumps the next set of instructions
+            jmp_place_holder
+        ]
+
+        verify_base_error = [       # an invalid base was used
+            (Opcode.PUSH0, b''),
+            (Opcode.ASSERT, b''),
+        ]
+
+        # region verify_base jump logic
+
+        jump_instructions = verify_base_error
+        verify_base_jump_error[-1] = Opcode.get_jump_and_data(Opcode.JMP, get_bytes_count(jump_instructions), True)
+
+        jump_instructions = verify_base_jump_error
+        verify_base_le_minus1[-1] = Opcode.get_jump_and_data(Opcode.JMPLE, get_bytes_count(jump_instructions), True)
+
+        jump_instructions = verify_base_jump_error + verify_base_le_minus1
+        verify_base_equal1[-1] = Opcode.get_jump_and_data(Opcode.JMPEQ, get_bytes_count(jump_instructions), True)
+
+        jump_instructions = verify_base_jump_error + verify_base_le_minus1 + verify_base_equal1
+        verify_base_ge37[-1] = Opcode.get_jump_and_data(Opcode.JMPGE, get_bytes_count(jump_instructions), True)
+
+        # endregion
+
+        verify_base = (
+                verify_base_ge37 +
+                verify_base_equal1 +
+                verify_base_le_minus1 +
+                verify_base_jump_error +
+                verify_base_error
+        )
+
+        # endregion
+
+        # region verify_code_literal
+
+        verify_code_literal_first_char_is_0 = [     # verifies if the first char in the value is '0'
+            (Opcode.DUP, b''),
+            (Opcode.PUSH0, b''),
+            (Opcode.PUSH1, b''),
+            (Opcode.SUBSTR, b''),
+            (Opcode.CONVERT, StackItemType.ByteString),
+            Opcode.get_pushdata_and_data('0'),
+            jmp_place_holder,                       # if first char is not 0, skip all verify_code_literal methods
+        ]
+
+        verify_code_literal_remove_first_char = [   # the first char is 0, so it will be removed from the value
+            (Opcode.PUSH1, b''),
+            (Opcode.OVER, b''),
+            (Opcode.SIZE, b''),
+            (Opcode.DEC, b''),
+            (Opcode.SUBSTR, b''),
+            (Opcode.CONVERT, StackItemType.ByteString),
+        ]
+
+        verify_code_literal_get_base_char = [       # puts the char that could refer to a base in the top of the stack
+            (Opcode.DUP, b''),
+            (Opcode.PUSH0, b''),
+            (Opcode.PUSH1, b''),
+            (Opcode.SUBSTR, b''),
+            (Opcode.CONVERT, StackItemType.ByteString),
+        ]
+
+        verify_code_literal_initialize_verification = [     # puts a False in the top of the stack to assist the
+            (Opcode.PUSH0, b'')                             # verifications above
+        ]
+
+        verify_code_literal_base_verification = (           # verifies if the original value starts with 0b, 0B, 0o, 0O
+            self._verify_is_specific_base('b', 2) +         # 0x, or 0X, and changes the base if necessary
+            self._verify_is_specific_base('B', 2) +
+            self._verify_is_specific_base('o', 8) +
+            self._verify_is_specific_base('O', 8) +
+            self._verify_is_specific_base('x', 16) +
+            self._verify_is_specific_base('X', 16)
+        )
+
+        verify_code_literal_drop_aux = [                    # drops auxiliary values from the stack and just keeps the
+            (Opcode.DROP, b''),                             # base and value on it
+            (Opcode.DROP, b''),
+        ]
+
+        # region verify_code_literal jump logic
+
+        jump_instructions = (
+            verify_code_literal_remove_first_char +
+            verify_code_literal_get_base_char +
+            verify_code_literal_initialize_verification +
+            verify_code_literal_base_verification +
+            verify_code_literal_drop_aux
+        )
+
+        verify_code_literal_first_char_is_0[-1] = Opcode.get_jump_and_data(Opcode.JMPNE_L,
+                                                                           get_bytes_count(jump_instructions), True)
+
+        # endregion
+
+        verify_code_literal = (
+            verify_code_literal_first_char_is_0 +
+            verify_code_literal_remove_first_char +
+            verify_code_literal_get_base_char +
+            verify_code_literal_initialize_verification +
+            verify_code_literal_base_verification +
+            verify_code_literal_drop_aux
+        )
+
+        # endregion
+
+        # region ascii to int
+
+        ascii_to_int_initialize = [     # initialize auxiliary variables on the stack
+            (Opcode.DUP, b''),
+            (Opcode.SIZE, b''),
+            (Opcode.DEC, b''),          # index = len(value) - 1
+            (Opcode.DUP, b''),
+            (Opcode.PUSH0, b''),
+            (Opcode.GE, b''),
+            (Opcode.ASSERT, b''),       # verifies if value was empty
+            (Opcode.PUSH0, b''),        # sum = 0
+            (Opcode.PUSH1, b''),        # mult = 1
+        ]
+
+        ascii_to_int_while = [      # loops from left to right of the value to calculate the equivalent sum in base 10
+            (Opcode.PUSH3, b''),
+            (Opcode.PICK, b''),
+            (Opcode.PUSH3, b''),
+            (Opcode.PICK, b''),
+            (Opcode.PUSH1, b''),
+            (Opcode.SUBSTR, b''),   # char = value[index]
+            (Opcode.CONVERT, StackItemType.Integer),
+        ]
+
+        ascii_to_int_verify_az_lower_lt = [     # verifies ord(char) is less than ord('a')
+            (Opcode.DUP, b''),                  # if ord(char) is indeed less, go to verify with ord('A')
+            Opcode.get_push_and_data(a_lower),
+            jmp_place_holder                    # jump to ascii_to_int_verify_az_upper_lt
+        ]
+
+        ascii_to_int_verify_az_lower_gt = [     # verifies ord(char) is greater than base + 86
+            (Opcode.DUP, b''),                  # the minimum base that accepts letters is base 11, that's why it's
+            (Opcode.PUSH6, b''),                # adding 86
+            (Opcode.PICK, b''),                 # if ord(char) is greater than base + 86, the char is invalid
+            Opcode.get_push_and_data(86),
+            (Opcode.ADD, b''),
+            (Opcode.LE, b''),
+            (Opcode.ASSERT, b''),               # if assert is False, then the char was indeed invalid
+        ]
+
+        ascii_to_int_verify_az_lower = [        # the char was in between 'a' and 'z',
+            Opcode.get_push_and_data(87),       # so it will be converted to the respective base 10 number
+            (Opcode.SUB, b''),
+            (Opcode.OVER, b''),
+            (Opcode.MUL, b''),
+            (Opcode.PUSH2, b''),
+            (Opcode.PICK, b''),
+            (Opcode.ADD, b''),                  # sum = sum + (ord(char) - 55)) * mult
+            (Opcode.REVERSE3, b''),
+            (Opcode.DROP, b''),
+            jmp_place_holder                    # jumps to ascii_to_int_verify_while
+        ]
+
+        ascii_to_int_verify_az_upper_lt = [     # verifies ord(char) is less than ord('A')
+            (Opcode.DUP, b''),                  # if ord(char) is indeed less, go to verify with ord('0')
+            Opcode.get_push_and_data(a_upper),
+            jmp_place_holder                    # jump to ascii_to_int_verify_09_lt
+        ]
+
+        ascii_to_int_verify_az_upper_gt = [     # verifies ord(char) is greater than base + 54
+            (Opcode.DUP, b''),                  # the minimum base that accepts letters is base 11, that's why it's
+            (Opcode.PUSH6, b''),                # adding 54
+            (Opcode.PICK, b''),                 # if ord(char) is greater than base + 54, the char is invalid
+            Opcode.get_push_and_data(54),
+            (Opcode.ADD, b''),
+            (Opcode.LE, b''),
+            (Opcode.ASSERT, b''),               # if assert is False, then the char was indeed invalid
+        ]
+
+        ascii_to_int_verify_az_upper = [        # the char was in between 'A' and 'Z',
+            Opcode.get_push_and_data(55),       # so it will be converted to the respective base 10 number
+            (Opcode.SUB, b''),
+            (Opcode.OVER, b''),
+            (Opcode.MUL, b''),
+            (Opcode.PUSH2, b''),
+            (Opcode.PICK, b''),
+            (Opcode.ADD, b''),                  # sum = sum + (ord(char) - 55)) * mult
+            (Opcode.REVERSE3, b''),
+            (Opcode.DROP, b''),
+            jmp_place_holder                    # jumps to ascii_to_int_verify_while
+        ]
+
+        ascii_to_int_verify_09_lt = [           # verifies ord(char) is less than ord('0')
+            (Opcode.DUP, b''),                  # if ord(char) is indeed less, the char is invalid
+            Opcode.get_push_and_data(zero),
+            (Opcode.GE, b''),
+            (Opcode.ASSERT, b''),               # if assert is False, then the char was indeed invalid
+        ]
+
+        ascii_to_int_verify_09_gt = [           # verifies ord(char) is greater than base + ord('0')
+            (Opcode.DUP, b''),                  # if ord(char) is greater than base + ord('0'), the char is invalid
+            (Opcode.PUSH6, b''),
+            (Opcode.PICK, b''),
+            Opcode.get_push_and_data(zero),
+            (Opcode.ADD, b''),
+            (Opcode.LE, b''),
+            (Opcode.ASSERT, b''),               # if assert is False, then the char was indeed invalid
+        ]
+
+        ascii_to_int_verify_09 = [              # the char was in between '0' and '9',
+            Opcode.get_push_and_data(zero),     # so it will be converted to the respective base 10 number
+            (Opcode.SUB, b''),
+            (Opcode.OVER, b''),
+            (Opcode.MUL, b''),
+            (Opcode.PUSH2, b''),
+            (Opcode.PICK, b''),
+            (Opcode.ADD, b''),                  # sum = sum + (ord(char) - ord('0')) * mult
+            (Opcode.REVERSE3, b''),
+            (Opcode.DROP, b''),
+        ]
+
+        ascii_to_int_verify_while = [           # verifies if the loop already went through all the chars in value
+            (Opcode.REVERSE3, b''),
+            (Opcode.DEC, b''),                  # index--
+            (Opcode.REVERSE3, b''),
+            (Opcode.PUSH4, b''),
+            (Opcode.PICK, b''),
+            (Opcode.MUL, b''),                  # mult = mult * base
+            (Opcode.PUSH2, b''),
+            (Opcode.PICK, b''),
+            (Opcode.PUSH0, b''),
+            # jmp back to ascii_to_int_while if index >= 0
+        ]
+
+        # region ascii to int jump logic
+
+        jump_instructions = (
+            ascii_to_int_verify_09_lt +
+            ascii_to_int_verify_09_gt +
+            ascii_to_int_verify_09
+        )
+
+        ascii_to_int_verify_az_upper[-1] = Opcode.get_jump_and_data(Opcode.JMP,
+                                                                    get_bytes_count(jump_instructions), True)
+
+        jump_instructions = (
+            ascii_to_int_verify_az_upper_gt +
+            ascii_to_int_verify_az_upper
+        )
+
+        ascii_to_int_verify_az_upper_lt[-1] = Opcode.get_jump_and_data(Opcode.JMPLT,
+                                                                       get_bytes_count(jump_instructions), True)
+
+        jump_instructions = (
+            ascii_to_int_verify_az_upper_lt +
+            ascii_to_int_verify_az_upper_gt +
+            ascii_to_int_verify_az_upper +
+            ascii_to_int_verify_09_lt +
+            ascii_to_int_verify_09_gt +
+            ascii_to_int_verify_09
+        )
+
+        ascii_to_int_verify_az_lower[-1] = Opcode.get_jump_and_data(Opcode.JMP,
+                                                                    get_bytes_count(jump_instructions), True)
+
+        jump_instructions = (
+            ascii_to_int_verify_az_lower_gt +
+            ascii_to_int_verify_az_lower
+        )
+
+        ascii_to_int_verify_az_lower_lt[-1] = Opcode.get_jump_and_data(Opcode.JMPLT,
+                                                                       get_bytes_count(jump_instructions), True)
+
+        jump_instructions = (
+                ascii_to_int_while +
+                ascii_to_int_verify_az_lower_lt +
+                ascii_to_int_verify_az_lower_gt +
+                ascii_to_int_verify_az_lower +
+                ascii_to_int_verify_az_upper_lt +
+                ascii_to_int_verify_az_upper_gt +
+                ascii_to_int_verify_az_upper +
+                ascii_to_int_verify_09_gt +
+                ascii_to_int_verify_09_lt +
+                ascii_to_int_verify_09 +
+                ascii_to_int_verify_while
+        )
+
+        ascii_to_int_verify_while.append(Opcode.get_jump_and_data(Opcode.JMPGE,
+                                                                  -get_bytes_count(jump_instructions), True))
+
+        # endregion
+
+        ascii_to_int = (
+            ascii_to_int_initialize +
+            ascii_to_int_while +
+            ascii_to_int_verify_az_lower_lt +
+            ascii_to_int_verify_az_lower_gt +
+            ascii_to_int_verify_az_lower +
+            ascii_to_int_verify_az_upper_lt +
+            ascii_to_int_verify_az_upper_gt +
+            ascii_to_int_verify_az_upper +
+            ascii_to_int_verify_09_lt +
+            ascii_to_int_verify_09_gt +
+            ascii_to_int_verify_09 +
+            ascii_to_int_verify_while
+        )
+
+        # endregion
+
+        # region clean stack
+
+        clean_stack = [         # clean everything but the number in base 10
+            (Opcode.DROP, b''),
+            (Opcode.NIP, b''),
+            (Opcode.NIP, b''),
+            (Opcode.NIP, b''),
+        ]
+
+        # endregion
+
+        return (
+            verify_base +
+            verify_code_literal +
+            ascii_to_int +
+            clean_stack
+        )
+
+    def _verify_is_specific_base(self, char: str, base: int) -> List[Tuple[Opcode, bytes]]:
+        from boa3.compiler.codegenerator import get_bytes_count
+        from boa3.neo.vm.type.StackItem import StackItemType
+        jmp_place_holder = (Opcode.JMP, b'\x01')
+
+        verify_top_stack = [    # verify if True is in the top of the stack
+            jmp_place_holder
+        ]
+
+        top_stack_is_true = [       # if True is indeed at the top, ignore the rest of this method
+            (Opcode.PUSH1, b''),
+            jmp_place_holder        # jumps everything below
+        ]
+
+        compare_char = [            # compares the char with b, B, o, O, x, or X
+            (Opcode.DUP, b''),
+            Opcode.get_pushdata_and_data(char),
+            jmp_place_holder
+        ]
+
+        char_not_equal = [          # if char at the top of the stack is not b, B, o, O, x, or X,
+            (Opcode.PUSH0, b''),    # put False at the top of the stack
+
+            jmp_place_holder        # jumps everything below
+        ]
+
+        verify_base_is_the_same = [     # verify if the equivalent base is the same as current base
+            (Opcode.PUSH2, b''),
+            (Opcode.PICK, b''),
+            Opcode.get_push_and_data(base),
+            jmp_place_holder            # jump to remove_base_char if equivalent base is the same as current base
+        ]
+
+        verify_base_is_0 = [            # verify if the current base is 0
+            (Opcode.PUSH2, b''),
+            (Opcode.PICK, b''),
+            (Opcode.PUSH0, b''),
+            jmp_place_holder            # if base is not 0, jump to put_true_in_stack
+        ]
+
+        change_base = [                 # if base was 0, then change it to the equivalent base
+            (Opcode.REVERSE3, b''),
+            (Opcode.DROP, b''),
+            Opcode.get_push_and_data(base),
+            (Opcode.REVERSE3, b''),
+        ]
+
+        remove_base_char = [            # if base was 0 or 16, remove the char in value
+            (Opcode.SWAP, b''),
+            (Opcode.PUSH1, b''),
+            (Opcode.OVER, b''),
+            (Opcode.SIZE, b''),
+            (Opcode.DEC, b''),
+            (Opcode.SUBSTR, b''),
+            (Opcode.CONVERT, StackItemType.ByteString),
+            (Opcode.SWAP, b''),
+        ]
+
+        put_true_in_stack = [           # puts True in the top of the stack to skip the next verifications
+            (Opcode.PUSH1, b'')
+        ]
+
+        # region jmp logic
+
+        jump_instructions = change_base + remove_base_char
+        verify_base_is_0[-1] = Opcode.get_jump_and_data(Opcode.JMPNE, get_bytes_count(jump_instructions), True)
+
+        jump_instructions = change_base + verify_base_is_0
+        verify_base_is_the_same[-1] = Opcode.get_jump_and_data(Opcode.JMPEQ, get_bytes_count(jump_instructions), True)
+
+        jump_instructions = change_base + remove_base_char + put_true_in_stack + verify_base_is_0 + verify_base_is_the_same
+        char_not_equal[-1] = Opcode.get_jump_and_data(Opcode.JMP, get_bytes_count(jump_instructions), True)
+
+        jump_instructions = char_not_equal
+        compare_char[-1] = Opcode.get_jump_and_data(Opcode.JMPEQ, get_bytes_count(jump_instructions), True)
+
+        jump_instructions = (
+                compare_char +
+                char_not_equal +
+                change_base +
+                put_true_in_stack +
+                verify_base_is_the_same +
+                verify_base_is_0 +
+                remove_base_char
+        )
+        top_stack_is_true[-1] = Opcode.get_jump_and_data(Opcode.JMP, get_bytes_count(jump_instructions), True)
+
+        jump_instructions = top_stack_is_true
+        verify_top_stack[-1] = Opcode.get_jump_and_data(Opcode.JMPIFNOT, get_bytes_count(jump_instructions), True)
+
+        # endregion
+
+        return (
+            verify_top_stack +
+            top_stack_is_true +
+            compare_char +
+            char_not_equal +
+            verify_base_is_the_same +
+            verify_base_is_0 +
+            change_base +
+            remove_base_char +
+            put_true_in_stack
+        )

--- a/boa3/model/builtin/method/intintmethod.py
+++ b/boa3/model/builtin/method/intintmethod.py
@@ -1,0 +1,25 @@
+import ast
+from typing import Dict, List, Tuple
+
+from boa3.model.builtin.method.intmethod import IntMethod
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class IntIntMethod(IntMethod):
+
+    def __init__(self):
+        from boa3.model.type.type import Type
+        args: Dict[str, Variable] = {
+            'value': Variable(Type.int),
+        }
+
+        value_default = ast.parse("{0}".format(Type.int.default_value)
+                                  ).body[0].value
+
+        super().__init__(args, [value_default])
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        # returns the same int
+        return [(Opcode.RET, b'')]

--- a/boa3/model/builtin/method/intmethod.py
+++ b/boa3/model/builtin/method/intmethod.py
@@ -1,0 +1,49 @@
+import ast
+from typing import Dict, List, Optional, Any
+
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.variable import Variable
+
+
+class IntMethod(IBuiltinMethod):
+
+    def __init__(self, args: Dict[str, Variable] = None, defaults: List[ast.AST] = None):
+        from boa3.model.type.type import Type
+        identifier = 'int'
+        super().__init__(identifier, args, defaults=defaults, return_type=Type.int)
+
+    @property
+    def _arg_value(self) -> Variable:
+        return self.args['value']
+
+    @property
+    def identifier(self) -> str:
+        from boa3.model.type.type import Type
+
+        if self._arg_value.type is Type.int:
+            return '-{0}_{1}'.format(self._identifier, Type.str.identifier + Type.bytes.identifier)
+
+        if self._arg_value.type is Type.str or self._arg_value.type is Type.bytes:
+            return '-{0}_{1}'.format(self._identifier, Type.sequence.identifier)
+
+        return self._identifier
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> Optional[str]:
+        return None
+
+    def build(self, value: Any) -> IBuiltinMethod:
+        if not isinstance(value, list):
+            value = [value]
+
+        from boa3.model.type.type import Type
+        from boa3.model.builtin.builtin import Builtin
+        if len(value) == 0 or Type.int.is_type_of(value[0]):
+            return Builtin.IntInt
+
+        if Type.str.is_type_of(value[0]) or Type.bytes.is_type_of(value[0]):
+            return Builtin.IntByteString

--- a/boa3/model/type/primitive/inttype.py
+++ b/boa3/model/type/primitive/inttype.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from boa3 import constants
 from boa3.model.type.itype import IType
 from boa3.model.type.primitive.primitivetype import PrimitiveType
 from boa3.neo.vm.type.AbiType import AbiType
@@ -37,6 +38,8 @@ class IntType(PrimitiveType):
 
         for instance_method in instance_methods:
             self._instance_methods[instance_method.raw_identifier] = instance_method.build(self)
+
+        self._instance_methods[constants.INIT_METHOD_ID] = Builtin.IntInt
 
     @classmethod
     def build(cls, value: Any) -> IType:

--- a/boa3_test/test_sc/built_in_methods_test/IntBytes.py
+++ b/boa3_test/test_sc/built_in_methods_test/IntBytes.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+
+
+@public
+def main(value: bytes, base: int) -> int:
+    a = int(value, base)
+    return a

--- a/boa3_test/test_sc/built_in_methods_test/IntInt.py
+++ b/boa3_test/test_sc/built_in_methods_test/IntInt.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+
+
+@public
+def main(value: int) -> int:
+    a = int(value)
+    return a

--- a/boa3_test/test_sc/built_in_methods_test/IntIntTooManyParameters.py
+++ b/boa3_test/test_sc/built_in_methods_test/IntIntTooManyParameters.py
@@ -1,0 +1,3 @@
+def main(value: int, base: int) -> int:
+    a = int(value, base)
+    return a

--- a/boa3_test/test_sc/built_in_methods_test/IntNoParameters.py
+++ b/boa3_test/test_sc/built_in_methods_test/IntNoParameters.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+
+
+@public
+def main() -> int:
+    a = int()
+    return a

--- a/boa3_test/test_sc/built_in_methods_test/IntStr.py
+++ b/boa3_test/test_sc/built_in_methods_test/IntStr.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+
+
+@public
+def main(value: str, base: int) -> int:
+    a = int(value, base)
+    return a

--- a/boa3_test/tests/compiler_tests/test_builtin_method.py
+++ b/boa3_test/tests/compiler_tests/test_builtin_method.py
@@ -1403,3 +1403,220 @@ class TestBuiltinMethod(BoaTest):
         self.assertEqual(super_method_expected_result, result)
 
     # endregion
+
+    # region int test
+
+    # TODO: Int constructor is not accepting more than one method
+    # def test_int_str(self):
+    #     path = self.get_contract_path('IntStr.py')
+    #     engine = TestEngine()
+    #
+    #     value = '0b101'
+    #     base = 0
+    #     result = self.run_smart_contract(engine, path, 'main', value, base)
+    #     self.assertEqual(int(value, base), result)
+    #
+    #     value = '0B101'
+    #     base = 0
+    #     result = self.run_smart_contract(engine, path, 'main', value, base)
+    #     self.assertEqual(int(value, base), result)
+    #
+    #     value = '0b101'
+    #     base = 2
+    #     result = self.run_smart_contract(engine, path, 'main', value, base)
+    #     self.assertEqual(int(value, base), result)
+    #
+    #     value = '0B101'
+    #     base = 2
+    #     result = self.run_smart_contract(engine, path, 'main', value, base)
+    #     self.assertEqual(int(value, base), result)
+    #
+    #     value = '0o123'
+    #     base = 0
+    #     result = self.run_smart_contract(engine, path, 'main', value, base)
+    #     self.assertEqual(int(value, base), result)
+    #
+    #     value = '0O123'
+    #     base = 0
+    #     result = self.run_smart_contract(engine, path, 'main', value, base)
+    #     self.assertEqual(int(value, base), result)
+    #
+    #     value = '0o123'
+    #     base = 8
+    #     result = self.run_smart_contract(engine, path, 'main', value, base)
+    #     self.assertEqual(int(value, base), result)
+    #
+    #     value = '0O123'
+    #     base = 8
+    #     result = self.run_smart_contract(engine, path, 'main', value, base)
+    #     self.assertEqual(int(value, base), result)
+    #
+    #     value = '0x123'
+    #     base = 0
+    #     result = self.run_smart_contract(engine, path, 'main', value, base)
+    #     self.assertEqual(int(value, base), result)
+    #
+    #     value = '0X123'
+    #     base = 0
+    #     result = self.run_smart_contract(engine, path, 'main', value, base)
+    #     self.assertEqual(int(value, base), result)
+    #
+    #     value = '0x123'
+    #     base = 16
+    #     result = self.run_smart_contract(engine, path, 'main', value, base)
+    #     self.assertEqual(int(value, base), result)
+    #
+    #     value = '0X123'
+    #     base = 16
+    #     result = self.run_smart_contract(engine, path, 'main', value, base)
+    #     self.assertEqual(int(value, base), result)
+    #
+    #     value = '123'
+    #     base = 16
+    #     result = self.run_smart_contract(engine, path, 'main', value, base)
+    #     self.assertEqual(int(value, base), result)
+    #
+    #     value = '11'
+    #     base = 11
+    #     result = self.run_smart_contract(engine, path, 'main', value, base)
+    #     self.assertEqual(int(value, base), result)
+    #
+    #     value = 'abcdef'
+    #     base = 16
+    #     result = self.run_smart_contract(engine, path, 'main', value, base)
+    #     self.assertEqual(int(value, base), result)
+    #
+    #     value = 'abcdefg'
+    #     base = 16
+    #     with self.assertRaises(TestExecutionException):
+    #         self.run_smart_contract(engine, path, 'main', value, base)
+    #     with self.assertRaises(ValueError):
+    #         int(value, base)
+    #
+    #     value = '0x123'
+    #     base = 8
+    #     with self.assertRaises(TestExecutionException):
+    #         self.run_smart_contract(engine, path, 'main', value, base)
+    #     with self.assertRaises(ValueError):
+    #         int(value, base)
+
+    # TODO: Int constructor is not accepting more than one method
+    # def test_int_bytes(self):
+    #     path = self.get_contract_path('IntBytes.py')
+    #     self.compile_and_save(path)
+    #     engine = TestEngine()
+    #
+    #     value = b'0b101'
+    #     base = 0
+    #     result = self.run_smart_contract(engine, path, 'main', value, base)
+    #     self.assertEqual(int(value, base), result)
+    #
+    #     value = b'0B101'
+    #     base = 0
+    #     result = self.run_smart_contract(engine, path, 'main', value, base)
+    #     self.assertEqual(int(value, base), result)
+    #
+    #     value = b'0b101'
+    #     base = 2
+    #     result = self.run_smart_contract(engine, path, 'main', value, base)
+    #     self.assertEqual(int(value, base), result)
+    #
+    #     value = b'0B101'
+    #     base = 2
+    #     result = self.run_smart_contract(engine, path, 'main', value, base)
+    #     self.assertEqual(int(value, base), result)
+    #
+    #     value = b'0o123'
+    #     base = 0
+    #     result = self.run_smart_contract(engine, path, 'main', value, base)
+    #     self.assertEqual(int(value, base), result)
+    #
+    #     value = b'0O123'
+    #     base = 0
+    #     result = self.run_smart_contract(engine, path, 'main', value, base)
+    #     self.assertEqual(int(value, base), result)
+    #
+    #     value = b'0o123'
+    #     base = 8
+    #     result = self.run_smart_contract(engine, path, 'main', value, base)
+    #     self.assertEqual(int(value, base), result)
+    #
+    #     value = b'0O123'
+    #     base = 8
+    #     result = self.run_smart_contract(engine, path, 'main', value, base)
+    #     self.assertEqual(int(value, base), result)
+    #
+    #     value = b'0x123'
+    #     base = 0
+    #     result = self.run_smart_contract(engine, path, 'main', value, base)
+    #     self.assertEqual(int(value, base), result)
+    #
+    #     value = b'0X123'
+    #     base = 0
+    #     result = self.run_smart_contract(engine, path, 'main', value, base)
+    #     self.assertEqual(int(value, base), result)
+    #
+    #     value = b'0x123'
+    #     base = 16
+    #     result = self.run_smart_contract(engine, path, 'main', value, base)
+    #     self.assertEqual(int(value, base), result)
+    #
+    #     value = b'0X123'
+    #     base = 16
+    #     result = self.run_smart_contract(engine, path, 'main', value, base)
+    #     self.assertEqual(int(value, base), result)
+    #
+    #     value = b'123'
+    #     base = 16
+    #     result = self.run_smart_contract(engine, path, 'main', value, base)
+    #     self.assertEqual(int(value, base), result)
+    #
+    #     value = b'11'
+    #     base = 11
+    #     result = self.run_smart_contract(engine, path, 'main', value, base)
+    #     self.assertEqual(int(value, base), result)
+    #
+    #     value = b'abcdef'
+    #     base = 16
+    #     result = self.run_smart_contract(engine, path, 'main', value, base)
+    #     self.assertEqual(int(value, base), result)
+    #
+    #     value = b'abcdefg'
+    #     base = 16
+    #     with self.assertRaises(TestExecutionException):
+    #         self.run_smart_contract(engine, path, 'main', value, base)
+    #     with self.assertRaises(ValueError):
+    #         int(value, base)
+    #
+    #     value = b'0x123'
+    #     base = 8
+    #     with self.assertRaises(TestExecutionException):
+    #         self.run_smart_contract(engine, path, 'main', value, base)
+    #     with self.assertRaises(ValueError):
+    #         int(value, base)
+
+    def test_int_int(self):
+        path = self.get_contract_path('IntInt.py')
+        engine = TestEngine()
+
+        value = 10
+        result = self.run_smart_contract(engine, path, 'main', value)
+        self.assertEqual(int(value), result)
+
+        value = -10
+        result = self.run_smart_contract(engine, path, 'main', value)
+        self.assertEqual(int(value), result)
+
+    def test_int_int_too_many_parameters(self):
+        path = self.get_contract_path('IntIntTooManyParameters.py')
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+
+    def test_int_no_parameters(self):
+        path = self.get_contract_path('IntNoParameters.py')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'main')
+        self.assertEqual(int(), result)
+
+    # endregion
+


### PR DESCRIPTION
**Related issue**
#754 

**Summary or solution description**
Added a constructor to int.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/36d4aa36211f77ec99267a4e59adfd6ed153b29b/boa3_test/test_sc/built_in_methods_test/IntInt.py#L1-L7

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/36d4aa36211f77ec99267a4e59adfd6ed153b29b/boa3_test/tests/compiler_tests/test_builtin_method.py#L1598-L1619

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7]

**(Optional) Additional context**
Even though the int method with str or bytes was implemented, it was not possible to use it together with the int method with int. 
