### PR TITLE
Log a compiler warning when symbols with the same identifier are used

### DIFF
--- a/boa3/analyser/moduleanalyser.py
+++ b/boa3/analyser/moduleanalyser.py
@@ -203,7 +203,15 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
         """
         if ((self._current_scope is self._current_class or callable_id not in self._current_scope.symbols)
                 and hasattr(self._current_scope, 'include_callable')):
-            self._current_scope.include_callable(callable_id, callable)
+            already_exists = not self._current_scope.include_callable(callable_id, callable)
+        else:
+            symbol = self.get_symbol(callable_id)
+            already_exists = symbol is not None and not isinstance(symbol, IBuiltinMethod)
+
+        if already_exists:
+            self._log_warning(CompilerWarning.DuplicatedIdentifier(callable.origin.lineno,
+                                                                   callable.origin.col_offset,
+                                                                   callable_id))
 
     def __include_class_variable(self, cl_var_id: str, cl_var: Variable):
         """

--- a/boa3/analyser/moduleanalyser.py
+++ b/boa3/analyser/moduleanalyser.py
@@ -209,9 +209,9 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
             already_exists = symbol is not None and not isinstance(symbol, IBuiltinMethod)
 
         if already_exists:
-            self._log_warning(CompilerWarning.DuplicatedIdentifier(callable.origin.lineno,
-                                                                   callable.origin.col_offset,
-                                                                   callable_id))
+            self._log_error(CompilerError.DuplicatedIdentifier(callable.origin.lineno,
+                                                               callable.origin.col_offset,
+                                                               callable_id))
 
     def __include_class_variable(self, cl_var_id: str, cl_var: Variable):
         """

--- a/boa3/exception/CompilerError.py
+++ b/boa3/exception/CompilerError.py
@@ -53,6 +53,20 @@ class CircularImport(CompilerError):
         return "Circular import with '%s' ('%s')" % (self.target_import, self.target_origin)
 
 
+class DuplicatedIdentifier(CompilerError):
+    """
+    An error raised when more than one symbol uses the same identifier in the same scope and cannot be overwritten.
+    """
+
+    def __init__(self, line: int, col: int, duplicated_id: str = None):
+        self._duplicated_id = duplicated_id
+        super().__init__(line, col)
+
+    @property
+    def _error_message(self) -> Optional[str]:
+        return f"Duplicate identifier: '{self._duplicated_id}'"
+
+
 class IncorrectNumberOfOperands(CompilerError):
     """
     An error raised when an operation is used with the wrong number of operands

--- a/boa3/exception/CompilerWarning.py
+++ b/boa3/exception/CompilerWarning.py
@@ -45,6 +45,20 @@ class InvalidArgument(CompilerWarning):
         return message
 
 
+class DuplicatedIdentifier(CompilerWarning):
+    """
+    An warning raised when more than one symbol uses the same identifier in the same scope and cannot be overwritten.
+    """
+
+    def __init__(self, line: int, col: int, duplicated_id: str = None):
+        self._duplicated_id = duplicated_id
+        super().__init__(line, col)
+
+    @property
+    def _warning_message(self) -> Optional[str]:
+        return f"Duplicate identifier: '{self._duplicated_id}'"
+
+
 class NameShadowing(CompilerWarning):
     """
     A warning raised when a name from an outer scope symbol is used as the name of an inner scope symbol

--- a/boa3/exception/CompilerWarning.py
+++ b/boa3/exception/CompilerWarning.py
@@ -45,20 +45,6 @@ class InvalidArgument(CompilerWarning):
         return message
 
 
-class DuplicatedIdentifier(CompilerWarning):
-    """
-    An warning raised when more than one symbol uses the same identifier in the same scope and cannot be overwritten.
-    """
-
-    def __init__(self, line: int, col: int, duplicated_id: str = None):
-        self._duplicated_id = duplicated_id
-        super().__init__(line, col)
-
-    @property
-    def _warning_message(self) -> Optional[str]:
-        return f"Duplicate identifier: '{self._duplicated_id}'"
-
-
 class NameShadowing(CompilerWarning):
     """
     A warning raised when a name from an outer scope symbol is used as the name of an inner scope symbol

--- a/boa3/model/module.py
+++ b/boa3/model/module.py
@@ -65,7 +65,7 @@ class Module(ISymbol):
         if var_id in self.variables:
             self.assigned_variables.append(var_id)
 
-    def include_callable(self, method_id: str, method: Callable):
+    def include_callable(self, method_id: str, method: Callable) -> bool:
         """
         Includes a method into the scope of the module
 
@@ -77,6 +77,10 @@ class Module(ISymbol):
                 self.methods[method_id] = method
             else:
                 self.callables[method_id] = method
+
+            return True
+
+        return False
 
     def include_class(self, class_id: str, class_obj: ClassType):
         """

