### PR TITLE
Update NEP-17 standard validation to verify the methods by the manifest name

### DIFF
--- a/boa3/analyser/supportedstandard/standardanalyser.py
+++ b/boa3/analyser/supportedstandard/standardanalyser.py
@@ -50,28 +50,46 @@ class StandardAnalyser(IAstAnalyser):
         self.standards.clear()
         self.standards.extend(filtered_standards)
 
+    def get_methods_by_display_name(self, method_id: str) -> List[Method]:
+        methods = []
+        for symbol_id, symbol in self.symbols.items():
+            if isinstance(symbol, Method) and symbol.is_public:
+                display_name = symbol.external_name if symbol.external_name is not None else symbol_id
+                if display_name == method_id:
+                    methods.append(symbol)
+        return methods
+
     def _validate_standards(self):
         for standard in self.standards:
             if standard in supportedstandard.neo_standards:
                 current_standard = supportedstandard.neo_standards[standard]
 
                 # validade standard's methods
-                for method_id, standard_method in current_standard.methods.items():
-                    if (method_id not in self.symbols or
-                            not isinstance(self.symbols[method_id], Method) or
-                            not current_standard.match_definition(method_id, self.symbols[method_id])):
+                for standard_method in current_standard.methods:
+                    method_id = standard_method.external_name
+                    is_implemented = False
+
+                    found_methods = self.get_methods_by_display_name(method_id)
+                    for method in found_methods:
+                        if isinstance(method, Method) and current_standard.match_definition(standard_method, method):
+                            is_implemented = True
+                            break
+
+                    if not is_implemented:
                         self._log_error(
                             CompilerError.MissingStandardDefinition(standard, method_id, standard_method)
                         )
 
                 # validade standard's events
                 events = [symbol for symbol in self.symbols.values() if isinstance(symbol, Event)]
