### PR TITLE
Implement manifest 'trusts' modifier

### DIFF
--- a/boa3/builtin/__init__.py
+++ b/boa3/builtin/__init__.py
@@ -1,5 +1,8 @@
 from typing import Any, Dict, List, Tuple, Union
 
+from boa3.constants import IMPORT_WILDCARD
+from boa3.neo3.core.types import UInt160
+
 
 def public(*args):
     """
@@ -86,7 +89,7 @@ class NeoMetadata:
         from typing import Optional
 
         self.supported_standards: List[str] = []
-        self.trusts: List[str] = []
+        self._trusts: List[str] = []
 
         # extras
         self.author: Optional[str] = None
@@ -117,27 +120,31 @@ class NeoMetadata:
         :param hash_or_address: a contract hash, group public key or *
         :type hash_or_address: str
         """
-        if len(self.trusts) == 1 and self.trusts == ['*']:
+        if not isinstance(hash_or_address, str):
             return
 
-        if hash_or_address == '*':
-            self.trusts.clear()
-            self.trusts = ['*']
+        if self._trusts == [IMPORT_WILDCARD]:
+            return
+
+        if hash_or_address == IMPORT_WILDCARD:
+            self._trusts.clear()
+            self._trusts = [IMPORT_WILDCARD]
 
         # verifies if it's a valid contract hash
         elif hash_or_address.startswith('0x'):
             try:
-                if len(bytes.fromhex(hash_or_address[2:])) == 20:
-                    if hash_or_address not in self.trusts:
-                        self.trusts.append(hash_or_address.lower())
+                if len(UInt160.from_string(hash_or_address[2:])) == 20:
+                    if hash_or_address not in self._trusts:
+                        self._trusts.append(hash_or_address.lower())
             except ValueError:
                 pass
 
         # verifies if it's a valid public key
+        # compressed public keys in Neo start with either 03 or 02 and is followed by 32 bytes
         elif hash_or_address.startswith('03') or hash_or_address.startswith('02'):
             try:
                 if len(bytes.fromhex(hash_or_address)) == 33:
-                    if hash_or_address not in self.trusts:
-                        self.trusts.append(hash_or_address.lower())
+                    if hash_or_address not in self._trusts:
+                        self._trusts.append(hash_or_address.lower())
             except ValueError:
                 pass

--- a/boa3/builtin/__init__.py
+++ b/boa3/builtin/__init__.py
@@ -70,6 +70,8 @@ class NeoMetadata:
 
     :ivar supported_standards: Neo standards supported by this smart contract. Empty by default;
     :vartype supported_standards: List[str]
+    :ivar trusts: a list of contracts that this smart contract trust. Empty by default;
+    :vartype trusts: List[str]
     :ivar author: the smart contract author. None by default;
     :vartype author: str or None
     :ivar email: the smart contract author email. None by default;
@@ -84,6 +86,7 @@ class NeoMetadata:
         from typing import Optional
 
         self.supported_standards: List[str] = []
+        self.trusts: List[str] = []
 
         # extras
         self.author: Optional[str] = None
@@ -106,3 +109,35 @@ class NeoMetadata:
         if isinstance(self.description, str):
             extra['Description'] = self.description
         return extra
+
+    def add_trusted_source(self, hash_or_address: str):
+        """
+        Adds a valid contract hash, valid group public key, or the * wildcard to trusts.
+
+        :param hash_or_address: a contract hash, group public key or *
+        :type hash_or_address: str
+        """
+        if len(self.trusts) == 1 and self.trusts == ['*']:
+            return
+
+        if hash_or_address == '*':
+            self.trusts.clear()
+            self.trusts = ['*']
+
+        # verifies if it's a valid contract hash
+        elif hash_or_address.startswith('0x'):
+            try:
+                if len(bytes.fromhex(hash_or_address[2:])) == 20:
+                    if hash_or_address not in self.trusts:
+                        self.trusts.append(hash_or_address.lower())
+            except ValueError:
+                pass
+
+        # verifies if it's a valid public key
+        elif hash_or_address.startswith('03') or hash_or_address.startswith('02'):
+            try:
+                if len(bytes.fromhex(hash_or_address)) == 33:
+                    if hash_or_address not in self.trusts:
+                        self.trusts.append(hash_or_address.lower())
+            except ValueError:
+                pass

