### PR TITLE
Implement manifest 'permissions' modifier

### DIFF
--- a/boa3/compiler/filegenerator.py
+++ b/boa3/compiler/filegenerator.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from boa3 import constants
 from boa3.analyser.analyser import Analyser
-from boa3.constants import ENCODING
+from boa3.constants import ENCODING, IMPORT_WILDCARD
 from boa3.model.event import Event
 from boa3.model.imports.importsymbol import Import
 from boa3.model.method import Method
@@ -151,17 +151,22 @@ class FileGenerator:
             "name": self._entry_file,
             "groups": [],
             "abi": self._get_abi_info(),
-            "permissions": [
-                {
-                    "contract": "*",
-                    "methods": "*"
-                }
-            ],
+            "permissions": self._get_permissions(),
             "trusts": self._metadata._trusts,
             "features": {},
             "supportedstandards": self._metadata.supported_standards,
             "extra": self._get_extras()
         }
+
+    def _get_permissions(self) -> List[Dict[str, Any]]:
+        """
+        Gets the permission information in a dictionary format, if _metadata._permissions is empty, then consider it
+        with the import wildcard inside it.
+
+        :return: a dictionary with the permission information
+        """
+        return self._metadata._permissions if len(self._metadata._permissions) else [{"contract": IMPORT_WILDCARD,
+                                                                                      "methods": IMPORT_WILDCARD}]
 
     def _get_abi_info(self) -> Dict[str, Any]:
         """

--- a/boa3/compiler/filegenerator.py
+++ b/boa3/compiler/filegenerator.py
@@ -165,8 +165,8 @@ class FileGenerator:
 
         :return: a dictionary with the permission information
         """
