### PR TITLE
Implement a decorator to annotate when the contract method name is different

### DIFF
--- a/boa3/builtin/__init__.py
+++ b/boa3/builtin/__init__.py
@@ -1,18 +1,17 @@
 from typing import Any, Dict, List, Tuple, Union
 
-from boa3.constants import IMPORT_WILDCARD
-from boa3.neo3.core.types import UInt160
 
-
-def public(*args, **kwargs):
+def public(name: str = None, safe: bool = True, *args, **kwargs):
     """
     This decorator identifies which methods should be included in the abi file.
+
+    :param name: Identifier for this method that'll be used on the abi. If not specified, it'll be the same
+    identifier from Python method definition
+    :type name: str
+    :param safe: Whether this method is an abi safe method. False by default
+    :type safe: bool
     """
-
-    def public_wrapper():
-        pass
-
-    return public_wrapper
+    pass
 
 
 def metadata(*args):
@@ -20,16 +19,26 @@ def metadata(*args):
     This decorator identifies the function that returns the metadata object of the smart contract.
     This can be used to only one function. Using this decorator in multiple functions will raise a compiler error.
     """
-
-    def metadata_wrapper():
-        pass
-
-    return metadata_wrapper
+    pass
 
 
 def contract(script_hash: Union[str, bytes]):
     """
     This decorator identifies a class that should be interpreted as an interface to an existing contract.
+
+    :param script_hash: Script hash of the interfaced contract
+    :type script_hash: str or bytes
+    """
+    pass
+
+
+def display_name(name: str):
+    """
+    This decorator identifies which methods from a contract interface should have a different identifier from the one
+    interfacing it. It only works in contract interface classes.
+
+    :param name: Method identifier from the contract manifest.
+    :type name: str
     """
     pass
 
@@ -87,6 +96,7 @@ class NeoMetadata:
     :ivar description: the smart contract description. None by default;
     :vartype description: str or None
     """
+    from boa3.constants import IMPORT_WILDCARD
 
     def __init__(self):
         self.name: str = ''
@@ -117,6 +127,14 @@ class NeoMetadata:
 
         return extra
 
+    @property
+    def trusts(self) -> List[str]:
+        return self._trusts.copy()
+
+    @property
+    def permissions(self) -> List[dict]:
+        return self._permissions.copy()
+
     def add_trusted_source(self, hash_or_address: str):
         """
         Adds a valid contract hash, valid group public key, or the * wildcard to trusts.
@@ -127,6 +145,7 @@ class NeoMetadata:
         if not isinstance(hash_or_address, str):
             return
 
+        from boa3.constants import IMPORT_WILDCARD
         if self._trusts == [IMPORT_WILDCARD]:
             return
 
@@ -159,6 +178,7 @@ class NeoMetadata:
         if not isinstance(methods, (str, list)):
             return
 
+        from boa3.constants import IMPORT_WILDCARD
         # verifies if contract is a valid value
         if (not self._verify_is_valid_contract_hash(contract) and
                 not self._verify_is_valid_public_key(contract) and
@@ -207,6 +227,7 @@ class NeoMetadata:
         """
         if contract_hash.startswith('0x'):
             try:
+                from boa3.neo3.core.types import UInt160
                 # if contract_hash is not a valid UInt160, it will raise a ValueError
                 UInt160.from_string(contract_hash[2:])
                 return True

--- a/boa3/compiler/codegenerator/codegenerator.py
+++ b/boa3/compiler/codegenerator/codegenerator.py
@@ -1631,10 +1631,13 @@ class CodeGenerator:
                     self.convert_new_empty_array(size, function_result)
 
         if isinstance(function.origin_class, ContractInterfaceClass):
-            function_id = next((symbol_id
-                                for symbol_id, symbol in function.origin_class.symbols.items()
-                                if symbol is function),
-                               None)
+            if function.external_name is not None:
+                function_id = function.external_name
+            else:
+                function_id = next((symbol_id
+                                    for symbol_id, symbol in function.origin_class.symbols.items()
+                                    if symbol is function),
+                                   None)
 
             if isinstance(function_id, str):
                 self.convert_new_array(len(function.args))

--- a/boa3/compiler/filegenerator.py
+++ b/boa3/compiler/filegenerator.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from boa3 import constants
 from boa3.analyser.analyser import Analyser
-from boa3.constants import ENCODING, IMPORT_WILDCARD
 from boa3.model.event import Event
 from boa3.model.imports.importsymbol import Import
 from boa3.model.method import Method
