### PR TITLE
Using in-line methods with class variables raises Internal compiler error

### DIFF
--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -26,6 +26,7 @@ from boa3.model.property import Property
 from boa3.model.symbol import ISymbol
 from boa3.model.type.annotation.metatype import MetaType
 from boa3.model.type.classes.classtype import ClassType
+from boa3.model.type.classes.pythonclass import PythonClass
 from boa3.model.type.classes.userclass import UserClass
 from boa3.model.type.collection.icollection import ICollectionType as Collection
 from boa3.model.type.type import IType, Type
@@ -1160,8 +1161,10 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
 
         elif isinstance(arg0, UserClass):
             arg0_identifier = arg0.identifier
-        else:
+        elif isinstance(arg0, ast.AST):
             arg0_identifier = self.visit(arg0)
+        else:
+            arg0_identifier = None
 
         if isinstance(arg0_identifier, ast.Name):
             arg0_identifier = arg0_identifier.id
@@ -1599,7 +1602,7 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
 
         if (isinstance(symbol, (Package, Attribute))
                 or (isinstance(symbol, ClassType) and isinstance(value, (Package, Attribute)))):
-            attr_value = symbol
+            attr_value = symbol if not isinstance(symbol, PythonClass) else attribute.value
         else:
             attr_value = attribute.value
 

--- a/boa3_test/test_sc/list_test/AppendInClassVariable.py
+++ b/boa3_test/test_sc/list_test/AppendInClassVariable.py
@@ -1,0 +1,23 @@
+from typing import List
+
+from boa3.builtin import public
+
+
+class SomeClass:
+    def __init__(self):
+        self._some_list: List[int] = [1, 2, 3]
+
+    @property
+    def inner_list(self) -> List[int]:
+        return self._some_list
+
+    def append(self, value: int) -> bool:
+        self._some_list.append(value)
+        return True
+
+
+@public
+def main() -> list:
+    a = SomeClass()
+    a.append(4)
+    return a.inner_list

--- a/boa3_test/tests/compiler_tests/test_list.py
+++ b/boa3_test/tests/compiler_tests/test_list.py
@@ -763,6 +763,12 @@ class TestList(BoaTest):
         result = self.run_smart_contract(engine, path, 'main')
         self.assertEqual([6, 7], result)
 
+    def test_list_append_in_class_variable(self):
+        path = self.get_contract_path('AppendInClassVariable.py')
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'main')
+        self.assertEqual([1, 2, 3, 4], result)
+
     # endregion
 
     # region TestClear

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [pycodestyle]
 ignore = W291,E501,E702,E704,E721
-exclude = */ico.py, *Python2.py, *TryExcept*
+exclude = *Python2.py, *TryExcept*, */docs/*, *boa3/builtin/__init__.py


### PR DESCRIPTION
**Related issue**
#827

**Summary or solution description**
Fixed the internal error caused by calling instance methods from inner variables.
It was caused by a recent refactoring that unified all the types in the compiler under the ``ClassType`` interface.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/fa6c2b87c168dda33293051a2004ba564614ad3e/boa3_test/test_sc/list_test/AppendInClassVariable.py#L6-L16

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/fa6c2b87c168dda33293051a2004ba564614ad3e/boa3_test/tests/compiler_tests/test_list.py#L766-L770

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7.0
