### PR TITLE
Can't run neo3-boa when installing from source due to requirement conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,3 @@ autopep8==1.4.4
 base58==1.0.3
 coverage==4.5.4
 pycodestyle==2.5.0
-Sphinx==4.0.0
-sphinx-rtd-theme==0.5.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,7 +3,7 @@ base58==1.0.3
 bump2version==1.0.0
 coverage==4.5.4
 pycodestyle==2.5.0
-Sphinx==4.0.0
-sphinx-rtd-theme==0.5.2
+Sphinx>=4.0.0
+sphinx-rtd-theme>=0.5.2
 twine>=1.10.0
 wheel>=0.30.0


### PR DESCRIPTION
**Related issue**
#780 

**Summary or solution description**
Removed `Sphinx` and `sphinx-rtd-theme` in the `requirements.txt`, they now are only at `requirements_dev.txt`.

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7

**(Optional) Additional context**
It was mentioned that the versions were outdated, that's why the version was changed on `requirements_dev.txt`.