--- a/boa3/compiler/filegenerator.py
+++ b/boa3/compiler/filegenerator.py
@@ -157,7 +157,7 @@ class FileGenerator:
                     "methods": "*"
                 }
             ],
-            "trusts": self._metadata.trusts,
+            "trusts": self._metadata._trusts,
             "features": {},
             "supportedstandards": self._metadata.supported_standards,
             "extra": self._metadata.extra if len(self._metadata.extra) > 0 else None

--- a/boa3/compiler/filegenerator.py
+++ b/boa3/compiler/filegenerator.py
@@ -157,7 +157,7 @@ class FileGenerator:
                     "methods": "*"
                 }
             ],
-            "trusts": [],
+            "trusts": self._metadata.trusts,
             "features": {},
             "supportedstandards": self._metadata.supported_standards,
             "extra": self._metadata.extra if len(self._metadata.extra) > 0 else None

--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -192,6 +192,7 @@ class Builtin:
 
     metadata_fields: Dict[str, Union[type, Tuple[type]]] = {
         'supported_standards': list,
+        'trusts': list,
         'author': (str, type(None)),
         'email': (str, type(None)),
         'description': (str, type(None)),

--- a/boa3_test/test_sc/metadata_test/MetadataInfoTrusts.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoTrusts.py
@@ -6,7 +6,7 @@ def Main() -> int:
 
 
 @metadata
-def author_manifest() -> NeoMetadata:
+def trusts_manifest() -> NeoMetadata:
     meta = NeoMetadata()
 
     # values added to manifest

--- a/boa3_test/test_sc/metadata_test/MetadataInfoTrusts.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoTrusts.py
@@ -1,0 +1,25 @@
+from boa3.builtin import NeoMetadata, metadata
+
+
+def Main() -> int:
+    return 5
+
+
+@metadata
+def author_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+
+    # values added to manifest
+    meta.add_trusted_source("0x1234567890123456789012345678901234567890")
+    meta.add_trusted_source("0x1234567890123456789012345678901234abcdef")
+    meta.add_trusted_source("030000123456789012345678901234567890123456789012345678901234abcdef")
+    meta.add_trusted_source("020000123456789012345678901234567890123456789012345678901234abcdef")
+
+    # values not added to manifest
+    meta.add_trusted_source("0x123456789012345678901234567890123abcdefg")   # only hex values are valid
+    meta.add_trusted_source("0x1234567890123456789012345678901234567890")   # can't repeat values
+    meta.add_trusted_source("030000123456789012345678901234567890123456789012345678901234abcdef")   # can't repeat values
+    meta.add_trusted_source("03000012345678901234567890123456789012345678901234567890123abcdefg")   # only hex values are valid
+    meta.add_trusted_source("000000123456789012345678901234567890123456789012345678901234567890")   # public keys must begin with 03 or 02
+
+    return meta

--- a/boa3_test/test_sc/metadata_test/MetadataInfoTrustsDefault.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoTrustsDefault.py
@@ -1,0 +1,11 @@
+from boa3.builtin import NeoMetadata, metadata
+
+
+def Main() -> int:
+    return 5
+
+
+@metadata
+def trusts_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+    return meta

--- a/boa3_test/test_sc/metadata_test/MetadataInfoTrustsMismatchedTypes.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoTrustsMismatchedTypes.py
@@ -1,0 +1,15 @@
+from boa3.builtin import NeoMetadata, metadata
+
+
+def Main() -> int:
+    return 5
+
+
+@metadata
+def trusts_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+
+    meta.add_trusted_source(0x0123456789012345678901234567890123456789)
+    meta.add_trusted_source(b'0123456789012345678901234567890123456789')
+    meta.add_trusted_source(True)
+    return meta

--- a/boa3_test/test_sc/metadata_test/MetadataInfoTrustsWildcard.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoTrustsWildcard.py
@@ -1,0 +1,17 @@
+from boa3.builtin import NeoMetadata, metadata
+
+
+def Main() -> int:
+    return 5
+
+
+@metadata
+def author_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+
+    # the * wildcard will remove all but itself from trusts
+    meta.add_trusted_source("0x1234567890123456789012345678901234567890")
+    meta.add_trusted_source("*")
+    meta.add_trusted_source("0x1234567890123456789012345678901234567890")
+
+    return meta

--- a/boa3_test/test_sc/metadata_test/MetadataInfoTrustsWildcard.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoTrustsWildcard.py
@@ -6,7 +6,7 @@ def Main() -> int:
 
 
 @metadata
-def author_manifest() -> NeoMetadata:
+def trusts_manifest() -> NeoMetadata:
     meta = NeoMetadata()
 
     # the * wildcard will remove all but itself from trusts

--- a/boa3_test/tests/compiler_tests/test_metadata.py
+++ b/boa3_test/tests/compiler_tests/test_metadata.py
@@ -1,3 +1,4 @@
+from boa3.constants import IMPORT_WILDCARD
 from boa3.exception import CompilerError, CompilerWarning
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3_test.tests.boa_test import BoaTest
@@ -193,4 +194,20 @@ class TestMetadata(BoaTest):
         self.assertIn('trusts', manifest)
         self.assertIsInstance(manifest['trusts'], list)
         self.assertEqual(len(manifest['trusts']), 1)
-        self.assertIn('*', manifest['trusts'])
+        self.assertIn(IMPORT_WILDCARD, manifest['trusts'])
+
+    def test_metadata_info_trusts_mismatched_types(self):
+        path = self.get_contract_path('MetadataInfoTrustsMismatchedTypes.py')
+        output, manifest = self.compile_and_save(path)
+
+        self.assertIn('trusts', manifest)
+        self.assertIsInstance(manifest['trusts'], list)
+        self.assertEqual(len(manifest['trusts']), 0)
+
+    def test_metadata_info_trusts_default(self):
+        path = self.get_contract_path('MetadataInfoTrustsDefault.py')
+        output, manifest = self.compile_and_save(path)
+
+        self.assertIn('trusts', manifest)
+        self.assertIsInstance(manifest['trusts'], list)
+        self.assertEqual(len(manifest['trusts']), 0)

--- a/boa3_test/tests/compiler_tests/test_metadata.py
+++ b/boa3_test/tests/compiler_tests/test_metadata.py
@@ -173,3 +173,24 @@ class TestMetadata(BoaTest):
     def test_metadata_info_supported_standards_mismatched_type(self):
         path = self.get_contract_path('MetadataInfoDescriptionMismatchedType.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+
+    def test_metadata_info_trusts(self):
+        path = self.get_contract_path('MetadataInfoTrusts.py')
+        output, manifest = self.compile_and_save(path)
+
+        self.assertIn('trusts', manifest)
+        self.assertIsInstance(manifest['trusts'], list)
+        self.assertEqual(len(manifest['trusts']), 4)
+        self.assertIn('0x1234567890123456789012345678901234567890', manifest['trusts'])
+        self.assertIn('0x1234567890123456789012345678901234abcdef', manifest['trusts'])
+        self.assertIn('030000123456789012345678901234567890123456789012345678901234abcdef', manifest['trusts'])
+        self.assertIn('020000123456789012345678901234567890123456789012345678901234abcdef', manifest['trusts'])
+
+    def test_metadata_info_trusts_wildcard(self):
+        path = self.get_contract_path('MetadataInfoTrustsWildcard.py')
+        output, manifest = self.compile_and_save(path)
+
+        self.assertIn('trusts', manifest)
+        self.assertIsInstance(manifest['trusts'], list)
+        self.assertEqual(len(manifest['trusts']), 1)
+        self.assertIn('*', manifest['trusts'])


### PR DESCRIPTION
**Related issue**
#783 

**Summary or solution description**
Added the possibility to the user add contract hash or public key into the trust modifier on the manifest.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/bd6e2ed57a6cb27144dbf53c3304b70a652fd224/boa3_test/test_sc/metadata_test/MetadataInfoTrusts.py#L8-L25

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/bd6e2ed57a6cb27144dbf53c3304b70a652fd224/boa3_test/tests/compiler_tests/test_metadata.py#L177-L196

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