@@ -138,7 +137,7 @@ class FileGenerator:
         """
         data: Dict[str, Any] = self._get_manifest_info()
         json_data: str = json.dumps(data, indent=4)
-        return bytes(json_data, ENCODING)
+        return bytes(json_data, constants.ENCODING)
 
     def _get_manifest_info(self) -> Dict[str, Any]:
         """
@@ -152,7 +151,7 @@ class FileGenerator:
             "groups": [],
             "abi": self._get_abi_info(),
             "permissions": self._get_permissions(),
-            "trusts": self._metadata._trusts,
+            "trusts": self._metadata.trusts,
             "features": {},
             "supportedstandards": self._metadata.supported_standards,
             "extra": self._get_extras()
@@ -173,8 +172,8 @@ class FileGenerator:
 
         :return: a dictionary with the permission information
         """
-        return self._metadata._permissions if self._metadata._permissions else [{"contract": IMPORT_WILDCARD,
-                                                                                 "methods": IMPORT_WILDCARD}]
+        return self._metadata.permissions if self._metadata.permissions else [{"contract": constants.IMPORT_WILDCARD,
+                                                                               "methods": constants.IMPORT_WILDCARD}]
 
     def _get_abi_info(self) -> Dict[str, Any]:
         """
@@ -261,7 +260,7 @@ class FileGenerator:
         """
         data: Dict[str, Any] = self._get_debug_info()
         json_data: str = json.dumps(data, indent=4)
-        return bytes(json_data, ENCODING)
+        return bytes(json_data, constants.ENCODING)
 
     def _get_debug_info(self) -> Dict[str, Any]:
         """

--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -150,6 +150,7 @@ class Builtin:
 
     # boa builtin decorator
     ContractInterface = ContractDecorator()
+    ContractMethodDisplayName = DisplayNameDecorator()
     Metadata = MetadataDecorator()
     Public = PublicDecorator()
 
