### PR TITLE
User defined class methods error without using returned value

### DIFF
--- a/boa3/builtin/__init__.py
+++ b/boa3/builtin/__init__.py
@@ -106,7 +106,7 @@ class NeoMetadata:
         self.name: str = ''
         self.supported_standards: List[str] = []
         self._trusts: List[str] = []
-        self._: List[dict] = []
+        self._permissions: List[dict] = []
 
     @property
     def extras(self) -> Dict[str, Any]:

--- a/boa3/compiler/codegenerator/codegeneratorvisitor.py
+++ b/boa3/compiler/codegenerator/codegeneratorvisitor.py
@@ -776,7 +776,9 @@ class VisitorCodeGenerator(IAstAnalyser):
             if self.generator.stack_size > num_args:
                 value = self.generator._stack_pop(-num_args - 1)
                 self.generator._stack_append(value)
-            VMCodeMapping.instance().move_to_end(last_address, args_begin_address)
+            end_address = VMCodeMapping.instance().move_to_end(last_address, args_begin_address)
+            if not symbol.is_init:
+                args_addresses.append(end_address)
 
         if self.is_exception_name(function_id):
             self.generator.convert_new_exception(len(call.args))

--- a/boa3/compiler/codegenerator/vmcodemapping.py
+++ b/boa3/compiler/codegenerator/vmcodemapping.py
@@ -258,10 +258,12 @@ class VMCodeMapping:
                 break
 
         self._update_addresses(first_code_address)
+        index = self.bytecode_size
 
         for code in moved_codes:
             self.insert_code(code)
         self._update_targets()
+        return index
 
     def remove_opcodes(self, first_code_address: int, last_code_address: int):
         if last_code_address < first_code_address:

--- a/boa3_test/test_sc/variable_test/ListGlobalAssignment.py
+++ b/boa3_test/test_sc/variable_test/ListGlobalAssignment.py
@@ -24,3 +24,9 @@ def get_from_global() -> List[int]:
 @public
 def get_from_class() -> List[int]:
     return Test.get_global()
+
+
+@public
+def get_from_class_without_assigning() -> List[int]:
+    Test.get_global()
+    return []

--- a/boa3_test/tests/compiler_tests/test_variable.py
+++ b/boa3_test/tests/compiler_tests/test_variable.py
@@ -546,6 +546,9 @@ class TestVariable(BoaTest):
         result = self.run_smart_contract(engine, path, 'get_from_class')
         self.assertEqual(expected_value, result)
 
+        result = self.run_smart_contract(engine, path, 'get_from_class_without_assigning')
+        self.assertEqual([], result)
+
     def test_global_assignment_between_functions(self):
         expected_output = (
             Opcode.LDSFLD0


### PR DESCRIPTION
**Related issue**
#737 

**Summary or solution description**
The previous fix (#745) had tests using the value in return statement, which didn't completely fix the issue since calling class methods without using their results were still broken.
Refined the existing unit test to check if the expressions with class method calls work at runtime.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/21abe48d7683dfa4490efadcbe194c974daef708/boa3_test/test_sc/variable_test/ListGlobalAssignment.py#L29-L32

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/21abe48d7683dfa4490efadcbe194c974daef708/boa3_test/tests/compiler_tests/test_variable.py#L538-L550

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8