### PR TITLE
Implement ByteString interface

### DIFF
--- a/boa3/builtin/__init__.py
+++ b/boa3/builtin/__init__.py
@@ -1,6 +1,27 @@
 from typing import Any, Dict, List, Tuple, Union
 
 
+def Event(*args, **kwargs):
+    """
+    Describes an action that happened in the blockchain.
+    """
+    pass
+
+
+def CreateNewEvent(arguments: List[Tuple[str, type]] = [], event_name: str = '') -> Event:
+    """
+    Creates a new event.
+
+    :param arguments: the list of the events args' names and types
+    :type arguments: List[Tuple[str, type]]
+    :param event_name: custom name of the event. It's filled with the variable name if not specified
+    :type event_name: str
+    :return: the new event
+    :rtype: Event
+    """
+    pass
+
+
 def public(name: str = None, safe: bool = True, *args, **kwargs):
     """
     This decorator identifies which methods should be included in the abi file.
@@ -22,7 +43,11 @@ def metadata(*args):
     pass
 
 
-def contract(script_hash: Union[str, bytes]):
+# import is after because there was conflict with Python built-in type
+from boa3.builtin import type
+
+
+def contract(script_hash: type.ByteString):
     """
     This decorator identifies a class that should be interpreted as an interface to an existing contract.
 
@@ -51,27 +76,6 @@ def to_script_hash(data_bytes: Any) -> bytes:
     :type data_bytes: Any
     :return: the script hash of the data
     :rtype: bytes
-    """
-    pass
-
-
-def Event(*args, **kwargs):
-    """
-    Describes an action that happened in the blockchain.
-    """
-    pass
-
-
-def CreateNewEvent(arguments: List[Tuple[str, type]] = [], event_name: str = '') -> Event:
-    """
-    Creates a new event.
-
-    :param arguments: the list of the events args' names and types
-    :type arguments: List[Tuple[str, type]]
-    :param event_name: custom name of the event. It's filled with the variable name if not specified
-    :type event_name: str
-    :return: the new event
-    :rtype: Event
     """
     pass
 

--- a/boa3/builtin/interop/crypto/__init__.py
+++ b/boa3/builtin/interop/crypto/__init__.py
@@ -1,7 +1,7 @@
-from typing import Any, List, Union
+from typing import Any, List
 
 from boa3.builtin.interop.crypto.namedcurve import NamedCurve
-from boa3.builtin.type import ECPoint
+from boa3.builtin.type import ByteString, ECPoint
 
 
 def sha256(key: Any) -> bytes:
@@ -80,7 +80,7 @@ def check_multisig(pubkeys: List[ECPoint], signatures: List[bytes]) -> bool:
     pass
 
 
-def verify_with_ecdsa(message: Any, pubkey: ECPoint, signature: Union[bytes, str], curve: NamedCurve) -> bool:
+def verify_with_ecdsa(message: Any, pubkey: ECPoint, signature: ByteString, curve: NamedCurve) -> bool:
     """
     Using the elliptic curve, it checks if the signature of the any item was originally produced by the public key.
 

--- a/boa3/builtin/interop/stdlib/__init__.py
+++ b/boa3/builtin/interop/stdlib/__init__.py
@@ -1,4 +1,6 @@
-from typing import Any, Union
+from typing import Any
+
+from boa3.builtin.type import ByteString
 
 
 def base58_encode(key: bytes) -> str:
@@ -133,7 +135,7 @@ def itoa(value: int, base: int = 10) -> str:
     pass
 
 
-def memory_search(mem: Union[bytes, str], value: Union[bytes, str], start: int = 0, backward: bool = False) -> int:
+def memory_search(mem: ByteString, value: ByteString, start: int = 0, backward: bool = False) -> int:
     """
     Searches for a given value in a given memory.
 
@@ -152,7 +154,7 @@ def memory_search(mem: Union[bytes, str], value: Union[bytes, str], start: int =
     pass
 
 
-def memory_compare(mem1: Union[bytes, str], mem2: Union[bytes, str]) -> int:
+def memory_compare(mem1: ByteString, mem2: ByteString) -> int:
     """
     Compares a memory with another one.
 

--- a/boa3/builtin/interop/storage/__init__.py
+++ b/boa3/builtin/interop/storage/__init__.py
@@ -4,9 +4,10 @@ from boa3.builtin.interop.iterator import Iterator
 from boa3.builtin.interop.storage.findoptions import FindOptions
 from boa3.builtin.interop.storage.storagecontext import StorageContext
 from boa3.builtin.interop.storage.storagemap import StorageMap
+from boa3.builtin.type import ByteString
 
 
-def get(key: Union[str, bytes], context: StorageContext = None) -> bytes:
+def get(key: ByteString, context: StorageContext = None) -> bytes:
     """
     Gets a value from the persistent store based on the given key.
 
@@ -40,7 +41,7 @@ def get_read_only_context() -> StorageContext:
     pass
 
 
-def put(key: Union[str, bytes], value: Union[int, str, bytes], context: StorageContext = None):
+def put(key: ByteString, value: Union[int, ByteString], context: StorageContext = None):
     """
     Inserts a given value in the key-value format into the persistent storage.
 