@@ -182,6 +183,7 @@ class Builtin:
     # endregion
 
     boa_builtins: List[IdentifiedSymbol] = [ContractInterface,
+                                            ContractMethodDisplayName,
                                             Event,
                                             Metadata,
                                             NeoMetadataType,

--- a/boa3/model/builtin/decorator/__init__.py
+++ b/boa3/model/builtin/decorator/__init__.py
@@ -1,5 +1,6 @@
 __all__ = ['ClassMethodDecorator',
            'ContractDecorator',
+           'DisplayNameDecorator',
            'InstanceMethodDecorator',
            'MetadataDecorator',
            'PropertyDecorator',
@@ -9,6 +10,7 @@ __all__ = ['ClassMethodDecorator',
 
 from boa3.model.builtin.decorator.classmethoddecorator import ClassMethodDecorator
 from boa3.model.builtin.decorator.contractdecorator import ContractDecorator
+from boa3.model.builtin.decorator.displaynamedecorator import DisplayNameDecorator
 from boa3.model.builtin.decorator.instancemethoddecorator import InstanceMethodDecorator
 from boa3.model.builtin.decorator.metadatadecorator import MetadataDecorator
 from boa3.model.builtin.decorator.propertydecorator import PropertyDecorator

--- a/boa3/model/builtin/decorator/contractdecorator.py
+++ b/boa3/model/builtin/decorator/contractdecorator.py
@@ -24,7 +24,7 @@ class ContractDecorator(IBuiltinDecorator):
             if len(args) > 1:
                 values = self.validate_values(*args[:2])
 
-                hash_arg = values[0]
+                hash_arg = values[0] if len(values) > 0 else None
                 if isinstance(hash_arg, UInt160):
                     decorator.contract_hash = hash_arg
             return decorator
@@ -39,11 +39,11 @@ class ContractDecorator(IBuiltinDecorator):
         origin, visitor = params
         values.append(self.contract_hash)
         from boa3.analyser.astanalyser import IAstAnalyser
-        if not isinstance(origin, ast.Call) or not isinstance(visitor, IAstAnalyser):
+        if not isinstance(visitor, IAstAnalyser):
             return values
 
         from boa3.exception import CompilerError
-        if len(origin.args) < 1:
+        if not isinstance(origin, ast.Call) or len(origin.args) < 1:
             visitor._log_error(
                 CompilerError.UnfilledArgument(origin.lineno, origin.col_offset, list(self.args.keys())[0])
             )

--- a/boa3/model/builtin/decorator/displaynamedecorator.py
+++ b/boa3/model/builtin/decorator/displaynamedecorator.py
@@ -1,0 +1,99 @@
+import ast
+from typing import Any, Dict, List, Sized
+
+from boa3.model.builtin.decorator.builtindecorator import IBuiltinDecorator
+from boa3.model.variable import Variable
+
+
+class DisplayNameDecorator(IBuiltinDecorator):
+    def __init__(self):
+        from boa3.model.type.type import Type
+
+        identifier = 'display_name'
+        args: Dict[str, Variable] = {'name': Variable(Type.str)}
+        super().__init__(identifier, args)
+        self.external_name = None
+
+    def build(self, *args) -> IBuiltinDecorator:
+        if isinstance(args, Sized) and len(args) > 0 and isinstance(args[0], ast.AST):
+            decorator = DisplayNameDecorator()
+            decorator._origin_node = args[0]
+
+            if len(args) > 1:
+                values = self.validate_values(*args[:2])
+
+                hash_arg = values[0] if len(values) > 0 else None
+                if isinstance(hash_arg, str):
+                    decorator.external_name = hash_arg
+            return decorator
+
+        return self
+
+    def validate_values(self, *params: Any) -> List[Any]:
+        values = []
+        if len(params) != 2:
+            return values
+
+        origin, visitor = params
+        values.append(self.external_name)
+        from boa3.analyser.astanalyser import IAstAnalyser
+        if not isinstance(visitor, IAstAnalyser):
+            return values
+
+        from boa3.exception import CompilerError
+        if not isinstance(origin, ast.Call):
+            visitor._log_error(
+                CompilerError.UnfilledArgument(origin.lineno, origin.col_offset, list(self.args.keys())[0])
+            )
+            return values
+
+        args_names = list(self.args.keys())
+        if len(origin.args) > len(args_names):
+            visitor._log_error(
+                CompilerError.UnexpectedArgument(origin.lineno, origin.col_offset)
+            )
+            return values
+
+        # read the called arguments
+        args_len = min(len(origin.args), len(args_names))
+        values.clear()
+
+        for x in range(args_len):
+            values.append(visitor.visit(origin.args[x]))
+
+        if len(values) < 1:
+            values.append(self.external_name)
+
+        # read the called keyword arguments
+        for kwarg in origin.keywords:
+            if kwarg.arg in args_names:
+                x = args_names.index(kwarg.arg)
+                value = visitor.visit(kwarg.value)
+                values[x] = value
+            else:
+                visitor._log_error(
+                    CompilerError.UnexpectedArgument(kwarg.lineno, kwarg.col_offset)
+                )
+
+        if not isinstance(values[0], str):
+            visitor._log_error(
+                CompilerError.UnfilledArgument(origin.lineno, origin.col_offset, list(self.args.keys())[0])
+            )
+            return values
+
+        if visitor.get_symbol(values[0]) is not None:
+            visitor._log_error(CompilerError.InvalidUsage(origin.lineno,
+                                                          origin.col_offset,
+                                                          "Only literal values are accepted for 'name' argument"
+                                                          ))
+            values[0] = self.external_name
+
+        return values
+
+    @property
+    def is_function_decorator(self) -> bool:
+        return False
+
+    @property
+    def is_class_decorator(self) -> bool:
+        return True

--- a/boa3/model/callable.py
+++ b/boa3/model/callable.py
@@ -26,6 +26,7 @@ class Callable(IExpression, ABC):
                  defaults: List[ast.AST] = None,
                  return_type: IType = Type.none, is_public: bool = False,
                  decorators: List[Callable] = None,
+                 external_name: str = None,
                  is_safe: bool = False,
                  origin_node: Optional[ast.AST] = None):
 
@@ -75,9 +76,12 @@ class Callable(IExpression, ABC):
                                 None)
 
         self.is_public: bool = is_public or public_decorator is not None
-        self.external_name: Optional[str] = (public_decorator.name
-                                             if isinstance(public_decorator, PublicDecorator)
-                                             else None)
+        if self.is_public:
+            external_name = (public_decorator.name
+                             if isinstance(public_decorator, PublicDecorator)
+                             else None)
+
+        self.external_name: Optional[str] = external_name
         self.is_safe: bool = is_safe or (isinstance(public_decorator, PublicDecorator) and public_decorator.safe)
 
         super().__init__(origin_node)

--- a/boa3/model/method.py
+++ b/boa3/model/method.py
@@ -27,9 +27,10 @@ class Method(Callable):
                  return_type: IType = Type.none, is_public: bool = False,
                  decorators: List[Callable] = None,
                  is_init: bool = False,
+                 external_name: str = None,
                  is_safe: bool = False,
                  origin_node: Optional[ast.AST] = None):
