### PR TITLE
Fix stack simulation during code generation when calling contract interface methods

### DIFF
--- a/boa3/compiler/codegenerator/codegenerator.py
+++ b/boa3/compiler/codegenerator/codegenerator.py
@@ -1640,7 +1640,13 @@ class CodeGenerator:
                                    None)
 
             if isinstance(function_id, str):
-                self.convert_new_array(len(function.args))
+                len_func_args = len(function.args)
+                if num_args >= len_func_args:
+                    num_args -= len_func_args
+                else:
+                    num_args = 0
+
+                self.convert_new_array(len_func_args)
                 self.convert_literal(Interop.CallFlagsType.default_value)
                 self.convert_literal(function_id)
                 self.convert_literal(function.origin_class.contract_hash.to_array())

--- a/boa3_test/test_sc/interop_test/iterator/IteratorValueAccess.py
+++ b/boa3_test/test_sc/interop_test/iterator/IteratorValueAccess.py
@@ -1,0 +1,21 @@
+from typing import Any, cast
+
+from boa3.builtin import public
+from boa3.builtin.interop import storage
+from boa3.builtin.nativecontract.stdlib import StdLib
+
+
+@public
+def store(prefix: str, value: Any):
+    serialized_value = StdLib.serialize(value)
+    storage.put(prefix, serialized_value)
+
+
+@public
+def search_storage(prefix: str) -> dict:
+    data_list = {}
+    data = storage.find(prefix)
+
+    while data.next():
+        data_list[data.value[0]] = StdLib.deserialize(cast(bytes, data.value[1]))
+    return data_list

--- a/boa3_test/tests/compiler_tests/test_interop/test_iterator.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_iterator.py
@@ -70,3 +70,21 @@ class TestIteratorInterop(BoaTest):
 
         result = self.run_smart_contract(engine, path, 'search_storage', prefix)
         self.assertEqual({f'{prefix}1': 1, f'{prefix}2': 2}, result)
+
+    def test_iterator_value_access(self):
+        path = self.get_contract_path('IteratorValueAccess.py')
+        self.compile_and_save(path)
+        engine = TestEngine()
+
+        prefix = 'test_iterator_'
+        result = self.run_smart_contract(engine, path, 'search_storage', prefix)
+        self.assertEqual({}, result)
+
+        result = self.run_smart_contract(engine, path, 'store', f'{prefix}1', 1)
+        self.assertIsVoid(result)
+
+        result = self.run_smart_contract(engine, path, 'store', f'{prefix}2', 2)
+        self.assertIsVoid(result)
+
+        result = self.run_smart_contract(engine, path, 'search_storage', prefix)
+        self.assertEqual({f'{prefix}1': 1, f'{prefix}2': 2}, result)


### PR DESCRIPTION
**Related issue**
#808

**Summary or solution description**
The error reported in the issue wasn't caused by the `Iterator.value`, but by `Nep11Contract` contract interface method `properties` call.
There was a bug in the internal result stack simulation that removed more values than expected when calling contract interface methods in-line with other methods.

**How to Reproduce**
```python
result = json_serialize(Nep11Contract.properties(cast(bytes, token.value)))
```

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/20d4270b21f3cf1246776f6dea22db3192c0720c/boa3_test/tests/compiler_tests/test_interop/test_iterator.py#L74-L90

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7