### PR TITLE
Add support to implicit boolean conversion

### DIFF
--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -665,14 +665,6 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
         test = self.visit(if_node.test)
         test_type: IType = self.get_type(test)
 
-        if test_type is not Type.bool:
-            self._log_error(
-                CompilerError.MismatchedTypes(
-                    if_node.lineno, if_node.col_offset,
-                    actual_type_id=test_type.identifier,
-                    expected_type_id=Type.bool.identifier)
-            )
-
         return self._get_is_instance_function_calls(if_node.test)
 
     def _get_is_instance_function_calls(self, node: ast.AST) -> Tuple[Dict[str, ISymbol], Dict[str, ISymbol]]:

--- a/boa3/compiler/codegenerator/codegeneratorvisitor.py
+++ b/boa3/compiler/codegenerator/codegeneratorvisitor.py
@@ -621,7 +621,10 @@ class VisitorCodeGenerator(IAstAnalyser):
 
         :param if_node: the python ast if statement node
         """
-        self.visit_to_map(if_node.test, generate=True)
+        test = self.visit_to_map(if_node.test, generate=True)
+
+        if not Type.bool.is_type_of(test.type) and test.type is not None:
+            self.generator.convert_builtin_method_call(Builtin.Bool)
 
         start_addr: int = self.generator.convert_begin_if()
         for stmt in if_node.body:

--- a/boa3_test/test_sc/if_test/IfImplicitBoolean.py
+++ b/boa3_test/test_sc/if_test/IfImplicitBoolean.py
@@ -1,0 +1,12 @@
+from typing import Any
+
+from boa3.builtin import public
+
+
+@public
+def main(a: Any) -> bool:
+    b = False
+
+    if a:
+        b = True
+    return b

--- a/boa3_test/test_sc/if_test/IfImplicitBooleanLiteral.py
+++ b/boa3_test/test_sc/if_test/IfImplicitBooleanLiteral.py
@@ -1,0 +1,24 @@
+from boa3.builtin import public
+
+
+@public
+def main() -> int:
+    b = 1
+
+    if None:
+        b = b * 10
+    if []:
+        b = b * 10
+    if {}:
+        b = b * 10
+    if ():
+        b = b * 10
+
+    if [1]:
+        b = b + 1
+    if {'a': 1}:
+        b = b + 1
+    if (1, 2):
+        b = b + 1
+
+    return b

--- a/boa3_test/test_sc/if_test/MismatchedTypeCondition.py
+++ b/boa3_test/test_sc/if_test/MismatchedTypeCondition.py
@@ -1,7 +1,0 @@
-def Main(condition: str) -> int:
-    a = 0
-
-    if condition:  # expecting bool, not str
-        a = a + 2
-
-    return a

--- a/boa3_test/tests/compiler_tests/test_if.py
+++ b/boa3_test/tests/compiler_tests/test_if.py
@@ -60,10 +60,6 @@ class TestIf(BoaTest):
         result = self.run_smart_contract(engine, path, 'Main', False)
         self.assertEqual(0, result)
 
-    def test_if_mismatched_type_condition(self):
-        path = self.get_contract_path('MismatchedTypeCondition.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
-
     def test_if_no_condition(self):
         path = self.get_contract_path('IfWithoutCondition.py')
 
@@ -478,7 +474,7 @@ class TestIf(BoaTest):
         self.assertEqual(False, result)
 
     def test_boa2_compare_test0int(self):
-        path = self.get_contract_path('CompareBoa2Test0str.py')
+        path = self.get_contract_path('CompareBoa2Test0int.py')
         engine = TestEngine()
 
         result = self.run_smart_contract(engine, path, 'main', 2, 4)
@@ -595,3 +591,44 @@ class TestIf(BoaTest):
 
         result = self.run_smart_contract(engine, path, 'Main', False)
         self.assertEqual('{[value1,value2,value3]}', result)
+
+    def test_if_implicit_boolean(self):
+        path = self.get_contract_path('IfImplicitBoolean.py')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'main', 1)
+        self.assertEqual(True, result)
+
+        result = self.run_smart_contract(engine, path, 'main', 0)
+        self.assertEqual(False, result)
+
+        result = self.run_smart_contract(engine, path, 'main', 'unit_test')
+        self.assertEqual(True, result)
+
+        result = self.run_smart_contract(engine, path, 'main', '')
+        self.assertEqual(False, result)
+
+        result = self.run_smart_contract(engine, path, 'main', b'unit test')
+        self.assertEqual(True, result)
+
+        result = self.run_smart_contract(engine, path, 'main', b'')
+        self.assertEqual(False, result)
+
+        result = self.run_smart_contract(engine, path, 'main', [1, 2, 3, 4])
+        self.assertEqual(True, result)
+
+        result = self.run_smart_contract(engine, path, 'main', [])
+        self.assertEqual(False, result)
+
+        result = self.run_smart_contract(engine, path, 'main', {'a': 1, 'b': 2})
+        self.assertEqual(True, result)
+
+        result = self.run_smart_contract(engine, path, 'main', {})
+        self.assertEqual(False, result)
+
+    def test_if_implicit_boolean_literal(self):
+        path = self.get_contract_path('IfImplicitBooleanLiteral.py')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'main')
+        self.assertEqual(4, result)


### PR DESCRIPTION
**Related issue**
#679 

**Summary or solution description**
It's now possible to use any type of value in the if condition.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/9e8bedb4cb1a7d856a0ca384678752e53e0904f3/boa3_test/test_sc/if_test/IfImplicitBoolean.py#L1-L12

**Tests**
[A clear and concise description of how you tested it.](https://github.com/CityOfZion/neo3-boa/blob/9e8bedb4cb1a7d856a0ca384678752e53e0904f3/boa3_test/tests/compiler_tests/test_if.py#L595-L634)

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
