### PR TITLE
Enhance 'public' decorator to support more manifest modifiers

### DIFF
--- a/boa3/builtin/__init__.py
+++ b/boa3/builtin/__init__.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Tuple, Union
 
 
-def public(*args):
+def public(*args, **kwargs):
     """
     This decorator identifies which methods should be included in the abi file.
     """

--- a/boa3/compiler/filegenerator.py
+++ b/boa3/compiler/filegenerator.py
@@ -189,7 +189,7 @@ class FileGenerator:
     def _construct_abi_method(self, method_id: str, method: Method) -> Dict[str, Any]:
         from boa3.compiler.codegenerator.vmcodemapping import VMCodeMapping
         return {
-            "name": method_id,
+            "name": method.external_name if isinstance(method.external_name, str) else method_id,
             "offset": (VMCodeMapping.instance().get_start_address(method.start_bytecode)
                        if method.start_bytecode is not None else 0),
             "parameters": [
@@ -199,7 +199,7 @@ class FileGenerator:
                 } for arg_id, arg in method.args.items()
             ],
             "returntype": method.type.abi_type,
-            "safe": False
+            "safe": method.is_safe
         }
 
     def _get_abi_events(self) -> List[Dict[str, Any]]:

--- a/boa3/model/builtin/decorator/builtindecorator.py
+++ b/boa3/model/builtin/decorator/builtindecorator.py
@@ -1,6 +1,6 @@
 import ast
 from abc import ABC
-from typing import Dict, List
+from typing import Any, Dict, List
 
 from boa3.model.builtin.builtincallable import IBuiltinCallable
 from boa3.model.decorator import IDecorator
@@ -16,3 +16,6 @@ class IBuiltinDecorator(IBuiltinCallable, IDecorator, ABC):
 
     def validate_parameters(self, *params: IExpression) -> bool:
         return len(params) == len(self.args)
+
+    def validate_values(self, *params: Any) -> List[Any]:
+        return []

--- a/boa3/model/builtin/decorator/contractdecorator.py
+++ b/boa3/model/builtin/decorator/contractdecorator.py
@@ -1,8 +1,9 @@
 import ast
-from typing import Dict, Sized
+from typing import Any, Dict, List, Sized
 
 from boa3.model.builtin.decorator.builtindecorator import IBuiltinDecorator
 from boa3.model.variable import Variable
+from boa3.neo3.core.types import UInt160
 
 
 class ContractDecorator(IBuiltinDecorator):
@@ -13,14 +14,56 @@ class ContractDecorator(IBuiltinDecorator):
         args: Dict[str, Variable] = {'script_hash': Variable(Type.union.build([Type.str,
                                                                                Type.bytes]))}
         super().__init__(identifier, args)
+        self.contract_hash = UInt160()
 
     def build(self, *args) -> IBuiltinDecorator:
-        if isinstance(args, Sized) and len(args) == 1 and isinstance(args[0], ast.AST):
+        if isinstance(args, Sized) and len(args) > 0 and isinstance(args[0], ast.AST):
             decorator = ContractDecorator()
             decorator._origin_node = args[0]
+
+            if len(args) > 1:
+                values = self.validate_values(*args[:2])
+
+                hash_arg = values[0]
+                if isinstance(hash_arg, UInt160):
+                    decorator.contract_hash = hash_arg
             return decorator
 
         return self
+
+    def validate_values(self, *params: Any) -> List[Any]:
+        values = []
+        if len(params) != 2:
+            return values
+
+        origin, visitor = params
+        values.append(self.contract_hash)
+        from boa3.analyser.astanalyser import IAstAnalyser
+        if not isinstance(origin, ast.Call) or not isinstance(visitor, IAstAnalyser):
+            return values
+
+        from boa3.exception import CompilerError
+        if len(origin.args) < 1:
+            visitor._log_error(
+                CompilerError.UnfilledArgument(origin.lineno, origin.col_offset, list(self.args.keys())[0])
+            )
+            return values
+        argument_hash = visitor.visit(origin.args[0])
+
+        try:
+            if isinstance(argument_hash, str):
+                from boa3.neo import from_hex_str
+                argument_hash = from_hex_str(argument_hash)
+
+            if isinstance(argument_hash, bytes):
+                values[0] = UInt160(argument_hash)
+        except BaseException:
+            visitor._log_error(CompilerError.InvalidUsage(origin.lineno,
+                                                          origin.col_offset,
+                                                          "Only literal values are accepted for 'script_hash' argument"
+                                                          ))
+
+        return values
 
     @property
     def is_function_decorator(self) -> bool:

--- a/boa3/model/builtin/decorator/publicdecorator.py
+++ b/boa3/model/builtin/decorator/publicdecorator.py
@@ -1,7 +1,90 @@
+import ast
+from typing import Any, Dict, List, Optional, Sized
+
 from boa3.model.builtin.decorator.builtindecorator import IBuiltinDecorator
+from boa3.model.type.type import Type
+from boa3.model.variable import Variable
 
 
 class PublicDecorator(IBuiltinDecorator):
     def __init__(self):
         identifier = 'public'
-        super().__init__(identifier)
+        args: Dict[str, Variable] = {'name': Variable(Type.str),
+                                     'safe': Variable(Type.bool),
+                                     }
+
+        name_default = ast.parse("'{0}'".format(Type.str.default_value)).body[0].value
+        safe_default = ast.parse("{0}".format(Type.bool.default_value)).body[0].value
+
+        defaults = [name_default, safe_default]
+        super().__init__(identifier, args, defaults)
+
+        self.name: Optional[str] = None
+        self.safe = False
+
+    def build(self, *args) -> IBuiltinDecorator:
+        if isinstance(args, Sized) and len(args) > 0 and isinstance(args[0], ast.AST):
+            decorator = PublicDecorator()
+            origin = args[0]
+            decorator._origin_node = origin
+
+            if len(args) > 1:
+                values = self.validate_values(*args[:2])
+
+                name_arg, safe_arg = values
+                if isinstance(name_arg, str) and len(name_arg) > 0:
+                    decorator.name = name_arg
+                if isinstance(safe_arg, bool):
+                    decorator.safe = safe_arg
+
+            return decorator
+
+        return self
+
+    def validate_values(self, *params: Any) -> List[Any]:
+        values = []
+        if len(params) != 2:
+            return values
+
+        origin, visitor = params
+        from boa3.analyser.astanalyser import IAstAnalyser
+        if not isinstance(origin, ast.Call) or not isinstance(visitor, IAstAnalyser):
+            return [self.name, self.safe]
+
+        # read the called arguments
+        args_names = list(self.args.keys())
+        args_len = min(len(origin.args), len(args_names))
+        for x in range(args_len):
+            values.append(visitor.visit(origin.args[x]))
+
+        if len(values) <= 1:
+            if len(values) == 0:
+                values.append('')
+            values.append(self.safe)
+
+        # read the called keyword arguments
+        for kwarg in origin.keywords:
+            if kwarg.arg in args_names:
+                x = args_names.index(kwarg.arg)
+                value = visitor.visit(kwarg.value)
+                values[x] = value
+
+        from boa3.exception import CompilerError
+        name, safe = values
+        if not isinstance(name, str):
+            visitor._log_error(
+                CompilerError.MismatchedTypes(
+                    origin.lineno, origin.col_offset,
+                    expected_type_id=Type.str.identifier,
+                    actual_type_id=type(name).__name__
+                ))
+
+        if not isinstance(safe, bool):
+            visitor._log_error(
+                CompilerError.MismatchedTypes(
+                    origin.lineno, origin.col_offset,
+                    expected_type_id=Type.bool.identifier,
+                    actual_type_id=type(safe).__name__
+                ))
+
+        return values

--- a/boa3/model/method.py
+++ b/boa3/model/method.py
@@ -27,8 +27,9 @@ class Method(Callable):
                  return_type: IType = Type.none, is_public: bool = False,
                  decorators: List[Callable] = None,
                  is_init: bool = False,
+                 is_safe: bool = False,
                  origin_node: Optional[ast.AST] = None):
-        super().__init__(args, vararg, kwargs, defaults, return_type, is_public, decorators, origin_node)
+        super().__init__(args, vararg, kwargs, defaults, return_type, is_public, decorators, is_safe, origin_node)
 
         self.imported_symbols = {}
         self._symbols = {}

