### PR TITLE
Include an option to set the project root for better evaluate local imports

### DIFF
--- a/boa3/analyser/analyser.py
+++ b/boa3/analyser/analyser.py
@@ -40,8 +40,13 @@ class Analyser:
         self.path: str = path
         self.filename: str = path if path is None else os.path.realpath(path)
 
-        if project_root is not None and os.path.isfile(project_root):
-            project_root = os.path.dirname(os.path.abspath(project_root))
+        if project_root is not None:
+            if not os.path.exists(project_root):
+                project_root = os.path.abspath(f'{os.path.curdir}{os.path.sep}{project_root}')
+
+            if os.path.isfile(project_root):
+                project_root = os.path.dirname(os.path.abspath(project_root))
+
         self.root: str = (os.path.realpath(project_root)
                           if project_root is not None and os.path.isdir(project_root)
                           else path)

--- a/boa3/boa3.py
+++ b/boa3/boa3.py
@@ -9,20 +9,21 @@ class Boa3:
     """
 
     @staticmethod
-    def compile(path: str) -> bytes:
+    def compile(path: str, root_folder: str = None) -> bytes:
         """
         Load a Python file to be compiled but don't write the result into a file
 
         :param path: the path of the Python file to compile
+        :param root_folder: the root path of the project
         :return: the bytecode of the compiled .nef file
         """
         if not path.endswith('.py'):
             raise InvalidPathException(path)
 
-        return Compiler().compile(path)
+        return Compiler().compile(path, root_folder)
 
     @staticmethod
-    def compile_and_save(path: str, output_path: str = None, show_errors: bool = True, debug: bool = False):
+    def compile_and_save(path: str, output_path: str = None, root_folder: str = None, show_errors: bool = True, debug: bool = False):
         """
         Load a Python file to be compiled and save the result into the files.
         By default, the resultant .nef file is saved in the same folder of the
@@ -30,6 +31,7 @@ class Boa3:
 
         :param path: the path of the Python file to compile
         :param output_path: Optional path to save the generated files
+        :param root_folder: the root path of the project
         :param show_errors: if compiler errors should be logged.
         :param debug: if nefdbgnfo file should be generated.
         """
@@ -41,4 +43,4 @@ class Boa3:
         elif not output_path.endswith('.nef'):
             raise InvalidPathException(path)
 
-        Compiler().compile_and_save(path, output_path, show_errors, debug)
+        Compiler().compile_and_save(path, output_path, root_folder, show_errors, debug)

--- a/boa3/cli.py
+++ b/boa3/cli.py
@@ -10,7 +10,8 @@ from boa3.exception.NotLoadedException import NotLoadedException
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("input", help=".py smart contract to compile")
-    parser.add_argument("-db", "--debug", action='store_true', help="generates a nefdbgnfo file")
+    parser.add_argument("-db", "--debug", action='store_true', help="generates a .nefdbgnfo file")
+    parser.add_argument("--project-path", help="Project root path. Path of the contract by default.", type=str)
     args = parser.parse_args()
 
     if not args.input.endswith(".py") or not os.path.isfile(args.input):
@@ -20,8 +21,11 @@ def main():
     fullpath = os.path.realpath(args.input)
     path, filename = os.path.split(fullpath)
 
+    if not args.project_path:
+        args.project_path = os.path.dirname(path)
+
     try:
-        Boa3.compile_and_save(args.input, debug=args.debug)
+        Boa3.compile_and_save(args.input, debug=args.debug, root_folder=args.project_path)
         logging.info(f"Wrote {filename.replace('.py', '.nef')} to {path}")
     except NotLoadedException as e:
         logging.error("Could not compile")

--- a/boa3/compiler/compiler.py
+++ b/boa3/compiler/compiler.py
@@ -20,11 +20,12 @@ class Compiler:
         self._analyser: Analyser = None
         self._entry_smart_contract: str = ''
 
-    def compile(self, path: str, log: bool = True) -> bytes:
+    def compile(self, path: str, root_folder: str = None, log: bool = True) -> bytes:
         """
         Load a Python file and tries to compile it
 
         :param path: the path of the Python file to compile
+        :param root_folder: the root path of the project
         :param log: if compiler errors should be logged.
         :return: the bytecode of the compiled .nef file
         """
@@ -34,29 +35,31 @@ class Compiler:
         logging.info(f'neo3-boa v{constants.BOA_VERSION}\tPython {constants.SYS_VERSION}')
         logging.info(f'Started compiling\t{filename}')
         self._entry_smart_contract = os.path.splitext(filename)[0]
-        self._analyse(fullpath, log)
+        self._analyse(fullpath, root_folder, log)
         return self._compile()
 
-    def compile_and_save(self, path: str, output_path: str, log: bool = True, debug: bool = False):
+    def compile_and_save(self, path: str, output_path: str, root_folder: str = None, log: bool = True, debug: bool = False):
         """
         Save the compiled file and the metadata files
 
         :param path: the path of the Python file to compile
         :param output_path: the path to save the generated files
+        :param root_folder: the root path of the project
         :param log: if compiler errors should be logged.
         :param debug: if nefdbgnfo file should be generated.
         """
-        self.bytecode = self.compile(path, log)
+        self.bytecode = self.compile(path, root_folder, log)
         self._save(output_path, debug)
 
-    def _analyse(self, path: str, log: bool = True):
+    def _analyse(self, path: str, root_folder: str = None, log: bool = True):
         """
         Load a Python file and analyses its syntax
 
         :param path: the path of the Python file to compile