--- a/boa3/model/type/classes/userclass.py
+++ b/boa3/model/type/classes/userclass.py
@@ -90,7 +90,7 @@ class UserClass(ClassArrayType):
         """
         self._properties[prop_id] = prop
 
-    def include_callable(self, method_id: str, method: Callable, scope: ClassScope = ClassScope.INSTANCE):
+    def include_callable(self, method_id: str, method: Callable, scope: ClassScope = ClassScope.INSTANCE) -> bool:
         """
         Includes a method into the scope of the class
 
@@ -101,11 +101,17 @@ class UserClass(ClassArrayType):
         from boa3.model.builtin.builtin import Builtin
         if isinstance(method, Method):
             if Builtin.ClassMethodDecorator in method.decorators or scope is ClassScope.CLASS:
-                self._class_methods[method_id] = method
+                methods_map = self._class_methods
             elif Builtin.StaticMethodDecorator in method.decorators or scope is ClassScope.STATIC:
-                self._static_methods[method_id] = method
+                methods_map = self._static_methods
             else:
-                self._instance_methods[method_id] = method
+                methods_map = self._instance_methods
+
+            if method_id not in methods_map:
+                methods_map[method_id] = method
+                return True
+
+        return False
 
     def include_symbol(self, symbol_id: str, symbol: ISymbol, scope: ClassScope = ClassScope.INSTANCE):
         """

--- a/boa3_test/test_sc/function_test/FunctionsWithDuplicatedName.py
+++ b/boa3_test/test_sc/function_test/FunctionsWithDuplicatedName.py
@@ -1,0 +1,13 @@
+from boa3.builtin import public
+from boa3.builtin.type import UInt160
+from typing import List
+
+
+@public
+def func_no_arg_with_return_array() -> List[int]:
+    return [1, 2]
+
+
+@public
+def func_no_arg_with_return_array() -> List[UInt160]:
+    return [UInt160(b'\x01' * 20), UInt160(b'\x02' * 20)]

--- a/boa3_test/test_sc/function_test/FunctionsWithDuplicatedName.py
+++ b/boa3_test/test_sc/function_test/FunctionsWithDuplicatedName.py
@@ -1,6 +1,7 @@
+from typing import List
+
 from boa3.builtin import public
 from boa3.builtin.type import UInt160
-from typing import List
 
 
 @public

--- a/boa3_test/tests/compiler_tests/test_function.py
+++ b/boa3_test/tests/compiler_tests/test_function.py
@@ -1,6 +1,6 @@
 from boa3 import constants
 from boa3.boa3 import Boa3
-from boa3.exception import CompilerError
+from boa3.exception import CompilerError, CompilerWarning
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.StackItem import StackItemType
@@ -1063,3 +1063,7 @@ class TestFunction(BoaTest):
     def test_function_with_dictionary_unpacking_operator(self):
         path = self.get_contract_path('FunctionWithDictionaryUnpackingOperator.py')
         self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+
+    def test_functions_with_duplicated_name(self):
+        path = self.get_contract_path('FunctionsWithDuplicatedName.py')
+        self.assertCompilerLogs(CompilerWarning.DuplicatedIdentifier, path)

--- a/boa3_test/tests/compiler_tests/test_function.py
+++ b/boa3_test/tests/compiler_tests/test_function.py
@@ -1,6 +1,6 @@
 from boa3 import constants
 from boa3.boa3 import Boa3
-from boa3.exception import CompilerError, CompilerWarning
+from boa3.exception import CompilerError
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.StackItem import StackItemType
@@ -1066,4 +1066,4 @@ class TestFunction(BoaTest):
 
     def test_functions_with_duplicated_name(self):
         path = self.get_contract_path('FunctionsWithDuplicatedName.py')
-        self.assertCompilerLogs(CompilerWarning.DuplicatedIdentifier, path)
+        self.assertCompilerLogs(CompilerError.DuplicatedIdentifier, path)


### PR DESCRIPTION
**Related issue**
#846

**Summary or solution description**
Included a new compiler warning to warn when multiple symbols are defined using the same identifier. The warning doesn't stop the compilation.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/247a3a46e421e055410edf90b2a7f955d4f8069c/boa3_test/test_sc/function_test/FunctionsWithDuplicatedName.py#L6-L13

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/247a3a46e421e055410edf90b2a7f955d4f8069c/boa3_test/tests/compiler_tests/test_function.py#L1067-L1069

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7