### PR TITLE
Assigning a value to a object variable with the same as another variable doesn't run

### DIFF
--- a/boa3/cli.py
+++ b/boa3/cli.py
@@ -21,7 +21,7 @@ def main():
     path, filename = os.path.split(fullpath)
 
     try:
-        Boa3.compile_and_save(args.input, args.debug)
+        Boa3.compile_and_save(args.input, debug=args.debug)
         logging.info(f"Wrote {filename.replace('.py', '.nef')} to {path}")
     except NotLoadedException as e:
         logging.error("Could not compile")

--- a/boa3/compiler/codegenerator/codegenerator.py
+++ b/boa3/compiler/codegenerator/codegenerator.py
@@ -1455,7 +1455,7 @@ class CodeGenerator:
         inner_index = None
         index, local, is_arg = self._get_variable_info(var_id)
 
-        if user_class is None and index < 0 and len(self._stack) > 1 and isinstance(self._stack[-2], UserClass):
+        if user_class is None and len(self._stack) > 1 and isinstance(self._stack[-2], UserClass):
             user_class = self._stack[-2]
 
         if isinstance(user_class, UserClass) and var_id in user_class.variables:

--- a/boa3_test/test_sc/variable_test/InstanceVariableAndVariableWithSameName.py
+++ b/boa3_test/test_sc/variable_test/InstanceVariableAndVariableWithSameName.py
@@ -1,0 +1,16 @@
+from typing import Any
+
+from boa3.builtin import public
+
+
+class Example:
+    def __init__(self):
+        self.number = 1
+
+
+@public
+def test() -> Any:
+    number = 10
+    x = Example()
+    x.number = number
+    return x

--- a/boa3_test/tests/compiler_tests/test_variable.py
+++ b/boa3_test/tests/compiler_tests/test_variable.py
@@ -676,3 +676,9 @@ class TestVariable(BoaTest):
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'test')
         self.assertEqual(1_000, result)
+
+    def test_instance_variable_and_variable_with_same_name(self):
+        path = self.get_contract_path('InstanceVariableAndVariableWithSameName.py')
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'test')
+        self.assertEqual([10], result)


### PR DESCRIPTION
**Related issue**
#800 

**Summary or solution description**
Fixed a bug, where, if an instance variable and a variable had the same name, the program would not run properly.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/df34c193310bad490bb2a5fbaee771a0391834e2/boa3_test/test_sc/variable_test/InstanceVariableAndVariableWithSameName.py#L1-L16

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/df34c193310bad490bb2a5fbaee771a0391834e2/boa3_test/tests/compiler_tests/test_variable.py#L680-L684

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8

**(Optional) Additional context**
Also fixed a error at `cli.py`.