-        return self._metadata._permissions if len(self._metadata._permissions) else [{"contract": IMPORT_WILDCARD,
-                                                                                      "methods": IMPORT_WILDCARD}]
+        return self._metadata._permissions if self._metadata._permissions else [{"contract": IMPORT_WILDCARD,
+                                                                                 "methods": IMPORT_WILDCARD}]
 
     def _get_abi_info(self) -> Dict[str, Any]:
         """

--- a/boa3_test/test_sc/metadata_test/MetadataInfoPermissions.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoPermissions.py
@@ -1,0 +1,21 @@
+from boa3.builtin import NeoMetadata, metadata
+
+
+def Main() -> int:
+    return 5
+
+
+@metadata
+def permissions_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+
+    # the contract needs permission to call this method from any contract
+    meta.add_permission(methods=['onNEP17Payment'])
+
+    # the contract needs permission to call this method from a specific contract
+    meta.add_permission(contract='0x3846a4aa420d9831044396dd3a56011514cd10e3', methods=['get_object'])
+
+    # the contract needs permission to call any methods from any contract in this group
+    meta.add_permission(contract='0333b24ee50a488caa5deec7e021ff515f57b7993b93b45d7df901e23ee3004916')
+
+    return meta

--- a/boa3_test/test_sc/metadata_test/MetadataInfoPermissionsDefault.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoPermissionsDefault.py
@@ -1,0 +1,11 @@
+from boa3.builtin import NeoMetadata, metadata
+
+
+def Main() -> int:
+    return 5
+
+
+@metadata
+def permissions_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+    return meta

--- a/boa3_test/test_sc/metadata_test/MetadataInfoPermissionsMismatchedType.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoPermissionsMismatchedType.py
@@ -22,6 +22,6 @@ def permissions_manifest() -> NeoMetadata:
     meta.add_permission(contract=True)
     meta.add_permission(contract=['0x3846a4aa420d9831044396dd3a56011514cd10e3'])
 
-    # meta.add_permission(contract='0x3846a4aa420d9831044396dd3a56011514cd10e3', methods=['get_object'])
+    meta.add_permission(contract=123, methods='onNEP17Payment')
 
     return meta

--- a/boa3_test/test_sc/metadata_test/MetadataInfoPermissionsMismatchedType.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoPermissionsMismatchedType.py
@@ -1,0 +1,27 @@
+from boa3.builtin import NeoMetadata, metadata
+
+
+def Main() -> int:
+    return 5
+
+
+@metadata
+def permissions_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+
+    meta.add_permission(methods=[b'onNEP17Payment'])
+    meta.add_permission(methods=[123])
+    meta.add_permission(methods=[True])
+    meta.add_permission(methods=b'onNEP17Payment')
+    meta.add_permission(methods=123)
+    meta.add_permission(methods=True)
+    meta.add_permission(methods='onNEP17Payment')
+
+    meta.add_permission(contract=b'12345678901234567890')
+    meta.add_permission(contract=123)
+    meta.add_permission(contract=True)
+    meta.add_permission(contract=['0x3846a4aa420d9831044396dd3a56011514cd10e3'])
+
+    # meta.add_permission(contract='0x3846a4aa420d9831044396dd3a56011514cd10e3', methods=['get_object'])
+
+    return meta

--- a/boa3_test/test_sc/metadata_test/MetadataInfoPermissionsWildcard.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoPermissionsWildcard.py
@@ -1,0 +1,14 @@
+from boa3.builtin import NeoMetadata, metadata
+
+
+def Main() -> int:
+    return 5
+
+
+@metadata
+def permissions_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+
+    meta.add_permission(contract='*', methods='*')
+
+    return meta

--- a/boa3_test/tests/compiler_tests/test_metadata.py
+++ b/boa3_test/tests/compiler_tests/test_metadata.py
@@ -211,3 +211,41 @@ class TestMetadata(BoaTest):
         self.assertIn('trusts', manifest)
         self.assertIsInstance(manifest['trusts'], list)
         self.assertEqual(len(manifest['trusts']), 0)
+
+    def test_metadata_info_permissions(self):
+        path = self.get_contract_path('MetadataInfoPermissions.py')
+        output, manifest = self.compile_and_save(path)
+
+        self.assertIn('permissions', manifest)
+        self.assertIsInstance(manifest['permissions'], list)
+        self.assertEqual(len(manifest['permissions']), 3)
+        self.assertIn({"contract": "*", "methods": ['onNEP17Payment']}, manifest['permissions'])
+        self.assertIn({"contract": "0x3846a4aa420d9831044396dd3a56011514cd10e3", "methods": ["get_object"]}, manifest['permissions'])
+        self.assertIn({"contract": "0333b24ee50a488caa5deec7e021ff515f57b7993b93b45d7df901e23ee3004916", "methods": "*"}, manifest['permissions'])
+
+    def test_metadata_info_permissions_mismatched_type(self):
+        path = self.get_contract_path('MetadataInfoPermissionsMismatchedType.py')
+        output, manifest = self.compile_and_save(path)
+
+        self.assertIn('permissions', manifest)
+        self.assertIsInstance(manifest['permissions'], list)
+        self.assertEqual(len(manifest['permissions']), 1)
+        self.assertIn({"contract": "*", "methods": "*"}, manifest['permissions'])
+
+    def test_metadata_info_permissions_default(self):
+        path = self.get_contract_path('MetadataInfoPermissionsDefault.py')
+        output, manifest = self.compile_and_save(path)
+
+        self.assertIn('permissions', manifest)
+        self.assertIsInstance(manifest['permissions'], list)
+        self.assertEqual(len(manifest['permissions']), 1)
+        self.assertIn({"contract": "*", "methods": "*"}, manifest['permissions'])
+
+    def test_metadata_info_permissions_Wildcard(self):
+        path = self.get_contract_path('MetadataInfoPermissionsWildcard.py')
+        output, manifest = self.compile_and_save(path)
+
+        self.assertIn('permissions', manifest)
+        self.assertIsInstance(manifest['permissions'], list)
+        self.assertEqual(len(manifest['permissions']), 1)
+        self.assertIn({"contract": "*", "methods": "*"}, manifest['permissions'])


### PR DESCRIPTION
**Related issue**
#784 

**Summary or solution description**
 Added the possibility to the user add a `Permission` on the manifest.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/59b9f9e3c5a8e9736c9ed12f2309bfbbb86fc596/boa3_test/test_sc/metadata_test/MetadataInfoPermissions.py#L1-L21

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/59b9f9e3c5a8e9736c9ed12f2309bfbbb86fc596/boa3_test/tests/compiler_tests/test_metadata.py#L215-L251

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
