### PR TITLE
Update assert to log message when specified

### DIFF
--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -882,6 +882,27 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
             expected_type: str = expected_op.operand_type.identifier
             raise CompilerError.MismatchedTypes(0, 0, expected_type, actual_type)
 
+    def visit_Assert(self, assert_: ast.Assert):
+        """
+        Verifies if the types of condition and error message in the assert are valid
+
+        If the operations are valid, changes de Python operator by the Boa operator in the syntax tree
+
+        :param assert_: the python ast assert operation node
+        :return: the type of the result of the operation if the operation is valid. Otherwise, returns None
+        """
+        self.visit(assert_.test)
+
+        if assert_.msg is not None:
+            msg = self.visit(assert_.msg)
+
+            if not isinstance(msg, str):
+                # TODO: remove this error when str constructor is implemented
+                self._log_error(
+                    CompilerError.NotSupportedOperation(assert_.msg.lineno, assert_.msg.col_offset,
+                                                        "assert error message should be a str")
+                )
+
     def visit_Compare(self, compare: ast.Compare) -> Optional[IType]:
         """
         Verifies if the types of the operands are valid to the compare operations

--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -895,12 +895,17 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
 
         if assert_.msg is not None:
             msg = self.visit(assert_.msg)
+            msg_type = self.get_type(msg)
 
-            if not isinstance(msg, str):
+            if not Type.str.is_type_of(msg_type) and not Type.bytes.is_type_of(msg_type):
+
                 # TODO: remove this error when str constructor is implemented
                 self._log_error(
-                    CompilerError.NotSupportedOperation(assert_.msg.lineno, assert_.msg.col_offset,
-                                                        "assert error message should be a str")
+                    CompilerError.MismatchedTypes(
+                        assert_.msg.lineno, assert_.msg.col_offset,
+                        expected_type_id=Type.str.identifier,
+                        actual_type_id=str(msg_type)
+                    )
                 )
 
     def visit_Compare(self, compare: ast.Compare) -> Optional[IType]:

--- a/boa3/compiler/codegenerator/codegenerator.py
+++ b/boa3/compiler/codegenerator/codegenerator.py
@@ -414,6 +414,12 @@ class CodeGenerator:
         """
         self.__insert1(OpcodeInfo.RET)
 
+    def insert_not(self):
+        """
+        Insert a `not` to change the value of a bool
+        """
+        self.__insert1(OpcodeInfo.NOT)
+
     def convert_begin_while(self, is_for: bool = False) -> int:
         """
         Converts the beginning of the while statement

--- a/boa3/compiler/codegenerator/codegeneratorvisitor.py
+++ b/boa3/compiler/codegenerator/codegeneratorvisitor.py
@@ -8,6 +8,7 @@ from boa3.compiler.codegenerator.codegenerator import CodeGenerator
 from boa3.compiler.codegenerator.generatordata import GeneratorData
 from boa3.compiler.codegenerator.vmcodemapping import VMCodeMapping
 from boa3.model.builtin.builtin import Builtin
+from boa3.model.builtin.interop.interop import Interop
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.expression import IExpression
 from boa3.model.imports.package import Package
@@ -683,6 +684,19 @@ class VisitorCodeGenerator(IAstAnalyser):
         :param assert_node: the python ast assert node
         """
         self.visit_to_generate(assert_node.test)
+
+        if assert_node.msg is not None:
+            self.generator.duplicate_stack_top_item()
+            self.generator.insert_not()
+
+            # if assert is false, log the message
+            start_addr: int = self.generator.convert_begin_if()
+
+            self.visit_to_generate(assert_node.msg)
+            self.generator.convert_builtin_method_call(Interop.Log)
+
+            self.generator.convert_end_if(start_addr)
+
         self.generator.convert_assert()
         return self.build_data(assert_node)
 

--- a/boa3_test/test_sc/assert_test/AssertWithBoolMessage.py
+++ b/boa3_test/test_sc/assert_test/AssertWithBoolMessage.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+
+
+@public
+def Main(a: int) -> int:
+    assert a > 0, False
+    return a

--- a/boa3_test/test_sc/assert_test/AssertWithBytesMessage.py
+++ b/boa3_test/test_sc/assert_test/AssertWithBytesMessage.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+
+
+@public
+def Main(a: int) -> int:
+    assert a > 0, b'a must be greater than zero'
+    return a

--- a/boa3_test/test_sc/assert_test/AssertWithIntMessage.py
+++ b/boa3_test/test_sc/assert_test/AssertWithIntMessage.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+
+
+@public
+def Main(a: int) -> int:
+    assert a > 0, 123
+    return a

--- a/boa3_test/test_sc/assert_test/AssertWithListMessage.py
+++ b/boa3_test/test_sc/assert_test/AssertWithListMessage.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+
+
+@public
+def Main(a: int) -> int:
+    assert a > 0, [0, 1, 2, 3, 4]
+    return a

