### PR TITLE
Change nef debug file generation to be optional

### DIFF
--- a/boa3/boa3.py
+++ b/boa3/boa3.py
@@ -22,7 +22,7 @@ class Boa3:
         return Compiler().compile(path)
 
     @staticmethod
-    def compile_and_save(path: str, output_path: str = None, show_errors: bool = True):
+    def compile_and_save(path: str, output_path: str = None, show_errors: bool = True, debug: bool = False):
         """
         Load a Python file to be compiled and save the result into the files.
         By default, the resultant .nef file is saved in the same folder of the
@@ -31,6 +31,7 @@ class Boa3:
         :param path: the path of the Python file to compile
         :param output_path: Optional path to save the generated files
         :param show_errors: if compiler errors should be logged.
+        :param debug: if nefdbgnfo file should be generated.
         """
         if not path.endswith('.py'):
             raise InvalidPathException(path)
@@ -40,4 +41,4 @@ class Boa3:
         elif not output_path.endswith('.nef'):
             raise InvalidPathException(path)
 
-        Compiler().compile_and_save(path, output_path, show_errors)
+        Compiler().compile_and_save(path, output_path, show_errors, debug)

--- a/boa3/cli.py
+++ b/boa3/cli.py
@@ -10,6 +10,7 @@ from boa3.exception.NotLoadedException import NotLoadedException
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("input", help=".py smart contract to compile")
+    parser.add_argument("-db", "--debug", action='store_true', help="generates a nefdbgnfo file")
     args = parser.parse_args()
 
     if not args.input.endswith(".py") or not os.path.isfile(args.input):
@@ -20,7 +21,7 @@ def main():
     path, filename = os.path.split(fullpath)
 
     try:
-        Boa3.compile_and_save(args.input)
+        Boa3.compile_and_save(args.input, args.debug)
         logging.info(f"Wrote {filename.replace('.py', '.nef')} to {path}")
     except NotLoadedException as e:
         logging.error("Could not compile")

--- a/boa3/compiler/compiler.py
+++ b/boa3/compiler/compiler.py
@@ -37,16 +37,17 @@ class Compiler:
         self._analyse(fullpath, log)
         return self._compile()
 
-    def compile_and_save(self, path: str, output_path: str, log: bool = True):
+    def compile_and_save(self, path: str, output_path: str, log: bool = True, debug: bool = False):
         """
         Save the compiled file and the metadata files
 
         :param path: the path of the Python file to compile
         :param output_path: the path to save the generated files
         :param log: if compiler errors should be logged.
+        :param debug: if nefdbgnfo file should be generated.
         """
         self.bytecode = self.compile(path, log)
-        self._save(output_path)
+        self._save(output_path, debug)
 
     def _analyse(self, path: str, log: bool = True):
         """
@@ -68,12 +69,13 @@ class Compiler:
             raise NotLoadedException
         return CodeGenerator.generate_code(self._analyser)
 
-    def _save(self, output_path: str):
+    def _save(self, output_path: str, debug: bool):
         """
         Save the compiled file and the metadata files
 
         :param output_path: the path to save the generated files
         :raise NotLoadedException: raised if no file were compiled