+        :param root_folder: the root path of the project
         :param log: if compiler errors should be logged.
         """
-        self._analyser = Analyser.analyse(path, log)
+        self._analyser = Analyser.analyse(path, log=log, root=root_folder)
 
     def _compile(self) -> bytes:
         """

--- a/boa3_test/test_sc/generation_test/GenerationWithUserModuleImportsFromProjectRoot.py
+++ b/boa3_test/test_sc/generation_test/GenerationWithUserModuleImportsFromProjectRoot.py
@@ -1,0 +1,13 @@
+from typing import List
+
+# only compile if pass boa3_test as project root
+from test_sc.interop_test.runtime.GetNotifications import with_param
+
+from boa3.builtin import public
+from boa3.builtin.interop.runtime import Notification
+from boa3.builtin.type import UInt160
+
+
+@public
+def main(args: list, key: UInt160) -> List[Notification]:
+    return with_param(args, key)

--- a/boa3_test/tests/boa_test.py
+++ b/boa3_test/tests/boa_test.py
@@ -72,6 +72,21 @@ class BoaTest(TestCase):
         if obj is not VoidType:
             self.fail('{0} is not Void'.format(obj))
 
+    def get_dir_path(self, *args: str) -> str:
+        type_error_message = 'get_contract_path() takes {0} positional argument but {1} were given'
+        num_args = len(args)
+        if num_args == 0:
+            raise TypeError(type_error_message.format(2, num_args + 1))
+        if num_args > 2:
+            raise TypeError(type_error_message.format(3, num_args + 1))
+
+        values = [None, env.PROJECT_ROOT_DIRECTORY]
+        for index, value in enumerate(reversed(args)):
+            values[index] = value
+
+        dir_folder, root_path = values
+        return '{0}/{1}'.format(root_path, dir_folder)
+
     def get_contract_path(self, *args: str) -> str:
         """
         Usages:
@@ -115,13 +130,13 @@ class BoaTest(TestCase):
             raise FileNotFoundError(path)
         return path
 
-    def compile_and_save(self, path: str, debug: bool = False, log: bool = True) -> Tuple[bytes, Dict[str, Any]]:
+    def compile_and_save(self, path: str, root_folder: str = None, debug: bool = False, log: bool = True) -> Tuple[bytes, Dict[str, Any]]:
         nef_output = path.replace('.py', '.nef')
         manifest_output = path.replace('.py', '.manifest.json')
 
         from boa3.boa3 import Boa3
         from boa3.neo.contracts.neffile import NefFile
-        Boa3.compile_and_save(path, show_errors=log, debug=debug)
+        Boa3.compile_and_save(path, root_folder=root_folder, show_errors=log, debug=debug)
 
         with open(nef_output, mode='rb') as nef:
             file = nef.read()
@@ -145,10 +160,10 @@ class BoaTest(TestCase):
             debug_info = json.loads(dbgnfo.read(os.path.basename(path.replace('.py', '.debug.json'))))
         return debug_info
 
-    def get_output(self, path: str) -> Tuple[bytes, Dict[str, Any]]:
+    def get_output(self, path: str, root_folder: str = None) -> Tuple[bytes, Dict[str, Any]]:
         nef_output = path.replace('.py', '.nef')
         if not os.path.isfile(nef_output):
-            return self.compile_and_save(path)
+            return self.compile_and_save(path, root_folder=root_folder)
 
         manifest_output = path.replace('.py', '.manifest.json')
 

--- a/boa3_test/tests/compiler_tests/test_file_generation.py
+++ b/boa3_test/tests/compiler_tests/test_file_generation.py
@@ -649,6 +649,24 @@ class TestFileGeneration(BoaTest):
         self.assertIn('events', abi)
         self.assertEqual(0, len(abi['events']))
 
+    def test_generate_with_user_module_import_with_project_root(self):
+        path = self.get_contract_path('GenerationWithUserModuleImportsFromProjectRoot.py')
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+
+        expected_manifest_output = path.replace('.py', '.manifest.json')
+        output, manifest = self.compile_and_save(path, root_folder=self.get_dir_path(self.test_root_dir))
+
+        self.assertTrue(os.path.exists(expected_manifest_output))
+        self.assertIn('abi', manifest)
+        abi = manifest['abi']
+
+        self.assertNotIn('entryPoint', abi)
+        self.assertIn('methods', abi)
+        self.assertEqual(2, len(abi['methods']))
+
+        self.assertIn('events', abi)
+        self.assertEqual(0, len(abi['events']))
+
     def test_compiler_error(self):
         path = self.get_contract_path('test_sc/built_in_methods_test', 'ClearTooManyParameters.py')
 


### PR DESCRIPTION
**Related issue**
#840

**Summary or solution description**
Included a new argument to the compiler for setting the project root path for improving importing analysis. 
If not given, the default value is the contract path.

**How to Reproduce**
With this smart contract:
https://github.com/CityOfZion/neo3-boa/blob/5aaf8156346e5cde15216bbe5a2a91dd60d7842b/boa3_test/test_sc/generation_test/GenerationWithUserModuleImportsFromProjectRoot.py#L1-L13

Compiling without passing the proper project root will fail.
https://github.com/CityOfZion/neo3-boa/blob/5aaf8156346e5cde15216bbe5a2a91dd60d7842b/boa3_test/tests/compiler_tests/test_file_generation.py#L652-L657

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/5aaf8156346e5cde15216bbe5a2a91dd60d7842b/boa3_test/tests/compiler_tests/test_file_generation.py#L652-L669

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7