### PR TITLE
Implement manifest 'name' modifier

### DIFF
--- a/boa3/builtin/__init__.py
+++ b/boa3/builtin/__init__.py
@@ -71,8 +71,13 @@ class NeoMetadata:
     """
     This class stores the smart contract manifest information.
 
+    :ivar name: the smart contract name. Will be the name of the file by default;
+    :vartype name: str
     :ivar supported_standards: Neo standards supported by this smart contract. Empty by default;
     :vartype supported_standards: List[str]
+    :ivar permissions: a list of contracts and methods that this smart contract permits to invoke and caçç. All
+    contracts and methods permitted by default;
+    :vartype permissions: List[str]
     :ivar trusts: a list of contracts that this smart contract trust. Empty by default;
     :vartype trusts: List[str]
     :ivar author: the smart contract author. None by default;
@@ -84,6 +89,7 @@ class NeoMetadata:
     """
 
     def __init__(self):
+        self.name: str = ''
         self.supported_standards: List[str] = []
         self._trusts: List[str] = []
         self._permissions: List[dict] = []
@@ -96,7 +102,8 @@ class NeoMetadata:
         :return: a dictionary that maps each extra value with its name. Empty by default
         """
         # list the variables names that are part of the manifest
-        specific_field_names = ['supported_standards',
+        specific_field_names = ['name',
+                                'supported_standards',
                                 ]
         extra = {}
 

--- a/boa3/compiler/filegenerator.py
+++ b/boa3/compiler/filegenerator.py
@@ -148,7 +148,7 @@ class FileGenerator:
         """
         # TODO: fill the information of the manifest
         return {
-            "name": self._entry_file,
+            "name": self._get_name(),
             "groups": [],
             "abi": self._get_abi_info(),
             "permissions": self._get_permissions(),
@@ -157,6 +157,14 @@ class FileGenerator:
             "supportedstandards": self._metadata.supported_standards,
             "extra": self._get_extras()
         }
+
+    def _get_name(self) -> str:
+        """
+        Gets the name of the contract, if name wasn't specified it will be the file name.
+
+        :return: the contract name
+        """
+        return self._metadata.name if self._metadata.name else self._entry_file
 
     def _get_permissions(self) -> List[Dict[str, Any]]:
         """

--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -191,6 +191,7 @@ class Builtin:
                                             ] + _modules
 
     metadata_fields: Dict[str, Union[type, Tuple[type]]] = {
+        'name': str,
         'supported_standards': list,
         'trusts': list,
         'author': (str, type(None)),

--- a/boa3_test/test_sc/metadata_test/MetadataInfoName.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoName.py
@@ -1,0 +1,14 @@
+from boa3.builtin import NeoMetadata, metadata
+
+
+def Main() -> int:
+    return 5
+
+
+@metadata
+def name_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+
+    meta.name = "SmartContractCustomName"
+
+    return meta

--- a/boa3_test/test_sc/metadata_test/MetadataInfoNameDefault.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoNameDefault.py
@@ -1,0 +1,12 @@
+from boa3.builtin import NeoMetadata, metadata
+
+
+def Main() -> int:
+    return 5
+
+
+@metadata
+def name_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+
+    return meta

--- a/boa3_test/test_sc/metadata_test/MetadataInfoNameMismatchedType.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoNameMismatchedType.py
@@ -1,0 +1,14 @@
+from boa3.builtin import NeoMetadata, metadata
+
+
+def Main() -> int:
+    return 5
+
+
+@metadata
+def name_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+
+    meta.name = 1234567
+
+    return meta

--- a/boa3_test/tests/compiler_tests/test_metadata.py
+++ b/boa3_test/tests/compiler_tests/test_metadata.py
@@ -249,3 +249,25 @@ class TestMetadata(BoaTest):
         self.assertIsInstance(manifest['permissions'], list)
         self.assertEqual(len(manifest['permissions']), 1)
         self.assertIn({"contract": "*", "methods": "*"}, manifest['permissions'])
+
+    def test_metadata_info_name(self):
+        path = self.get_contract_path('MetadataInfoName.py')
+        output, manifest = self.compile_and_save(path)
+
+        self.assertIn('name', manifest)
+        self.assertIsInstance(manifest['name'], str)
+        self.assertGreater(len(manifest['name']), 0)
+        self.assertEqual((manifest['name']), "SmartContractCustomName")
+
+    def test_metadata_info_name_default(self):
+        path = self.get_contract_path('MetadataInfoNameDefault.py')
+        output, manifest = self.compile_and_save(path)
+
+        self.assertIn('name', manifest)
+        self.assertIsInstance(manifest['name'], str)
+        self.assertGreater(len(manifest['name']), 0)
+        self.assertEqual((manifest['name']), "MetadataInfoNameDefault")
+
+    def test_metadata_info_name_mismatched_type(self):
+        path = self.get_contract_path('MetadataInfoNameMismatchedType.py')
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)


### PR DESCRIPTION
**Related issue**
#782 

**Summary or solution description**
Added a way to the user specify the name of the smart contract.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/8befad5e1380dc21c0807b8d81aaa51b96bb3fe1/boa3_test/test_sc/metadata_test/MetadataInfoName.py#L1-L14

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/8befad5e1380dc21c0807b8d81aaa51b96bb3fe1/boa3_test/tests/compiler_tests/test_metadata.py#L215-L235

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
