### PR TITLE
Attribute type validation in module analyser is raising errors with dynamic type validation

### DIFF
--- a/boa3/analyser/moduleanalyser.py
+++ b/boa3/analyser/moduleanalyser.py
@@ -1176,6 +1176,8 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
             return value.inner_packages[attribute.attr]
         elif Builtin.get_symbol(attribute.attr) is not None:
             return Builtin.get_symbol(attribute.attr)
+        elif isinstance(value, UndefinedType):
+            return value
         else:
             return '{0}.{1}'.format(value_id, attribute.attr)
 

--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Union
 from boa3 import constants
 from boa3.analyser.astanalyser import IAstAnalyser
 from boa3.analyser.builtinfunctioncallanalyser import BuiltinFunctionCallAnalyser
-from boa3.analyser.model.optimizer import UndefinedType
+from boa3.analyser.model.optimizer import Undefined, UndefinedType
 from boa3.analyser.model.symbolscope import SymbolScope
 from boa3.exception import CompilerError, CompilerWarning
 from boa3.model.attribute import Attribute
@@ -360,10 +360,11 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
             target_type = None
             var: ISymbol = self.get_symbol(node.id if hasattr(node, 'id') else node)
             if isinstance(var, Variable):
-                if var.type is UndefinedType:
+                if (var.type is UndefinedType
+                        or (var.type is Undefined and var not in self.symbols.values())):
                     var = var.copy()
 
-                if var.type in (None, UndefinedType):
+                if var.type in (None, UndefinedType, Undefined):
                     # it is an declaration with assignment and the value is neither literal nor another variable
                     var.set_type(value_type)
                 target_type = var.type

--- a/boa3/model/variable.py
+++ b/boa3/model/variable.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import ast
-from typing import Optional
+from typing import Optional, Union
 
 from boa3.model.expression import IExpression
 from boa3.model.type.itype import IType
@@ -17,7 +17,11 @@ class Variable(IExpression):
     def __init__(self, var_type: Optional[IType], origin_node: Optional[ast.AST] = None):
         super().__init__(origin_node)
         self.defined_by_entry = True
-        self._var_type: Optional[IType] = var_type
+        if var_type is None:
+            from boa3.analyser.model.optimizer import Undefined, UndefinedType
+            var_type = Undefined
+
+        self._var_type: Union[IType, UndefinedType] = var_type
 
         self.is_reassigned = False
         self._origin_variable: Optional[Variable] = None

--- a/boa3_test/test_sc/interop_test/iterator/IteratorImplicitTyping.py
+++ b/boa3_test/test_sc/interop_test/iterator/IteratorImplicitTyping.py
@@ -1,0 +1,25 @@
+from typing import Any
+
+from boa3.builtin import public
+from boa3.builtin.interop import storage
+from boa3.builtin.nativecontract.stdlib import StdLib
+
+
+@public
+def store(prefix: str, value: Any):
+    serialized_value = StdLib.serialize(value)
+    storage.put(prefix, serialized_value)
+
+
+@public
+def search_storage(prefix: str) -> dict:
+    data_list = {}
+    data = storage.find(prefix)
+
+    while data.next():
+        iterator_value = data.value
+        key: str = iterator_value[0]
+        serialized_value: bytes = iterator_value[1]
+        value = StdLib.deserialize(serialized_value)
+        data_list[key] = value
+    return data_list

--- a/boa3_test/tests/compiler_tests/test_interop/test_iterator.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_iterator.py
@@ -52,3 +52,21 @@ class TestIteratorInterop(BoaTest):
 
         result = self.run_smart_contract(engine, path, 'return_iterator')
         self.assertEqual([], result)
+
+    def test_iterator_implicit_typing(self):
+        path = self.get_contract_path('IteratorImplicitTyping.py')
+        self.compile_and_save(path)
+        engine = TestEngine()
+
+        prefix = 'test_iterator_'
+        result = self.run_smart_contract(engine, path, 'search_storage', prefix)
+        self.assertEqual({}, result)
+
+        result = self.run_smart_contract(engine, path, 'store', f'{prefix}1', 1)
+        self.assertIsVoid(result)
+
+        result = self.run_smart_contract(engine, path, 'store', f'{prefix}2', 2)
+        self.assertIsVoid(result)
+
+        result = self.run_smart_contract(engine, path, 'search_storage', prefix)
+        self.assertEqual({f'{prefix}1': 1, f'{prefix}2': 2}, result)


### PR DESCRIPTION
**Related issue**
#809

**Summary or solution description**
Fixed issue with implicit typing not detecting the type attributes

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/0363b1bda4615af79e2e26d18087dfc541f91193/boa3_test/test_sc/interop_test/iterator/IteratorImplicitTyping.py#L14-L25

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/0363b1bda4615af79e2e26d18087dfc541f91193/boa3_test/tests/compiler_tests/test_interop/test_iterator.py#L56-L72

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
