### PR TITLE
Invalid contract created

### DIFF
--- a/boa3/analyser/analyser.py
+++ b/boa3/analyser/analyser.py
@@ -143,7 +143,8 @@ class Analyser:
         """
         Tries to optimize the ast after validations
         """
-        AstOptimizer(self, log=self._log)
+        optimizer = AstOptimizer(self, log=self._log)
+        self.__update_logs(optimizer)
 
     def update_symbol_table(self, symbol_table: Dict[str, ISymbol]):
         for symbol_id, symbol in symbol_table.items():

--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -117,8 +117,15 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
             # the symbol exists in the modules scope
             return self.modules[symbol_id]
 
+        if self._current_method is not None:
+            cur_symbols = self._current_method.symbols
+        elif self._current_class is not None:
+            cur_symbols = self._current_class.symbols
+        else:
+            cur_symbols = self.modules
+
         if check_raw_id:
-            found_symbol = self._search_by_raw_id(symbol_id, list(self._current_method.symbols.values()))
+            found_symbol = self._search_by_raw_id(symbol_id, list(cur_symbols.values()))
             if found_symbol is not None:
                 return found_symbol
 

--- a/boa3/exception/CompilerWarning.py
+++ b/boa3/exception/CompilerWarning.py
@@ -28,6 +28,23 @@ class CompilerWarning(ABC, BaseException):
         return self.message == other.message
 
 
+class InvalidArgument(CompilerWarning):
+    """
+    An warning raised when an attempt of method evaluation fails during optimization because an argument is invalid.
+    """
+
+    def __init__(self, line: int, col: int, custom_error_message: str = None):
+        self.custom_error_message = custom_error_message
+        super().__init__(line, col)
+
+    @property
+    def _warning_message(self) -> Optional[str]:
+        message = "One or more arguments are invalid values"
+        if self.custom_error_message is not None:
+            message += f": {self.custom_error_message}"
+        return message
+
+
 class NameShadowing(CompilerWarning):
     """
     A warning raised when a name from an outer scope symbol is used as the name of an inner scope symbol

--- a/boa3/model/builtin/method/builtinmethod.py
+++ b/boa3/model/builtin/method/builtinmethod.py
@@ -167,6 +167,16 @@ class IBuiltinMethod(IBuiltinCallable, Method, ABC):
         """
         return False
 