--- a/boa3_test/test_sc/generation_test/MetadataMethodName.py
+++ b/boa3_test/test_sc/generation_test/MetadataMethodName.py
@@ -1,0 +1,16 @@
+from boa3.builtin import public
+
+
+@public(name='Add')
+def Main(a: int, b: int) -> int:
+    c = Add(a, b)
+    return c
+
+
+def Add(a: int, b: int) -> int:
+    return a + b
+
+
+@public
+def Sub(a: int, b: int) -> int:
+    return a - b

--- a/boa3_test/test_sc/generation_test/MetadataMethodNameArg.py
+++ b/boa3_test/test_sc/generation_test/MetadataMethodNameArg.py
@@ -1,0 +1,16 @@
+from boa3.builtin import public
+
+
+@public('Add')
+def Main(a: int, b: int) -> int:
+    c = Add(a, b)
+    return c
+
+
+def Add(a: int, b: int) -> int:
+    return a + b
+
+
+@public
+def Sub(a: int, b: int) -> int:
+    return a - b

--- a/boa3_test/test_sc/generation_test/MetadataMethodNameMismatchedType.py
+++ b/boa3_test/test_sc/generation_test/MetadataMethodNameMismatchedType.py
@@ -1,0 +1,16 @@
+from boa3.builtin import public
+
+
+@public(name=b'Add')
+def Main(a: int, b: int) -> int:
+    c = Add(a, b)
+    return c
+
+
+def Add(a: int, b: int) -> int:
+    return a + b
+
+
+@public
+def Sub(a: int, b: int) -> int:
+    return a - b

--- a/boa3_test/test_sc/generation_test/MetadataMethodSafe.py
+++ b/boa3_test/test_sc/generation_test/MetadataMethodSafe.py
@@ -1,0 +1,16 @@
+from boa3.builtin import public
+
+
+@public(safe=True)
+def Main(a: int, b: int) -> int:
+    c = Add(a, b)
+    return c
+
+
+def Add(a: int, b: int) -> int:
+    return a + b
+
+
+@public
+def Sub(a: int, b: int) -> int:
+    return a - b

--- a/boa3_test/test_sc/generation_test/MetadataMethodSafeArg.py
+++ b/boa3_test/test_sc/generation_test/MetadataMethodSafeArg.py
@@ -1,0 +1,16 @@
+from boa3.builtin import public
+
+
+@public('Add', True)
+def Main(a: int, b: int) -> int:
+    c = Add(a, b)
+    return c
+
+
+def Add(a: int, b: int) -> int:
+    return a + b
+
+
+@public
+def Sub(a: int, b: int) -> int:
+    return a - b

--- a/boa3_test/test_sc/generation_test/MetadataMethodSafeMismatchedType.py
+++ b/boa3_test/test_sc/generation_test/MetadataMethodSafeMismatchedType.py
@@ -1,0 +1,16 @@
+from boa3.builtin import public
+
+
+@public(safe=42)
+def Main(a: int, b: int) -> int:
+    c = Add(a, b)
+    return c
+
+
+def Add(a: int, b: int) -> int:
+    return a + b
+
+
+@public
+def Sub(a: int, b: int) -> int:
+    return a - b

--- a/boa3_test/tests/compiler_tests/test_file_generation.py
+++ b/boa3_test/tests/compiler_tests/test_file_generation.py
@@ -4,6 +4,7 @@ from typing import Dict
 from boa3 import constants
 from boa3.boa3 import Boa3
 from boa3.compiler.compiler import Compiler
+from boa3.exception import CompilerError
 from boa3.exception.NotLoadedException import NotLoadedException
 from boa3.model.event import Event
 from boa3.model.method import Method
@@ -192,6 +193,84 @@ class TestFileGeneration(BoaTest):
                 self.assertIn('type', event_param)
                 self.assertEqual(event_args[event_param['name']].type.abi_type,
                                  event_param['type'])
