### PR TITLE
Add support to pow

### DIFF
--- a/boa3/model/builtin/math/__init__.py
+++ b/boa3/model/builtin/math/__init__.py
@@ -1,8 +1,10 @@
 __all__ = ['DecimalCeilingMethod',
            'DecimalFloorMethod',
+           'PowMethod',
            'SqrtMethod',
            ]
 
 from boa3.model.builtin.math.decimalceil import DecimalCeilingMethod
 from boa3.model.builtin.math.decimalfloor import DecimalFloorMethod
+from boa3.model.builtin.math.powmethod import PowMethod
 from boa3.model.builtin.math.sqrtmethod import SqrtMethod

--- a/boa3/model/builtin/math/powmethod.py
+++ b/boa3/model/builtin/math/powmethod.py
@@ -1,0 +1,37 @@
+from typing import Dict, List, Optional, Tuple
+
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class PowMethod(IBuiltinMethod):
+
+    def __init__(self):
+        from boa3.model.type.type import Type
+        identifier = 'pow'
+        args: Dict[str, Variable] = {
+            'base': Variable(Type.int),
+            'exponent': Variable(Type.int),
+        }
+        super().__init__(identifier, args, return_type=Type.int)
+
+    @property
+    def requires_reordering(self) -> bool:
+        return True
+
+    def reorder(self, arguments: list):
+        # swap base and exponent  positions
+        arguments[0], arguments[1] = arguments[1], arguments[0]
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        return [(Opcode.POW, b'')]
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> Optional[str]:
+        return

--- a/boa3/model/type/math.py
+++ b/boa3/model/type/math.py
@@ -8,6 +8,7 @@ from boa3.model.symbol import ISymbol
 class Math:
 
     # python math methods
+    Pow = PowMethod()
     Sqrt = SqrtMethod()
 
     @classmethod
@@ -15,7 +16,8 @@ class Math:
         from boa3.model.builtin.builtincallable import IBuiltinCallable
 
         functions = [
-            cls.Sqrt
+            cls.Pow,
+            cls.Sqrt,
         ]
 
         return {method._identifier: method for method in functions if isinstance(method, IBuiltinCallable)}

--- a/boa3_test/test_sc/math_test/Pow.py
+++ b/boa3_test/test_sc/math_test/Pow.py
@@ -1,0 +1,8 @@
+import math
+
+from boa3.builtin import public
+
+
+@public
+def main(x: int, y: int) -> int:
+    return math.pow(x, y)

--- a/boa3_test/test_sc/math_test/PowFromMath.py
+++ b/boa3_test/test_sc/math_test/PowFromMath.py
@@ -1,0 +1,8 @@
+from math import pow
+
+from boa3.builtin import public
+
+
+@public
+def main(x: int, y: int) -> int:
+    return pow(x, y)

--- a/boa3_test/tests/compiler_tests/test_math.py
+++ b/boa3_test/tests/compiler_tests/test_math.py
@@ -12,6 +12,52 @@ class TestMath(BoaTest):
         path = self.get_contract_path('NoImport.py')
         self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
 
+    # region pow test
+
+    def test_pow_method(self):
+        path = self.get_contract_path('Pow.py')
+        engine = TestEngine()
+
+        import math
+
+        base = 1
+        exponent = 4
+        result = self.run_smart_contract(engine, path, 'main', base, exponent)
+        self.assertEqual(math.pow(base, exponent), result)
+
+        base = 5
+        exponent = 2
+        result = self.run_smart_contract(engine, path, 'main', base, exponent)
+        self.assertEqual(math.pow(base, exponent), result)
+
+        base = -2
+        exponent = 2
+        result = self.run_smart_contract(engine, path, 'main', base, exponent)
+        self.assertEqual(math.pow(base, exponent), result)
+
+        base = -2
+        exponent = 3
+        result = self.run_smart_contract(engine, path, 'main', base, exponent)
+        self.assertEqual(math.pow(base, exponent), result)
+
+        base = 2
+        exponent = 0
+        result = self.run_smart_contract(engine, path, 'main', base, exponent)
+        self.assertEqual(math.pow(base, exponent), result)
+
+    def test_pow_method_from_math(self):
+        path = self.get_contract_path('PowFromMath.py')
+        engine = TestEngine()
+
+        from math import pow
+
+        base = 2
+        exponent = 3
+        result = self.run_smart_contract(engine, path, 'main', base, exponent)
+        self.assertEqual(pow(base, exponent), result)
+
+    # endregion
+
     # region sqrt test
 
     def test_sqrt_method(self):


### PR DESCRIPTION
**Related issue**
#664 

**Summary or solution description**
Added the pow method from the math module.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/0cdc1126df20ce0a8ae6387f352a9a415bb3433d/boa3_test/test_sc/math_test/Pow.py#L1-L8

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/0cdc1126df20ce0a8ae6387f352a9a415bb3433d/boa3_test/tests/compiler_tests/test_math.py#L17-L57

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