-        super().__init__(args, vararg, kwargs, defaults, return_type, is_public, decorators, is_safe, origin_node)
+        super().__init__(args, vararg, kwargs, defaults, return_type, is_public, decorators, external_name, is_safe, origin_node)
 
         self.imported_symbols = {}
         self._symbols = {}

--- a/boa3_test/test_sc/contract_interface_test/ContractInterfaceDisplayNameKeywordArgument.py
+++ b/boa3_test/test_sc/contract_interface_test/ContractInterfaceDisplayNameKeywordArgument.py
@@ -1,0 +1,10 @@
+from boa3.builtin import contract, display_name
+
+
+@contract('0x0102030405060708090A0B0C0D0E0F1011121314')
+class ContractInterface:
+
+    @staticmethod
+    @display_name(name='someMethod')
+    def foo():
+        pass

--- a/boa3_test/test_sc/contract_interface_test/ContractInterfaceDisplayNameRegularArgument.py
+++ b/boa3_test/test_sc/contract_interface_test/ContractInterfaceDisplayNameRegularArgument.py
@@ -1,0 +1,10 @@
+from boa3.builtin import contract, display_name
+
+
+@contract('0x0102030405060708090A0B0C0D0E0F1011121314')
+class ContractInterface:
+
+    @staticmethod
+    @display_name('someMethod')
+    def foo():
+        pass

--- a/boa3_test/test_sc/contract_interface_test/ContractInterfaceDisplayNameTooFewArguments.py
+++ b/boa3_test/test_sc/contract_interface_test/ContractInterfaceDisplayNameTooFewArguments.py
@@ -1,0 +1,10 @@
+from boa3.builtin import contract, display_name
+
+
+@contract('0x0102030405060708090A0B0C0D0E0F1011121314')
+class ContractInterface:
+
+    @staticmethod
+    @display_name()
+    def foo():
+        pass

--- a/boa3_test/test_sc/contract_interface_test/ContractInterfaceDisplayNameTooManyArguments.py
+++ b/boa3_test/test_sc/contract_interface_test/ContractInterfaceDisplayNameTooManyArguments.py
@@ -1,0 +1,10 @@
+from boa3.builtin import contract, display_name
+
+
+@contract('0x0102030405060708090A0B0C0D0E0F1011121314')
+class ContractInterface:
+
+    @staticmethod
+    @display_name('someMethod', 'anotherArgument')
+    def foo():
+        pass

--- a/boa3_test/test_sc/contract_interface_test/ContractInterfaceDisplayNameVariableArgument.py
+++ b/boa3_test/test_sc/contract_interface_test/ContractInterfaceDisplayNameVariableArgument.py
@@ -1,0 +1,12 @@
+from boa3.builtin import contract, display_name
+
+bar = 'someMethod'
+
+
+@contract('0x0102030405060708090A0B0C0D0E0F1011121314')
+class ContractInterface:
+
+    @staticmethod
+    @display_name(name=bar)
+    def foo():
+        pass

--- a/boa3_test/test_sc/contract_interface_test/ContractInterfaceDisplayNameWithoutCall.py
+++ b/boa3_test/test_sc/contract_interface_test/ContractInterfaceDisplayNameWithoutCall.py
@@ -1,0 +1,10 @@
+from boa3.builtin import contract, display_name
+
+
+@contract('0x0102030405060708090A0B0C0D0E0F1011121314')
+class ContractInterface:
+
+    @staticmethod
+    @display_name
+    def foo():
+        pass

--- a/boa3_test/test_sc/contract_interface_test/Nep17InterfaceWithDisplayName.py
+++ b/boa3_test/test_sc/contract_interface_test/Nep17InterfaceWithDisplayName.py
@@ -21,11 +21,6 @@ class Nep17:
         pass
 
     @staticmethod
-    @display_name('totalSupply')
-    def total_supply_2(a: int) -> int:
-        pass
-
-    @staticmethod
     @display_name('balanceOf')
     def balance_of(account: UInt160) -> int:
         pass