+
+    def test_generate_manifest_file_with_public_name_decorator_kwarg(self):
+        path = self.get_contract_path('MetadataMethodName.py')
+        expected_manifest_output = path.replace('.py', '.manifest.json')
+        output, manifest = self.compile_and_save(path)
+
+        self.assertTrue(os.path.exists(expected_manifest_output))
+        self.assertIn('abi', manifest)
+        abi = manifest['abi']
+
+        self.assertIn('methods', abi)
+        self.assertEqual(2, len(abi['methods']))
+
+        # method Main named as Add
+        method0 = abi['methods'][0]
+        self.assertIn('name', method0)
+        self.assertEqual('Add', method0['name'])
+
+    def test_generate_manifest_file_with_public_name_decorator_arg(self):
+        path = self.get_contract_path('MetadataMethodNameArg.py')
+        expected_manifest_output = path.replace('.py', '.manifest.json')
+        output, manifest = self.compile_and_save(path)
+
+        self.assertTrue(os.path.exists(expected_manifest_output))
+        self.assertIn('abi', manifest)
+        abi = manifest['abi']
+
+        self.assertIn('methods', abi)
+        self.assertEqual(2, len(abi['methods']))
+
+        # method Main named as Add
+        method0 = abi['methods'][0]
+        self.assertIn('name', method0)
+        self.assertEqual('Add', method0['name'])
+
+    def test_metadata_abi_method_name_mismatched_type(self):
+        path = self.get_contract_path('MetadataMethodNameMismatchedType.py')
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+
+    def test_generate_manifest_file_with_public_safe_decorator_kwarg(self):
+        path = self.get_contract_path('MetadataMethodSafe.py')
+        expected_manifest_output = path.replace('.py', '.manifest.json')
+        output, manifest = self.compile_and_save(path)
+
+        self.assertTrue(os.path.exists(expected_manifest_output))
+        self.assertIn('abi', manifest)
+        abi = manifest['abi']
+
+        self.assertIn('methods', abi)
+        self.assertEqual(2, len(abi['methods']))
+
+        # method Main
+        method0 = abi['methods'][0]
+        self.assertIn('safe', method0)
+        self.assertEqual(True, method0['safe'])
+
+    def test_generate_manifest_file_with_public_safe_decorator_arg(self):
+        path = self.get_contract_path('MetadataMethodSafeArg.py')
+        expected_manifest_output = path.replace('.py', '.manifest.json')
+        output, manifest = self.compile_and_save(path)
+
+        self.assertTrue(os.path.exists(expected_manifest_output))
+        self.assertIn('abi', manifest)
+        abi = manifest['abi']
+
+        self.assertIn('methods', abi)
+        self.assertEqual(2, len(abi['methods']))
+
+        # method Main named as Add
+        method0 = abi['methods'][0]
+        self.assertIn('name', method0)
+        self.assertEqual('Add', method0['name'])
+        self.assertIn('safe', method0)
+        self.assertEqual(True, method0['safe'])
+
+    def test_metadata_abi_method_safe_mismatched_type(self):
+        path = self.get_contract_path('MetadataMethodSafeMismatchedType.py')
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_generate_nefdbgnfo_file(self):
         from boa3.model.type.itype import IType

--- a/boa3_test/tests/compiler_tests/test_if.py
+++ b/boa3_test/tests/compiler_tests/test_if.py
@@ -1,5 +1,5 @@
 from boa3.boa3 import Boa3
-from boa3.exception import CompilerError, CompilerWarning
+from boa3.exception import CompilerWarning
 from boa3.model.type.type import Type
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer

--- a/boa3_test/tests/compiler_tests/test_list.py
+++ b/boa3_test/tests/compiler_tests/test_list.py
@@ -1,5 +1,3 @@
-import unittest
-
 from boa3.boa3 import Boa3
 from boa3.exception import CompilerError, CompilerWarning
 from boa3.model.type.type import Type

--- a/boa3_test/tests/compiler_tests/test_tuple.py
+++ b/boa3_test/tests/compiler_tests/test_tuple.py
@@ -1,5 +1,3 @@
-import unittest
-
 from boa3.boa3 import Boa3
 from boa3.exception import CompilerError
 from boa3.neo.vm.opcode.Opcode import Opcode


### PR DESCRIPTION
**Related issue**
#786

**Summary or solution description**
Included arguments to the `public` decorator to support manifest abi methods modifiers

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/393e94aa4e4250183297dc635d5fdb87bbac7d14/boa3_test/test_sc/generation_test/MetadataMethodName.py#L4-L7
https://github.com/CityOfZion/neo3-boa/blob/393e94aa4e4250183297dc635d5fdb87bbac7d14/boa3_test/test_sc/generation_test/MetadataMethodSafe.py#L4-L7

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/393e94aa4e4250183297dc635d5fdb87bbac7d14/boa3_test/tests/compiler_tests/test_file_generation.py#L197-L273

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7