@@ -54,7 +55,7 @@ def put(key: Union[str, bytes], value: Union[int, str, bytes], context: StorageC
     pass
 
 
-def delete(key: Union[str, bytes], context: StorageContext = None):
+def delete(key: ByteString, context: StorageContext = None):
     """
     Removes a given key from the persistent storage if exists.
 
@@ -66,7 +67,7 @@ def delete(key: Union[str, bytes], context: StorageContext = None):
     pass
 
 
-def find(prefix: Union[str, bytes],
+def find(prefix: ByteString,
          context: StorageContext = None,
          options: FindOptions = FindOptions.NONE) -> Iterator:
     """

--- a/boa3/builtin/interop/storage/storagecontext.py
+++ b/boa3/builtin/interop/storage/storagecontext.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from typing import Union
-
 from boa3.builtin.interop.storage.storagemap import StorageMap
+from boa3.builtin.type import ByteString
 
 
 class StorageContext:
@@ -13,7 +12,7 @@ class StorageContext:
     def __init__(self):
         pass
 
-    def create_map(self, prefix: Union[str, bytes]) -> StorageMap:
+    def create_map(self, prefix: ByteString) -> StorageMap:
         """
         Creates a storage map with the given prefix.
 

--- a/boa3/builtin/interop/storage/storagemap.py
+++ b/boa3/builtin/interop/storage/storagemap.py
@@ -1,18 +1,20 @@
 from typing import Union
 
+from boa3.builtin.type import ByteString
+
 
 class StorageMap:
     """
     The key-value storage for the specific prefix in the given storage context.
     """
 
-    def __init__(self, context, prefix: Union[bytes, str]):
+    def __init__(self, context, prefix: ByteString):
         from boa3.builtin.interop.storage.storagecontext import StorageContext
 
         self._context: StorageContext
-        self._prefix: Union[bytes, str]
+        self._prefix: ByteString
 
-    def get(self, key: Union[str, bytes]) -> bytes:
+    def get(self, key: ByteString) -> bytes:
         """
         Gets a value from the map based on the given key.
 
@@ -23,7 +25,7 @@ class StorageMap:
         """
         pass
 
-    def put(self, key: Union[str, bytes], value: Union[int, str, bytes]):
+    def put(self, key: ByteString, value: Union[int, ByteString]):
         """
         Inserts a given value in the key-value format into the map.
 
@@ -34,7 +36,7 @@ class StorageMap:
         """
         pass
 
-    def delete(self, key: Union[str, bytes]):
+    def delete(self, key: ByteString):
         """
         Removes a given key from the map if exists.
 

--- a/boa3/builtin/nativecontract/cryptolib.py
+++ b/boa3/builtin/nativecontract/cryptolib.py
@@ -1,7 +1,7 @@
-from typing import Any, Union
+from typing import Any
 
 from boa3.builtin.interop.crypto import NamedCurve
-from boa3.builtin.type import ECPoint
+from boa3.builtin.type import ByteString, ECPoint
 
 
 class CryptoLib:
@@ -34,7 +34,7 @@ class CryptoLib:
         pass
 
     @classmethod
-    def verify_with_ecdsa(cls, message: Any, pubkey: ECPoint, signature: Union[bytes, str], curve: NamedCurve) -> bool:
+    def verify_with_ecdsa(cls, message: Any, pubkey: ECPoint, signature: ByteString, curve: NamedCurve) -> bool:
         """
         Using the elliptic curve, it checks if the signature of the any item was originally produced by the public key.
 

--- a/boa3/builtin/nativecontract/stdlib.py
+++ b/boa3/builtin/nativecontract/stdlib.py
@@ -1,4 +1,6 @@
-from typing import Any, Union
+from typing import Any
+
+from boa3.builtin.type import ByteString
 
 
 class StdLib:
@@ -168,7 +170,7 @@ class StdLib:
         pass
 
     @classmethod
-    def memory_compare(cls, mem1: Union[bytes, str], mem2: Union[bytes, str]) -> int:
+    def memory_compare(cls, mem1: ByteString, mem2: ByteString) -> int:
         """
         Compares a memory with another one.
 
@@ -183,7 +185,7 @@ class StdLib:
         pass
 
     @classmethod
-    def memory_search(cls, mem: Union[bytes, str], value: Union[bytes, str], start: int = 0, backward: bool = False) -> int:
+    def memory_search(cls, mem: ByteString, value: ByteString, start: int = 0, backward: bool = False) -> int:
         """
         Searches for a given value in a given memory.
 

--- a/boa3/builtin/type/__init__.py
+++ b/boa3/builtin/type/__init__.py
@@ -29,3 +29,10 @@ class ECPoint(bytes):
     def __init__(self, arg: bytes):
         super().__init__()
         pass
+
+
+class ByteString:
+    """
+    An type annotation for values that can be str or bytes. Same as Union[str, bytes]
+    """
+    pass

--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -18,6 +18,7 @@ from boa3.model.type.collection.sequence.uint160type import UInt160Type
 from boa3.model.type.collection.sequence.uint256type import UInt256Type
 from boa3.model.type.itype import IType
 from boa3.model.type.math import Math
+from boa3.model.type.primitive.bytestringtype import ByteStringType
 
 
 class BoaPackage(str, Enum):
@@ -155,6 +156,7 @@ class Builtin:
     Public = PublicDecorator()
 
     # boa builtin type
+    ByteString = ByteStringType.build()
     Event = EventType
     UInt160 = UInt160Type.build()
     UInt256 = UInt256Type.build()
@@ -220,7 +222,8 @@ class Builtin:
                               Nep5Transfer,
                               ],
         BoaPackage.Interop: Interop.package_symbols,
-        BoaPackage.Type: [ECPoint,
+        BoaPackage.Type: [ByteString,
+                          ECPoint,
                           UInt160,
                           UInt256
                           ]

--- a/boa3/model/builtin/classmethod/isdigitmethod.py
+++ b/boa3/model/builtin/classmethod/isdigitmethod.py
@@ -1,17 +1,18 @@
 from typing import Any, Dict, List, Optional, Tuple
 
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
-from boa3.model.type.primitive.bytestringtype import ByteStringType
+from boa3.model.type.primitive.ibytestringtype import IByteStringType
 from boa3.model.variable import Variable
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
 class IsDigitMethod(IBuiltinMethod):
-    def __init__(self, self_type: ByteStringType = None):
+    def __init__(self, self_type: IByteStringType = None):
         from boa3.model.type.type import Type
 
-        if not isinstance(self_type, ByteStringType):
-            self_type = Type.str
+        if not isinstance(self_type, IByteStringType):
+            from boa3.model.type.primitive.bytestringtype import ByteStringType
+            self_type = ByteStringType.build()
 
         identifier = 'isdigit'
         args: Dict[str, Variable] = {'self': Variable(self_type)}
@@ -151,6 +152,6 @@ class IsDigitMethod(IBuiltinMethod):
         return None
 
     def build(self, value: Any) -> IBuiltinMethod:
-        if isinstance(value, ByteStringType):
+        if isinstance(value, IByteStringType):
             return IsDigitMethod(value)
         return super().build(value)

--- a/boa3/model/builtin/classmethod/joinmethod.py
+++ b/boa3/model/builtin/classmethod/joinmethod.py
@@ -1,20 +1,20 @@
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.type.collection.mapping.mutable.dicttype import DictType
 from boa3.model.type.collection.sequence.sequencetype import SequenceType
-from boa3.model.type.primitive.bytestringtype import ByteStringType
-from boa3.model.type.primitive.strtype import StrType
+from boa3.model.type.primitive.ibytestringtype import IByteStringType
 from boa3.model.variable import Variable
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
 class JoinMethod(IBuiltinMethod):
-    def __init__(self, self_type: ByteStringType = None, iterable_type: Union[SequenceType, DictType] = None):
+    def __init__(self, self_type: IByteStringType = None, iterable_type: Union[SequenceType, DictType] = None):
         from boa3.model.type.type import Type
 
-        if not isinstance(self_type, ByteStringType):
-            self_type = Type.str
+        if not isinstance(self_type, IByteStringType):
+            from boa3.model.type.primitive.bytestringtype import ByteStringType
+            self_type = ByteStringType.build()
 
         if not isinstance(iterable_type, (SequenceType, DictType)):
             iterable_type = Type.sequence.build_collection([self_type])
@@ -147,9 +147,15 @@ class JoinMethod(IBuiltinMethod):
         return None
 
     def build(self, value: Any) -> IBuiltinMethod:
+        if not isinstance(value, Iterable):
+            value = [value]
         if isinstance(value, list) and len(value) <= 2:
-            if isinstance(value[0], StrType) and isinstance(value[1], SequenceType):
+            self_type = self._arg_self.type
+            if len(value) < 2:
+                value.append(None)
+            if isinstance(value[0], type(self_type)) and isinstance(value[1], SequenceType):
                 return self
             else:
                 return JoinMethod(value[0], value[1])
+
         return super().build(value)

--- a/boa3/model/builtin/classmethod/lowermethod.py
+++ b/boa3/model/builtin/classmethod/lowermethod.py
@@ -1,17 +1,16 @@
 from typing import Any, Dict, List, Optional, Tuple
 
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
-from boa3.model.type.primitive.bytestringtype import ByteStringType
+from boa3.model.type.primitive.ibytestringtype import IByteStringType
 from boa3.model.variable import Variable
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
 class LowerMethod(IBuiltinMethod):
-    def __init__(self, self_type: ByteStringType = None):
-        from boa3.model.type.type import Type
-
-        if not isinstance(self_type, ByteStringType):
-            self_type = Type.str
+    def __init__(self, self_type: IByteStringType = None):
+        if not isinstance(self_type, IByteStringType):
+            from boa3.model.type.primitive.bytestringtype import ByteStringType
+            self_type = ByteStringType.build()
 
         identifier = 'lower'
         args: Dict[str, Variable] = {'self': Variable(self_type)}
@@ -152,6 +151,6 @@ class LowerMethod(IBuiltinMethod):
         return None
 
     def build(self, value: Any) -> IBuiltinMethod:
-        if isinstance(value, ByteStringType):
+        if isinstance(value, IByteStringType):
             return LowerMethod(value)
         return super().build(value)

--- a/boa3/model/builtin/classmethod/startswithmethod.py
+++ b/boa3/model/builtin/classmethod/startswithmethod.py
@@ -2,17 +2,18 @@ import ast
 from typing import Any, Dict, List, Optional, Tuple
 
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
-from boa3.model.type.primitive.bytestringtype import ByteStringType
+from boa3.model.type.primitive.ibytestringtype import IByteStringType
 from boa3.model.variable import Variable
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
 class StartsWithMethod(IBuiltinMethod):
-    def __init__(self, self_type: ByteStringType = None):
+    def __init__(self, self_type: IByteStringType = None):
         from boa3.model.type.type import Type
 
-        if not isinstance(self_type, ByteStringType):
-            self_type = Type.str
+        if not isinstance(self_type, IByteStringType):
+            from boa3.model.type.primitive.bytestringtype import ByteStringType
+            self_type = ByteStringType.build()
 
         identifier = 'startswith'
         args: Dict[str, Variable] = {
@@ -186,6 +187,6 @@ class StartsWithMethod(IBuiltinMethod):
         return None
 
     def build(self, value: Any) -> IBuiltinMethod:
-        if isinstance(value, ByteStringType):
+        if isinstance(value, IByteStringType):
             return StartsWithMethod(value)
         return super().build(value)

--- a/boa3/model/builtin/classmethod/stripmethod.py
+++ b/boa3/model/builtin/classmethod/stripmethod.py
@@ -2,17 +2,18 @@ import ast
 from typing import Any, Dict, List, Optional, Tuple
 
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
-from boa3.model.type.primitive.bytestringtype import ByteStringType
+from boa3.model.type.primitive.ibytestringtype import IByteStringType
 from boa3.model.variable import Variable
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
 class StripMethod(IBuiltinMethod):
-    def __init__(self, self_type: ByteStringType = None):
+    def __init__(self, self_type: IByteStringType = None):
         from boa3.model.type.type import Type
 
-        if not isinstance(self_type, ByteStringType):
-            self_type = Type.str
+        if not isinstance(self_type, IByteStringType):
+            from boa3.model.type.primitive.bytestringtype import ByteStringType
+            self_type = ByteStringType.build()
 
         identifier = 'strip'
         args: Dict[str, Variable] = {
@@ -230,6 +231,6 @@ class StripMethod(IBuiltinMethod):
     def build(self, value: Any) -> IBuiltinMethod:
         if type(value) == type(self.args['self'].type):
             return self
-        if isinstance(value, ByteStringType):
+        if isinstance(value, IByteStringType):
             return StripMethod(value)
         return super().build(value)

--- a/boa3/model/builtin/classmethod/toboolmethod.py
+++ b/boa3/model/builtin/classmethod/toboolmethod.py
@@ -5,6 +5,7 @@ from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.expression import IExpression
 from boa3.model.identifiedsymbol import IdentifiedSymbol
 from boa3.model.type.itype import IType
+from boa3.model.type.primitive.bytestringtype import ByteStringType
 from boa3.model.type.primitive.bytestype import BytesType
 from boa3.model.variable import Variable
 from boa3.neo.vm.opcode.Opcode import Opcode
@@ -53,7 +54,7 @@ class _ConvertToBoolMethod(ToBoolMethod):
         super().__init__(None)
 
     def build(self, value: Any) -> IBuiltinMethod:
-        if isinstance(value, BytesType):
+        if isinstance(value, (BytesType, ByteStringType)):
             return BytesToBoolMethod(value)
         # if it is not a valid type, show mismatched type with bytes
         return BytesToBoolMethod()
@@ -64,7 +65,7 @@ ToBool = _ConvertToBoolMethod()
 
 class BytesToBoolMethod(ToBoolMethod):
     def __init__(self, self_type: IType = None):
-        if not isinstance(self_type, BytesType):
+        if not isinstance(self_type, (BytesType, ByteStringType)):
             from boa3.model.type.type import Type
             self_type = Type.bytes
         super().__init__(self_type)

--- a/boa3/model/builtin/classmethod/tobytesmethod.py
+++ b/boa3/model/builtin/classmethod/tobytesmethod.py
@@ -5,6 +5,7 @@ from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.expression import IExpression
 from boa3.model.identifiedsymbol import IdentifiedSymbol
 from boa3.model.type.itype import IType
+from boa3.model.type.primitive.bytestringtype import ByteStringType
 from boa3.model.type.primitive.bytestype import BytesType
 from boa3.model.type.primitive.inttype import IntType
 from boa3.model.type.primitive.strtype import StrType
@@ -57,7 +58,7 @@ class _ConvertToBytesMethod(ToBytesMethod):
     def build(self, value: Any) -> IBuiltinMethod:
         if isinstance(value, IntType):
             return IntToBytesMethod(value)
-        elif isinstance(value, StrType):
+        elif isinstance(value, (StrType, ByteStringType)):
             return StrToBytesMethod(value)
         # if it is not a valid type, show mismatched type with int
         return IntToBytesMethod()
@@ -83,7 +84,7 @@ class IntToBytesMethod(ToBytesMethod):
 
 class StrToBytesMethod(ToBytesMethod):
     def __init__(self, self_type: IType = None):
-        if not isinstance(self_type, StrType):
+        if not isinstance(self_type, (StrType, ByteStringType)):
             from boa3.model.type.type import Type
             self_type = Type.str
         super().__init__(self_type)

--- a/boa3/model/builtin/classmethod/tointmethod.py
+++ b/boa3/model/builtin/classmethod/tointmethod.py
@@ -5,6 +5,7 @@ from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.expression import IExpression
 from boa3.model.identifiedsymbol import IdentifiedSymbol
 from boa3.model.type.itype import IType
+from boa3.model.type.primitive.bytestringtype import ByteStringType
 from boa3.model.type.primitive.bytestype import BytesType
 from boa3.model.variable import Variable
 from boa3.neo.vm.opcode.Opcode import Opcode
@@ -53,7 +54,7 @@ class _ConvertToIntMethod(ToIntMethod):
         super().__init__(None)
 
     def build(self, value: Any) -> IBuiltinMethod:
-        if isinstance(value, BytesType):
+        if isinstance(value, (BytesType, ByteStringType)):
             return BytesToIntMethod(value)
         # if it is not a valid type, show mismatched type with bytes
         return BytesToIntMethod()
@@ -64,7 +65,7 @@ ToInt = _ConvertToIntMethod()
 
 class BytesToIntMethod(ToIntMethod):
     def __init__(self, self_type: IType = None):
-        if not isinstance(self_type, BytesType):
+        if not isinstance(self_type, (BytesType, ByteStringType)):
             from boa3.model.type.type import Type
             self_type = Type.bytes
         super().__init__(self_type)

--- a/boa3/model/builtin/classmethod/tostrmethod.py
+++ b/boa3/model/builtin/classmethod/tostrmethod.py
@@ -5,6 +5,7 @@ from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.expression import IExpression
 from boa3.model.identifiedsymbol import IdentifiedSymbol
 from boa3.model.type.itype import IType
+from boa3.model.type.primitive.bytestringtype import ByteStringType
 from boa3.model.type.primitive.bytestype import BytesType
 from boa3.model.variable import Variable
 from boa3.neo.vm.opcode.Opcode import Opcode
@@ -53,7 +54,7 @@ class _ConvertToStrMethod(ToStrMethod):
         super().__init__(None)
 
     def build(self, value: Any) -> IBuiltinMethod:
-        if isinstance(value, BytesType):
+        if isinstance(value, (BytesType, ByteStringType)):
             return BytesToStrMethod(value)
         # if it is not a valid type, show mismatched type with bytes
         return BytesToStrMethod()
@@ -64,7 +65,7 @@ ToStr = _ConvertToStrMethod()
 
 class BytesToStrMethod(ToStrMethod):
     def __init__(self, self_type: IType = None):
-        if not isinstance(self_type, BytesType):
+        if not isinstance(self_type, (BytesType, ByteStringType)):
             from boa3.model.type.type import Type
             self_type = Type.bytes
         super().__init__(self_type)

--- a/boa3/model/builtin/classmethod/uppermethod.py
+++ b/boa3/model/builtin/classmethod/uppermethod.py
@@ -1,17 +1,17 @@
 from typing import Any, Dict, List, Optional, Tuple
 
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
-from boa3.model.type.primitive.bytestringtype import ByteStringType
+from boa3.model.type.primitive.ibytestringtype import IByteStringType
 from boa3.model.variable import Variable
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
 class UpperMethod(IBuiltinMethod):
-    def __init__(self, self_type: ByteStringType = None):
-        from boa3.model.type.type import Type
+    def __init__(self, self_type: IByteStringType = None):
 
-        if not isinstance(self_type, ByteStringType):
-            self_type = Type.str
+        if not isinstance(self_type, IByteStringType):
+            from boa3.model.type.primitive.bytestringtype import ByteStringType
+            self_type = ByteStringType.build()
 
         identifier = 'upper'
         args: Dict[str, Variable] = {'self': Variable(self_type)}
@@ -152,6 +152,6 @@ class UpperMethod(IBuiltinMethod):
         return None
 
     def build(self, value: Any) -> IBuiltinMethod:
-        if isinstance(value, ByteStringType):
+        if isinstance(value, IByteStringType):
             return UpperMethod(value)
         return super().build(value)

--- a/boa3/model/builtin/decorator/contractdecorator.py
+++ b/boa3/model/builtin/decorator/contractdecorator.py
@@ -8,11 +8,10 @@ from boa3.neo3.core.types import UInt160
 
 class ContractDecorator(IBuiltinDecorator):
     def __init__(self):
-        from boa3.model.type.type import Type
+        from boa3.model.type.primitive.bytestringtype import ByteStringType
 
         identifier = 'contract'
-        args: Dict[str, Variable] = {'script_hash': Variable(Type.union.build([Type.str,
-                                                                               Type.bytes]))}
+        args: Dict[str, Variable] = {'script_hash': Variable(ByteStringType.build())}
         super().__init__(identifier, args)
         self.contract_hash = UInt160()
 

--- a/boa3/model/builtin/interop/crypto/verifywithecdsa.py
+++ b/boa3/model/builtin/interop/crypto/verifywithecdsa.py
@@ -9,6 +9,7 @@ class VerifyWithECDsaMethod(CryptoLibMethod):
     def __init__(self):
         from boa3.model.type.type import Type
         from boa3.model.type.collection.sequence.ecpointtype import ECPointType
+        from boa3.model.type.primitive.bytestringtype import ByteStringType
         from boa3.model.builtin.interop.crypto.namedcurvetype import NamedCurveType
 
         identifier = 'verify_with_ecdsa'
@@ -16,8 +17,7 @@ class VerifyWithECDsaMethod(CryptoLibMethod):
         args: Dict[str, Variable] = {
             'data': Variable(Type.any),
             'pubkey': Variable(ECPointType.build()),
-            'signature': Variable(Type.union.build([Type.str,
-                                                    Type.bytes])),
+            'signature': Variable(ByteStringType.build()),
             'curve': Variable(NamedCurveType.build())
         }
         super().__init__(identifier, native_identifier, args, return_type=Type.bool)

--- a/boa3/model/builtin/interop/stdlib/memorycomparemethod.py
+++ b/boa3/model/builtin/interop/stdlib/memorycomparemethod.py
@@ -8,11 +8,15 @@ class MemoryCompareMethod(StdLibMethod):
 
     def __init__(self):
         from boa3.model.type.type import Type
+        from boa3.model.type.primitive.bytestringtype import ByteStringType
+
         identifier = 'memory_compare'
         syscall = 'memoryCompare'
+        byte_string_type = ByteStringType.build()
+
         args: Dict[str, Variable] = {
-            'mem1': Variable(Type.union.build([Type.bytes, Type.str])),
-            'mem2': Variable(Type.union.build([Type.bytes, Type.str]))
+            'mem1': Variable(byte_string_type),
+            'mem2': Variable(byte_string_type)
         }
 
         super().__init__(identifier, syscall, args, return_type=Type.int)

--- a/boa3/model/builtin/interop/stdlib/memorysearchmethod.py
+++ b/boa3/model/builtin/interop/stdlib/memorysearchmethod.py
@@ -10,11 +10,15 @@ class MemorySearchMethod(StdLibMethod):
 
     def __init__(self):
         from boa3.model.type.type import Type
+        from boa3.model.type.primitive.bytestringtype import ByteStringType
+
         identifier = 'memory_search'
         native_identifier = 'memorySearch'
+        byte_string_type = ByteStringType.build()
+
         args: Dict[str, Variable] = {
-            'mem': Variable(Type.union.build([Type.str, Type.bytes])),
-            'value': Variable(Type.union.build([Type.str, Type.bytes])),
+            'mem': Variable(byte_string_type),
+            'value': Variable(byte_string_type),
             'start': Variable(Type.int),
             'backward': Variable(Type.bool),
         }

--- a/boa3/model/builtin/interop/storage/storagecontext/storagecontextcreatemapmethod.py
+++ b/boa3/model/builtin/interop/storage/storagecontext/storagecontextcreatemapmethod.py
@@ -10,13 +10,13 @@ class StorageContextCreateMapMethod(IBuiltinMethod):
     def __init__(self):
         from boa3.model.builtin.interop.storage.storagecontext.storagecontexttype import _StorageContext
         from boa3.model.builtin.interop.storage.storagemap.storagemaptype import _StorageMap
-        from boa3.model.type.type import Type
+        from boa3.model.type.primitive.bytestringtype import ByteStringType
 
         identifier = 'create_map'
+        byte_string_type = ByteStringType.build()
+
         args: Dict[str, Variable] = {'self': Variable(_StorageContext),
-                                     'prefix': Variable(Type.union.build([Type.bytes,
-                                                                          Type.str
-                                                                          ]))}
+                                     'prefix': Variable(byte_string_type)}
 
         super().__init__(identifier, args, return_type=_StorageMap)
 

--- a/boa3/model/builtin/interop/storage/storagedeletemethod.py
+++ b/boa3/model/builtin/interop/storage/storagedeletemethod.py
@@ -14,14 +14,14 @@ class StorageDeleteMethod(InteropMethod):
     def __init__(self):
         from boa3.model.type.type import Type
         from boa3.model.builtin.interop.storage.storagecontext.storagecontexttype import StorageContextType
+        from boa3.model.type.primitive.bytestringtype import ByteStringType
 
         identifier = 'delete'
         syscall = 'System.Storage.Delete'
         context_type = StorageContextType.build()
+        byte_string_type = ByteStringType.build()
 
-        args: Dict[str, Variable] = {'key': Variable(Type.union.build([Type.bytes,
-                                                                       Type.str
-                                                                       ])),
+        args: Dict[str, Variable] = {'key': Variable(byte_string_type),
                                      'context': Variable(context_type)}
 
         from boa3.model.builtin.interop.storage.storagegetcontextmethod import StorageGetContextMethod
@@ -29,22 +29,6 @@ class StorageDeleteMethod(InteropMethod):
         context_default = set_internal_call(ast.parse("{0}()".format(default_id)
                                                       ).body[0].value)
         super().__init__(identifier, syscall, args, defaults=[context_default], return_type=Type.none)
-
-    def validate_parameters(self, *params: IExpression) -> bool:
-        if any(not isinstance(param, IExpression) for param in params):
-            return False
-
-        args: List[IType] = [arg.type for arg in self.args.values()]
-        # TODO: refactor when default arguments are implemented
-        if len(params) != len(args):
-            return False
-
-        return self._validate_key_type(params[0].type)
-
-    def _validate_key_type(self, key_type: IType):
-        # TODO: refactor when `Union` type is implemented
-        from boa3.model.type.type import Type
-        return Type.str.is_type_of(key_type) or Type.bytes.is_type_of(key_type)
 
     @property
     def generation_order(self) -> List[int]:

--- a/boa3/model/builtin/interop/storage/storagefindmethod.py
+++ b/boa3/model/builtin/interop/storage/storagefindmethod.py
@@ -21,9 +21,9 @@ class StorageFindMethod(InteropMethod):
         context_type = StorageContextType.build()
 
         if prefix_type is None:
-            prefix_type = Type.union.build([Type.bytes,
-                                            Type.str
-                                            ])
+            from boa3.model.type.primitive.bytestringtype import ByteStringType
+            prefix_type = ByteStringType.build()
+
         args: Dict[str, Variable] = {'prefix': Variable(prefix_type),
                                      'context': Variable(context_type),
                                      'options': Variable(find_options_type)}
@@ -47,17 +47,6 @@ class StorageFindMethod(InteropMethod):
     @property
     def identifier(self) -> str:
         return '-{0}_{1}'.format(self._identifier, self.prefix_arg.type.identifier)
-
-    def validate_parameters(self, *params: IExpression) -> bool:
-        if any(not isinstance(param, IExpression) for param in params):
-            return False
-
-        args: List[IType] = [arg.type for arg in self.args.values()]
-        # TODO: refactor when default arguments are implemented
-        if len(params) != len(args):
-            return False
-
-        return self.prefix_arg.type.is_type_of(params[0].type)
 
     @property
     def generation_order(self) -> List[int]:

--- a/boa3/model/builtin/interop/storage/storagegetmethod.py
+++ b/boa3/model/builtin/interop/storage/storagegetmethod.py
@@ -15,13 +15,14 @@ class StorageGetMethod(InteropMethod):
     def __init__(self):
         from boa3.model.type.type import Type
         from boa3.model.builtin.interop.storage.storagecontext.storagecontexttype import StorageContextType
+        from boa3.model.type.primitive.bytestringtype import ByteStringType
 
         identifier = 'get'
         syscall = 'System.Storage.Get'
         context_type = StorageContextType.build()
-        args: Dict[str, Variable] = {'key': Variable(Type.union.build([Type.bytes,
-                                                                       Type.str
-                                                                       ])),
+        byte_string_type = ByteStringType.build()
+
+        args: Dict[str, Variable] = {'key': Variable(byte_string_type),
                                      'context': Variable(context_type)}
 
         from boa3.model.builtin.interop.storage.storagegetcontextmethod import StorageGetContextMethod
@@ -29,17 +30,6 @@ class StorageGetMethod(InteropMethod):
         context_default = set_internal_call(ast.parse("{0}()".format(default_id)
                                                       ).body[0].value)
         super().__init__(identifier, syscall, args, defaults=[context_default], return_type=Type.bytes)
-
-    def validate_parameters(self, *params: IExpression) -> bool:
-        if any(not isinstance(param, IExpression) for param in params):
-            return False
-
-        args: List[IType] = [arg.type for arg in self.args.values()]
-        # TODO: refactor when default arguments are implemented
-        if len(params) != len(args):
-            return False
-
-        return self.key_arg.type.is_type_of(params[0].type)
 
     @property
     def opcode(self) -> List[Tuple[Opcode, bytes]]:

--- a/boa3/model/builtin/interop/storage/storagemap/storagemapdeletemethod.py
+++ b/boa3/model/builtin/interop/storage/storagemap/storagemapdeletemethod.py
@@ -10,12 +10,13 @@ class StorageMapDeleteMethod(IBuiltinMethod):
     def __init__(self):
         from boa3.model.builtin.interop.storage.storagemap.storagemaptype import _StorageMap
         from boa3.model.type.type import Type
+        from boa3.model.type.primitive.bytestringtype import ByteStringType
 
         identifier = 'delete'
+        byte_string_type = ByteStringType.build()
+
         args: Dict[str, Variable] = {'self': Variable(_StorageMap),
-                                     'key': Variable(Type.union.build([Type.bytes,
-                                                                       Type.str
-                                                                       ]))}
+                                     'key': Variable(byte_string_type)}
 
         super().__init__(identifier, args, return_type=Type.none)
 

--- a/boa3/model/builtin/interop/storage/storagemap/storagemapgetmethod.py
+++ b/boa3/model/builtin/interop/storage/storagemap/storagemapgetmethod.py
@@ -10,12 +10,13 @@ class StorageMapGetMethod(IBuiltinMethod):
     def __init__(self):
         from boa3.model.builtin.interop.storage.storagemap.storagemaptype import _StorageMap
         from boa3.model.type.type import Type
+        from boa3.model.type.primitive.bytestringtype import ByteStringType
 
         identifier = 'get'
+        byte_string_type = ByteStringType.build()
+
         args: Dict[str, Variable] = {'self': Variable(_StorageMap),
-                                     'key': Variable(Type.union.build([Type.bytes,
-                                                                       Type.str
-                                                                       ]))}
+                                     'key': Variable(byte_string_type)}
 
         super().__init__(identifier, args, return_type=Type.bytes)
 

--- a/boa3/model/builtin/interop/storage/storagemap/storagemapputmethod.py
+++ b/boa3/model/builtin/interop/storage/storagemap/storagemapputmethod.py
@@ -10,14 +10,14 @@ class StorageMapPutMethod(IBuiltinMethod):
     def __init__(self):
         from boa3.model.builtin.interop.storage.storagemap.storagemaptype import _StorageMap
         from boa3.model.type.type import Type
+        from boa3.model.type.primitive.bytestringtype import ByteStringType
 
         identifier = 'put'
+        byte_string_type = ByteStringType.build()
+
         args: Dict[str, Variable] = {'self': Variable(_StorageMap),
-                                     'key': Variable(Type.union.build([Type.bytes,
-                                                                       Type.str
-                                                                       ])),
-                                     'value': Variable(Type.union.build([Type.bytes,
-                                                                         Type.str,
+                                     'key': Variable(byte_string_type),
+                                     'value': Variable(Type.union.build([byte_string_type,
                                                                          Type.int
                                                                          ]))}
 

--- a/boa3/model/builtin/interop/storage/storagemap/storagemaptype.py
+++ b/boa3/model/builtin/interop/storage/storagemap/storagemaptype.py
@@ -35,13 +35,12 @@ class StorageMapType(ClassArrayType):
     def _all_variables(self) -> Dict[str, Variable]:
         from boa3.model.builtin.interop.storage.storagecontext.storagecontexttype import \
             _StorageContext as StorageContextType
-        from boa3.model.type.type import Type
+        from boa3.model.type.primitive.bytestringtype import ByteStringType
 
+        byte_string_type = ByteStringType.build()
         private_variables = {
             '_context': Variable(StorageContextType),
-            '_prefix': Variable(Type.union.build([Type.bytes,
-                                                  Type.str
-                                                  ]))
+            '_prefix': Variable(byte_string_type)
         }
         variables = super()._all_variables
         variables.update(private_variables)

--- a/boa3/model/builtin/interop/storage/storageputmethod.py
+++ b/boa3/model/builtin/interop/storage/storageputmethod.py
@@ -14,15 +14,15 @@ class StoragePutMethod(InteropMethod):
     def __init__(self):
         from boa3.model.type.type import Type
         from boa3.model.builtin.interop.storage.storagecontext.storagecontexttype import StorageContextType
+        from boa3.model.type.primitive.bytestringtype import ByteStringType
 
         identifier = 'put'
         syscall = 'System.Storage.Put'
         context_type = StorageContextType.build()
-        args: Dict[str, Variable] = {'key': Variable(Type.union.build([Type.bytes,
-                                                                       Type.str
-                                                                       ])),
-                                     'value': Variable(Type.union.build([Type.bytes,
-                                                                         Type.str,
+        byte_string_type = ByteStringType.build()
+
+        args: Dict[str, Variable] = {'key': Variable(byte_string_type),
+                                     'value': Variable(Type.union.build([byte_string_type,
                                                                          Type.int
                                                                          ])),
                                      'context': Variable(context_type)}
@@ -32,18 +32,6 @@ class StoragePutMethod(InteropMethod):
         context_default = set_internal_call(ast.parse("{0}()".format(default_id)
                                                       ).body[0].value)
         super().__init__(identifier, syscall, args, defaults=[context_default], return_type=Type.none)
-
-    def validate_parameters(self, *params: IExpression) -> bool:
-        if any(not isinstance(param, IExpression) for param in params):
-            return False
-
-        args: List[IType] = [arg.type for arg in self.args.values()]
-        # TODO: refactor when default arguments are implemented
-        if len(params) != len(args):
-            return False
-
-        return (self.key_arg.type.is_type_of(params[0].type)
-                and self.value_arg.type.is_type_of(params[1].type))
 
     @property
     def generation_order(self) -> List[int]:

--- a/boa3/model/type/annotation/uniontype.py
+++ b/boa3/model/type/annotation/uniontype.py
@@ -1,6 +1,8 @@
 from typing import Any, Iterable, List, Set
 
 from boa3.model.type.itype import IType
+from boa3.neo.vm.type.AbiType import AbiType
+from boa3.neo.vm.type.StackItem import StackItemType
 
 
 class UnionType(IType):
@@ -13,6 +15,10 @@ class UnionType(IType):
         super().__init__(identifier)
         self._union_types: Set[IType] = union_types
 
+        # variables to not reevaluate everytime we need to access
+        self._abi_type: AbiType = None
+        self._stack_item: StackItemType = None
+
     @property
     def identifier(self) -> str:
         return '{0}[{1}]'.format(self._identifier,
@@ -21,6 +27,18 @@ class UnionType(IType):
     @property
     def union_types(self) -> List[IType]:
         return list(self._union_types)
+
+    @property
+    def abi_type(self) -> AbiType:
+        if self._abi_type is None:
+            self._abi_type = AbiType.union([union.abi_type for union in self._union_types])
+        return self._abi_type
+
+    @property
+    def stack_item(self) -> StackItemType:
+        if self._stack_item is None:
+            self._stack_item = StackItemType.union([union.stack_item for union in self._union_types])
+        return self._stack_item
 
     def _is_type_of(self, value: Any) -> bool:
         if not isinstance(self._union_types, Iterable):

--- a/boa3/model/type/primitive/bytestringtype.py
+++ b/boa3/model/type/primitive/bytestringtype.py
@@ -1,52 +1,43 @@
-import abc
-from typing import List
+from typing import Any
 
-from boa3.model.type.collection.sequence.sequencetype import SequenceType
 from boa3.model.type.itype import IType
-from boa3.model.type.primitive.primitivetype import PrimitiveType
-from boa3.neo.vm.type.StackItem import StackItemType
+from boa3.model.type.primitive.ibytestringtype import IByteStringType
 
 
-class ByteStringType(SequenceType, PrimitiveType, abc.ABC):
+class ByteStringType(IByteStringType):
     """
-    A class used to represent Neo ByteString type
+    A class used to represent ByteString type interface
     """
 
-    def __init__(self, identifier: str, values_type: List[IType]):
+    def __init__(self):
+        identifier = 'ByteString'
+        values_type = [self]
         super().__init__(identifier, values_type)
 
-    @property
-    def identifier(self) -> str:
-        return self._identifier
-
-    @property
-    def stack_item(self) -> StackItemType:
-        return StackItemType.ByteString
+    @classmethod
+    def _is_type_of(cls, value: Any) -> bool:
+        from boa3.model.type.type import Type
+        return (Type.str.is_type_of(value)
+                or Type.bytes.is_type_of(value)
+                or isinstance(value, ByteStringType))
 
     def _init_class_symbols(self):
         super()._init_class_symbols()
 
         from boa3.model.builtin.builtin import Builtin
 
-        instance_methods = [Builtin.BytesStringIsDigit,
-                            Builtin.BytesStringJoin,
-                            Builtin.BytesStringLower,
-                            Builtin.BytesStringUpper,
-                            Builtin.BytesStringStartswith,
-                            Builtin.BytesStringStrip,
+        instance_methods = [Builtin.ConvertToBytes,
+                            Builtin.ConvertToBool,
+                            Builtin.ConvertToInt,
+                            Builtin.ConvertToStr,
                             ]
 
         for instance_method in instance_methods:
             self._instance_methods[instance_method.raw_identifier] = instance_method.build(self)
 
-    def is_valid_key(self, key_type: IType) -> bool:
-        return key_type == self.valid_key
+    @classmethod
+    def build(cls, value: Any = None) -> IType:
+        return _ByteString
 
-    @property
-    def valid_key(self) -> IType:
-        from boa3.model.type.type import Type
-        return Type.int
 
-    @property
-    def can_reassign_values(self) -> bool:
-        return False
+_ByteString = ByteStringType()

--- a/boa3/model/type/primitive/bytestype.py
+++ b/boa3/model/type/primitive/bytestype.py
@@ -1,11 +1,11 @@
 from typing import Any
 
 from boa3.model.type.itype import IType
-from boa3.model.type.primitive.bytestringtype import ByteStringType
+from boa3.model.type.primitive.ibytestringtype import IByteStringType
 from boa3.neo.vm.type.AbiType import AbiType
 
 
-class BytesType(ByteStringType):
+class BytesType(IByteStringType):
     """
     A class used to represent Python bytes type
     """

--- a/boa3/model/type/primitive/ibytestringtype.py
+++ b/boa3/model/type/primitive/ibytestringtype.py
@@ -1,0 +1,55 @@
+import abc
+from typing import Any, List
+
+from boa3.model.type.collection.sequence.sequencetype import SequenceType
+from boa3.model.type.itype import IType
+from boa3.model.type.primitive.primitivetype import PrimitiveType
+from boa3.neo.vm.type.StackItem import StackItemType
+
+
+class IByteStringType(SequenceType, PrimitiveType, abc.ABC):
+    """
+    A class used to represent Neo ByteString type
+    """
+
+    def __init__(self, identifier: str, values_type: List[IType]):
+        super().__init__(identifier, values_type)
+
+    @property
+    def identifier(self) -> str:
+        return self._identifier
+
+    @property
+    def stack_item(self) -> StackItemType:
+        return StackItemType.ByteString
+
+    def is_type_of(self, value: Any) -> bool:
+        return self._is_type_of(value)
+
+    def _init_class_symbols(self):
+        super()._init_class_symbols()
+
+        from boa3.model.builtin.builtin import Builtin
+
+        instance_methods = [Builtin.BytesStringIsDigit,
+                            Builtin.BytesStringJoin,
+                            Builtin.BytesStringLower,
+                            Builtin.BytesStringUpper,
+                            Builtin.BytesStringStartswith,
+                            Builtin.BytesStringStrip,
+                            ]
+
+        for instance_method in instance_methods:
+            self._instance_methods[instance_method.raw_identifier] = instance_method.build(self)
+
+    def is_valid_key(self, key_type: IType) -> bool:
+        return key_type == self.valid_key
+
+    @property
+    def valid_key(self) -> IType:
+        from boa3.model.type.type import Type
+        return Type.int
+
+    @property
+    def can_reassign_values(self) -> bool:
+        return False

--- a/boa3/model/type/primitive/strtype.py
+++ b/boa3/model/type/primitive/strtype.py
@@ -1,11 +1,11 @@
 from typing import Any
 
 from boa3.model.type.itype import IType
-from boa3.model.type.primitive.bytestringtype import ByteStringType
+from boa3.model.type.primitive.ibytestringtype import IByteStringType
 from boa3.neo.vm.type.AbiType import AbiType
 
 
-class StrType(ByteStringType):
+class StrType(IByteStringType):
     """
     A class used to represent Python str type
     """

--- a/boa3/neo/vm/type/AbiType.py
+++ b/boa3/neo/vm/type/AbiType.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from enum import Enum
+from typing import List
 
 
 class AbiType(str, Enum):
@@ -15,3 +18,46 @@ class AbiType(str, Enum):
     InteropInterface = 'InteropInterface'
     Any = 'Any'
     Void = 'Void'
+
+    @staticmethod
+    def union(abi_types: List[AbiType]) -> AbiType:
+        if len(abi_types) == 0:
+            return AbiType.Any
+
+        if len(abi_types) == 1:
+            return abi_types[0]
+
+        abis = abi_types[:1]
+        for abi in abi_types[1:]:
+            if abi not in abis:
+                abis.append(abi)
+
+        if len(abis) == 1:
+            return abis[0]
+
+        generic_mapping = {
+            AbiType.Signature: AbiType.ByteArray,
+            AbiType.Boolean: AbiType.Integer,
+            AbiType.Integer: AbiType.Integer,
+            AbiType.Hash160: AbiType.ByteArray,
+            AbiType.Hash256: AbiType.ByteArray,
+            AbiType.ByteArray: AbiType.ByteArray,
+            AbiType.PublicKey: AbiType.ByteArray,
+            AbiType.String: AbiType.ByteArray,
+            AbiType.Array: AbiType.Array,
+            AbiType.Map: AbiType.Map,
+            AbiType.InteropInterface: AbiType.InteropInterface,
+            AbiType.Any: AbiType.Any,
+            AbiType.Void: AbiType.Void
+        }
+
+        generic_abis = [generic_mapping[abis[0]]]
+        for abi in abis[1:]:
+            generic = generic_mapping[abi]
+            if generic not in generic_abis:
+                generic_abis.append(generic)
+
+        if len(generic_abis) == 1:
+            return generic_abis[0]
+        else:
+            return AbiType.Any

--- a/boa3/neo/vm/type/StackItem.py
+++ b/boa3/neo/vm/type/StackItem.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any
+from typing import Any, List
 
 from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.String import String
@@ -19,11 +19,29 @@ class StackItemType(bytes, Enum):
     Map = b'\x48'
     InteropInterface = b'\x60'
 
-    @classmethod
-    def get_stack_item_type(cls, stack_item_type: str) -> StackItemType:
+    @staticmethod
+    def get_stack_item_type(stack_item_type: str) -> StackItemType:
         try:
             return StackItemType[stack_item_type]
         except BaseException:
+            return StackItemType.Any
+
+    @staticmethod
+    def union(stack_item_types: List[StackItemType]) -> StackItemType:
+        if len(stack_item_types) == 0:
+            return StackItemType.Any
+
+        if len(stack_item_types) == 1:
+            return stack_item_types[0]
+
+        stacks = stack_item_types[:1]
+        for union in stack_item_types[1:]:
+            if union not in stacks:
+                stacks.append(union)
+
+        if len(stacks) == 1:
+            return stacks[0]
+        else:
             return StackItemType.Any
 
 

--- a/boa3_test/test_sc/interop_test/crypto/VerifyWithECDsa.py
+++ b/boa3_test/test_sc/interop_test/crypto/VerifyWithECDsa.py
@@ -1,10 +1,10 @@
-from typing import Any, Union
+from typing import Any
 
 from boa3.builtin import public
 from boa3.builtin.interop.crypto import NamedCurve, verify_with_ecdsa
-from boa3.builtin.type import ECPoint
+from boa3.builtin.type import ByteString, ECPoint
 
 
 @public
-def Main(message: Any, pubkey: ECPoint, signature: Union[bytes, str], curve: NamedCurve) -> bool:
+def Main(message: Any, pubkey: ECPoint, signature: ByteString, curve: NamedCurve) -> bool:
     return verify_with_ecdsa(message, pubkey, signature, curve)

--- a/boa3_test/test_sc/interop_test/stdlib/MemoryCompare.py
+++ b/boa3_test/test_sc/interop_test/stdlib/MemoryCompare.py
@@ -1,9 +1,8 @@
-from typing import Union
-
 from boa3.builtin import public
 from boa3.builtin.interop.stdlib import memory_compare
+from boa3.builtin.type import ByteString
 
 
 @public
-def main(mem1: Union[bytes, str], mem2: Union[bytes, str]) -> int:
+def main(mem1: ByteString, mem2: ByteString) -> int:
     return memory_compare(mem1, mem2)

--- a/boa3_test/test_sc/interop_test/stdlib/MemoryCompareTooFewArguments.py
+++ b/boa3_test/test_sc/interop_test/stdlib/MemoryCompareTooFewArguments.py
@@ -1,7 +1,6 @@
-from typing import Union
-
 from boa3.builtin.interop.stdlib import memory_compare
+from boa3.builtin.type import ByteString
 
 
-def main(mem1: Union[bytes, str]) -> int:
+def main(mem1: ByteString) -> int:
     return memory_compare(mem1)

--- a/boa3_test/test_sc/interop_test/stdlib/MemoryCompareTooManyArguments.py
+++ b/boa3_test/test_sc/interop_test/stdlib/MemoryCompareTooManyArguments.py
@@ -1,7 +1,8 @@
-from typing import Any, Union
+from typing import Any
 
 from boa3.builtin.interop.stdlib import memory_compare
+from boa3.builtin.type import ByteString
 
 
-def main(mem1: Union[bytes, str], mem2: Union[bytes, str], arg: Any) -> int:
+def main(mem1: ByteString, mem2: ByteString, arg: Any) -> int:
     return memory_compare(mem1, mem2, arg)

--- a/boa3_test/test_sc/interop_test/stdlib/MemorySearch.py
+++ b/boa3_test/test_sc/interop_test/stdlib/MemorySearch.py
@@ -1,9 +1,8 @@
-from typing import Union
-
 from boa3.builtin import public
 from boa3.builtin.interop.stdlib import memory_search
+from boa3.builtin.type import ByteString
 
 
 @public
-def main(mem: Union[bytes, str], value: Union[bytes, str], start: int, backward: bool) -> int:
+def main(mem: ByteString, value: ByteString, start: int, backward: bool) -> int:
     return memory_search(mem, value, start, backward)

--- a/boa3_test/test_sc/interop_test/stdlib/MemorySearchDefault.py
+++ b/boa3_test/test_sc/interop_test/stdlib/MemorySearchDefault.py
@@ -1,9 +1,8 @@
-from typing import Union
-
 from boa3.builtin import public
 from boa3.builtin.interop.stdlib import memory_search
+from boa3.builtin.type import ByteString
 
 
 @public
-def main(mem: Union[bytes, str], value: Union[bytes, str]) -> int:
+def main(mem: ByteString, value: ByteString) -> int:
     return memory_search(mem, value)

--- a/boa3_test/test_sc/interop_test/stdlib/MemorySearchStart.py
+++ b/boa3_test/test_sc/interop_test/stdlib/MemorySearchStart.py
@@ -1,9 +1,8 @@
-from typing import Union
-
 from boa3.builtin import public
 from boa3.builtin.interop.stdlib import memory_search
+from boa3.builtin.type import ByteString
 
 
 @public
-def main(mem: Union[bytes, str], value: Union[bytes, str], start: int) -> int:
+def main(mem: ByteString, value: ByteString, start: int) -> int:
     return memory_search(mem, value, start)

--- a/boa3_test/test_sc/interop_test/stdlib/MemorySearchTooFewArguments.py
+++ b/boa3_test/test_sc/interop_test/stdlib/MemorySearchTooFewArguments.py
@@ -1,7 +1,6 @@
-from typing import Union
-
 from boa3.builtin.interop.stdlib import memory_search
+from boa3.builtin.type import ByteString
 
 
-def main(mem: Union[bytes, str]) -> int:
+def main(mem: ByteString) -> int:
     return memory_search(mem)

--- a/boa3_test/test_sc/interop_test/stdlib/MemorySearchTooManyArguments.py
+++ b/boa3_test/test_sc/interop_test/stdlib/MemorySearchTooManyArguments.py
@@ -1,7 +1,8 @@
-from typing import Any, Union
+from typing import Any
 
 from boa3.builtin.interop.stdlib import memory_search
+from boa3.builtin.type import ByteString
 
 
-def main(mem: Union[bytes, str], value: Union[bytes, str], start: int, backward: bool, arg: Any) -> int:
+def main(mem: ByteString, value: ByteString, start: int, backward: bool, arg: Any) -> int:
     return memory_search(mem, value, start, backward, arg)

--- a/boa3_test/test_sc/interop_test/storage/StorageDeleteWithContext.py
+++ b/boa3_test/test_sc/interop_test/storage/StorageDeleteWithContext.py
@@ -1,10 +1,9 @@
-from typing import Union
-
 from boa3.builtin import public
 from boa3.builtin.interop.storage import delete, get_context
+from boa3.builtin.type import ByteString
 
 
 @public
-def Main(key: Union[bytes, str]):
+def Main(key: ByteString):
     context = get_context()
     delete(key, context)

--- a/boa3_test/test_sc/interop_test/storage/StorageFindBytesPrefix.py
+++ b/boa3_test/test_sc/interop_test/storage/StorageFindBytesPrefix.py
@@ -3,6 +3,7 @@ from typing import Union
 from boa3.builtin import public
 from boa3.builtin.interop.iterator import Iterator
 from boa3.builtin.interop.storage import find, put
+from boa3.builtin.type import ByteString
 
 
 @public
@@ -11,5 +12,5 @@ def find_by_prefix(prefix: bytes) -> Iterator:
 
 
 @public
-def put_on_storage(key: Union[str, bytes], value: Union[int, str, bytes]):
+def put_on_storage(key: ByteString, value: Union[int, ByteString]):
     put(key, value)

--- a/boa3_test/test_sc/interop_test/storage/StorageFindStrPrefix.py
+++ b/boa3_test/test_sc/interop_test/storage/StorageFindStrPrefix.py
@@ -3,6 +3,7 @@ from typing import Union
 from boa3.builtin import public
 from boa3.builtin.interop.iterator import Iterator
 from boa3.builtin.interop.storage import find, put
+from boa3.builtin.type import ByteString
 
 
 @public
@@ -11,5 +12,5 @@ def find_by_prefix(prefix: str) -> Iterator:
 
 
 @public
-def put_on_storage(key: Union[str, bytes], value: Union[int, str, bytes]):
+def put_on_storage(key: ByteString, value: Union[int, ByteString]):
     put(key, value)

--- a/boa3_test/test_sc/interop_test/storage/StorageFindWithContext.py
+++ b/boa3_test/test_sc/interop_test/storage/StorageFindWithContext.py
@@ -3,14 +3,15 @@ from typing import Union
 from boa3.builtin import public
 from boa3.builtin.interop.iterator import Iterator
 from boa3.builtin.interop.storage import find, get_context, put
+from boa3.builtin.type import ByteString
 
 
 @public
-def find_by_prefix(prefix: Union[str, bytes]) -> Iterator:
+def find_by_prefix(prefix: ByteString) -> Iterator:
     context = get_context()
     return find(prefix, context)
 
 
 @public
-def put_on_storage(key: Union[str, bytes], value: Union[int, str, bytes]):
+def put_on_storage(key: ByteString, value: Union[int, ByteString]):
     put(key, value)

--- a/boa3_test/test_sc/interop_test/storage/StorageFindWithOptions.py
+++ b/boa3_test/test_sc/interop_test/storage/StorageFindWithOptions.py
@@ -4,14 +4,15 @@ from boa3.builtin import public
 from boa3.builtin.interop.iterator import Iterator
 from boa3.builtin.interop.storage import find, get_context, put
 from boa3.builtin.interop.storage.findoptions import FindOptions
+from boa3.builtin.type import ByteString
 
 
 @public
-def find_by_prefix(prefix: Union[str, bytes]) -> Iterator:
+def find_by_prefix(prefix: ByteString) -> Iterator:
     context = get_context()
     return find(prefix, context, FindOptions.REMOVE_PREFIX)
 
 
 @public
-def put_on_storage(key: Union[str, bytes], value: Union[int, str, bytes]):
+def put_on_storage(key: ByteString, value: Union[int, ByteString]):
     put(key, value)

--- a/boa3_test/test_sc/interop_test/storage/StorageGetWithContext.py
+++ b/boa3_test/test_sc/interop_test/storage/StorageGetWithContext.py
@@ -1,10 +1,9 @@
-from typing import Union
-
 from boa3.builtin import public
 from boa3.builtin.interop.storage import get, get_context
+from boa3.builtin.type import ByteString
 
 
 @public
-def Main(key: Union[bytes, str]) -> bytes:
+def Main(key: ByteString) -> bytes:
     context = get_context()
     return get(key, context)

--- a/boa3_test/test_sc/native_test/cryptolib/VerifyWithECDsa.py
+++ b/boa3_test/test_sc/native_test/cryptolib/VerifyWithECDsa.py
@@ -1,11 +1,11 @@
-from typing import Any, Union
+from typing import Any
 
 from boa3.builtin import public
 from boa3.builtin.interop.crypto import NamedCurve
 from boa3.builtin.nativecontract.cryptolib import CryptoLib
-from boa3.builtin.type import ECPoint
+from boa3.builtin.type import ByteString, ECPoint
 
 
 @public
-def Main(message: Any, pubkey: ECPoint, signature: Union[bytes, str], curve: NamedCurve) -> bool:
+def Main(message: Any, pubkey: ECPoint, signature: ByteString, curve: NamedCurve) -> bool:
     return CryptoLib.verify_with_ecdsa(message, pubkey, signature, curve)

--- a/boa3_test/test_sc/native_test/stdlib/MemoryCompare.py
+++ b/boa3_test/test_sc/native_test/stdlib/MemoryCompare.py
@@ -1,9 +1,8 @@
-from typing import Union
-
 from boa3.builtin import public
 from boa3.builtin.nativecontract.stdlib import StdLib
+from boa3.builtin.type import ByteString
 
 
 @public
-def main(mem1: Union[bytes, str], mem2: Union[bytes, str]) -> int:
+def main(mem1: ByteString, mem2: ByteString) -> int:
     return StdLib.memory_compare(mem1, mem2)

--- a/boa3_test/test_sc/native_test/stdlib/MemoryCompareTooFewArguments.py
+++ b/boa3_test/test_sc/native_test/stdlib/MemoryCompareTooFewArguments.py
@@ -1,7 +1,6 @@
-from typing import Union
-
 from boa3.builtin.nativecontract.stdlib import StdLib
+from boa3.builtin.type import ByteString
 
 
-def main(mem1: Union[bytes, str]) -> int:
+def main(mem1: ByteString) -> int:
     return StdLib.memory_compare(mem1)

--- a/boa3_test/test_sc/native_test/stdlib/MemoryCompareTooManyArguments.py
+++ b/boa3_test/test_sc/native_test/stdlib/MemoryCompareTooManyArguments.py
@@ -1,7 +1,8 @@
-from typing import Any, Union
+from typing import Any
 
 from boa3.builtin.nativecontract.stdlib import StdLib
+from boa3.builtin.type import ByteString
 
 
-def main(mem1: Union[bytes, str], mem2: Union[bytes, str], arg: Any) -> int:
+def main(mem1: ByteString, mem2: ByteString, arg: Any) -> int:
     return StdLib.memory_compare(mem1, mem2, arg)

--- a/boa3_test/test_sc/native_test/stdlib/MemorySearch.py
+++ b/boa3_test/test_sc/native_test/stdlib/MemorySearch.py
@@ -1,9 +1,8 @@
-from typing import Union
-
 from boa3.builtin import public
 from boa3.builtin.nativecontract.stdlib import StdLib
+from boa3.builtin.type import ByteString
 
 
 @public
-def main(mem: Union[bytes, str], value: Union[bytes, str], start: int, backward: bool) -> int:
+def main(mem: ByteString, value: ByteString, start: int, backward: bool) -> int:
     return StdLib.memory_search(mem, value, start, backward)

--- a/boa3_test/test_sc/native_test/stdlib/MemorySearchDefault.py
+++ b/boa3_test/test_sc/native_test/stdlib/MemorySearchDefault.py
@@ -1,9 +1,8 @@
-from typing import Union
-
 from boa3.builtin import public
 from boa3.builtin.nativecontract.stdlib import StdLib
+from boa3.builtin.type import ByteString
 
 
 @public
-def main(mem: Union[bytes, str], value: Union[bytes, str]) -> int:
+def main(mem: ByteString, value: ByteString) -> int:
     return StdLib.memory_search(mem, value)

--- a/boa3_test/test_sc/native_test/stdlib/MemorySearchStart.py
+++ b/boa3_test/test_sc/native_test/stdlib/MemorySearchStart.py
@@ -1,9 +1,8 @@
-from typing import Union
-
 from boa3.builtin import public
 from boa3.builtin.nativecontract.stdlib import StdLib
+from boa3.builtin.type import ByteString
 
 
 @public
-def main(mem: Union[bytes, str], value: Union[bytes, str], start: int) -> int:
+def main(mem: ByteString, value: ByteString, start: int) -> int:
     return StdLib.memory_search(mem, value, start)

--- a/boa3_test/test_sc/native_test/stdlib/MemorySearchTooFewArguments.py
+++ b/boa3_test/test_sc/native_test/stdlib/MemorySearchTooFewArguments.py
@@ -1,7 +1,6 @@
-from typing import Union
-
 from boa3.builtin.nativecontract.stdlib import StdLib
+from boa3.builtin.type import ByteString
 
 
-def main(mem: Union[bytes, str]) -> int:
+def main(mem: ByteString) -> int:
     return StdLib.memory_search(mem)

--- a/boa3_test/test_sc/native_test/stdlib/MemorySearchTooManyArguments.py
+++ b/boa3_test/test_sc/native_test/stdlib/MemorySearchTooManyArguments.py
@@ -1,7 +1,8 @@
-from typing import Any, Union
+from typing import Any
 
 from boa3.builtin.nativecontract.stdlib import StdLib
+from boa3.builtin.type import ByteString
 
 
-def main(mem: Union[bytes, str], value: Union[bytes, str], start: int, backward: bool, arg: Any) -> int:
+def main(mem: ByteString, value: ByteString, start: int, backward: bool, arg: Any) -> int:
     return StdLib.memory_search(mem, value, start, backward, arg)

--- a/boa3_test/test_sc/neo_type_test/ByteStringToBool.py
+++ b/boa3_test/test_sc/neo_type_test/ByteStringToBool.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.type import ByteString
+
+
+@public
+def to_bool(arg: ByteString) -> bool:
+    return arg.to_bool()

--- a/boa3_test/test_sc/neo_type_test/ByteStringToBoolWithBuiltin.py
+++ b/boa3_test/test_sc/neo_type_test/ByteStringToBoolWithBuiltin.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.type import ByteString
+
+
+@public
+def to_bool(arg: ByteString) -> bool:
+    return ByteString.to_bool(arg)

--- a/boa3_test/test_sc/neo_type_test/ByteStringToBytes.py
+++ b/boa3_test/test_sc/neo_type_test/ByteStringToBytes.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.type import ByteString
+
+
+@public
+def to_bytes(arg: ByteString) -> bytes:
+    return arg.to_bytes()

--- a/boa3_test/test_sc/neo_type_test/ByteStringToBytesWithBuiltin.py
+++ b/boa3_test/test_sc/neo_type_test/ByteStringToBytesWithBuiltin.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.type import ByteString
+
+
+@public
+def to_bytes(arg: ByteString) -> bytes:
+    return ByteString.to_bytes(arg)

--- a/boa3_test/test_sc/neo_type_test/ByteStringToInt.py
+++ b/boa3_test/test_sc/neo_type_test/ByteStringToInt.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.type import ByteString
+
+
+@public
+def to_int(arg: ByteString) -> int:
+    return arg.to_int()

--- a/boa3_test/test_sc/neo_type_test/ByteStringToIntWithBuiltin.py
+++ b/boa3_test/test_sc/neo_type_test/ByteStringToIntWithBuiltin.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.type import ByteString
+
+
+@public
+def to_int(arg: ByteString) -> int:
+    return ByteString.to_int(arg)

--- a/boa3_test/test_sc/neo_type_test/ByteStringToStr.py
+++ b/boa3_test/test_sc/neo_type_test/ByteStringToStr.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.type import ByteString
+
+
+@public
+def to_str(arg: ByteString) -> str:
+    return arg.to_str()

--- a/boa3_test/test_sc/neo_type_test/ByteStringToStrWithBuiltin.py
+++ b/boa3_test/test_sc/neo_type_test/ByteStringToStrWithBuiltin.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.type import ByteString
+
+
+@public
+def to_str(arg: ByteString) -> str:
+    return ByteString.to_str(arg)

--- a/boa3_test/tests/compiler_tests/test_neo_types.py
+++ b/boa3_test/tests/compiler_tests/test_neo_types.py
@@ -264,6 +264,110 @@ class TestNeoTypes(BoaTest):
 
     # endregion
 
+    # region ByteString
+
+    def test_byte_string_to_bool(self):
+        path = self.get_contract_path('ByteStringToBool.py')
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'to_bool', b'\x00')
+        self.assertEqual(False, result)
+        result = self.run_smart_contract(engine, path, 'to_bool', '\x00')
+        self.assertEqual(False, result)
+
+        result = self.run_smart_contract(engine, path, 'to_bool', b'\x01')
+        self.assertEqual(True, result)
+        result = self.run_smart_contract(engine, path, 'to_bool', '\x01')
+        self.assertEqual(True, result)
+
+        result = self.run_smart_contract(engine, path, 'to_bool', b'\x02')
+        self.assertEqual(True, result)
+        result = self.run_smart_contract(engine, path, 'to_bool', '\x02')
+        self.assertEqual(True, result)
+
+    def test_byte_string_to_bool_with_builtin(self):
+        path = self.get_contract_path('ByteStringToBoolWithBuiltin.py')
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'to_bool', b'\x00')
+        self.assertEqual(False, result)
+        result = self.run_smart_contract(engine, path, 'to_bool', '\x00')
+        self.assertEqual(False, result)
+
+        result = self.run_smart_contract(engine, path, 'to_bool', b'\x01')
+        self.assertEqual(True, result)
+        result = self.run_smart_contract(engine, path, 'to_bool', '\x01')
+        self.assertEqual(True, result)
+
+        result = self.run_smart_contract(engine, path, 'to_bool', b'\x02')
+        self.assertEqual(True, result)
+        result = self.run_smart_contract(engine, path, 'to_bool', '\x02')
+        self.assertEqual(True, result)
+
+    def test_byte_string_to_int(self):
+        path = self.get_contract_path('ByteStringToInt.py')
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'to_int', b'\x01\x02')
+        self.assertEqual(513, result)
+        result = self.run_smart_contract(engine, path, 'to_int', '\x01\x02')
+        self.assertEqual(513, result)
+
+    def test_byte_string_to_int_with_builtin(self):
+        path = self.get_contract_path('ByteStringToIntWithBuiltin.py')
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'to_int', b'\x01\x02')
+        self.assertEqual(513, result)
+        result = self.run_smart_contract(engine, path, 'to_int', '\x01\x02')
+        self.assertEqual(513, result)
+
+    def test_byte_string_to_str(self):
+        path = self.get_contract_path('ByteStringToStr.py')
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'to_str', b'abc')
+        self.assertEqual('abc', result)
+
+        result = self.run_smart_contract(engine, path, 'to_str', b'123')
+        self.assertEqual('123', result)
+
+    def test_byte_string_to_str_with_builtin(self):
+        path = self.get_contract_path('ByteStringToStrWithBuiltin.py')
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'to_str', b'abc')
+        self.assertEqual('abc', result)
+
+        result = self.run_smart_contract(engine, path, 'to_str', b'123')
+        self.assertEqual('123', result)
+
+    def test_byte_string_to_bytes(self):
+        path = self.get_contract_path('ByteStringToBytes.py')
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'to_bytes', 'abc',
+                                         expected_result_type=bytes)
+        self.assertEqual(b'abc', result)
+
+        result = self.run_smart_contract(engine, path, 'to_bytes', '123',
+                                         expected_result_type=bytes)
+        self.assertEqual(b'123', result)
+
+    def test_byte_string_to_bytes_with_builtin(self):
+        path = self.get_contract_path('ByteStringToBytesWithBuiltin.py')
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'to_bytes', 'abc',
+                                         expected_result_type=bytes)
+        self.assertEqual(b'abc', result)
+
+        result = self.run_smart_contract(engine, path, 'to_bytes', '123',
+                                         expected_result_type=bytes)
+        self.assertEqual(b'123', result)
+
+    # endregion
+
     # region IsInstance Neo Types
 
     def test_isinstance_contract(self):


### PR DESCRIPTION
**Related issue**
#806

**Summary or solution description**
Implemented `ByteString` to interface with `str` and `bytes` values. 
Also changed the native interfaces that used `Union[str, bytes]` to `ByteString`.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/e1ebbb7091f676321635c14f8089f05482d1da5b/boa3_test/test_sc/interop_test/storage/StorageGetWithContext.py#L6-L9
https://github.com/CityOfZion/neo3-boa/blob/e1ebbb7091f676321635c14f8089f05482d1da5b/boa3_test/test_sc/neo_type_test/ByteStringToInt.py#L5-L7

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/e1ebbb7091f676321635c14f8089f05482d1da5b/boa3_test/tests/compiler_tests/test_neo_types.py#L267-L369

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7