--- a/boa3_test/test_sc/contract_interface_test/Nep17InterfaceWithDisplayName.py
+++ b/boa3_test/test_sc/contract_interface_test/Nep17InterfaceWithDisplayName.py
@@ -1,0 +1,60 @@
+from typing import Any
+
+from boa3.builtin import contract, display_name, public
+from boa3.builtin.type import UInt160
+
+
+@contract('0x5695642fcf208fc8b55c6163b3518afd7d35ff02')
+class Nep17:
+
+    @staticmethod
+    def symbol() -> str:
+        pass
+
+    @staticmethod
+    def decimals() -> int:
+        pass
+
+    @staticmethod
+    @display_name('totalSupply')
+    def total_supply() -> int:
+        pass
+
+    @staticmethod
+    @display_name('totalSupply')
+    def total_supply_2(a: int) -> int:
+        pass
+
+    @staticmethod
+    @display_name('balanceOf')
+    def balance_of(account: UInt160) -> int:
+        pass
+
+    @staticmethod
+    def transfer(from_address: UInt160, to_address: UInt160, amount: int, data: Any) -> bool:
+        pass
+
+
+@public
+def nep17_symbol() -> str:
+    return Nep17.symbol()
+
+
+@public
+def nep17_decimals() -> int:
+    return Nep17.decimals()
+
+
+@public
+def nep17_total_supply() -> int:
+    return Nep17.total_supply()
+
+
+@public
+def nep17_balance_of(account: UInt160) -> int:
+    return Nep17.balance_of(account)
+
+
+@public
+def nep17_transfer(from_account: UInt160, to_account: UInt160, amount: int, additional_data: Any) -> bool:
+    return Nep17.transfer(from_account, to_account, amount, additional_data)

--- a/boa3_test/tests/compiler_tests/test_contract_interface.py
+++ b/boa3_test/tests/compiler_tests/test_contract_interface.py
@@ -31,6 +31,10 @@ class TestContractInterface(BoaTest):
         path = self.get_contract_path('ContractInterfaceTooManyArguments.py')
         self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
 
+    def test_contract_interface_decorator_without_call(self):
+        path = self.get_contract_path('ContractInterfaceWithoutCall.py')
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+
     def test_contract_interface_with_instance_method(self):
         path = self.get_contract_path('ContractInterfaceInstanceMethod.py')
         self.assertCompilerLogs(CompilerError.InvalidUsage, path)
@@ -48,4 +52,39 @@ class TestContractInterface(BoaTest):
 
         nep17_result = self.run_smart_contract(engine, nep17_path, 'symbol')
         result = self.run_smart_contract(engine, path, 'nep17_symbol')
+        self.assertEqual(nep17_result, result)
+
+    def test_contract_interface_display_name_argument(self):
+        path = self.get_contract_path('ContractInterfaceDisplayNameRegularArgument.py')
+        Boa3.compile(path)  # test if compiles because the smart contract doesn't exist
+
+    def test_contract_interface_display_name_keyword_argument(self):
+        path = self.get_contract_path('ContractInterfaceDisplayNameKeywordArgument.py')
+        Boa3.compile(path)  # test if compiles because the smart contract doesn't exist
+
+    def test_contract_interface_display_name_variable_name(self):
+        path = self.get_contract_path('ContractInterfaceDisplayNameVariableArgument.py')
+        self.assertCompilerLogs(CompilerError.InvalidUsage, path)
+
+    def test_contract_interface_display_name_too_few_arguments(self):
+        path = self.get_contract_path('ContractInterfaceDisplayNameTooFewArguments.py')
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+
+    def test_contract_interface_display_name_without_call(self):
+        path = self.get_contract_path('ContractInterfaceDisplayNameWithoutCall.py')
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+
+    def test_contract_interface_display_name_too_many_arguments(self):
+        path = self.get_contract_path('ContractInterfaceDisplayNameTooManyArguments.py')
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+
+    def test_contract_interface_nep17_with_display_name(self):
+        path = self.get_contract_path('Nep17InterfaceWithDisplayName.py')
+        nep17_path = self.get_contract_path('examples', 'nep17.py')
+
+        self.compile_and_save(path)
+        engine = TestEngine()
+
+        nep17_result = self.run_smart_contract(engine, nep17_path, 'totalSupply')
+        result = self.run_smart_contract(engine, path, 'nep17_total_supply')
         self.assertEqual(nep17_result, result)


### PR DESCRIPTION
**Related issue**
#788

**Summary or solution description**
Implemented a decorator to identify methods in a contract interface which identifiers are different in the contract's manifest.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/2787f29e1892f0b8068dafc2ba2655e3091be27d/boa3_test/test_sc/contract_interface_test/Nep17InterfaceWithDisplayName.py#L7-L35

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/2787f29e1892f0b8068dafc2ba2655e3091be27d/boa3_test/tests/compiler_tests/test_contract_interface.py#L57-L90

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7