### PR TITLE
Validate pass keyword #831

### DIFF
--- a/boa3/compiler/codegenerator/codegenerator.py
+++ b/boa3/compiler/codegenerator/codegenerator.py
@@ -426,6 +426,12 @@ class CodeGenerator:
         """
         self.__insert1(OpcodeInfo.NOT)
 
+    def insert_nop(self):
+        """
+        Insert a NOP opcode
+        """
+        self.__insert1(OpcodeInfo.NOP)
+
     def convert_begin_while(self, is_for: bool = False) -> int:
         """
         Converts the beginning of the while statement

--- a/boa3/compiler/codegenerator/codegeneratorvisitor.py
+++ b/boa3/compiler/codegenerator/codegeneratorvisitor.py
@@ -1085,6 +1085,18 @@ class VisitorCodeGenerator(IAstAnalyser):
 
         return self.build_data(dict_node, result_type=result_type, already_generated=True)
 
+    def visit_Pass(self, pass_node: ast.Pass) -> GeneratorData:
+        """
+        Visitor of pass node
+
+        :param pass_node: the python ast dict node
+        """
+        result_type = None
+
+        self.generator.insert_nop()
+
+        return self.build_data(pass_node, result_type=result_type, already_generated=True)
+
     def _create_array(self, values: List[ast.AST], array_type: IType):
         """
         Creates a new array from a literal sequence

--- a/boa3_test/test_sc/for_test/ForPass.py
+++ b/boa3_test/test_sc/for_test/ForPass.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+
+
+@public
+def main():
+    for x in range(0, 10):
+        pass

--- a/boa3_test/test_sc/if_test/ElsePass.py
+++ b/boa3_test/test_sc/if_test/ElsePass.py
@@ -1,0 +1,13 @@
+from boa3.builtin import public
+
+
+@public
+def main(condition: bool) -> int:
+    a = 0
+
+    if condition:
+        a = 5
+    else:
+        pass
+
+    return a

--- a/boa3_test/test_sc/if_test/IfElsePass.py
+++ b/boa3_test/test_sc/if_test/IfElsePass.py
@@ -1,0 +1,13 @@
+from boa3.builtin import public
+
+
+@public
+def main(condition: bool) -> int:
+    a = 0
+
+    if condition:
+        pass
+    else:
+        pass
+
+    return a

--- a/boa3_test/test_sc/if_test/IfPass.py
+++ b/boa3_test/test_sc/if_test/IfPass.py
@@ -1,0 +1,11 @@
+from boa3.builtin import public
+
+
+@public
+def main(condition: bool) -> int:
+    a = 0
+
+    if condition:
+        pass
+
+    return a

--- a/boa3_test/tests/compiler_tests/test_class.py
+++ b/boa3_test/tests/compiler_tests/test_class.py
@@ -97,6 +97,7 @@ class TestClass(BoaTest):
             + b'\x01'
             + Opcode.LDARG0
             + Opcode.RET
+            + Opcode.NOP
         )
 
         path = self.get_contract_path('UserClassEmpty.py')

--- a/boa3_test/tests/compiler_tests/test_for.py
+++ b/boa3_test/tests/compiler_tests/test_for.py
@@ -304,3 +304,13 @@ class TestFor(BoaTest):
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'main')
         self.assertEqual(6, result)
+
+    def test_for_pass(self):
+        path = self.get_contract_path('ForPass.py')
+        engine = TestEngine()
+
+        output = Boa3.compile(path)
+        self.assertIn(Opcode.NOP, output)
+
+        result = self.run_smart_contract(engine, path, 'main')
+        self.assertIsVoid(result)

--- a/boa3_test/tests/compiler_tests/test_function.py
+++ b/boa3_test/tests/compiler_tests/test_function.py
@@ -67,6 +67,9 @@ class TestFunction(BoaTest):
         path = self.get_contract_path('NoneFunctionPass.py')
         engine = TestEngine()
 
+        output = Boa3.compile(path)
+        self.assertIn(Opcode.NOP, output)
+
         result = self.run_smart_contract(engine, path, 'main', 1)
         self.assertIsVoid(result)
 
@@ -136,6 +139,7 @@ class TestFunction(BoaTest):
             Opcode.INITSLOT  # function signature
             + b'\x00'  # num local variables
             + b'\x01'  # num arguments
+            + Opcode.NOP  # pass
             + Opcode.RET  # return
         )
 

--- a/boa3_test/tests/compiler_tests/test_if.py
+++ b/boa3_test/tests/compiler_tests/test_if.py
@@ -634,3 +634,39 @@ class TestIf(BoaTest):
 
         result = self.run_smart_contract(engine, path, 'main')
         self.assertEqual(4, result)
+
+    def test_if_pass(self):
+        path = self.get_contract_path('IfPass.py')
+        engine = TestEngine()
+
+        output = Boa3.compile(path)
+        self.assertIn(Opcode.NOP, output)
+
+        result = self.run_smart_contract(engine, path, 'main', True)
+        self.assertEqual(result, 0)
+
+    def test_else_pass(self):
+        path = self.get_contract_path('ElsePass.py')
+        engine = TestEngine()
+
+        output = Boa3.compile(path)
+        self.assertIn(Opcode.NOP, output)
+
+        result = self.run_smart_contract(engine, path, 'main', True)
+        self.assertEqual(result, 5)
+        result = self.run_smart_contract(engine, path, 'main', False)
+        self.assertEqual(result, 0)
+
+    def test_if_else_pass(self):
+        path = self.get_contract_path('IfElsePass.py')
+        engine = TestEngine()
+
+        output = Boa3.compile(path)
+        n_nop = 0
+        for byte_value in output:
+            if byte_value == int.from_bytes(Opcode.NOP.value, 'little'):
+                n_nop += 1
+        self.assertEqual(n_nop, 2)
+
+        result = self.run_smart_contract(engine, path, 'main', True)
+        self.assertEqual(result, 0)

--- a/boa3_test/tests/compiler_tests/test_variable.py
+++ b/boa3_test/tests/compiler_tests/test_variable.py
@@ -664,6 +664,10 @@ class TestVariable(BoaTest):
     def test_assign_void_function_call(self):
         path = self.get_contract_path('AssignVoidFunctionCall.py')
         engine = TestEngine()
+
+        output = Boa3.compile(path)
+        self.assertIn(Opcode.NOP, output)
+
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual(None, result)
 


### PR DESCRIPTION
**Related issue**
#831

**Summary or solution description**
Added the opcode NOP when `pass` is being used on the smart contract.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/97e225cb16ead49f5ae7a7554a09c5766078378f/boa3_test/test_sc/function_test/NoReturnFunction.py#L1-L6
https://github.com/CityOfZion/neo3-boa/blob/97e225cb16ead49f5ae7a7554a09c5766078378f/boa3_test/test_sc/for_test/ForPass.py#L1-L7

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/97e225cb16ead49f5ae7a7554a09c5766078378f/boa3_test/tests/compiler_tests/test_function.py#L137-L152
https://github.com/CityOfZion/neo3-boa/blob/97e225cb16ead49f5ae7a7554a09c5766078378f/boa3_test/tests/compiler_tests/test_for.py#L308-L316

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8