-                for standard_event in current_standard.events.values():
-                    events_with_same_name = [event for event in events if event.name == standard_event.name]
-                    if (len(events_with_same_name) == 0 or
-                            all(not current_standard.match_definition(event.name, event)
-                                for event in events_with_same_name
-                                )):
+                for standard_event in current_standard.events:
+                    is_implemented = False
+                    for event in events:
+                        if event.name == standard_event.name and current_standard.match_definition(standard_event, event):
+                            is_implemented = True
+                            break
+
+                    if not is_implemented:
                         self._log_error(
                             CompilerError.MissingStandardDefinition(standard,
                                                                     standard_event.name,

--- a/boa3/exception/CompilerError.py
+++ b/boa3/exception/CompilerError.py
@@ -253,6 +253,10 @@ class MissingStandardDefinition(CompilerError):
                                                                   self.symbol.shadowing_name,
                                                                   self.symbol)
 
+    @property
+    def message(self) -> str:
+        return self._error_message
+
 
 class NotSupportedOperation(CompilerError):
     """

--- a/boa3/model/callable.py
+++ b/boa3/model/callable.py
@@ -77,9 +77,10 @@ class Callable(IExpression, ABC):
 
         self.is_public: bool = is_public or public_decorator is not None
         if self.is_public:
-            external_name = (public_decorator.name
-                             if isinstance(public_decorator, PublicDecorator)
-                             else None)
+            if isinstance(public_decorator, PublicDecorator):
+                external_name = public_decorator.name
+            elif self.defined_by_entry:
+                external_name = None
 
         self.external_name: Optional[str] = external_name
         self.is_safe: bool = is_safe or (isinstance(public_decorator, PublicDecorator) and public_decorator.safe)

--- a/boa3/model/standards/neostandard.py
+++ b/boa3/model/standards/neostandard.py
@@ -1,25 +1,24 @@
 import abc
-from typing import Dict, List, Union
+from typing import List, Union
 
 from boa3.model.event import Event
 from boa3.model.method import Method
 
 
 class INeoStandard(abc.ABC):
-    def __init__(self, methods: Dict[str, Method], events: List[Event]):
-        self.methods: Dict[str, Method] = methods
-        self.events: Dict[str, Event] = {event.name: event for event in events}
+    def __init__(self, methods: List[Method], events: List[Event]):
+        self.methods: List[Method] = methods.copy()
+        self.events: List[Event] = events.copy()
 
-    def match_definition(self, symbol_id: str, symbol: Union[Method, Event]) -> bool:
-        if not isinstance(symbol, (Method, Event)) or not isinstance(symbol_id, str):
+    def match_definition(self, standard: Union[Method, Event], symbol: Union[Method, Event]) -> bool:
+        if not isinstance(standard, (Method, Event)) or not isinstance(symbol, (Method, Event)):
             return False
 
         standard_symbols = self.methods if isinstance(symbol, Method) else self.events
-        if symbol_id not in standard_symbols:
+        if standard not in standard_symbols:
             return False
 
-        standard_def = standard_symbols[symbol_id]
-        return self._have_same_signature(standard_def, symbol)
+        return self._have_same_signature(standard, symbol)
 
     def _have_same_signature(self, symbol: Union[Method, Event], other: Union[Method, Event]) -> bool:
         if (isinstance(symbol, Method) and not isinstance(other, Method)
@@ -30,6 +29,9 @@ class INeoStandard(abc.ABC):
             return False
 
         if symbol.is_public != other.is_public:
+            return False
+
+        if symbol.is_safe != other.is_safe:
             return False
 
         if len(symbol.args) != len(other.args):

--- a/boa3/model/standards/nep17standard.py
+++ b/boa3/model/standards/nep17standard.py
@@ -9,21 +9,26 @@ class Nep17Standard(INeoStandard):
     def __init__(self):
         type_uint160 = UInt160Type.build()
 
-        methods = {
-            'symbol': StandardMethod(args={},
-                                     return_type=Type.str),
-            'decimals': StandardMethod(args={},
-                                       return_type=Type.int),
-            'totalSupply': StandardMethod(args={},
-                                          return_type=Type.int),
-            'balanceOf': StandardMethod(args={'account': type_uint160},
-                                        return_type=Type.int),
-            'transfer': StandardMethod(args={'from': type_uint160,
-                                             'to': type_uint160,
-                                             'amount': Type.int,
-                                             'data': Type.any},
-                                       return_type=Type.bool)
-        }
+        methods = [
+            StandardMethod('symbol', safe=True,
+                           args={},
+                           return_type=Type.str),
+            StandardMethod('decimals', safe=True,
+                           args={},
+                           return_type=Type.int),
+            StandardMethod('totalSupply', safe=True,
+                           args={},
+                           return_type=Type.int),
+            StandardMethod('balanceOf', safe=True,
+                           args={'account': type_uint160},
+                           return_type=Type.int),
+            StandardMethod('transfer',
+                           args={'from': type_uint160,
+                                 'to': type_uint160,
+                                 'amount': Type.int,
+                                 'data': Type.any},
+                           return_type=Type.bool)
+        ]
         events = [
             Builtin.Nep17Transfer
         ]

--- a/boa3/model/standards/standardmethod.py
+++ b/boa3/model/standards/standardmethod.py
@@ -7,8 +7,12 @@ from boa3.model.variable import Variable
 
 
 class StandardMethod(Method):
-    def __init__(self, args: Dict[str, IType] = None, return_type: IType = Type.none):
+    def __init__(self, display_name: str,
+                 args: Dict[str, IType] = None,
+                 return_type: IType = Type.none,
+                 safe: bool = False):
         if not isinstance(args, dict):
             args = {}
         method_args = {key: Variable(value) for key, value in args.items()}
-        super().__init__(args=method_args, return_type=return_type, is_public=True)
+        super().__init__(args=method_args, return_type=return_type, is_public=True,
+                         external_name=display_name, is_safe=safe)

--- a/boa3_test/examples/amm.py
+++ b/boa3_test/examples/amm.py
@@ -134,8 +134,8 @@ def decimals() -> int:
     return TOKEN_DECIMALS
 
 
-@public(safe=True)
-def totalSupply() -> int:
+@public(name='totalSupply', safe=True)
+def total_supply() -> int:
     """
     Gets the total token supply deployed in the system.
 
@@ -147,8 +147,8 @@ def totalSupply() -> int:
     return storage.get(SUPPLY_KEY).to_int()
 
 
-@public(safe=True)
-def balanceOf(account: UInt160) -> int:
+@public(name='balanceOf', safe=True)
+def balance_of(account: UInt160) -> int:
     """
     Get the current balance of an address
 
@@ -469,7 +469,7 @@ def remove_liquidity(liquidity: int, amount_token_a_min: int, amount_token_b_min
         assert runtime.check_witness(user_address)
 
     assert runtime.check_witness(user_address)
-    assert liquidity <= balanceOf(user_address)
+    assert liquidity <= balance_of(user_address)
     amount = burn(liquidity, user_address)
     # Verify if the amount of token_a and token_b are equal or greater than the minimum amount
     assert amount[0] >= amount_token_a_min and amount[1] >= amount_token_b_min
@@ -510,7 +510,7 @@ def burn(liquidity: int, user_address: UInt160) -> List[int]:
         assert amount_token_a > 0 and amount_token_b > 0
 
         # changing the user balance after burning the liquidity
-        storage.put(user_address, balanceOf(user_address) - liquidity)
+        storage.put(user_address, balance_of(user_address) - liquidity)
         # update the amount of AMM tokens in this smart contract
         storage.put(SUPPLY_KEY, total_supply - liquidity)
         on_transfer(user_address, None, liquidity)

--- a/boa3_test/examples/auxiliary_contracts/update_contract.py
+++ b/boa3_test/examples/auxiliary_contracts/update_contract.py
@@ -90,8 +90,8 @@ def _deploy(data: Any, update: bool):
         on_transfer(None, OWNER, TOKEN_TOTAL_SUPPLY)
 
 
-@public(safe=True)
-def balanceOf(account: UInt160) -> int:
+@public(name='balanceOf', safe=True)
+def balance_of(account: UInt160) -> int:
     """
     Get the current balance of an address.
     """

--- a/boa3_test/examples/ico.py
+++ b/boa3_test/examples/ico.py
@@ -128,8 +128,8 @@ def mint(amount: int) -> bool:
         return False
 
     if amount > 0:
-        current_total_supply = totalSupply()
-        owner_balance = balanceOf(TOKEN_OWNER)
+        current_total_supply = total_supply()
+        owner_balance = balance_of(TOKEN_OWNER)
 
         storage.put(TOKEN_TOTAL_SUPPLY_PREFIX, current_total_supply + amount)
         storage.put(TOKEN_OWNER, owner_balance + amount)
@@ -207,8 +207,8 @@ def decimals() -> int:
     return TOKEN_DECIMALS
 
 
-@public(safe=True)
-def totalSupply() -> int:
+@public(name='totalSupply', safe=True)
+def total_supply() -> int:
     """
     Gets the total token supply deployed in the system.
 
@@ -220,8 +220,8 @@ def totalSupply() -> int:
     return storage.get(TOKEN_TOTAL_SUPPLY_PREFIX).to_int()
 
 
-@public(safe=True)
-def balanceOf(account: UInt160) -> int:
+@public(name='balanceOf', safe=True)
+def balance_of(account: UInt160) -> int:
     """
     Get the current balance of an address
 
@@ -365,7 +365,7 @@ def transfer_from(originator: UInt160, from_address: UInt160, to_address: UInt16
     if approved_transfer_amount < amount:
         return False
 
-    originator_balance = balanceOf(originator)
+    originator_balance = balance_of(originator)
     if originator_balance < amount:
         return False
 
@@ -423,7 +423,7 @@ def approve(originator: UInt160, to_address: UInt160, amount: int) -> bool:
         # one of the address doesn't passed the kyc yet
         return False
 
-    if balanceOf(originator) < amount:
+    if balance_of(originator) < amount:
         return False
 
     storage.put(TRANSFER_ALLOWANCE_PREFIX + originator + to_address, amount)

--- a/boa3_test/examples/nep17.py
+++ b/boa3_test/examples/nep17.py
@@ -91,8 +91,8 @@ def decimals() -> int:
     return TOKEN_DECIMALS
 
 
-@public(safe=True)
-def totalSupply() -> int:
+@public(name='totalSupply', safe=True)
+def total_supply() -> int:
     """
     Gets the total token supply deployed in the system.
 
@@ -104,8 +104,8 @@ def totalSupply() -> int:
     return storage.get(SUPPLY_KEY).to_int()
 
 
-@public(safe=True)
-def balanceOf(account: UInt160) -> int:
+@public(name='balanceOf', safe=True)
+def balance_of(account: UInt160) -> int:
     """
     Get the current balance of an address
 
@@ -204,8 +204,8 @@ def mint(account: UInt160, amount: int):
     """
     assert amount >= 0
     if amount != 0:
-        current_total_supply = totalSupply()
-        account_balance = balanceOf(account)
+        current_total_supply = total_supply()
+        account_balance = balance_of(account)
 
         storage.put(SUPPLY_KEY, current_total_supply + amount)
         storage.put(account, account_balance + amount)

--- a/boa3_test/examples/update_contract.py
+++ b/boa3_test/examples/update_contract.py
@@ -89,8 +89,8 @@ def _deploy(data: Any, update: bool):
         on_transfer(None, OWNER, TOKEN_TOTAL_SUPPLY)
 
 
-@public(safe=True)
-def balanceOf(account: UInt160) -> int:
+@public(name='balanceOf', safe=True)
+def balance_of(account: UInt160) -> int:
     """
     Get the current balance of an address.
     """

--- a/boa3_test/examples/wrapped_gas.py
+++ b/boa3_test/examples/wrapped_gas.py
@@ -100,8 +100,8 @@ def decimals() -> int:
     return TOKEN_DECIMALS
 
 
-@public(safe=True)
-def totalSupply() -> int:
+@public(name='totalSupply', safe=True)
+def total_supply() -> int:
     """
     Gets the total token supply deployed in the system.
 
@@ -113,8 +113,8 @@ def totalSupply() -> int:
     return storage.get(SUPPLY_KEY).to_int()
 
 
-@public(safe=True)
-def balanceOf(account: UInt160) -> int:
+@public(name='balanceOf', safe=True)
+def balance_of(account: UInt160) -> int:
     """
     Get the current balance of an address.
 
@@ -265,7 +265,7 @@ def approve(spender: UInt160, amount: int) -> bool:
     assert len(spender) == 20
     assert amount >= 0
 
-    if balanceOf(runtime.calling_script_hash) >= amount:
+    if balance_of(runtime.calling_script_hash) >= amount:
         storage.put(ALLOWANCE_PREFIX + runtime.calling_script_hash + spender, amount)
         on_approval(runtime.calling_script_hash, spender, amount)
         return True
@@ -320,8 +320,8 @@ def mint(account: UInt160, amount: int):
     """
     assert amount >= 0
     if amount != 0:
-        current_total_supply = totalSupply()
-        account_balance = balanceOf(account)
+        current_total_supply = total_supply()
+        account_balance = balance_of(account)
 
         storage.put(SUPPLY_KEY, current_total_supply + amount)
         storage.put(account, account_balance + amount)
@@ -346,8 +346,8 @@ def burn(account: UInt160, amount: int):
     assert amount >= 0
     if runtime.check_witness(account):
         if amount != 0:
-            current_total_supply = totalSupply()
-            account_balance = balanceOf(account)
+            current_total_supply = total_supply()
+            account_balance = balance_of(account)
 
             assert account_balance >= amount
 

--- a/boa3_test/examples/wrapped_neo.py
+++ b/boa3_test/examples/wrapped_neo.py
@@ -99,8 +99,8 @@ def decimals() -> int:
     return TOKEN_DECIMALS
 
 
-@public(safe=True)
-def totalSupply() -> int:
+@public(name='totalSupply', safe=True)
+def total_supply() -> int:
     """
     Gets the total token supply deployed in the system.
 
@@ -112,8 +112,8 @@ def totalSupply() -> int:
     return storage.get(SUPPLY_KEY).to_int()
 
 
-@public(safe=True)
-def balanceOf(account: UInt160) -> int:
+@public(name='balanceOf', safe=True)
+def balance_of(account: UInt160) -> int:
     """
     Get the current balance of an address.
 
@@ -264,7 +264,7 @@ def approve(spender: UInt160, amount: int) -> bool:
     assert len(spender) == 20
     assert amount >= 0
 
-    if balanceOf(runtime.calling_script_hash) >= amount:
+    if balance_of(runtime.calling_script_hash) >= amount:
         storage.put(ALLOWANCE_PREFIX + runtime.calling_script_hash + spender, amount)
         on_approval(runtime.calling_script_hash, spender, amount)
         return True
@@ -319,8 +319,8 @@ def mint(account: UInt160, amount: int):
     """
     assert amount >= 0
     if amount != 0:
-        current_total_supply = totalSupply()
-        account_balance = balanceOf(account)
+        current_total_supply = total_supply()
+        account_balance = balance_of(account)
 
         storage.put(SUPPLY_KEY, current_total_supply + amount)
         storage.put(account, account_balance + amount)
@@ -345,8 +345,8 @@ def burn(account: UInt160, amount: int):
     assert amount >= 0
     if runtime.check_witness(account):
         if amount != 0:
-            current_total_supply = totalSupply()
-            account_balance = balanceOf(account)
+            current_total_supply = total_supply()
+            account_balance = balance_of(account)
 
             assert account_balance >= amount
 

--- a/boa3_test/test_sc/contract_interface_test/Nep17Interface.py
+++ b/boa3_test/test_sc/contract_interface_test/Nep17Interface.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from boa3.builtin import contract, public
+from boa3.builtin import contract, display_name, public
 from boa3.builtin.type import UInt160
 
 
@@ -16,11 +16,13 @@ class Nep17:
         pass
 
     @staticmethod
-    def totalSupply() -> int:
+    @display_name('totalSupply')
+    def total_supply() -> int:
         pass
 
     @staticmethod
-    def balanceOf(account: UInt160) -> int:
+    @display_name('balanceOf')
+    def balance_of(account: UInt160) -> int:
         pass
 
     @staticmethod
@@ -40,12 +42,12 @@ def nep17_decimals() -> int:
 
 @public
 def nep17_total_supply() -> int:
-    return Nep17.totalSupply()
+    return Nep17.total_supply()
 
 
 @public
 def nep17_balance_of(account: UInt160) -> int:
-    return Nep17.balanceOf(account)
+    return Nep17.balance_of(account)
 
 
 @public

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -138,8 +138,8 @@ All of the examples presented here can be found in the `examples folder of the N
         return TOKEN_DECIMALS
 
 
-    @public(safe=True)
-    def totalSupply() -> int:
+    @public(name='totalSupply', safe=True)
+    def total_supply() -> int:
         """
         Gets the total token supply deployed in the system.
 
@@ -151,8 +151,8 @@ All of the examples presented here can be found in the `examples folder of the N
         return storage.get(SUPPLY_KEY).to_int()
 
 
-    @public(safe=True)
-    def balanceOf(account: UInt160) -> int:
+    @public(name='balanceOf', safe=True)
+    def balance_of(account: UInt160) -> int:
         """
         Get the current balance of an address
 
@@ -251,8 +251,8 @@ All of the examples presented here can be found in the `examples folder of the N
         """
         assert amount >= 0
         if amount != 0:
-            current_total_supply = totalSupply()
-            account_balance = balanceOf(account)
+            current_total_supply = total_supply()
+            account_balance = balance_of(account)
 
             storage.put(SUPPLY_KEY, current_total_supply + amount)
             storage.put(account, account_balance + amount)
@@ -697,8 +697,8 @@ All of the examples presented here can be found in the `examples folder of the N
             return False
 
         if amount > 0:
-            current_total_supply = totalSupply()
-            owner_balance = balanceOf(TOKEN_OWNER)
+            current_total_supply = total_supply()
+            owner_balance = balance_of(TOKEN_OWNER)
 
             storage.put(TOKEN_TOTAL_SUPPLY_PREFIX, current_total_supply + amount)
             storage.put(TOKEN_OWNER, owner_balance + amount)
@@ -776,8 +776,8 @@ All of the examples presented here can be found in the `examples folder of the N
         return TOKEN_DECIMALS
 
 
-    @public(safe=True)
-    def totalSupply() -> int:
+    @public(name='totalSupply', safe=True)
+    def total_supply() -> int:
         """
         Gets the total token supply deployed in the system.
 
@@ -789,8 +789,8 @@ All of the examples presented here can be found in the `examples folder of the N
         return storage.get(TOKEN_TOTAL_SUPPLY_PREFIX).to_int()
 
 
-    @public(safe=True)
-    def balanceOf(account: UInt160) -> int:
+    @public(name='balanceOf', safe=True)
+    def balance_of(account: UInt160) -> int:
         """
         Get the current balance of an address
 
@@ -934,7 +934,7 @@ All of the examples presented here can be found in the `examples folder of the N
         if approved_transfer_amount < amount:
             return False
 
-        originator_balance = balanceOf(originator)
+        originator_balance = balance_of(originator)
         if originator_balance < amount:
             return False
 
@@ -992,7 +992,7 @@ All of the examples presented here can be found in the `examples folder of the N
             # one of the address doesn't passed the kyc yet
             return False
 
-        if balanceOf(originator) < amount:
+        if balance_of(originator) < amount:
             return False
 
         storage.put(TRANSFER_ALLOWANCE_PREFIX + originator + to_address, amount)
@@ -1151,8 +1151,8 @@ All of the examples presented here can be found in the `examples folder of the N
         return TOKEN_DECIMALS
 
 
-    @public(safe=True)
-    def totalSupply() -> int:
+    @public(name='totalSupply', safe=True)
+    def total_supply() -> int:
         """
         Gets the total token supply deployed in the system.
 
@@ -1164,8 +1164,8 @@ All of the examples presented here can be found in the `examples folder of the N
         return storage.get(SUPPLY_KEY).to_int()
 
 
-    @public(safe=True)
-    def balanceOf(account: UInt160) -> int:
+    @public(name='balanceOf', safe=True)
+    def balance_of(account: UInt160) -> int:
         """
         Get the current balance of an address.
 
@@ -1316,7 +1316,7 @@ All of the examples presented here can be found in the `examples folder of the N
         assert len(spender) == 20
         assert amount >= 0
 
-        if balanceOf(runtime.calling_script_hash) >= amount:
+        if balance_of(runtime.calling_script_hash) >= amount:
             storage.put(ALLOWANCE_PREFIX + runtime.calling_script_hash + spender, amount)
             on_approval(runtime.calling_script_hash, spender, amount)
             return True
@@ -1371,8 +1371,8 @@ All of the examples presented here can be found in the `examples folder of the N
         """
         assert amount >= 0
         if amount != 0:
-            current_total_supply = totalSupply()
-            account_balance = balanceOf(account)
+            current_total_supply = total_supply()
+            account_balance = balance_of(account)
 
             storage.put(SUPPLY_KEY, current_total_supply + amount)
             storage.put(account, account_balance + amount)
@@ -1397,8 +1397,8 @@ All of the examples presented here can be found in the `examples folder of the N
         assert amount >= 0
         if runtime.check_witness(account):
             if amount != 0:
-                current_total_supply = totalSupply()
-                account_balance = balanceOf(account)
+                current_total_supply = total_supply()
+                account_balance = balance_of(account)
 
                 assert account_balance >= amount
 


### PR DESCRIPTION
**Related issue**
#801

**Summary or solution description**
Changed the NEP-17 validator to search the methods by the manifest name to check if the standard is implemented correctly.

**How to Reproduce**
`totalSupply` and `balanceOf` have different names in the Python definition, but it's the name that's on the manifest that matters
https://github.com/CityOfZion/neo3-boa/blob/6a1e982118ffb87c1c1966b283ed2ebda8b48846/boa3_test/examples/nep17.py#L94-L118

**Tests**
Changed the NEP-17 contracts in the examples folders and rerun their 'test_compile'
https://github.com/CityOfZion/neo3-boa/blob/6a1e982118ffb87c1c1966b283ed2ebda8b48846/boa3_test/tests/examples_tests/test_nep17.py#L17-L24

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7