+    def evaluate_literal(self, *args: Any) -> Any:
+        """
+        Tries to evaluate the result during compile time. If it cannot be evaluated, returns Undefined.
+
+        :return: arguments to try to run the method
+        :rtype: Any
+        """
+        from boa3.analyser.model.optimizer import Undefined
+        return Undefined
+
     @property
     def body(self) -> Optional[str]:
         """

--- a/boa3/model/builtin/method/uint160method.py
+++ b/boa3/model/builtin/method/uint160method.py
@@ -51,6 +51,23 @@ class UInt160Method(IBuiltinMethod):
         return (Type.bytes.is_type_of(param_type)
                 or Type.int.is_type_of(param_type))
 
+    def evaluate_literal(self, *args: Any) -> Any:
+        from boa3.neo3.core.types import UInt160
+
+        if len(args) == 0:
+            return UInt160.zero().to_array()
+
+        if len(args) == 1:
+            arg = args[0]
+            if isinstance(arg, int):
+                from boa3.neo.vm.type.Integer import Integer
+                arg = Integer(arg).to_byte_array(min_length=UInt160._BYTE_LEN)
+            if isinstance(arg, bytes):
+                value = UInt160(arg).to_array()
+                return value
+
+        return super().evaluate_literal(*args)
+
     @property
     def opcode(self) -> List[Tuple[Opcode, bytes]]:
         from boa3.neo.vm.type.Integer import Integer

--- a/boa3/model/builtin/method/uint256method.py
+++ b/boa3/model/builtin/method/uint256method.py
@@ -51,6 +51,23 @@ class UInt256Method(IBuiltinMethod):
         return (Type.bytes.is_type_of(param_type)
                 or Type.int.is_type_of(param_type))
 
+    def evaluate_literal(self, *args: Any) -> Any:
+        from boa3.neo3.core.types import UInt256
+
+        if len(args) == 0:
+            return UInt256.zero().to_array()
+
+        if len(args) == 1:
+            arg = args[0]
+            if isinstance(arg, int):
+                from boa3.neo.vm.type.Integer import Integer
+                arg = Integer(arg).to_byte_array(min_length=UInt256._BYTE_LEN)
+            if isinstance(arg, bytes):
+                value = UInt256(arg).to_array()
+                return value
+
+        return super().evaluate_literal(*args)
+
     @property
     def opcode(self) -> List[Tuple[Opcode, bytes]]:
         from boa3.neo.vm.type.Integer import Integer

--- a/boa3_test/test_sc/contract_interface_test/Nep17Interface.py
+++ b/boa3_test/test_sc/contract_interface_test/Nep17Interface.py
@@ -6,7 +6,6 @@ from boa3.builtin.type import UInt160
 
 @contract('0xa34afa0e5414255d1093e92a1a6f1f505c82cd3f')
 class Nep17:
-    _hash = UInt160(b'\x0d\xbf\x77\x30\x13\x17\x66\x9c\xec\x3d\xab\x7f\xfb\x9c\x7b\x09\x89\xa9\x6c\x42')
 
     @staticmethod
     def symbol() -> str:

--- a/boa3_test/test_sc/contract_interface_test/Nep17Interface.py
+++ b/boa3_test/test_sc/contract_interface_test/Nep17Interface.py
@@ -4,8 +4,9 @@ from boa3.builtin import contract, display_name, public
 from boa3.builtin.type import UInt160
 
 
-@contract('0x0dbf77301317669cec3dab7ffb9c7b0989a96c42')
+@contract('0xa34afa0e5414255d1093e92a1a6f1f505c82cd3f')
 class Nep17:
+    _hash = UInt160(b'\x0d\xbf\x77\x30\x13\x17\x66\x9c\xec\x3d\xab\x7f\xfb\x9c\x7b\x09\x89\xa9\x6c\x42')
 
     @staticmethod
     def symbol() -> str:

--- a/boa3_test/test_sc/contract_interface_test/Nep17InterfaceWithDisplayName.py
+++ b/boa3_test/test_sc/contract_interface_test/Nep17InterfaceWithDisplayName.py
@@ -4,7 +4,7 @@ from boa3.builtin import contract, display_name, public
 from boa3.builtin.type import UInt160
 
 
-@contract('0x0dbf77301317669cec3dab7ffb9c7b0989a96c42')
+@contract('0xa34afa0e5414255d1093e92a1a6f1f505c82cd3f')
 class Nep17:
 
     @staticmethod

--- a/boa3_test/tests/compiler_tests/test_constant.py
+++ b/boa3_test/tests/compiler_tests/test_constant.py
@@ -164,12 +164,14 @@ class TestConstant(BoaTest):
     def test_integer_tuple_constant(self):
         input = (1, 2, 3)
         expected_output = (
-            Opcode.PUSH3        # 3
+            Opcode.INITSSLOT + b'\x01'
+            + Opcode.PUSH3      # 3
             + Opcode.PUSH2      # 2
             + Opcode.PUSH1      # 1
             + Opcode.PUSH3      # tuple length
             + Opcode.PACK
             + Opcode.DROP
+            + Opcode.RET
         )
 
         analyser = Analyser(ast.parse(str(input)))
@@ -185,7 +187,8 @@ class TestConstant(BoaTest):
         byte_input2 = String(input[2]).to_bytes()
 
         expected_output = (
-            Opcode.PUSHDATA1    # '3'
+            Opcode.INITSSLOT + b'\x01'
+            + Opcode.PUSHDATA1  # '3'
             + Integer(len(byte_input2)).to_byte_array()
             + byte_input2
             + Opcode.PUSHDATA1  # '2'
@@ -197,6 +200,7 @@ class TestConstant(BoaTest):
             + Opcode.PUSH3      # tuple length
             + Opcode.PACK
             + Opcode.DROP
+            + Opcode.RET
         )
 
         analyser = Analyser(ast.parse(str(input)))
@@ -210,7 +214,8 @@ class TestConstant(BoaTest):
         byte_input1 = String(input[1]).to_bytes()
 
         expected_output = (
-            Opcode.PUSH0        # False
+            Opcode.INITSSLOT + b'\x01'
+            + Opcode.PUSH0      # False
             + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.PUSHDATA1  # '2'
             + Integer(len(byte_input1)).to_byte_array()
@@ -219,6 +224,7 @@ class TestConstant(BoaTest):
             + Opcode.PUSH3      # tuple length
             + Opcode.PACK
             + Opcode.DROP
+            + Opcode.RET
         )
 
         analyser = Analyser(ast.parse(str(input)))
@@ -231,7 +237,8 @@ class TestConstant(BoaTest):
         input = ((1, 2), (3, 4, 5, 6), (7,))
         expected_output = (
             # tuple[2]
-            Opcode.PUSH7    # 7
+            Opcode.INITSSLOT + b'\x01'
+            + Opcode.PUSH7  # 7
             + Opcode.PUSH1  # tuple length
             + Opcode.PACK
             # tuple[1]
@@ -249,6 +256,7 @@ class TestConstant(BoaTest):
             + Opcode.PUSH3  # tuple length
             + Opcode.PACK
             + Opcode.DROP
+            + Opcode.RET
         )
 
         analyser = Analyser(ast.parse(str(input)))
@@ -260,12 +268,14 @@ class TestConstant(BoaTest):
     def test_integer_list_constant(self):
         input = [1, 2, 3]
         expected_output = (
-            Opcode.PUSH3    # 3
+            Opcode.INITSSLOT + b'\x01'
+            + Opcode.PUSH3  # 3
             + Opcode.PUSH2  # 2
             + Opcode.PUSH1  # 1
             + Opcode.PUSH3  # list length
             + Opcode.PACK
             + Opcode.DROP
+            + Opcode.RET
         )
 
         analyser = Analyser(ast.parse(str(input)))
@@ -281,7 +291,8 @@ class TestConstant(BoaTest):
         byte_input2 = String(input[2]).to_bytes()
 
         expected_output = (
-            Opcode.PUSHDATA1        # '2'
+            Opcode.INITSSLOT + b'\x01'
+            + Opcode.PUSHDATA1      # '2'
             + Integer(len(byte_input2)).to_byte_array()
             + byte_input2
             + Opcode.PUSHDATA1      # '1'
@@ -293,6 +304,7 @@ class TestConstant(BoaTest):
             + Opcode.PUSH3          # list length
             + Opcode.PACK
             + Opcode.DROP
+            + Opcode.RET
         )
 
         analyser = Analyser(ast.parse(str(input)))
@@ -306,7 +318,8 @@ class TestConstant(BoaTest):
         byte_input1 = String(input[1]).to_bytes()
 
         expected_output = (
-            Opcode.PUSH0        # False
+            Opcode.INITSSLOT + b'\x01'
+            + Opcode.PUSH0      # False
             + Opcode.CONVERT + StackItemType.Boolean
             + Opcode.PUSHDATA1  # '2'
             + Integer(len(byte_input1)).to_byte_array()
@@ -315,6 +328,7 @@ class TestConstant(BoaTest):
             + Opcode.PUSH3      # list length
             + Opcode.PACK
             + Opcode.DROP
+            + Opcode.RET
         )
 
         analyser = Analyser(ast.parse(str(input)))
@@ -327,7 +341,8 @@ class TestConstant(BoaTest):
         input = [[1, 2], [3, 4, 5, 6], [7]]
         expected_output = (
             # list[2]
-            Opcode.PUSH7    # 7
+            Opcode.INITSSLOT + b'\x01'
+            + Opcode.PUSH7  # 7
             + Opcode.PUSH1  # list length
             + Opcode.PACK
             # list[1]
@@ -345,6 +360,7 @@ class TestConstant(BoaTest):
             + Opcode.PUSH3  # list length
             + Opcode.PACK
             + Opcode.DROP
+            + Opcode.RET
         )
 
         analyser = Analyser(ast.parse(str(input)))

--- a/boa3_test/tests/compiler_tests/test_contract_interface.py
+++ b/boa3_test/tests/compiler_tests/test_contract_interface.py
@@ -47,7 +47,6 @@ class TestContractInterface(BoaTest):
         path = self.get_contract_path('Nep17Interface.py')
         nep17_path = self.get_contract_path('examples', 'nep17.py')
 
-        self.compile_and_save(path)
         engine = TestEngine()
 
         nep17_result = self.run_smart_contract(engine, nep17_path, 'symbol')
@@ -82,7 +81,6 @@ class TestContractInterface(BoaTest):
         path = self.get_contract_path('Nep17InterfaceWithDisplayName.py')
         nep17_path = self.get_contract_path('examples', 'nep17.py')
 
-        self.compile_and_save(path)
         engine = TestEngine()
 
         nep17_result = self.run_smart_contract(engine, nep17_path, 'totalSupply')


### PR DESCRIPTION
**Related issue**
#815

**Summary or solution description**
Fixed multiple issues related to calling methods and casting types in-line and importing symbols from different files.
All of them related to not finding imported symbols from different files during code generation.

**How to Reproduce**
From #815:
> **How to Reproduce** 
> The attached zip contains 3 contracts for reproduction.
> 
> 1. Deploy the contract in the folder `1_target_contract` and note the script hash
> 2. Update the contract hash in the file `/2_entry_contract_fails/sample/samplecontract.py` with the hash noted in step 1
> 3. Compile `/2_entry_contract_fails/mycontract.py` , deploy and note the hash
> 4. Call the function `test` on the contract deployed in step 3.
> 
> The 3rd contract in the script is the result of manually building contract using this code
> 
> ```python
>     target_contract = types.UInt160(b"\xb30\xa1\x86\xfa\x05' \x17\r{\x02\xc0\x05\x12B\x8a\xc8\xf5\xd9")
>     sb = vm.ScriptBuilder()
>     sb.emit_dynamic_call(target_contract, "func_no_arg_with_return_boolean")
>     nef = NEF("manual-compiler", script=sb.to_array())
>     with open('manual.nef', 'wb') as f:
>         f.write(nef.to_array())
> ```
> 
> Which works. The side note here is that the result is an Integer instead of Boolean due to #817

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