+        :param debug: if nefdbgnfo file should be generated.
         """
         if (self._analyser is None
                 or not self._analyser.is_analysed
@@ -91,7 +93,8 @@ class Compiler:
             manifest_file.write(manifest_bytes)
             manifest_file.close()
 
-        from zipfile import ZipFile, ZIP_DEFLATED
-        with ZipFile(output_path.replace('.nef', '.nefdbgnfo'), 'w', ZIP_DEFLATED) as nef_debug_info:
-            debug_bytes = generator.generate_nefdbgnfo_file()
-            nef_debug_info.writestr(os.path.basename(output_path.replace('.nef', '.debug.json')), debug_bytes)
+        if debug:
+            from zipfile import ZipFile, ZIP_DEFLATED
+            with ZipFile(output_path.replace('.nef', '.nefdbgnfo'), 'w', ZIP_DEFLATED) as nef_debug_info:
+                debug_bytes = generator.generate_nefdbgnfo_file()
+                nef_debug_info.writestr(os.path.basename(output_path.replace('.nef', '.debug.json')), debug_bytes)

--- a/boa3_test/tests/compiler_tests/test_file_generation.py
+++ b/boa3_test/tests/compiler_tests/test_file_generation.py
@@ -20,8 +20,17 @@ class TestFileGeneration(BoaTest):
         path = self.get_contract_path('GenerationWithDecorator.py')
         expected_nef_output = path.replace('.py', '.nef')
         expected_manifest_output = path.replace('.py', '.manifest.json')
-        expected_debug_info_output = path.replace('.py', '.nefdbgnfo')
         Boa3.compile_and_save(path)
+
+        self.assertTrue(os.path.exists(expected_nef_output))
+        self.assertTrue(os.path.exists(expected_manifest_output))
+
+    def test_generate_files_with_debug_info(self):
+        path = self.get_contract_path('GenerationWithDecorator.py')
+        expected_nef_output = path.replace('.py', '.nef')
+        expected_manifest_output = path.replace('.py', '.manifest.json')
+        expected_debug_info_output = path.replace('.py', '.nefdbgnfo')
+        Boa3.compile_and_save(path, debug=True)
 
         self.assertTrue(os.path.exists(expected_nef_output))
         self.assertTrue(os.path.exists(expected_manifest_output))
@@ -199,7 +208,7 @@ class TestFileGeneration(BoaTest):
 
         expected_nef_output = path.replace('.py', '.nefdbgnfo')
         compiler = Compiler()
-        compiler.compile_and_save(path, path.replace('.py', '.nef'))
+        compiler.compile_and_save(path, path.replace('.py', '.nef'), debug=True)
         methods: Dict[str, Method] = {
             name: method
             for name, method in self.get_compiler_analyser(compiler).symbol_table.items()
@@ -247,7 +256,7 @@ class TestFileGeneration(BoaTest):
 
         expected_nef_output = path.replace('.py', '.nefdbgnfo')
         compiler = Compiler()
-        compiler.compile_and_save(path, path.replace('.py', '.nef'))
+        compiler.compile_and_save(path, path.replace('.py', '.nef'), debug=True)
         events: Dict[str, Event] = {
             name: method
             for name, method in self.get_compiler_analyser(compiler).symbol_table.items()
@@ -285,7 +294,7 @@ class TestFileGeneration(BoaTest):
 
         expected_nef_output = path.replace('.py', '.nefdbgnfo')
         compiler = Compiler()
-        compiler.compile_and_save(path, path.replace('.py', '.nef'))
+        compiler.compile_and_save(path, path.replace('.py', '.nef'), debug=True)
         variables: Dict[str, Method] = {
             name: method
             for name, method in self.get_compiler_analyser(compiler).symbol_table.items()
@@ -321,7 +330,7 @@ class TestFileGeneration(BoaTest):
 
         expected_nef_output = path.replace('.py', '.nefdbgnfo')
         compiler = Compiler()
-        compiler.compile_and_save(path, path.replace('.py', '.nef'))
+        compiler.compile_and_save(path, path.replace('.py', '.nef'), debug=True)
         methods: Dict[str, Method] = {
             name: method
             for name, method in self.get_all_imported_methods(compiler).items()
@@ -449,7 +458,7 @@ class TestFileGeneration(BoaTest):
         path = self.get_contract_path('GenerationWithMultipleFlows.py')
 
         compiler = Compiler()
-        compiler.compile_and_save(path, path.replace('.py', '.nef'))
+        compiler.compile_and_save(path, path.replace('.py', '.nef'), debug=True)
         methods: Dict[str, Method] = {
             name: method
             for name, method in self.get_compiler_analyser(compiler).symbol_table.items()
@@ -494,7 +503,7 @@ class TestFileGeneration(BoaTest):
         path = self.get_contract_path('test_sc/variable_test', 'GlobalAssignmentWithType.py')
 
         compiler = Compiler()
-        compiler.compile_and_save(path, path.replace('.py', '.nef'))
+        compiler.compile_and_save(path, path.replace('.py', '.nef'), debug=True)
         methods: Dict[str, Method] = {
             name: method
             for name, method in self.get_compiler_analyser(compiler).symbol_table.items()


### PR DESCRIPTION
**Related issue**
#787 

**Summary or solution description**
Added an extra argument to verify whether the debug info should be generated or not.

**How to Reproduce**
 via command line:
`neo3-boa path/to/your/file.py --debug` or `neo3-boa path/to/your/file.py -db`

via script:
```python
from boa3.boa3 import Boa3

Boa3.compile_and_save('path/to/your/file.py', debug=True)
```

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/2531423bd0a9d913316206f418662af0a845bd47/boa3_test/tests/compiler_tests/test_file_generation.py#L19-L37

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