--- a/boa3_test/test_sc/assert_test/AssertWithStrFunctionMessage.py
+++ b/boa3_test/test_sc/assert_test/AssertWithStrFunctionMessage.py
@@ -1,0 +1,11 @@
+from boa3.builtin import public
+
+
+@public
+def Main(a: int) -> int:
+    assert a > 0, message()
+    return a
+
+
+def message() -> str:
+    return 'a must be greater than zero'

--- a/boa3_test/test_sc/assert_test/AssertWithStrVarMessage.py
+++ b/boa3_test/test_sc/assert_test/AssertWithStrVarMessage.py
@@ -1,0 +1,8 @@
+from boa3.builtin import public
+
+
+@public
+def Main(a: int) -> int:
+    message = 'a must be greater than zero'
+    assert a > 0, message
+    return a

--- a/boa3_test/tests/compiler_tests/test_assert.py
+++ b/boa3_test/tests/compiler_tests/test_assert.py
@@ -1,4 +1,5 @@
 from boa3.boa3 import Boa3
+from boa3.exception import CompilerError
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.StackItem import StackItemType
@@ -59,28 +60,18 @@ class TestAssert(BoaTest):
             self.run_smart_contract(engine, path, 'Main', 20, 20)
 
     def test_assert_with_message(self):
-        expected_output = (
-            Opcode.INITSLOT     # function signature
-            + b'\x00'
-            + b'\x01'
-            + Opcode.LDARG0     # assert a > 0, 'a must be greater than zero'
-            + Opcode.PUSH0
-            + Opcode.GT
-            + Opcode.ASSERT         # neo assert doesn't receive messages yet
-            + Opcode.LDARG0     # return a
-            + Opcode.RET
-        )
-
         path = self.get_contract_path('AssertWithMessage.py')
-        output = Boa3.compile(path)
-        self.assertEqual(expected_output, output)
-
         engine = TestEngine()
+
         result = self.run_smart_contract(engine, path, 'Main', 10)
         self.assertEqual(10, result)
 
         with self.assertRaises(TestExecutionException, msg=self.ASSERT_RESULTED_FALSE_MSG):
             self.run_smart_contract(engine, path, 'Main', -10)
+
+    def test_assert_with_int_message(self):
+        path = self.get_contract_path('AssertWithIntMessage.py')
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
 
     def test_assert_int(self):
         expected_output = (

--- a/boa3_test/tests/compiler_tests/test_assert.py
+++ b/boa3_test/tests/compiler_tests/test_assert.py
@@ -69,9 +69,47 @@ class TestAssert(BoaTest):
         with self.assertRaises(TestExecutionException, msg=self.ASSERT_RESULTED_FALSE_MSG):
             self.run_smart_contract(engine, path, 'Main', -10)
 
+    def test_assert_with_bytes_message(self):
+        path = self.get_contract_path('AssertWithBytesMessage.py')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'Main', 10)
+        self.assertEqual(10, result)
+
+        with self.assertRaises(TestExecutionException, msg=self.ASSERT_RESULTED_FALSE_MSG):
+            self.run_smart_contract(engine, path, 'Main', -10)
+
     def test_assert_with_int_message(self):
         path = self.get_contract_path('AssertWithIntMessage.py')
-        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+
+    def test_assert_with_bool_message(self):
+        path = self.get_contract_path('AssertWithBoolMessage.py')
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+
+    def test_assert_with_list_message(self):
+        path = self.get_contract_path('AssertWithListMessage.py')
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+
+    def test_assert_with_str_var_message(self):
+        path = self.get_contract_path('AssertWithStrVarMessage.py')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'Main', 10)
+        self.assertEqual(10, result)
+
+        with self.assertRaises(TestExecutionException, msg=self.ASSERT_RESULTED_FALSE_MSG):
+            self.run_smart_contract(engine, path, 'Main', -10)
+
+    def test_assert_with_str_function_message(self):
+        path = self.get_contract_path('AssertWithStrFunctionMessage.py')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'Main', 10)
+        self.assertEqual(10, result)
+
+        with self.assertRaises(TestExecutionException, msg=self.ASSERT_RESULTED_FALSE_MSG):
+            self.run_smart_contract(engine, path, 'Main', -10)
 
     def test_assert_int(self):
         expected_output = (


### PR DESCRIPTION
**Related issue**
#807

**Summary or solution description**
Now, when an assert fails and there is a message, it will log the message.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/5bf3b181eb2fd9c919bfe2dcb4a3185d38bb3fec/boa3_test/test_sc/assert_test/AssertWithMessage.py#L1-L7

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/5bf3b181eb2fd9c919bfe2dcb4a3185d38bb3fec/boa3_test/tests/compiler_tests/test_assert.py#L62-L74

**Screenshots**
![image](https://user-images.githubusercontent.com/49196318/154560266-c12c095c-adc7-40f0-8f99-75958964e459.png)


**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8

**(Optional) Additional context**
Python accepts any type in the message, but since the `str` constructor is not implemented, `assert` only accepts strings for now.
#820 