### PR TITLE
Generated script does not respect return type annotation

### DIFF
--- a/boa3/compiler/codegenerator/vmcodemapping.py
+++ b/boa3/compiler/codegenerator/vmcodemapping.py
@@ -116,6 +116,16 @@ class VMCodeMapping:
                 code_address = addr
             return self._codes[code_address]
 
+    def get_addresses(self, start_address: int, end_address: int) -> List[int]:
+        if start_address > end_address:
+            start_address, end_address = end_address, start_address
+
+        addresses = []
+        for address in range(start_address, end_address + 1):
+            if address in self._codes:
+                addresses.append(address)
+        return addresses
+
     def get_start_address(self, vm_code: VMCode) -> int:
         """
         Gets the vm code's first byte address

--- a/boa3/neo/vm/type/StackItem.py
+++ b/boa3/neo/vm/type/StackItem.py
@@ -49,6 +49,11 @@ def serialize(value: Any) -> bytes:
     if value is None:
         return StackItemType.Any
 
+    if isinstance(value, bool):
+        stack_type = StackItemType.Boolean
+        span = Integer(value).to_byte_array(signed=False, min_length=1)
+        return stack_type + span
+
     if isinstance(value, (int, str, bytes)):
         if isinstance(value, int):
             stack_type = StackItemType.Integer

--- a/boa3_test/test_sc/contract_interface_test/Nep17Interface.py
+++ b/boa3_test/test_sc/contract_interface_test/Nep17Interface.py
@@ -4,7 +4,7 @@ from boa3.builtin import contract, display_name, public
 from boa3.builtin.type import UInt160
 
 
-@contract('0x5695642fcf208fc8b55c6163b3518afd7d35ff02')
+@contract('0x0dbf77301317669cec3dab7ffb9c7b0989a96c42')
 class Nep17:
 
     @staticmethod

--- a/boa3_test/test_sc/contract_interface_test/Nep17InterfaceWithDisplayName.py
+++ b/boa3_test/test_sc/contract_interface_test/Nep17InterfaceWithDisplayName.py
@@ -4,7 +4,7 @@ from boa3.builtin import contract, display_name, public
 from boa3.builtin.type import UInt160
 
 
-@contract('0x5695642fcf208fc8b55c6163b3518afd7d35ff02')
+@contract('0x0dbf77301317669cec3dab7ffb9c7b0989a96c42')
 class Nep17:
 
     @staticmethod

--- a/boa3_test/tests/compiler_tests/test_any.py
+++ b/boa3_test/tests/compiler_tests/test_any.py
@@ -2,6 +2,7 @@ from boa3.boa3 import Boa3
 from boa3.exception import CompilerError, CompilerWarning
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
+from boa3.neo.vm.type.StackItem import StackItemType
 from boa3.neo.vm.type.String import String
 from boa3_test.tests.boa_test import BoaTest
 
@@ -23,6 +24,7 @@ class TestAny(BoaTest):
             + Integer(len(two)).to_byte_array() + two
             + Opcode.STLOC0
             + Opcode.PUSH1      # a = True
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.STLOC0
             + Opcode.PUSH3      # a = [1, 2, 3]
             + Opcode.PUSH2
@@ -51,6 +53,7 @@ class TestAny(BoaTest):
             + Integer(len(ok)).to_byte_array() + ok
             + Opcode.PUSH1
             + Opcode.PUSH1
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.PUSH3
             + Opcode.PACK
             + Opcode.STLOC0
@@ -71,6 +74,7 @@ class TestAny(BoaTest):
             + Integer(len(ok)).to_byte_array() + ok
             + Opcode.PUSH1
             + Opcode.PUSH1
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.PUSH3
             + Opcode.PACK
             + Opcode.STLOC0
@@ -92,30 +96,34 @@ class TestAny(BoaTest):
             + b'\x01'
             + b'\x00'
             + Opcode.PUSH0          # bool_tuple = True, False
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.PUSH1
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.PUSH2
             + Opcode.PACK
             + Opcode.STLOC0
             + Opcode.LDLOC0         # SequenceFunction(bool_tuple)
             + Opcode.CALL
-            + Integer(45).to_byte_array(min_length=1, signed=True)
+            + Integer(49).to_byte_array(min_length=1, signed=True)
             + Opcode.PUSHDATA1      # SequenceFunction([True, 1, 'ok'])
             + Integer(len(ok)).to_byte_array() + ok
             + Opcode.PUSH1
             + Opcode.PUSH1
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.PUSH3
             + Opcode.PACK
             + Opcode.CALL
-            + Integer(35).to_byte_array(min_length=1, signed=True)
+            + Integer(37).to_byte_array(min_length=1, signed=True)
             + Opcode.PUSHDATA1      # SequenceFunction('some_string')
             + Integer(len(some_string)).to_byte_array()
             + some_string
             + Opcode.CALL
-            + Integer(20).to_byte_array(min_length=1, signed=True)
+            + Integer(22).to_byte_array(min_length=1, signed=True)
             + Opcode.PUSHDATA1      # SequenceFunction((True, 1, 'ok'))
             + Integer(len(ok)).to_byte_array() + ok
             + Opcode.PUSH1
             + Opcode.PUSH1
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.PUSH3
             + Opcode.PACK
             + Opcode.CALL
@@ -152,6 +160,7 @@ class TestAny(BoaTest):
             + Integer(len(ok)).to_byte_array() + ok
             + Opcode.PUSH1
             + Opcode.PUSH1
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.PUSH3
             + Opcode.PACK
             + Opcode.STLOC0
@@ -165,11 +174,14 @@ class TestAny(BoaTest):
             + Integer(len(ok)).to_byte_array() + ok
             + Opcode.PUSH1
             + Opcode.PUSH1
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.PUSH3
             + Opcode.PACK
             + Opcode.STLOC2
             + Opcode.PUSH0      # bool_tuple = True, False
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.PUSH1
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.PUSH2
             + Opcode.PACK
             + Opcode.STLOC3
@@ -201,6 +213,7 @@ class TestAny(BoaTest):
             + Integer(len(ok)).to_byte_array() + ok
             + Opcode.PUSH1
             + Opcode.PUSH1
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.PUSH3
             + Opcode.PACK
             + Opcode.STLOC0
@@ -223,6 +236,7 @@ class TestAny(BoaTest):
             + Integer(len(ok)).to_byte_array() + ok
             + Opcode.PUSH1
             + Opcode.PUSH1
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.PUSH3
             + Opcode.PACK
             + Opcode.STLOC0
@@ -263,6 +277,7 @@ class TestAny(BoaTest):
             + Integer(len(ok)).to_byte_array() + ok
             + Opcode.PUSH1
             + Opcode.PUSH1
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.PUSH3
             + Opcode.PACK
             + Opcode.STLOC0
@@ -280,7 +295,9 @@ class TestAny(BoaTest):
             + Opcode.PACK
             + Opcode.STLOC2
             + Opcode.PUSH0      # bool_tuple = True, False
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.PUSH1
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.PUSH2
             + Opcode.PACK
             + Opcode.STLOC3
@@ -343,6 +360,7 @@ class TestAny(BoaTest):
             + Integer(len(ok)).to_byte_array() + ok
             + Opcode.PUSH1
             + Opcode.PUSH1
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.PUSH3
             + Opcode.PACK
             + Opcode.STLOC1

--- a/boa3_test/tests/compiler_tests/test_builtin_method.py
+++ b/boa3_test/tests/compiler_tests/test_builtin_method.py
@@ -720,59 +720,44 @@ class TestBuiltinMethod(BoaTest):
         path = self.get_contract_path('IsInstanceManyTypesWithClass.py')
 
         engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', 42,
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'Main', 42)
         self.assertEqual(True, result)
-        result = self.run_smart_contract(engine, path, 'Main', bytes(10),
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'Main', bytes(10))
         self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'Main', [],
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'Main', [])
         self.assertEqual(True, result)
-        result = self.run_smart_contract(engine, path, 'Main', 'some string',
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'Main', 'some string')
         self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'Main', bytes(20),
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'Main', bytes(20))
         self.assertEqual(True, result)
-        result = self.run_smart_contract(engine, path, 'Main', None,
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'Main', None)
         self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'Main', {1: 2, 2: 4},
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'Main', {1: 2, 2: 4})
         self.assertEqual(True, result)
 
     def test_isinstance_uint160(self):
         path = self.get_contract_path('IsInstanceUInt160.py')
 
         engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', bytes(10),
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'Main', bytes(10))
         self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'Main', bytes(20),
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'Main', bytes(20))
         self.assertEqual(True, result)
-        result = self.run_smart_contract(engine, path, 'Main', bytes(30),
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'Main', bytes(30))
         self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'Main', 42,
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'Main', 42)
         self.assertEqual(False, result)
 
     def test_isinstance_uint256(self):
         path = self.get_contract_path('IsInstanceUInt256.py')
         engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', bytes(10),
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'main', bytes(10))
         self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'main', bytes(20),
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'main', bytes(20))
         self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'main', bytes(30),
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'main', bytes(30))
         self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'main', bytes(32),
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'main', bytes(32))
         self.assertEqual(True, result)
 
     # endregion

--- a/boa3_test/tests/compiler_tests/test_bytes.py
+++ b/boa3_test/tests/compiler_tests/test_bytes.py
@@ -151,7 +151,7 @@ class TestBytes(BoaTest):
         path = self.get_contract_path('BytesToBoolWithBuiltinHardCodedFalse.py')
 
         engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'bytes_to_bool', expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'bytes_to_bool')
         self.assertEqual(False, result)
 
     def test_bytes_to_bool_with_builtin_hard_coded_true(self):

--- a/boa3_test/tests/compiler_tests/test_constant.py
+++ b/boa3_test/tests/compiler_tests/test_constant.py
@@ -6,6 +6,7 @@ from boa3.model.type.type import Type
 from boa3.model.variable import Variable
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
+from boa3.neo.vm.type.StackItem import StackItemType
 from boa3.neo.vm.type.String import String
 from boa3_test.tests.boa_test import BoaTest
 
@@ -209,7 +210,8 @@ class TestConstant(BoaTest):
         byte_input1 = String(input[1]).to_bytes()
 
         expected_output = (
-            Opcode.PUSH0        # True
+            Opcode.PUSH0        # False
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.PUSHDATA1  # '2'
             + Integer(len(byte_input1)).to_byte_array()
             + byte_input1
@@ -305,6 +307,7 @@ class TestConstant(BoaTest):
 
         expected_output = (
             Opcode.PUSH0        # False
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.PUSHDATA1  # '2'
             + Integer(len(byte_input1)).to_byte_array()
             + byte_input1

--- a/boa3_test/tests/compiler_tests/test_dict.py
+++ b/boa3_test/tests/compiler_tests/test_dict.py
@@ -2,6 +2,7 @@ from boa3.boa3 import Boa3
 from boa3.exception import CompilerError, CompilerWarning
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
+from boa3.neo.vm.type.StackItem import StackItemType
 from boa3.neo.vm.type.String import String
 from boa3_test.tests.boa_test import BoaTest
 from boa3_test.tests.test_classes.TestExecutionException import TestExecutionException
@@ -84,6 +85,7 @@ class TestDict(BoaTest):
             + Opcode.DUP
             + Opcode.PUSH1      # map[1] = True
             + Opcode.PUSH1
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.SETITEM
             + Opcode.DUP
             + Opcode.PUSH2      # map[2] = 4
@@ -115,14 +117,17 @@ class TestDict(BoaTest):
             + Opcode.DUP
             + Opcode.PUSH14
             + Opcode.PUSH0
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.SETITEM
             + Opcode.DUP
             + Opcode.PUSH12
             + Opcode.PUSH1
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.SETITEM
             + Opcode.DUP
             + Opcode.PUSH5
             + Opcode.PUSH1
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.SETITEM
             + Opcode.SETITEM
             + Opcode.DUP
@@ -131,10 +136,12 @@ class TestDict(BoaTest):
             + Opcode.DUP
             + Opcode.PUSH0
             + Opcode.PUSH1
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.SETITEM
             + Opcode.DUP
             + Opcode.PUSH6
             + Opcode.PUSH0
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.SETITEM
             + Opcode.SETITEM
             + Opcode.DUP
@@ -143,6 +150,7 @@ class TestDict(BoaTest):
             + Opcode.DUP
             + Opcode.PUSH11
             + Opcode.PUSH0
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.SETITEM
             + Opcode.SETITEM
             + Opcode.STLOC0

--- a/boa3_test/tests/compiler_tests/test_function.py
+++ b/boa3_test/tests/compiler_tests/test_function.py
@@ -3,6 +3,7 @@ from boa3.boa3 import Boa3
 from boa3.exception import CompilerError
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
+from boa3.neo.vm.type.StackItem import StackItemType
 from boa3_test.tests.boa_test import BoaTest
 from boa3_test.tests.test_classes.testengine import TestEngine
 
@@ -50,6 +51,7 @@ class TestFunction(BoaTest):
         expected_output = (
             # functions without arguments and local variables don't need initslot
             Opcode.PUSH1  # body
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.RET  # return
         )
 
@@ -59,7 +61,7 @@ class TestFunction(BoaTest):
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(1, result)
+        self.assertEqual(True, result)
 
     def test_none_function_pass(self):
         path = self.get_contract_path('NoneFunctionPass.py')
@@ -184,12 +186,13 @@ class TestFunction(BoaTest):
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_call_void_function_without_args(self):
-        called_function_address = Integer(4).to_byte_array(min_length=1, signed=True)
+        called_function_address = Integer(6).to_byte_array(min_length=1, signed=True)
 
         expected_output = (
             Opcode.CALL  # TestFunction()
             + called_function_address
             + Opcode.PUSH1  # return True
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.RET
             + Opcode.INITSLOT  # TestFunction
             + b'\x01'
@@ -232,7 +235,7 @@ class TestFunction(BoaTest):
         self.assertEqual(1, result)
 
     def test_call_void_function_with_literal_args(self):
-        called_function_address = Integer(4).to_byte_array(min_length=1, signed=True)
+        called_function_address = Integer(6).to_byte_array(min_length=1, signed=True)
 
         expected_output = (
             Opcode.PUSH2  # TestAdd(1, 2)
@@ -240,6 +243,7 @@ class TestFunction(BoaTest):
             + Opcode.CALL
             + called_function_address
             + Opcode.PUSH1  # return True
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.RET
             + Opcode.INITSLOT  # TestFunction
             + b'\x01'
@@ -291,7 +295,7 @@ class TestFunction(BoaTest):
         self.assertEqual(3, result)
 
     def test_call_void_function_with_variable_args(self):
-        called_function_address = Integer(4).to_byte_array(min_length=1, signed=True)
+        called_function_address = Integer(6).to_byte_array(min_length=1, signed=True)
 
         expected_output = (
             Opcode.INITSLOT  # Main
@@ -306,6 +310,7 @@ class TestFunction(BoaTest):
             + Opcode.CALL
             + called_function_address
             + Opcode.PUSH1  # return True
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.RET
             + Opcode.INITSLOT  # TestFunction
             + b'\x01'

--- a/boa3_test/tests/compiler_tests/test_if.py
+++ b/boa3_test/tests/compiler_tests/test_if.py
@@ -3,6 +3,7 @@ from boa3.exception import CompilerWarning
 from boa3.model.type.type import Type
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
+from boa3.neo.vm.type.StackItem import StackItemType
 from boa3_test.tests.boa_test import BoaTest
 from boa3_test.tests.test_classes.testengine import TestEngine
 
@@ -18,6 +19,7 @@ class TestIf(BoaTest):
             + Opcode.PUSH0      # a = 0
             + Opcode.STLOC0
             + Opcode.PUSH1
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.JMPIFNOT   # if True
             + Integer(4).to_byte_array(min_length=1, signed=True)
             + Opcode.PUSH2     # a = a + 2
@@ -449,28 +451,28 @@ class TestIf(BoaTest):
         path = self.get_contract_path('VariablesInIfScopes.py')
         engine = TestEngine()
 
-        result = self.run_smart_contract(engine, path, 'main', 1, expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'main', 1)
         self.assertEqual(False, result)
 
-        result = self.run_smart_contract(engine, path, 'main', 2, expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'main', 2)
         self.assertEqual(True, result)
 
-        result = self.run_smart_contract(engine, path, 'main', 3, expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'main', 3)
         self.assertEqual(False, result)
 
-        result = self.run_smart_contract(engine, path, 'main', 4, expected_result_type=bool)
-        self.assertEqual(True, result)
-
-        result = self.run_smart_contract(engine, path, 'main', 5, expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'main', 4)
         self.assertEqual(False, result)
 
-        result = self.run_smart_contract(engine, path, 'main', 6, expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'main', 5)
         self.assertEqual(False, result)
 
-        result = self.run_smart_contract(engine, path, 'main', 7, expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'main', 6)
         self.assertEqual(False, result)
 
-        result = self.run_smart_contract(engine, path, 'main', 8, expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'main', 7)
+        self.assertEqual(False, result)
+
+        result = self.run_smart_contract(engine, path, 'main', 8)
         self.assertEqual(False, result)
 
     def test_boa2_compare_test0int(self):

--- a/boa3_test/tests/compiler_tests/test_interop/test_crypto.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_crypto.py
@@ -7,6 +7,7 @@ from boa3.model.builtin.interop.interop import Interop
 from boa3.model.type.type import Type
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
+from boa3.neo.vm.type.StackItem import StackItemType
 from boa3.neo.vm.type.String import String
 from boa3.neo3.contracts.contracttypes import CallFlags
 from boa3.neo3.contracts.namedcurve import NamedCurve
@@ -309,6 +310,7 @@ class TestCryptoInterop(BoaTest):
             + byte_input1
             + self.ecpoint_init
             + Opcode.PUSH0
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.PUSH4
             + Opcode.PACK
             + Opcode.PUSHDATA1
@@ -474,6 +476,7 @@ class TestCryptoInterop(BoaTest):
             + byte_input1
             + self.ecpoint_init
             + Opcode.PUSH0
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.PUSH4
             + Opcode.PACK
             + Opcode.PUSHDATA1

--- a/boa3_test/tests/compiler_tests/test_interop/test_json.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_json.py
@@ -29,7 +29,7 @@ class TestJsonInterop(BoaTest):
         path = self.get_contract_path('JsonSerializeBool.py')
 
         engine = TestEngine()
-        expected_result = json.dumps(1)
+        expected_result = json.dumps(True)
         result = self.run_smart_contract(engine, path, 'main')
         self.assertEqual(expected_result, result)
 

--- a/boa3_test/tests/compiler_tests/test_interop/test_runtime.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_runtime.py
@@ -6,6 +6,7 @@ from boa3.neo import to_script_hash
 from boa3.neo.cryptography import hash160
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
+from boa3.neo.vm.type.StackItem import StackItemType
 from boa3.neo.vm.type.String import String
 from boa3.neo3.contracts import TriggerType
 from boa3_test.tests.boa_test import BoaTest
@@ -111,6 +112,7 @@ class TestRuntimeInterop(BoaTest):
             + Integer(len(event_name)).to_byte_array(min_length=1)
             + event_name
             + Opcode.PUSH1
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.PUSH1
             + Opcode.PACK
             + Opcode.SWAP
@@ -130,7 +132,7 @@ class TestRuntimeInterop(BoaTest):
 
         event_notifications = engine.get_events(event_name=Interop.Notify.name)
         self.assertEqual(1, len(event_notifications))
-        self.assertEqual((1,), event_notifications[0].arguments)
+        self.assertEqual((True,), event_notifications[0].arguments)
 
     def test_notify_none(self):
         event_name = String('notify').to_bytes()

--- a/boa3_test/tests/compiler_tests/test_interop/test_stdlib.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_stdlib.py
@@ -242,16 +242,11 @@ class TestStdlibInterop(BoaTest):
         expected_result = True
         value = serialize(expected_result)
         result = self.run_smart_contract(engine, path, 'deserialize_arg', value)
-
-        # it shouldn't be equal to the convertion, because it converts as an int instead of a boolean
         self.assertEqual(expected_result, result)
-        self.assertNotEqual(type(expected_result), type(result))
 
         value = StackItemType.Boolean + value[1:]
-        result = self.run_smart_contract(engine, path, 'deserialize_arg', value,
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'deserialize_arg', value)
         self.assertEqual(expected_result, result)
-        self.assertEqual(type(expected_result), type(result))
 
         expected_result = '42'
         value = serialize(expected_result)

--- a/boa3_test/tests/compiler_tests/test_list.py
+++ b/boa3_test/tests/compiler_tests/test_list.py
@@ -3,6 +3,7 @@ from boa3.exception import CompilerError, CompilerWarning
 from boa3.model.type.type import Type
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
+from boa3.neo.vm.type.StackItem import StackItemType
 from boa3.neo.vm.type.String import String
 from boa3_test.tests.boa_test import BoaTest
 from boa3_test.tests.test_classes.TestExecutionException import TestExecutionException
@@ -65,8 +66,11 @@ class TestList(BoaTest):
             + b'\x01'
             + b'\x00'
             + Opcode.PUSH0      # a = [True, True, False]
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.PUSH1
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.PUSH1
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.PUSH3      # array length
             + Opcode.PACK
             + Opcode.STLOC0
@@ -238,8 +242,7 @@ class TestList(BoaTest):
         Boa3.compile(path)
 
         engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main',
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(True, result)
 
     def test_boa2_array_test(self):

--- a/boa3_test/tests/compiler_tests/test_multiple_expressions.py
+++ b/boa3_test/tests/compiler_tests/test_multiple_expressions.py
@@ -1,6 +1,7 @@
 from boa3.boa3 import Boa3
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
+from boa3.neo.vm.type.StackItem import StackItemType
 from boa3.neo.vm.type.String import String
 from boa3_test.tests.boa_test import BoaTest
 from boa3_test.tests.test_classes.testengine import TestEngine
@@ -177,6 +178,7 @@ class TestMultipleExpressions(BoaTest):
             + Opcode.PUSHDATA1
             + Integer(len(one)).to_byte_array() + one
             + Opcode.PUSH0
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.PUSH5
             + Opcode.PACK
             + Opcode.STLOC0     # items2 = array

--- a/boa3_test/tests/compiler_tests/test_native/test_cryptolib.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_cryptolib.py
@@ -7,6 +7,7 @@ from boa3.model.builtin.interop.interop import Interop
 from boa3.model.type.type import Type
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
+from boa3.neo.vm.type.StackItem import StackItemType
 from boa3.neo.vm.type.String import String
 from boa3.neo3.contracts.contracttypes import CallFlags
 from boa3.neo3.contracts.namedcurve import NamedCurve
@@ -174,6 +175,7 @@ class TestCryptoLibClass(BoaTest):
             + byte_input1
             + self.ecpoint_init
             + Opcode.PUSH0
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.PUSH4
             + Opcode.PACK
             + Opcode.PUSHDATA1
@@ -339,6 +341,7 @@ class TestCryptoLibClass(BoaTest):
             + byte_input1
             + self.ecpoint_init
             + Opcode.PUSH0
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.PUSH4
             + Opcode.PACK
             + Opcode.PUSHDATA1

--- a/boa3_test/tests/compiler_tests/test_native/test_stdlib.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_stdlib.py
@@ -244,16 +244,11 @@ class TestStdlibClass(BoaTest):
         expected_result = True
         value = serialize(expected_result)
         result = self.run_smart_contract(engine, path, 'deserialize_arg', value)
-
-        # it shouldn't be equal to the convertion, because it converts as an int instead of a boolean
         self.assertEqual(expected_result, result)
-        self.assertNotEqual(type(expected_result), type(result))
 
         value = StackItemType.Boolean + value[1:]
-        result = self.run_smart_contract(engine, path, 'deserialize_arg', value,
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'deserialize_arg', value)
         self.assertEqual(expected_result, result)
-        self.assertEqual(type(expected_result), type(result))
 
         expected_result = '42'
         value = serialize(expected_result)
@@ -303,7 +298,7 @@ class TestStdlibClass(BoaTest):
         path = self.get_contract_path('JsonSerializeBool.py')
 
         engine = TestEngine()
-        expected_result = json.dumps(1)
+        expected_result = json.dumps(True)
         result = self.run_smart_contract(engine, path, 'main')
         self.assertEqual(expected_result, result)
 

--- a/boa3_test/tests/compiler_tests/test_neo_types.py
+++ b/boa3_test/tests/compiler_tests/test_neo_types.py
@@ -373,42 +373,32 @@ class TestNeoTypes(BoaTest):
     def test_isinstance_contract(self):
         path = self.get_contract_path('IsInstanceContract.py')
         engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'is_contract', bytes(10),
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'is_contract', bytes(10))
         self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_contract', [1, 2, 3],
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'is_contract', [1, 2, 3])
         self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_contract', "test_with_string",
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'is_contract', "test_with_string")
         self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_contract', 42,
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'is_contract', 42)
         self.assertEqual(False, result)
 
-        result = self.run_smart_contract(engine, path, 'is_get_contract_a_contract',
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'is_get_contract_a_contract')
         self.assertEqual(True, result)
 
     def test_isinstance_block(self):
         path = self.get_contract_path('IsInstanceBlock.py')
         engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'is_block', bytes(10),
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'is_block', bytes(10))
         self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_block', [1, 2, 3],
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'is_block', [1, 2, 3])
         self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_block', "test_with_string",
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'is_block', "test_with_string")
         self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_block', 42,
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'is_block', 42)
         self.assertEqual(False, result)
 
         engine.increase_block(10)
-        result = self.run_smart_contract(engine, path, 'get_block_is_block', 5,
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'get_block_is_block', 5)
         self.assertEqual(True, result)
 
     def test_transaction_cast_and_get_hash(self):
@@ -426,122 +416,93 @@ class TestNeoTypes(BoaTest):
     def test_isinstance_transaction(self):
         path = self.get_contract_path('IsInstanceTransaction.py')
         engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'is_tx', bytes(10),
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'is_tx', bytes(10))
         self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_tx', [1, 2, 3],
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'is_tx', [1, 2, 3])
         self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_tx', "test_with_string",
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'is_tx', "test_with_string")
         self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_tx', 42,
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'is_tx', 42)
         self.assertEqual(False, result)
 
         txs = engine.current_block.get_transactions()
         self.assertGreater(len(txs), 0)
         tx_hash = txs[-1].hash
 
-        result = self.run_smart_contract(engine, path, 'get_transaction_is_tx', tx_hash,
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'get_transaction_is_tx', tx_hash)
         self.assertEqual(True, result)
 
     def test_isinstance_notification(self):
         path = self.get_contract_path('IsInstanceNotification.py')
         engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'is_notification', bytes(10),
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'is_notification', bytes(10))
         self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_notification', [1, 2, 3],
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'is_notification', [1, 2, 3])
         self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_notification', "test_with_string",
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'is_notification', "test_with_string")
         self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_notification', 42,
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'is_notification', 42)
         self.assertEqual(False, result)
 
-        result = self.run_smart_contract(engine, path, 'get_notifications_is_notification',
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'get_notifications_is_notification')
         self.assertEqual(True, result)
 
     def test_isinstance_storage_context(self):
         path = self.get_contract_path('IsInstanceStorageContext.py')
         engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'is_context', bytes(10),
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'is_context', bytes(10))
         self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_context', [1, 2, 3],
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'is_context', [1, 2, 3])
         self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_context', "test_with_string",
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'is_context', "test_with_string")
         self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_context', 42,
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'is_context', 42)
         self.assertEqual(False, result)
 
-        result = self.run_smart_contract(engine, path, 'get_context_is_context',
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'get_context_is_context')
         self.assertEqual(True, result)
 
     def test_isinstance_storage_map(self):
         path = self.get_contract_path('IsInstanceStorageMap.py')
         engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'is_storage_map', bytes(10),
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'is_storage_map', bytes(10))
         self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_storage_map', [1, 2, 3],
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'is_storage_map', [1, 2, 3])
         self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_storage_map', "test_with_string",
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'is_storage_map', "test_with_string")
         self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_storage_map', 42,
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'is_storage_map', 42)
         self.assertEqual(False, result)
 
-        result = self.run_smart_contract(engine, path, 'create_map_is_storage_map',
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'create_map_is_storage_map')
         self.assertEqual(True, result)
 
     def test_isinstance_iterator(self):
         path = self.get_contract_path('IsInstanceIterator.py')
         engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'is_iterator', bytes(10),
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'is_iterator', bytes(10))
         self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_iterator', [1, 2, 3],
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'is_iterator', [1, 2, 3])
         self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_iterator', "test_with_string",
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'is_iterator', "test_with_string")
         self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_iterator', 42,
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'is_iterator', 42)
         self.assertEqual(False, result)
 
-        result = self.run_smart_contract(engine, path, 'storage_find_is_context',
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'storage_find_is_context')
         self.assertEqual(True, result)
 
     def test_isinstance_ecpoint(self):
         path = self.get_contract_path('IsInstanceECPoint.py')
         engine = TestEngine()
 
-        result = self.run_smart_contract(engine, path, 'is_ecpoint', bytes(10),
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'is_ecpoint', bytes(10))
         self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_ecpoint', bytes(33),
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'is_ecpoint', bytes(33))
         self.assertEqual(True, result)
-        result = self.run_smart_contract(engine, path, 'is_ecpoint', bytes(30),
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'is_ecpoint', bytes(30))
         self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_ecpoint', 42,
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'is_ecpoint', 42)
         self.assertEqual(False, result)
 
     # endregion

--- a/boa3_test/tests/compiler_tests/test_relational.py
+++ b/boa3_test/tests/compiler_tests/test_relational.py
@@ -164,13 +164,13 @@ class TestRelational(BoaTest):
         a = [1, 2, 3]
         b = a
         expected_result = a is b
-        result = self.run_smart_contract(engine, path, 'with_attribution', expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'with_attribution')
         self.assertEqual(expected_result, result)
 
         a = [1, 2, 3]
         b = [1, 2, 3]
         expected_result = a is b
-        result = self.run_smart_contract(engine, path, 'without_attribution', expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'without_attribution')
         self.assertEqual(expected_result, result)
 
     def test_mixed_identity(self):
@@ -178,7 +178,7 @@ class TestRelational(BoaTest):
         engine = TestEngine()
 
         # a mixed identity should always result in False, but will compile
-        result = self.run_smart_contract(engine, path, 'mixed', expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'mixed')
         self.assertEqual(False, result)
 
     def test_none_identity_operation(self):
@@ -251,12 +251,12 @@ class TestRelational(BoaTest):
         a = (1, 2, 3)
         b = a
         expected_result = a is b
-        result = self.run_smart_contract(engine, path, 'with_attribution', expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'with_attribution')
         self.assertEqual(expected_result, result)
 
         # Python will try conserve memory and will make a and b reference the same position, since Tuples are immutable
         # this will deviate from Neo's expected behavior
-        result = self.run_smart_contract(engine, path, 'without_attribution', expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'without_attribution')
         self.assertEqual(False, result)
 
     # endregion
@@ -422,7 +422,7 @@ class TestRelational(BoaTest):
         self.assertEqual(True, result)
 
         result = self.run_smart_contract(engine, path, 'main', 4)
-        self.assertEqual(True, result)
+        self.assertEqual(False, result)
 
         result = self.run_smart_contract(engine, path, 'main', 5)
         self.assertEqual(False, result)
@@ -493,13 +493,13 @@ class TestRelational(BoaTest):
         a = [1, 2, 3]
         b = a
         expected_result = a is not b
-        result = self.run_smart_contract(engine, path, 'with_attribution', expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'with_attribution')
         self.assertEqual(expected_result, result)
 
         a = [1, 2, 3]
         b = [1, 2, 3]
         expected_result = a is not b
-        result = self.run_smart_contract(engine, path, 'without_attribution', expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'without_attribution')
         self.assertEqual(expected_result, result)
 
     def test_none_not_identity_operation(self):
@@ -572,12 +572,12 @@ class TestRelational(BoaTest):
         a = (1, 2, 3)
         b = a
         expected_result = a is not b
-        result = self.run_smart_contract(engine, path, 'with_attribution', expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'with_attribution')
         self.assertEqual(expected_result, result)
 
         # Python will try conserve memory and will make a and b reference the same position, since Tuples are immutable
         # this will deviate from Neo's expected behavior
-        result = self.run_smart_contract(engine, path, 'without_attribution', expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'without_attribution')
         self.assertEqual(True, result)
 
     # endregion
@@ -728,46 +728,38 @@ class TestRelational(BoaTest):
     def test_compare_same_value_argument(self):
         path = self.get_contract_path('CompareSameValueArgument.py')
         engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'testing_something', bytes(20),
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'testing_something', bytes(20))
         self.assertEqual(True, result)
 
     def test_compare_same_value_hard_coded(self):
         path = self.get_contract_path('CompareSameValueHardCoded.py')
         engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'testing_something',
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'testing_something')
         self.assertEqual(True, result)
 
     def test_compare_string(self):
         path = self.get_contract_path('CompareString.py')
         engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'test1', '|',
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'test1', '|')
         self.assertEqual(True, result)
 
-        result = self.run_smart_contract(engine, path, 'test2', '|',
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'test2', '|')
         self.assertEqual(True, result)
 
-        result = self.run_smart_contract(engine, path, 'test3', '|',
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'test3', '|')
         self.assertEqual(True, result)
 
-        result = self.run_smart_contract(engine, path, 'test4', '|',
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'test4', '|')
         self.assertEqual(True, result)
 
     def test_list_equality_with_slice(self):
         path = self.get_contract_path('ListEqualityWithSlice.py')
 
         engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', ['unittest', '123'], 'unittest',
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'main', ['unittest', '123'], 'unittest')
         self.assertEqual(True, result)
 
-        result = self.run_smart_contract(engine, path, 'main', ['unittest', '123'], '123',
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'main', ['unittest', '123'], '123')
         self.assertEqual(False, result)
 
         with self.assertRaises(TestExecutionException):

--- a/boa3_test/tests/compiler_tests/test_tuple.py
+++ b/boa3_test/tests/compiler_tests/test_tuple.py
@@ -2,6 +2,7 @@ from boa3.boa3 import Boa3
 from boa3.exception import CompilerError
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
+from boa3.neo.vm.type.StackItem import StackItemType
 from boa3.neo.vm.type.String import String
 from boa3_test.tests.boa_test import BoaTest
 from boa3_test.tests.test_classes.TestExecutionException import TestExecutionException
@@ -63,8 +64,11 @@ class TestTuple(BoaTest):
             + b'\x01'
             + b'\x00'
             + Opcode.PUSH0      # a = (True, True, False)
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.PUSH1
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.PUSH1
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.PUSH3      # tuple length
             + Opcode.PACK
             + Opcode.STLOC0

--- a/boa3_test/tests/compiler_tests/test_variable.py
+++ b/boa3_test/tests/compiler_tests/test_variable.py
@@ -8,6 +8,7 @@ from boa3.model.symbol import ISymbol
 from boa3.model.variable import Variable
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
+from boa3.neo.vm.type.StackItem import StackItemType
 from boa3.neo.vm.type.String import String
 from boa3_test.tests.boa_test import BoaTest
 from boa3_test.tests.test_classes.testengine import TestEngine
@@ -104,6 +105,7 @@ class TestVariable(BoaTest):
             + b'\x03'
             + b'\x00'
             + Opcode.PUSH1      # a = b = c = True
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.DUP            # c = True
             + Opcode.STLOC2
             + Opcode.DUP            # b = True
@@ -197,6 +199,7 @@ class TestVariable(BoaTest):
             + string
             + Opcode.STLOC0
             + Opcode.PUSH1      # a = b = c = True
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.DUP            # c = True
             + Opcode.STLOC0
             + Opcode.DUP            # b = True

--- a/boa3_test/tests/compiler_tests/test_while.py
+++ b/boa3_test/tests/compiler_tests/test_while.py
@@ -4,6 +4,7 @@ from boa3.exception import CompilerError
 from boa3.neo.cryptography import hash160
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
+from boa3.neo.vm.type.StackItem import StackItemType
 from boa3.neo.vm.type.String import String
 from boa3_test.tests.boa_test import BoaTest
 from boa3_test.tests.test_classes.testengine import TestEngine
@@ -14,7 +15,7 @@ class TestWhile(BoaTest):
 
     def test_while_constant_condition(self):
         jmpif_address = Integer(6).to_byte_array(min_length=1, signed=True)
-        jmp_address = Integer(-5).to_byte_array(min_length=1, signed=True)
+        jmp_address = Integer(-7).to_byte_array(min_length=1, signed=True)
 
         expected_output = (
             Opcode.INITSLOT
@@ -29,6 +30,7 @@ class TestWhile(BoaTest):
             + Opcode.ADD
             + Opcode.STLOC0
             + Opcode.PUSH0
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.JMPIF      # end while False
             + jmp_address
             + Opcode.LDLOC0     # return a
@@ -107,7 +109,7 @@ class TestWhile(BoaTest):
 
     def test_while_else(self):
         jmpif_address = Integer(6).to_byte_array(min_length=1, signed=True)
-        jmp_address = Integer(-5).to_byte_array(min_length=1, signed=True)
+        jmp_address = Integer(-7).to_byte_array(min_length=1, signed=True)
 
         expected_output = (
             Opcode.INITSLOT
@@ -122,6 +124,7 @@ class TestWhile(BoaTest):
             + Opcode.ADD
             + Opcode.STLOC0
             + Opcode.PUSH0
+            + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.JMPIF      # end while False
             + jmp_address
             + Opcode.LDLOC0     # else

--- a/boa3_test/tests/examples_tests/test_amm.py
+++ b/boa3_test/tests/examples_tests/test_amm.py
@@ -36,20 +36,17 @@ class TestTemplate(BoaTest):
 
         # won't work because it needs the owner signature
         result = self.run_smart_contract(engine, path, 'set_address', zneo_address, zgas_address,
-                                         signer_accounts=[self.OTHER_ACCOUNT_1],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OTHER_ACCOUNT_1])
         self.assertEqual(False, result)
 
         # it will work now
         result = self.run_smart_contract(engine, path, 'set_address', zneo_address, zgas_address,
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(True, result)
 
         # initialize will work once
         result = self.run_smart_contract(engine, path, 'set_address', zneo_address, zgas_address,
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(False, result)
 
     def test_amm_symbol(self):
@@ -118,8 +115,7 @@ class TestTemplate(BoaTest):
         zgas_address = hash160(output)
 
         result = self.run_smart_contract(engine, path, 'set_address', zneo_address, zgas_address,
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(True, result)
 
         # the smart contract will abort if some address other than zNEO or zGAS calls the onPayment method
@@ -132,16 +128,14 @@ class TestTemplate(BoaTest):
         # adding the transferred_amount into the aux_address
         result = self.run_smart_contract(engine, path_aux, 'calling_transfer',
                                          constants.NEO_SCRIPT, aux_address, zneo_address, transferred_amount, None,
-                                         signer_accounts=[aux_address],
-                                         expected_result_type=bool)
+                                         signer_accounts=[aux_address])
         self.assertEqual(True, result)
 
         # the AMM will accept this transaction, but there is no reason to send tokens directly to the smart contract.
         # to send tokens to the AMM you should use the add_liquidity function
         result = self.run_smart_contract(engine, path_aux, 'calling_transfer',
                                          zneo_address, aux_address, amm_address, transferred_amount, None,
-                                         signer_accounts=[aux_address],
-                                         expected_result_type=bool)
+                                         signer_accounts=[aux_address])
         self.assertEqual(True, result)
 
     def test_amm_add_liquidity(self):
@@ -171,24 +165,21 @@ class TestTemplate(BoaTest):
         aux_address = hash160(output)
 
         result = self.run_smart_contract(engine, path, 'set_address', zneo_address, zgas_address,
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(True, result)
 
         engine.add_neo(aux_address, 10_000_000 * 10 ** 8)
         # minting zNEO to this auxiliary smart contract is needed, because the test engine has some limitations
         result = self.run_smart_contract(engine, path_aux, 'calling_transfer',
                                          constants.NEO_SCRIPT, aux_address, zneo_address, 10_000_000 * 10 ** 8, None,
-                                         signer_accounts=[aux_address],
-                                         expected_result_type=bool)
+                                         signer_accounts=[aux_address])
         self.assertEqual(True, result)
 
         engine.add_gas(aux_address, 10_000_000 * 10 ** 8)
         # minting zGAS to this auxiliary smart contract is needed, because the test engine has some limitations
         result = self.run_smart_contract(engine, path_aux, 'calling_transfer',
                                          constants.GAS_SCRIPT, aux_address, zgas_address, 10_000_000 * 10 ** 8, None,
-                                         signer_accounts=[aux_address],
-                                         expected_result_type=bool)
+                                         signer_accounts=[aux_address])
         self.assertEqual(True, result)
 
         # won't work, because the user did not allow the amm to transfer zNEO and zGAS
@@ -200,15 +191,13 @@ class TestTemplate(BoaTest):
         # approving the AMM contract, so that it will be able to transfer zNEO from test_address
         result = self.run_smart_contract(engine, path_aux, 'calling_approve',
                                          zneo_address, amm_address, transferred_amount_zneo,
-                                         signer_accounts=[aux_address],
-                                         expected_result_type=bool)
+                                         signer_accounts=[aux_address])
         self.assertEqual(True, result)
 
         # approving the AMM contract, so that it will be able to transfer zGAS from test_address
         result = self.run_smart_contract(engine, path_aux, 'calling_approve',
                                          zgas_address, amm_address, transferred_amount_zgas,
-                                         signer_accounts=[aux_address],
-                                         expected_result_type=bool)
+                                         signer_accounts=[aux_address])
         self.assertEqual(True, result)
 
         # saving data to demonstrate that the value will change later
@@ -288,15 +277,13 @@ class TestTemplate(BoaTest):
         # approving the AMM contract, so that it will be able to transfer zNEO from test_address
         result = self.run_smart_contract(engine, path_aux, 'calling_approve',
                                          zneo_address, amm_address, transferred_amount_zneo,
-                                         signer_accounts=[aux_address],
-                                         expected_result_type=bool)
+                                         signer_accounts=[aux_address])
         self.assertEqual(True, result)
 
         # approving the AMM contract, so that it will be able to transfer zGAS from test_address
         result = self.run_smart_contract(engine, path_aux, 'calling_approve',
                                          zgas_address, amm_address, transferred_amount_zgas,
-                                         signer_accounts=[aux_address],
-                                         expected_result_type=bool)
+                                         signer_accounts=[aux_address])
         self.assertEqual(True, result)
 
         # saving data to demonstrate that the value will change later
@@ -401,8 +388,7 @@ class TestTemplate(BoaTest):
         aux_address = hash160(output)
 
         result = self.run_smart_contract(engine, path, 'set_address', zneo_address, zgas_address,
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(True, result)
 
         # can't remove liquidity, because the user doesn't have any
@@ -413,29 +399,25 @@ class TestTemplate(BoaTest):
         # transferring zNEO to this auxiliary smart contract is needed, because the test engine has some limitations
         result = self.run_smart_contract(engine, path_zneo, 'transfer', self.OWNER_SCRIPT_HASH, aux_address,
                                          10_000_000 * 10 ** 8, None,
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(True, result)
 
         # transferring zGAS to this auxiliary smart contract is needed, because the test engine has some limitations
         result = self.run_smart_contract(engine, path_zgas, 'transfer', self.OWNER_SCRIPT_HASH, aux_address,
                                          10_000_000 * 10 ** 8, None,
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(True, result)
 
         # approving the AMM contract, so that it will be able to transfer zNEO from test_address
         result = self.run_smart_contract(engine, path_aux, 'calling_approve',
                                          zneo_address, amm_address, transferred_amount_zneo,
-                                         signer_accounts=[aux_address],
-                                         expected_result_type=bool)
+                                         signer_accounts=[aux_address])
         self.assertEqual(True, result)
 
         # approving the AMM contract, so that it will be able to transfer zGAS from test_address
         result = self.run_smart_contract(engine, path_aux, 'calling_approve',
                                          zgas_address, amm_address, transferred_amount_zgas,
-                                         signer_accounts=[aux_address],
-                                         expected_result_type=bool)
+                                         signer_accounts=[aux_address])
         self.assertEqual(True, result)
 
         # adding liquidity to the pool will give you AMM tokens in return
@@ -544,36 +526,31 @@ class TestTemplate(BoaTest):
         aux_address = hash160(output)
 
         result = self.run_smart_contract(engine, path, 'set_address', zneo_address, zgas_address,
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(True, result)
 
         # transferring zNEO to this auxiliary smart contract is needed, because the test engine has some limitations
         result = self.run_smart_contract(engine, path_zneo, 'transfer', self.OWNER_SCRIPT_HASH, aux_address,
                                          10_000_000 * 10 ** 8, None,
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(True, result)
 
         # transferring zGAS to this auxiliary smart contract is needed, because the test engine has some limitations
         result = self.run_smart_contract(engine, path_zgas, 'transfer', self.OWNER_SCRIPT_HASH, aux_address,
                                          10_000_000 * 10 ** 8, None,
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(True, result)
 
         # approving the AMM contract, so that it will be able to transfer zNEO from test_address
         result = self.run_smart_contract(engine, path_aux, 'calling_approve',
                                          zneo_address, amm_address, transferred_amount_zneo,
-                                         signer_accounts=[aux_address],
-                                         expected_result_type=bool)
+                                         signer_accounts=[aux_address])
         self.assertEqual(True, result)
 
         # approving the AMM contract, so that it will be able to transfer zGAS from test_address
         result = self.run_smart_contract(engine, path_aux, 'calling_approve',
                                          zgas_address, amm_address, transferred_amount_zgas,
-                                         signer_accounts=[aux_address],
-                                         expected_result_type=bool)
+                                         signer_accounts=[aux_address])
         self.assertEqual(True, result)
 
         # adding liquidity to the pool will give you AMM tokens in return
@@ -597,8 +574,7 @@ class TestTemplate(BoaTest):
         # approving the AMM contract, so that it will be able to transfer zNEO from test_address
         result = self.run_smart_contract(engine, path_aux, 'calling_approve',
                                          zneo_address, amm_address, swapped_zneo,
-                                         signer_accounts=[aux_address],
-                                         expected_result_type=bool)
+                                         signer_accounts=[aux_address])
         self.assertEqual(True, result)
 
         # saving data to demonstrate that the value will change later
@@ -686,36 +662,31 @@ class TestTemplate(BoaTest):
         aux_address = hash160(output)
 
         result = self.run_smart_contract(engine, path, 'set_address', zneo_address, zgas_address,
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(True, result)
 
         # transferring zNEO to this auxiliary smart contract is needed, because the test engine has some limitations
         result = self.run_smart_contract(engine, path_zneo, 'transfer', self.OWNER_SCRIPT_HASH, aux_address,
                                          10_000_000 * 10 ** 8, None,
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(True, result)
 
         # transferring zGAS to this auxiliary smart contract is needed, because the test engine has some limitations
         result = self.run_smart_contract(engine, path_zgas, 'transfer', self.OWNER_SCRIPT_HASH, aux_address,
                                          10_000_000 * 10 ** 8, None,
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(True, result)
 
         # approving the AMM contract, so that it will be able to transfer zNEO from test_address
         result = self.run_smart_contract(engine, path_aux, 'calling_approve',
                                          zneo_address, amm_address, transferred_amount_zneo,
-                                         signer_accounts=[aux_address],
-                                         expected_result_type=bool)
+                                         signer_accounts=[aux_address])
         self.assertEqual(True, result)
 
         # approving the AMM contract, so that it will be able to transfer zGAS from test_address
         result = self.run_smart_contract(engine, path_aux, 'calling_approve',
                                          zgas_address, amm_address, transferred_amount_zgas,
-                                         signer_accounts=[aux_address],
-                                         expected_result_type=bool)
+                                         signer_accounts=[aux_address])
         self.assertEqual(True, result)
 
         # adding liquidity to the pool will give you AMM tokens in return
@@ -739,8 +710,7 @@ class TestTemplate(BoaTest):
         # approving the AMM contract, so that it will be able to transfer zNEO from test_address
         result = self.run_smart_contract(engine, path_aux, 'calling_approve',
                                          zgas_address, amm_address, swapped_zgas,
-                                         signer_accounts=[aux_address],
-                                         expected_result_type=bool)
+                                         signer_accounts=[aux_address])
         self.assertEqual(True, result)
 
         # saving data to demonstrate that the value will change later

--- a/boa3_test/tests/examples_tests/test_htlc.py
+++ b/boa3_test/tests/examples_tests/test_htlc.py
@@ -31,8 +31,7 @@ class TestHTLCTemplate(BoaTest):
                                          self.OWNER_SCRIPT_HASH, constants.NEO_SCRIPT, 10 * 10 ** 8,
                                          self.OTHER_ACCOUNT_1, constants.GAS_SCRIPT, 10000 * 10 ** 8,
                                          hash160(String('unit test').to_bytes()),
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(True, result)
 
     def test_htlc_on_nep17_payment(self):
@@ -60,8 +59,7 @@ class TestHTLCTemplate(BoaTest):
                                          aux_address, constants.NEO_SCRIPT, transferred_amount_neo,
                                          aux_address2, constants.GAS_SCRIPT, transferred_amount_gas,
                                          hash160(String('unit test').to_bytes()),
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(True, result)
 
         # transfer wil be aborted at onPayment if the transfer is not valid
@@ -69,8 +67,7 @@ class TestHTLCTemplate(BoaTest):
             self.run_smart_contract(engine, aux_path, 'calling_transfer',
                                     constants.NEO_SCRIPT, aux_address, htlc_address,
                                     transferred_amount_neo - 100, None,
-                                    signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                    expected_result_type=bool)
+                                    signer_accounts=[self.OWNER_SCRIPT_HASH])
 
         # since the transfer was aborted, it was not registered in the events
         transfer_events = engine.get_events('Transfer')
@@ -83,8 +80,7 @@ class TestHTLCTemplate(BoaTest):
         # this transfer will be accepted
         result = self.run_smart_contract(engine, aux_path, 'calling_transfer',
                                          constants.NEO_SCRIPT, aux_address, htlc_address, transferred_amount_neo, None,
-                                         signer_accounts=[aux_address],
-                                         expected_result_type=bool)
+                                         signer_accounts=[aux_address])
         self.assertEqual(True, result)
 
         # transfer was accepted so it was registered
@@ -114,8 +110,7 @@ class TestHTLCTemplate(BoaTest):
             self.run_smart_contract(engine, aux_path2, 'calling_transfer',
                                     constants.GAS_SCRIPT, aux_address2, htlc_address,
                                     transferred_amount_gas - 100, None,
-                                    signer_accounts=[aux_address2],
-                                    expected_result_type=bool)
+                                    signer_accounts=[aux_address2])
 
         transfer_events = engine.get_events('Transfer', origin=constants.NEO_SCRIPT)
         # the NEO transfer
@@ -128,8 +123,7 @@ class TestHTLCTemplate(BoaTest):
         # this transfer will be accepted
         result = self.run_smart_contract(engine, aux_path2, 'calling_transfer',
                                          constants.GAS_SCRIPT, aux_address2, htlc_address, transferred_amount_gas, None,
-                                         signer_accounts=[aux_address2],
-                                         expected_result_type=bool)
+                                         signer_accounts=[aux_address2])
         self.assertEqual(True, result)
 
         # the transfer was accepted so it was registered
@@ -187,42 +181,36 @@ class TestHTLCTemplate(BoaTest):
                                          aux_address, constants.NEO_SCRIPT, transferred_amount_neo,
                                          aux_address2, constants.GAS_SCRIPT, transferred_amount_gas,
                                          hash160(String('unit test').to_bytes()),
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(True, result)
 
         # won't be able to withdraw, because no one transferred cryptocurrency to the smart contract
         result = self.run_smart_contract(engine, path, 'withdraw', 'unit test',
-                                         signer_accounts=[aux_address],
-                                         expected_result_type=bool)
+                                         signer_accounts=[aux_address])
         self.assertEqual(False, result)
 
         result = self.run_smart_contract(engine, aux_path, 'calling_transfer',
                                          constants.NEO_SCRIPT, aux_address, htlc_address, transferred_amount_neo, None,
-                                         signer_accounts=[aux_address],
-                                         expected_result_type=bool)
+                                         signer_accounts=[aux_address])
         self.assertEqual(True, result)
         transfer_events = engine.get_events('Transfer', origin=constants.NEO_SCRIPT)
         self.assertEqual(1, len(transfer_events))
 
         result = self.run_smart_contract(engine, aux_path2, 'calling_transfer',
                                          constants.GAS_SCRIPT, aux_address2, htlc_address, transferred_amount_gas, None,
-                                         signer_accounts=[aux_address2],
-                                         expected_result_type=bool)
+                                         signer_accounts=[aux_address2])
         self.assertEqual(True, result)
         transfer_events = engine.get_events('Transfer', constants.GAS_SCRIPT)
         self.assertEqual(2, len(transfer_events))
 
         # the withdraw will fail, because the secret is wrong
         result = self.run_smart_contract(engine, path, 'withdraw', 'wrong one',
-                                         signer_accounts=[aux_address],
-                                         expected_result_type=bool)
+                                         signer_accounts=[aux_address])
         self.assertEqual(False, result)
 
         # the withdraw will occur
         result = self.run_smart_contract(engine, path, 'withdraw', 'unit test',
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(True, result)
 
         # the transfer were accepted so they were registered
@@ -295,14 +283,12 @@ class TestHTLCTemplate(BoaTest):
                                          aux_address, constants.NEO_SCRIPT, transferred_amount_neo,
                                          aux_address2, constants.GAS_SCRIPT, transferred_amount_gas,
                                          hash160(String('unit test').to_bytes()),
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(True, result)
 
         # won't be able to refund, because not enough time has passed
         result = self.run_smart_contract(engine, path, 'refund',
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(False, result)
 
         # this simulates a new block in the blockchain
@@ -310,8 +296,7 @@ class TestHTLCTemplate(BoaTest):
         engine.increase_block()
         # will be able to refund, because enough time has passed
         result = self.run_smart_contract(engine, path, 'refund',
-                                         signer_accounts=[aux_address],
-                                         expected_result_type=bool)
+                                         signer_accounts=[aux_address])
         self.assertEqual(True, result)
 
         transfer_events: List[Notification] = []
@@ -327,14 +312,12 @@ class TestHTLCTemplate(BoaTest):
                                          aux_address, constants.NEO_SCRIPT, transferred_amount_neo,
                                          aux_address2, constants.GAS_SCRIPT, transferred_amount_gas,
                                          hash160(String('unit test').to_bytes()),
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(True, result)
 
         result = self.run_smart_contract(engine, aux_path, 'calling_transfer',
                                          constants.NEO_SCRIPT, aux_address, htlc_address, transferred_amount_neo, None,
-                                         signer_accounts=[aux_address],
-                                         expected_result_type=bool)
+                                         signer_accounts=[aux_address])
         self.assertEqual(True, result)
         for k in engine.get_events('Transfer'):
             if k.arguments[0] is not None:
@@ -345,8 +328,7 @@ class TestHTLCTemplate(BoaTest):
         engine.increase_block()
         # will be able to refund, because enough time has passed
         result = self.run_smart_contract(engine, path, 'refund',
-                                         signer_accounts=[aux_address],
-                                         expected_result_type=bool)
+                                         signer_accounts=[aux_address])
         self.assertEqual(True, result)
 
         # OWNER transferred cryptocurrency to the contract, so only he will be refunded
@@ -372,14 +354,12 @@ class TestHTLCTemplate(BoaTest):
                                          aux_address, constants.NEO_SCRIPT, transferred_amount_neo,
                                          aux_address2, constants.GAS_SCRIPT, transferred_amount_gas,
                                          hash160(String('unit test').to_bytes()),
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(True, result)
 
         result = self.run_smart_contract(engine, aux_path, 'calling_transfer',
                                          constants.NEO_SCRIPT, aux_address, htlc_address, transferred_amount_neo, None,
-                                         signer_accounts=[aux_address],
-                                         expected_result_type=bool)
+                                         signer_accounts=[aux_address])
         self.assertEqual(True, result)
         transfer_events = []
         for k in engine.get_events('Transfer'):
@@ -390,8 +370,7 @@ class TestHTLCTemplate(BoaTest):
 
         result = self.run_smart_contract(engine, aux_path2, 'calling_transfer',
                                          constants.GAS_SCRIPT, aux_address2, htlc_address, transferred_amount_gas, None,
-                                         signer_accounts=[aux_address2],
-                                         expected_result_type=bool)
+                                         signer_accounts=[aux_address2])
         self.assertEqual(True, result)
         transfer_events = []
         for k in engine.get_events('Transfer'):
@@ -403,8 +382,7 @@ class TestHTLCTemplate(BoaTest):
         engine.increase_block()
         # will be able to refund, because enough time has passed
         result = self.run_smart_contract(engine, path, 'refund',
-                                         signer_accounts=[aux_address],
-                                         expected_result_type=bool)
+                                         signer_accounts=[aux_address])
         self.assertEqual(True, result)
 
         # OWNER and OTHER_ACCOUNT transferred cryptocurrency to the contract, so they both will be refunded

--- a/boa3_test/tests/examples_tests/test_ico.py
+++ b/boa3_test/tests/examples_tests/test_ico.py
@@ -23,13 +23,11 @@ class TestTemplate(BoaTest):
         engine = TestEngine()
 
         result = self.run_smart_contract(engine, path, 'verify',
-                                         signer_accounts=[self.OTHER_ACCOUNT_1],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OTHER_ACCOUNT_1])
         self.assertEqual(False, result)
 
         result = self.run_smart_contract(engine, path, 'verify',
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(True, result)
 
     def test_ico_total_supply(self):
@@ -137,22 +135,19 @@ class TestTemplate(BoaTest):
 
         # should fail if the origin doesn't sign
         result = self.run_smart_contract(engine, path, 'approve',
-                                         self.OWNER_SCRIPT_HASH, self.OTHER_ACCOUNT_1, approved_amount,
-                                         expected_result_type=bool)
+                                         self.OWNER_SCRIPT_HASH, self.OTHER_ACCOUNT_1, approved_amount)
         self.assertEqual(False, result)
 
         # should fail if origin and target are the same
         result = self.run_smart_contract(engine, path, 'approve',
                                          self.OWNER_SCRIPT_HASH, self.OWNER_SCRIPT_HASH, approved_amount,
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(False, result)
 
         # should fail if any of the addresses is not included in the kyc
         result = self.run_smart_contract(engine, path, 'approve',
                                          self.OWNER_SCRIPT_HASH, self.OTHER_ACCOUNT_1, approved_amount,
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(False, result)
 
         result = self.run_smart_contract(engine, path, 'kyc_register',
@@ -162,8 +157,7 @@ class TestTemplate(BoaTest):
 
         result = self.run_smart_contract(engine, path, 'approve',
                                          self.OWNER_SCRIPT_HASH, self.OTHER_ACCOUNT_1, approved_amount,
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(True, result)
 
     def test_ico_allowance(self):
@@ -182,8 +176,7 @@ class TestTemplate(BoaTest):
 
         result = self.run_smart_contract(engine, path, 'approve',
                                          self.OWNER_SCRIPT_HASH, self.OTHER_ACCOUNT_1, approved_amount,
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(True, result)
 
         result = self.run_smart_contract(engine, path, 'allowance', self.OWNER_SCRIPT_HASH, self.OTHER_ACCOUNT_1)
@@ -214,16 +207,14 @@ class TestTemplate(BoaTest):
         # should fail if the sender doesn't sign
         result = self.run_smart_contract(engine, path, 'transferFrom',
                                          self.OWNER_SCRIPT_HASH, self.OTHER_ACCOUNT_1, self.OTHER_ACCOUNT_2,
-                                         transferred_amount, None,
-                                         expected_result_type=bool)
+                                         transferred_amount, None)
         self.assertEqual(False, result)
 
         # should fail if the allowed amount is less than the given amount
         result = self.run_smart_contract(engine, path, 'transferFrom',
                                          self.OWNER_SCRIPT_HASH, self.OTHER_ACCOUNT_1, self.OTHER_ACCOUNT_2,
                                          transferred_amount, None,
-                                         signer_accounts=[self.OTHER_ACCOUNT_1],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OTHER_ACCOUNT_1])
         self.assertEqual(False, result)
 
         result = self.run_smart_contract(engine, path, 'kyc_register',
@@ -233,8 +224,7 @@ class TestTemplate(BoaTest):
 
         result = self.run_smart_contract(engine, path, 'approve',
                                          self.OWNER_SCRIPT_HASH, self.OTHER_ACCOUNT_1, transferred_amount * 2,
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(True, result)
 
         # doesn't fire the transfer event when transferring to yourself or amount is zero
@@ -242,8 +232,7 @@ class TestTemplate(BoaTest):
         result = self.run_smart_contract(engine, path, 'transferFrom',
                                          self.OWNER_SCRIPT_HASH, self.OTHER_ACCOUNT_1, self.OWNER_SCRIPT_HASH,
                                          transferred_amount, None,
-                                         signer_accounts=[self.OTHER_ACCOUNT_1],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OTHER_ACCOUNT_1])
         self.assertEqual(True, result)
         self.assertEqual(0, len(engine.get_events('transfer')))
         balance_after = self.run_smart_contract(engine, path, 'balanceOf', self.OWNER_SCRIPT_HASH)
@@ -253,8 +242,7 @@ class TestTemplate(BoaTest):
         result = self.run_smart_contract(engine, path, 'transferFrom',
                                          self.OWNER_SCRIPT_HASH, self.OTHER_ACCOUNT_1, self.OTHER_ACCOUNT_1,
                                          transferred_amount, None,
-                                         signer_accounts=[self.OTHER_ACCOUNT_1],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OTHER_ACCOUNT_1])
         self.assertEqual(True, result)
         self.assertEqual(0, len(engine.get_events('transfer')))
         balance_after = self.run_smart_contract(engine, path, 'balanceOf', self.OTHER_ACCOUNT_1)
@@ -262,8 +250,7 @@ class TestTemplate(BoaTest):
 
         result = self.run_smart_contract(engine, path, 'transferFrom',
                                          self.OWNER_SCRIPT_HASH, self.OTHER_ACCOUNT_1, self.OTHER_ACCOUNT_2, 0, None,
-                                         signer_accounts=[self.OTHER_ACCOUNT_1],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OTHER_ACCOUNT_1])
         self.assertEqual(True, result)
         self.assertEqual(0, len(engine.get_events('transfer')))
 
@@ -273,8 +260,7 @@ class TestTemplate(BoaTest):
         result = self.run_smart_contract(engine, path, 'transferFrom',
                                          self.OWNER_SCRIPT_HASH, self.OTHER_ACCOUNT_1, self.OTHER_ACCOUNT_2,
                                          transferred_amount, None,
-                                         signer_accounts=[self.OTHER_ACCOUNT_1],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OTHER_ACCOUNT_1])
         self.assertEqual(False, result)
 
         balance_originator_after = self.run_smart_contract(engine, path, 'balanceOf', self.OWNER_SCRIPT_HASH)
@@ -294,16 +280,14 @@ class TestTemplate(BoaTest):
 
         minted_amount = 10_000 * 10 ** 8
         # should fail if not signed by the administrator
-        result = self.run_smart_contract(engine, path, 'mint', minted_amount,
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'mint', minted_amount)
         self.assertEqual(False, result)
 
         total_supply_before = self.run_smart_contract(engine, path, 'totalSupply')
         owner_balance_before = self.run_smart_contract(engine, path, 'balanceOf', self.OWNER_SCRIPT_HASH)
 
         result = self.run_smart_contract(engine, path, 'mint', minted_amount,
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(True, result)
 
         total_supply_after = self.run_smart_contract(engine, path, 'totalSupply')

--- a/boa3_test/tests/examples_tests/test_nep17.py
+++ b/boa3_test/tests/examples_tests/test_nep17.py
@@ -66,15 +66,13 @@ class TestNEP17Template(BoaTest):
 
         # should fail if the sender doesn't sign
         result = self.run_smart_contract(engine, path, 'transfer',
-                                         self.OWNER_SCRIPT_HASH, self.OTHER_ACCOUNT_1, transferred_amount, None,
-                                         expected_result_type=bool)
+                                         self.OWNER_SCRIPT_HASH, self.OTHER_ACCOUNT_1, transferred_amount, None)
         self.assertEqual(False, result)
 
         # should fail if the sender doesn't have enough balance
         result = self.run_smart_contract(engine, path, 'transfer',
                                          self.OTHER_ACCOUNT_1, self.OWNER_SCRIPT_HASH, transferred_amount, None,
-                                         signer_accounts=[self.OTHER_ACCOUNT_1],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OTHER_ACCOUNT_1])
         self.assertEqual(False, result)
 
         # should fail when any of the scripts' length is not 20
@@ -94,8 +92,7 @@ class TestNEP17Template(BoaTest):
         balance_before = self.run_smart_contract(engine, path, 'balanceOf', self.OWNER_SCRIPT_HASH)
         result = self.run_smart_contract(engine, path, 'transfer',
                                          self.OWNER_SCRIPT_HASH, self.OWNER_SCRIPT_HASH, transferred_amount, None,
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(True, result)
         transfer_events = engine.get_events('Transfer')
         self.assertEqual(2, len(transfer_events))
@@ -119,8 +116,7 @@ class TestNEP17Template(BoaTest):
         balance_receiver_before = self.run_smart_contract(engine, path, 'balanceOf', self.OTHER_ACCOUNT_1)
         result = self.run_smart_contract(engine, path, 'transfer',
                                          self.OWNER_SCRIPT_HASH, self.OTHER_ACCOUNT_1, transferred_amount, None,
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(True, result)
         transfer_events = engine.get_events('Transfer')
         self.assertEqual(3, len(transfer_events))
@@ -167,8 +163,7 @@ class TestNEP17Template(BoaTest):
 
         result = self.run_smart_contract(engine, aux_path, 'calling_transfer', constants.NEO_SCRIPT,
                                          aux_address, nep17_address, transferred_amount, None,
-                                         signer_accounts=[aux_address],
-                                         expected_result_type=bool)
+                                         signer_accounts=[aux_address])
         self.assertEqual(True, result)
         transfer_events = engine.get_events('Transfer')
         self.assertEqual(4, len(transfer_events))
@@ -216,8 +211,7 @@ class TestNEP17Template(BoaTest):
 
         result = self.run_smart_contract(engine, aux_path, 'calling_transfer', constants.GAS_SCRIPT,
                                          aux_address, nep17_address, transferred_amount, None,
-                                         signer_accounts=[aux_address],
-                                         expected_result_type=bool)
+                                         signer_accounts=[aux_address])
         self.assertEqual(True, result)
         transfer_events = engine.get_events('Transfer')
         self.assertEqual(6, len(transfer_events))
@@ -267,17 +261,14 @@ class TestNEP17Template(BoaTest):
         engine = TestEngine()
 
         # should fail without signature
-        result = self.run_smart_contract(engine, path, 'verify',
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'verify')
         self.assertEqual(False, result)
 
         # should fail if not signed by the owner
         result = self.run_smart_contract(engine, path, 'verify',
-                                         signer_accounts=[self.OTHER_ACCOUNT_1],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OTHER_ACCOUNT_1])
         self.assertEqual(False, result)
 
         result = self.run_smart_contract(engine, path, 'verify',
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(True, result)

--- a/boa3_test/tests/examples_tests/test_nep5.py
+++ b/boa3_test/tests/examples_tests/test_nep5.py
@@ -65,15 +65,13 @@ class TestTemplate(BoaTest):
 
         # should fail if the sender doesn't sign
         result = self.run_smart_contract(engine, path, 'transfer',
-                                         self.OWNER_SCRIPT_HASH, self.OTHER_ACCOUNT_1, transferred_amount,
-                                         expected_result_type=bool)
+                                         self.OWNER_SCRIPT_HASH, self.OTHER_ACCOUNT_1, transferred_amount)
         self.assertEqual(False, result)
 
         # other account doesn't have enough balance
         result = self.run_smart_contract(engine, path, 'transfer',
                                          self.OTHER_ACCOUNT_1, self.OWNER_SCRIPT_HASH, transferred_amount,
-                                         signer_accounts=[self.OTHER_ACCOUNT_1],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OTHER_ACCOUNT_1])
         self.assertEqual(False, result)
 
         # should fail when any of the scripts' length is not 20
@@ -93,8 +91,7 @@ class TestTemplate(BoaTest):
         balance_before = self.run_smart_contract(engine, path, 'balanceOf', self.OWNER_SCRIPT_HASH)
         result = self.run_smart_contract(engine, path, 'transfer',
                                          self.OWNER_SCRIPT_HASH, self.OWNER_SCRIPT_HASH, transferred_amount,
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(True, result)
         transfer_events = engine.get_events('transfer')
         # there is one transfer event thanks to the deploy
@@ -109,8 +106,7 @@ class TestTemplate(BoaTest):
         balance_receiver_before = self.run_smart_contract(engine, path, 'balanceOf', self.OTHER_ACCOUNT_1)
         result = self.run_smart_contract(engine, path, 'transfer',
                                          self.OWNER_SCRIPT_HASH, self.OTHER_ACCOUNT_1, transferred_amount,
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(True, result)
         transfer_events = engine.get_events('transfer')
         self.assertEqual(2, len(transfer_events))
@@ -136,17 +132,14 @@ class TestTemplate(BoaTest):
         engine = TestEngine()
 
         # should fail without signature
-        result = self.run_smart_contract(engine, path, 'verify',
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'verify')
         self.assertEqual(False, result)
 
         # should fail if not signed by the owner
         result = self.run_smart_contract(engine, path, 'verify',
-                                         signer_accounts=[self.OTHER_ACCOUNT_1],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OTHER_ACCOUNT_1])
         self.assertEqual(False, result)
 
         result = self.run_smart_contract(engine, path, 'verify',
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(True, result)

--- a/boa3_test/tests/examples_tests/test_wrapped_neo.py
+++ b/boa3_test/tests/examples_tests/test_wrapped_neo.py
@@ -66,15 +66,13 @@ class TestTemplate(BoaTest):
 
         # should fail if the sender doesn't sign
         result = self.run_smart_contract(engine, path, 'transfer',
-                                         self.OWNER_SCRIPT_HASH, self.OTHER_ACCOUNT_1, transferred_amount, "",
-                                         expected_result_type=bool)
+                                         self.OWNER_SCRIPT_HASH, self.OTHER_ACCOUNT_1, transferred_amount, "")
         self.assertEqual(False, result)
 
         # should fail if the sender doesn't have enough balance
         result = self.run_smart_contract(engine, path, 'transfer',
                                          self.OTHER_ACCOUNT_1, self.OWNER_SCRIPT_HASH, transferred_amount, "",
-                                         signer_accounts=[self.OTHER_ACCOUNT_1],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OTHER_ACCOUNT_1])
         self.assertEqual(False, result)
 
         # should fail when any of the scripts' length is not 20
@@ -94,8 +92,7 @@ class TestTemplate(BoaTest):
         balance_before = self.run_smart_contract(engine, path, 'balanceOf', self.OWNER_SCRIPT_HASH)
         result = self.run_smart_contract(engine, path, 'transfer',
                                          self.OWNER_SCRIPT_HASH, self.OWNER_SCRIPT_HASH, transferred_amount, "",
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(True, result)
         transfer_events = engine.get_events('Transfer', origin=wrapped_neo_address)
         self.assertEqual(1, len(transfer_events))
@@ -119,8 +116,7 @@ class TestTemplate(BoaTest):
         balance_receiver_before = self.run_smart_contract(engine, path, 'balanceOf', self.OTHER_ACCOUNT_1)
         result = self.run_smart_contract(engine, path, 'transfer',
                                          self.OWNER_SCRIPT_HASH, self.OTHER_ACCOUNT_1, transferred_amount, "",
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(True, result)
         transfer_events = engine.get_events('Transfer')
         self.assertEqual(3, len(transfer_events))
@@ -146,19 +142,16 @@ class TestTemplate(BoaTest):
         engine = TestEngine()
 
         # should fail without signature
-        result = self.run_smart_contract(engine, path, 'verify',
-                                         expected_result_type=bool)
+        result = self.run_smart_contract(engine, path, 'verify')
         self.assertEqual(False, result)
 
         # should fail if not signed by the owner
         result = self.run_smart_contract(engine, path, 'verify',
-                                         signer_accounts=[self.OTHER_ACCOUNT_1],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OTHER_ACCOUNT_1])
         self.assertEqual(False, result)
 
         result = self.run_smart_contract(engine, path, 'verify',
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(True, result)
 
     def test_wrapped_neo_burn(self):
@@ -177,8 +170,7 @@ class TestTemplate(BoaTest):
         zneo_owner_before = self.run_smart_contract(engine, path, 'balanceOf', self.OWNER_SCRIPT_HASH)
         # in this case, NEO will be given to the OWNER_SCRIPT_HASH
         result = self.run_smart_contract(engine, path, 'burn', self.OWNER_SCRIPT_HASH, burned_amount,
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertIsVoid(result)
 
         transfer_events = engine.get_events('Transfer', origin=wrapped_neo_address)
@@ -242,22 +234,19 @@ class TestTemplate(BoaTest):
         # this approve will fail, because aux_contract_address doesn't have enough zNEO
         result = self.run_smart_contract(engine, path_aux_contract, 'calling_approve',
                                          wrapped_neo_address, self.OTHER_ACCOUNT_1, allowed_amount,
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(False, result)
 
         # OWNER will give zNEO to aux_contract_address so that it can approve
         result = self.run_smart_contract(engine, path, 'transfer',
                                          self.OWNER_SCRIPT_HASH, aux_contract_address, allowed_amount, None,
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(True, result)
 
         # this approve will succeed, because aux_contract_address have enough zNEO
         result = self.run_smart_contract(engine, path_aux_contract, 'calling_approve',
                                          wrapped_neo_address, self.OTHER_ACCOUNT_1, allowed_amount,
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(True, result)
 
         # approved fired an event
@@ -288,22 +277,19 @@ class TestTemplate(BoaTest):
 
         # aux_contract_address did not approve OTHER_SCRIPT_HASH
         result = self.run_smart_contract(engine, path, 'allowance', aux_contract_address, self.OTHER_ACCOUNT_1,
-                                         signer_accounts=[aux_contract_address],
-                                         expected_result_type=bool)
+                                         signer_accounts=[aux_contract_address])
         self.assertEqual(0, result)
 
         # OWNER will give zNEO to aux_contract_address so that it can approve
         result = self.run_smart_contract(engine, path, 'transfer',
                                          self.OWNER_SCRIPT_HASH, aux_contract_address, allowed_amount, None,
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(True, result)
 
         # this approve will succeed, because aux_contract_address have enough zNEO
         result = self.run_smart_contract(engine, path_aux_contract, 'calling_approve',
                                          wrapped_neo_address, self.OTHER_ACCOUNT_1, allowed_amount,
-                                         signer_accounts=[aux_contract_address],
-                                         expected_result_type=bool)
+                                         signer_accounts=[aux_contract_address])
         self.assertEqual(True, result)
 
         # aux_contract_address allowed OTHER_SCRIPT_HASH to spend transferred_amount of zNEO
@@ -327,8 +313,7 @@ class TestTemplate(BoaTest):
         # OWNER will give zNEO to aux_contract_address so that it can approve another contracts
         result = self.run_smart_contract(engine, path, 'transfer',
                                          self.OWNER_SCRIPT_HASH, aux_contract_address, 10_000_000 * 10 ** 8, None,
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
         self.assertEqual(True, result)
         transfer_events = engine.get_events('Transfer')
         self.assertEqual(2, len(transfer_events))
@@ -346,8 +331,7 @@ class TestTemplate(BoaTest):
         # this approve will succeed, because aux_contract_address have enough zNEO
         result = self.run_smart_contract(engine, path_aux_contract, 'calling_approve',
                                          wrapped_neo_address, self.OTHER_ACCOUNT_1, allowed_amount,
-                                         signer_accounts=[aux_contract_address],
-                                         expected_result_type=bool)
+                                         signer_accounts=[aux_contract_address])
         self.assertEqual(True, result)
 
         transferred_amount = allowed_amount
@@ -356,8 +340,7 @@ class TestTemplate(BoaTest):
         # because OTHER_SCRIPT_HASH is not allowed to transfer more than aux_contract_address approved
         result = self.run_smart_contract(engine, path, 'transferFrom', self.OTHER_ACCOUNT_1, aux_contract_address,
                                          self.OTHER_ACCOUNT_2, transferred_amount + 1 * 10 ** 8, None,
-                                         signer_accounts=[self.OTHER_ACCOUNT_1],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OTHER_ACCOUNT_1])
         self.assertEqual(False, result)
         transfer_events = engine.get_events('Transfer')
         self.assertEqual(2, len(transfer_events))
@@ -368,8 +351,7 @@ class TestTemplate(BoaTest):
         balance_receiver_before = self.run_smart_contract(engine, path, 'balanceOf', self.OTHER_ACCOUNT_2)
         result = self.run_smart_contract(engine, path, 'transferFrom', self.OTHER_ACCOUNT_1, aux_contract_address,
                                          self.OTHER_ACCOUNT_2, transferred_amount, None,
-                                         signer_accounts=[self.OTHER_ACCOUNT_1],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OTHER_ACCOUNT_1])
         self.assertEqual(True, result)
         transfer_events = engine.get_events('Transfer')
         self.assertEqual(3, len(transfer_events))
@@ -394,29 +376,25 @@ class TestTemplate(BoaTest):
 
         # aux_contract_address and OTHER_SCRIPT_HASH allowance was reduced to 0
         result = self.run_smart_contract(engine, path, 'allowance', aux_contract_address, self.OTHER_ACCOUNT_1,
-                                         signer_accounts=[aux_contract_address],
-                                         expected_result_type=bool)
+                                         signer_accounts=[aux_contract_address])
         self.assertEqual(0, result)
 
         # this approve will succeed, because aux_contract_address have enough zNEO
         result = self.run_smart_contract(engine, path_aux_contract, 'calling_approve',
                                          wrapped_neo_address, self.OTHER_ACCOUNT_1, allowed_amount,
-                                         signer_accounts=[aux_contract_address],
-                                         expected_result_type=bool)
+                                         signer_accounts=[aux_contract_address])
         self.assertEqual(True, result)
 
         transferred_amount = allowed_amount - 4 * 10 ** 8
 
         result = self.run_smart_contract(engine, path, 'transferFrom', self.OTHER_ACCOUNT_1, aux_contract_address,
                                          self.OTHER_ACCOUNT_2, transferred_amount, None,
-                                         signer_accounts=[self.OTHER_ACCOUNT_1],
-                                         expected_result_type=bool)
+                                         signer_accounts=[self.OTHER_ACCOUNT_1])
         self.assertEqual(True, result)
 
         # aux_contract_address and OTHER_SCRIPT_HASH allowance was reduced to allowed_amount - transferred_amount
         result = self.run_smart_contract(engine, path, 'allowance', aux_contract_address, self.OTHER_ACCOUNT_1,
-                                         signer_accounts=[aux_contract_address],
-                                         expected_result_type=bool)
+                                         signer_accounts=[aux_contract_address])
         self.assertEqual(allowed_amount - transferred_amount, result)
 
         # should fail when any of the scripts' length is not 20
@@ -462,8 +440,7 @@ class TestTemplate(BoaTest):
         # transferring NEO to the wrapped_neo_address will mint them
         result = self.run_smart_contract(engine, aux_path, 'calling_transfer', constants.NEO_SCRIPT,
                                          aux_address, wrapped_neo_address, minted_amount, None,
-                                         signer_accounts=[aux_address],
-                                         expected_result_type=bool)
+                                         signer_accounts=[aux_address])
         self.assertEqual(True, result)
 
         transfer_events = engine.get_events('Transfer', origin=constants.NEO_SCRIPT)


### PR DESCRIPTION
**Related issue**
#817

**Summary or solution description**
Changed the `bool` literal values conversion (`True` and `False`) to be implemented as Neo `Boolean` stack type instead of `Integer` stack type.

**How to Reproduce**
```python
@public
def return_true() -> bool:
    return True

@public
def return_false() -> bool:
    return False
```

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/e943c538712eec0d1638a02e39439eaf635bca69/boa3_test/tests/compiler_tests/test_if.py#L451-L476

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7

**(Optional) Additional context**
Since this changed the previous `bool` behavior, some modifications had to be done in the compilation of `while`, `for`, and `if` statements as well.
