### PR TITLE
Optimize opcode instructions class-related in the cases they're generated but not used #835

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@
 
 ## Overview
 
-Neo3-Boa is a tool for creating Neo Smart Contracts using Python. It compiles `.py` files to `.nef` and `.manisfest.json` formats for usage in the [Neo Virtual Machine](https://github.com/neo-project/neo-vm/) which is used to execute contracts on the [Neo Blockchain](https://github.com/neo-project/neo/).
+Neo3-Boa is a tool for creating Neo Smart Contracts using Python. It compiles `.py` files to `.nef` and `.manifest.json` formats for usage in the [Neo Virtual Machine](https://github.com/neo-project/neo-vm/) which is used to execute contracts on the [Neo Blockchain](https://github.com/neo-project/neo/).
 
 Neo-boa is part of the Neo Python Framework, aimed to allow the full development of dApps using Python alone.
 

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Python compiler for the Neo3 Virtual Machine
 Overview
 --------
 
-Neo3-Boa is a tool for creating Neo Smart Contracts using Python. It compiles `.py` files to `.nef` and `.manisfest.json` formats for usage in the `Neo Virtual Machine <https://github.com/neo-project/neo-vm/>`__ which is used to execute contracts on the `Neo Blockchain <https://github.com/neo-project/neo/>`__.
+Neo3-Boa is a tool for creating Neo Smart Contracts using Python. It compiles `.py` files to `.nef` and `.manifest.json` formats for usage in the `Neo Virtual Machine <https://github.com/neo-project/neo-vm/>`__ which is used to execute contracts on the `Neo Blockchain <https://github.com/neo-project/neo/>`__.
 
 Neo-boa is part of the Neo Python Framework, aimed to allow the full development of dApps using Python alone.
 

--- a/boa3/analyser/astanalyser.py
+++ b/boa3/analyser/astanalyser.py
@@ -63,6 +63,15 @@ class IAstAnalyser(ABC, ast.NodeVisitor):
             if self._log:
                 logging.warning(warning)
 
+    def _log_info(self, info_message: str, log_filename: bool = True):
+        if self._log:
+            if log_filename and self.filename:
+                formatted_message = f'{info_message} <{self.filename}>'
+            else:
+                formatted_message = info_message
+
+            logging.info(formatted_message)
+
     def visit(self, node: ast.AST) -> Any:
         try:
             return super().visit(node)

--- a/boa3/analyser/moduleanalyser.py
+++ b/boa3/analyser/moduleanalyser.py
@@ -91,6 +91,9 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
         self._metadata: NeoMetadata = None
         self._metadata_node: ast.AST = ast.parse('')
         self.imported_nodes: List[ast.AST] = []
+
+        if self.filename:
+            self._tree.filename = self.filename
         self.visit(self._tree)
 
         analyser.metadata = self._metadata if self._metadata is not None else NeoMetadata()

--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -1384,6 +1384,8 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
         return None
 
     def update_callable_after_validation(self, call: ast.Call, callable_id: str, callable_target: Callable):
+        callable_target.add_call_origin(call)
+
         # if the arguments are not generic, include the specified method in the symbol table
         if (isinstance(callable_target, IBuiltinMethod)
                 and callable_target.identifier != callable_id
@@ -1606,6 +1608,9 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
         else:
             attr_value = attribute.value
 
+        if isinstance(attr_symbol, Property):
+            if isinstance(attribute.ctx, ast.Load):
+                attr_symbol.getter.add_call_origin(attribute)
         return Attribute(attr_value, attribute.attr, attr_symbol, attribute)
 
     def visit_Constant(self, constant: ast.Constant) -> Any:

--- a/boa3/compiler/codegenerator/codegenerator.py
+++ b/boa3/compiler/codegenerator/codegenerator.py
@@ -2047,6 +2047,9 @@ class CodeGenerator:
             self._stack_pop()
 
     def generate_implicit_init_user_class(self, init_method: Method):
+        if not init_method.is_called:
+            return
+
         self.convert_begin_method(init_method)
         class_type = init_method.return_type
         for base in class_type.bases:

--- a/boa3/compiler/codegenerator/codegenerator.py
+++ b/boa3/compiler/codegenerator/codegenerator.py
@@ -67,7 +67,7 @@ class CodeGenerator:
         if hasattr(deploy_method, 'origin') and deploy_method.origin in analyser.ast_tree.body:
             analyser.ast_tree.body.remove(deploy_method.origin)
 
-        visitor = VisitorCodeGenerator(generator)
+        visitor = VisitorCodeGenerator(generator, analyser.filename)
         visitor._root_module = analyser.ast_tree
         visitor.visit(analyser.ast_tree)
 
@@ -82,6 +82,7 @@ class CodeGenerator:
                 symbol.ast.body.remove(deploy_method.origin)
                 deploy_origin_module = symbol.ast
 
+            visitor.set_filename(symbol.origin)
             visitor.visit(symbol.ast)
 
             analyser.update_symbol_table(symbol.all_symbols)
@@ -115,6 +116,7 @@ class CodeGenerator:
             generator.symbol_table.clear()
             generator.symbol_table.update(analyser.symbol_table.copy())
 
+        visitor.set_filename(analyser.filename)
         generator.can_init_static_fields = True
         if len(visitor.global_stmts) > 0:
             global_ast = ast.parse("")

--- a/boa3/compiler/codegenerator/codegeneratorvisitor.py
+++ b/boa3/compiler/codegenerator/codegeneratorvisitor.py
@@ -314,7 +314,7 @@ class VisitorCodeGenerator(IAstAnalyser):
 
                     self.generator.convert_end_method(function.name)
 
-                self.current_method = None
+            self.current_method = None
 
         return self.build_data(function, symbol=method, symbol_id=function.name)
 

--- a/boa3/compiler/codegenerator/codegeneratorvisitor.py
+++ b/boa3/compiler/codegenerator/codegeneratorvisitor.py
@@ -1,4 +1,5 @@
 import ast
+import os.path
 from inspect import isclass
 from typing import Dict, List, Optional, Tuple
 
@@ -36,8 +37,9 @@ class VisitorCodeGenerator(IAstAnalyser):
     :ivar generator:
     """
 
-    def __init__(self, generator: CodeGenerator):
-        super().__init__(ast.parse(""), log=True)
+    def __init__(self, generator: CodeGenerator, filename: str = None):
+        super().__init__(ast.parse(""), filename=filename, log=True)
+
         self.generator = generator
         self.current_method: Optional[Method] = None
         self.current_class: Optional[UserClass] = None
@@ -164,6 +166,13 @@ class VisitorCodeGenerator(IAstAnalyser):
     def _get_unique_name(self, name_id: str, node: ast.AST) -> str:
         return '{0}{2}{1}'.format(node.__hash__(), name_id, constants.VARIABLE_NAME_SEPARATOR)
 
+    def set_filename(self, filename: str):
+        if isinstance(filename, str) and os.path.isfile(filename):
+            if constants.PATH_SEPARATOR != os.path.sep:
+                self.filename = filename.replace(constants.PATH_SEPARATOR, os.path.sep)
+            else:
+                self.filename = filename
+
     def visit_Module(self, module: ast.Module) -> GeneratorData:
         """
         Visitor of the module node
@@ -221,7 +230,12 @@ class VisitorCodeGenerator(IAstAnalyser):
             # to generate the 'initialize' method for Neo
             self._is_generating_initialize = True
             for stmt in global_stmts:
+                cur_filename = self.filename
+                if hasattr(stmt, 'origin') and hasattr(stmt.origin, 'filename'):
+                    self.set_filename(stmt.origin.filename)
+
                 self.visit(stmt)
+                self.filename = cur_filename
 
             self._is_generating_initialize = False
             self.generator.end_initialize()
@@ -282,8 +296,16 @@ class VisitorCodeGenerator(IAstAnalyser):
         if isinstance(method, Property):
             method = method.getter
 
-        if isinstance(method, Method):
+        if isinstance(method, Method) and (method.is_public or method.is_called):
             self.current_method = method
+
+            if isinstance(self.current_class, ClassType):
+                function_name = self.current_class.identifier + constants.ATTRIBUTE_NAME_SEPARATOR + function.name
+            else:
+                function_name = function.name
+
+            self._log_info(f"Compiling '{function_name}' function")
+
             if not isinstance(self.current_class, ClassType) or not self.current_class.is_interface:
                 self.generator.convert_begin_method(method)
 

--- a/boa3/compiler/filegenerator.py
+++ b/boa3/compiler/filegenerator.py
@@ -194,14 +194,17 @@ class FileGenerator:
         """
         methods = []
         for method_id, method in self._public_methods.items():
-            logging.info("'{0}' method included in the ABI".format(method_id))
             methods.append(self._construct_abi_method(method_id, method))
         return methods
 
     def _construct_abi_method(self, method_id: str, method: Method) -> Dict[str, Any]:
         from boa3.compiler.codegenerator.vmcodemapping import VMCodeMapping
+
+        abi_method_name = method.external_name if isinstance(method.external_name, str) else method_id
+        logging.info(f"'{abi_method_name}' method included in the manifest")
+
         return {
-            "name": method.external_name if isinstance(method.external_name, str) else method_id,
+            "name": abi_method_name,
             "offset": (VMCodeMapping.instance().get_start_address(method.start_bytecode)
                        if method.start_bytecode is not None else 0),
             "parameters": [

--- a/boa3/model/callable.py
+++ b/boa3/model/callable.py
@@ -168,7 +168,7 @@ class Callable(IExpression, ABC):
         try:
             self._self_calls.add(origin)
             return True
-        except:
+        except BaseException:
             return False
 
     def __str__(self) -> str:

--- a/boa3/model/callable.py
+++ b/boa3/model/callable.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import ast
 from abc import ABC
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 from boa3.model import set_internal_call
 from boa3.model.expression import IExpression
@@ -85,6 +85,8 @@ class Callable(IExpression, ABC):
         self.external_name: Optional[str] = external_name
         self.is_safe: bool = is_safe or (isinstance(public_decorator, PublicDecorator) and public_decorator.safe)
 
+        self._self_calls: Set[ast.AST] = set()
+
         super().__init__(origin_node)
 
         self.init_address: Optional[int] = None
@@ -157,6 +159,17 @@ class Callable(IExpression, ABC):
         else:
             from boa3.compiler.codegenerator.vmcodemapping import VMCodeMapping
             return VMCodeMapping.instance().get_end_address(self.end_bytecode)
+
+    @property
+    def is_called(self) -> bool:
+        return len(self._self_calls) > 0
+
+    def add_call_origin(self, origin: ast.AST) -> bool:
+        try:
+            self._self_calls.add(origin)
+            return True
+        except:
+            return False
 
     def __str__(self) -> str:
         args_types: List[str] = [str(arg.type) for arg in self.args.values()]

--- a/boa3/model/type/classes/classinitmethoddefault.py
+++ b/boa3/model/type/classes/classinitmethoddefault.py
@@ -13,10 +13,12 @@ class ClassInitMethod(IdentifiedSymbol, Method):
         args = {
             'self': self_var
         }
+        base_init = None
         if len(user_class.bases) == 1:
             # TODO: change when class inheritance with multiple bases is implemented
             # use update to keep the original order
-            args.update(user_class.bases[0].constructor_method().args)
+            base_init = user_class.bases[0].constructor_method()
+            args.update(base_init.args)
             # but change the self type
             args['self'] = self_var
 
@@ -29,6 +31,10 @@ class ClassInitMethod(IdentifiedSymbol, Method):
         # __init__ method behave like class methods
         from boa3.model.builtin.builtin import Builtin
         self.decorators.append(Builtin.ClassMethodDecorator)
+
+        if base_init is not None:
+            origin = self.origin if self.origin else self
+            base_init.add_call_origin(origin)
 
     @property
     def _args_on_stack(self) -> int:

--- a/boa3_test/test_sc/any_test/AnyList.py
+++ b/boa3_test/test_sc/any_test/AnyList.py
@@ -1,5 +1,8 @@
 from typing import Any, List
 
+from boa3.builtin import public
 
+
+@public
 def Main():
     a: List[Any] = [True, 1, 'ok']

--- a/boa3_test/test_sc/any_test/AnySequenceAssignments.py
+++ b/boa3_test/test_sc/any_test/AnySequenceAssignments.py
@@ -1,6 +1,9 @@
 from typing import Any, Sequence
 
+from boa3.builtin import public
 
+
+@public
 def Main():
     any_list = [True, 1, 'ok']
     int_list = [1, 2, 3]

--- a/boa3_test/test_sc/any_test/AnyTuple.py
+++ b/boa3_test/test_sc/any_test/AnyTuple.py
@@ -1,5 +1,8 @@
 from typing import Any, Tuple
 
+from boa3.builtin import public
 
+
+@public
 def Main():
     a: Tuple[Any] = (True, 1, 'ok')

--- a/boa3_test/test_sc/any_test/AnyVariableAssignments.py
+++ b/boa3_test/test_sc/any_test/AnyVariableAssignments.py
@@ -1,6 +1,9 @@
 from typing import Any
 
+from boa3.builtin import public
 
+
+@public
 def Main():
     a: Any = 1
     a = '2'

--- a/boa3_test/test_sc/any_test/FunctionAnyParam.py
+++ b/boa3_test/test_sc/any_test/FunctionAnyParam.py
@@ -1,6 +1,9 @@
 from typing import Any, Sequence
 
+from boa3.builtin import public
 
+
+@public
 def Main():
     bool_tuple = True, False
 

--- a/boa3_test/test_sc/any_test/IntSequenceAnyAssignment.py
+++ b/boa3_test/test_sc/any_test/IntSequenceAnyAssignment.py
@@ -1,6 +1,9 @@
 from typing import Sequence
 
+from boa3.builtin import public
 
+
+@public
 def Main():
     any_list = [True, 1, 'ok']
     int_sequence: Sequence[int] = any_list

--- a/boa3_test/test_sc/any_test/SequenceOfAnyIntSequence.py
+++ b/boa3_test/test_sc/any_test/SequenceOfAnyIntSequence.py
@@ -1,6 +1,9 @@
 from typing import Sequence
 
+from boa3.builtin import public
 
+
+@public
 def Main():
     int_list = [1, 2, 3]
     any_tuple = (True, 1, 'ok')

--- a/boa3_test/test_sc/any_test/SequenceOfAnySequence.py
+++ b/boa3_test/test_sc/any_test/SequenceOfAnySequence.py
@@ -1,6 +1,9 @@
 from typing import Any, Sequence
 
+from boa3.builtin import public
 
+
+@public
 def Main():
     any_list = [True, 1, 'ok']
     int_list = [1, 2, 3]

--- a/boa3_test/test_sc/any_test/SequenceOfIntSequence.py
+++ b/boa3_test/test_sc/any_test/SequenceOfIntSequence.py
@@ -1,6 +1,9 @@
 from typing import Sequence
 
+from boa3.builtin import public
 
+
+@public
 def Main():
     int_list = [1, 2, 3]
     int_tuple = 10, 9, 8

--- a/boa3_test/test_sc/any_test/StrSequenceAnyAssignment.py
+++ b/boa3_test/test_sc/any_test/StrSequenceAnyAssignment.py
@@ -1,6 +1,9 @@
 from typing import Sequence
 
+from boa3.builtin import public
 
+
+@public
 def Main():
     any_tuple = (True, 1, 'ok')
     str_sequence: Sequence[str] = any_tuple

--- a/boa3_test/test_sc/any_test/StrSequenceStrAssignment.py
+++ b/boa3_test/test_sc/any_test/StrSequenceStrAssignment.py
@@ -1,5 +1,8 @@
 from typing import Sequence
 
+from boa3.builtin import public
 
+
+@public
 def Main():
     str_sequence: Sequence[str] = 'some_string'

--- a/boa3_test/test_sc/arithmetic_test/AdditionAugmentedAssignment.py
+++ b/boa3_test/test_sc/arithmetic_test/AdditionAugmentedAssignment.py
@@ -1,2 +1,6 @@
+from boa3.builtin import public
+
+
+@public
 def Main(a: int, b: int):
     a += b

--- a/boa3_test/test_sc/arithmetic_test/ConcatenationAugmentedAssignment.py
+++ b/boa3_test/test_sc/arithmetic_test/ConcatenationAugmentedAssignment.py
@@ -1,2 +1,6 @@
+from boa3.builtin import public
+
+
+@public
 def Main(a: str, b: str):
     a += b

--- a/boa3_test/test_sc/arithmetic_test/IntegerDivisionAugmentedAssignment.py
+++ b/boa3_test/test_sc/arithmetic_test/IntegerDivisionAugmentedAssignment.py
@@ -1,2 +1,6 @@
+from boa3.builtin import public
+
+
+@public
 def Main(a: int, b: int):
     a //= b

--- a/boa3_test/test_sc/arithmetic_test/MultiplicationAugmentedAssignment.py
+++ b/boa3_test/test_sc/arithmetic_test/MultiplicationAugmentedAssignment.py
@@ -1,2 +1,6 @@
+from boa3.builtin import public
+
+
+@public
 def Main(a: int, b: int):
     a *= b

--- a/boa3_test/test_sc/arithmetic_test/PowerAugmentedAssignment.py
+++ b/boa3_test/test_sc/arithmetic_test/PowerAugmentedAssignment.py
@@ -1,2 +1,6 @@
+from boa3.builtin import public
+
+
+@public
 def Main(a: int, b: int):
     a **= b

--- a/boa3_test/test_sc/arithmetic_test/SubtractionAugmentedAssignment.py
+++ b/boa3_test/test_sc/arithmetic_test/SubtractionAugmentedAssignment.py
@@ -1,2 +1,6 @@
+from boa3.builtin import public
+
+
+@public
 def Main(a: int, b: int):
     a -= b

--- a/boa3_test/test_sc/bytes_test/BytearrayFromLiteralBytes.py
+++ b/boa3_test/test_sc/bytes_test/BytearrayFromLiteralBytes.py
@@ -1,2 +1,6 @@
+from boa3.builtin import public
+
+
+@public
 def Main():
     a: bytearray = bytearray(b'\x01\x02\x03')

--- a/boa3_test/test_sc/bytes_test/BytearrayFromVariableBytes.py
+++ b/boa3_test/test_sc/bytes_test/BytearrayFromVariableBytes.py
@@ -1,3 +1,7 @@
+from boa3.builtin import public
+
+
+@public
 def Main():
     a = b'\x01\x02\x03'
     b: bytearray = bytearray(a)

--- a/boa3_test/test_sc/bytes_test/BytearrayLiteral.py
+++ b/boa3_test/test_sc/bytes_test/BytearrayLiteral.py
@@ -1,2 +1,6 @@
+from boa3.builtin import public
+
+
+@public
 def Main():
     a: bytearray = b'\x01\x02\x03'  # mismatched type error

--- a/boa3_test/test_sc/bytes_test/BytesFromBytearray.py
+++ b/boa3_test/test_sc/bytes_test/BytesFromBytearray.py
@@ -1,3 +1,7 @@
+from boa3.builtin import public
+
+
+@public
 def Main():
     a: bytearray = bytearray(b'\x01\x02\x03')
     b: bytes = a

--- a/boa3_test/test_sc/bytes_test/BytesLiteral.py
+++ b/boa3_test/test_sc/bytes_test/BytesLiteral.py
@@ -1,2 +1,6 @@
+from boa3.builtin import public
+
+
+@public
 def Main():
     a: bytes = b'\x01\x02\x03'

--- a/boa3_test/test_sc/contract_interface_test/ContractInterfaceCodeOptimization.py
+++ b/boa3_test/test_sc/contract_interface_test/ContractInterfaceCodeOptimization.py
@@ -1,0 +1,35 @@
+from typing import Any
+
+from boa3.builtin import contract, display_name, public
+from boa3.builtin.type import UInt160
+
+
+@contract('0xa34afa0e5414255d1093e92a1a6f1f505c82cd3f')
+class Nep17:
+
+    @staticmethod
+    def symbol() -> str:
+        pass
+
+    @staticmethod
+    def decimals() -> int:
+        pass
+
+    @staticmethod
+    @display_name('totalSupply')
+    def total_supply() -> int:
+        pass
+
+    @staticmethod
+    @display_name('balanceOf')
+    def balance_of(account: UInt160) -> int:
+        pass
+
+    @staticmethod
+    def transfer(from_address: UInt160, to_address: UInt160, amount: int, data: Any) -> bool:
+        pass
+
+
+@public
+def nep17_symbol() -> str:
+    return Nep17.symbol()

--- a/boa3_test/test_sc/contract_interface_test/ContractManualInterfaceCodeOptimization.py
+++ b/boa3_test/test_sc/contract_interface_test/ContractManualInterfaceCodeOptimization.py
@@ -1,0 +1,34 @@
+from typing import Any, cast
+
+from boa3.builtin import public
+from boa3.builtin.interop.contract import call_contract
+from boa3.builtin.type import UInt160
+
+
+class Nep17:
+    _hash = UInt160(b'\x3f\xcd\x82\x5c\x50\x1f\x6f\x1a\x2a\xe9\x93\x10\x5d\x25\x14\x54\x0e\xfa\x4a\xa3')
+
+    @classmethod
+    def symbol(cls) -> str:
+        return cast(str, call_contract(cls._hash, 'symbol'))
+
+    @classmethod
+    def decimals(cls) -> int:
+        return cast(int, call_contract(cls._hash, 'decimals'))
+
+    @classmethod
+    def total_supply(cls) -> int:
+        return cast(int, call_contract(cls._hash, 'totalSupply'))
+
+    @classmethod
+    def balance_of(cls, account: UInt160) -> int:
+        return cast(int, call_contract(cls._hash, 'balanceOf', [account]))
+
+    @classmethod
+    def transfer(cls, from_address: UInt160, to_address: UInt160, amount: int, data: Any) -> bool:
+        return cast(bool, call_contract(cls._hash, 'transfer', [from_address, to_address, amount, data]))
+
+
+@public
+def nep17_symbol() -> str:
+    return Nep17.symbol()

--- a/boa3_test/test_sc/dict_test/AnyValueDict.py
+++ b/boa3_test/test_sc/dict_test/AnyValueDict.py
@@ -1,6 +1,9 @@
 from typing import Any, Dict
 
+from boa3.builtin import public
 
+
+@public
 def Main():
     a: Dict[int, Any] = {
         1: True,

--- a/boa3_test/test_sc/dict_test/DictOfDict.py
+++ b/boa3_test/test_sc/dict_test/DictOfDict.py
@@ -1,6 +1,9 @@
 from typing import Dict
 
+from boa3.builtin import public
 
+
+@public
 def Main():
     a: Dict[int, Dict[int, bool]] = {
         1: {

--- a/boa3_test/test_sc/dict_test/EmptyDictAssignment.py
+++ b/boa3_test/test_sc/dict_test/EmptyDictAssignment.py
@@ -1,5 +1,8 @@
 from typing import Dict
 
+from boa3.builtin import public
 
+
+@public
 def Main():
     a: Dict[int, int] = {}

--- a/boa3_test/test_sc/dict_test/IntKeyDict.py
+++ b/boa3_test/test_sc/dict_test/IntKeyDict.py
@@ -1,2 +1,6 @@
+from boa3.builtin import public
+
+
+@public
 def Main():
     a = {1: 15, 2: 14, 3: 13}

--- a/boa3_test/test_sc/dict_test/StrKeyDict.py
+++ b/boa3_test/test_sc/dict_test/StrKeyDict.py
@@ -1,2 +1,6 @@
+from boa3.builtin import public
+
+
+@public
 def Main():
     a = {'one': 1, 'two': 2, 'three': 3}

--- a/boa3_test/test_sc/dict_test/TypeHintAssignment.py
+++ b/boa3_test/test_sc/dict_test/TypeHintAssignment.py
@@ -1,5 +1,8 @@
 from typing import Dict
 
+from boa3.builtin import public
 
+
+@public
 def Main():
     a: Dict[int, int] = {1: 15, 2: 14, 3: 13}

--- a/boa3_test/test_sc/dict_test/VariableDict.py
+++ b/boa3_test/test_sc/dict_test/VariableDict.py
@@ -1,3 +1,7 @@
+from boa3.builtin import public
+
+
+@public
 def Main():
     a = 1
     b = 2

--- a/boa3_test/test_sc/function_test/CallReturnFunctionWithVariableArgs.py
+++ b/boa3_test/test_sc/function_test/CallReturnFunctionWithVariableArgs.py
@@ -1,6 +1,7 @@
 from boa3.builtin import public
 
 
+@public
 def Main(operation: str, args: tuple) -> int:
     a = 1
     b = 2

--- a/boa3_test/test_sc/generation_test/GenerationWithoutDecorator.py
+++ b/boa3_test/test_sc/generation_test/GenerationWithoutDecorator.py
@@ -1,3 +1,7 @@
+from boa3.builtin import public
+
+
+@public
 def Main(a: int, b: int) -> int:
     return a + b
 

--- a/boa3_test/test_sc/import_test/FromImportAll.py
+++ b/boa3_test/test_sc/import_test/FromImportAll.py
@@ -1,4 +1,5 @@
 from boa3.builtin import public
+
 from boa3_test.test_sc.import_test.FromImportTyping import *
 
 

--- a/boa3_test/test_sc/import_test/FromImportTyping.py
+++ b/boa3_test/test_sc/import_test/FromImportTyping.py
@@ -1,6 +1,9 @@
 from typing import Any, List
 
+from boa3.builtin import public as public_method  # alias to not change other tests when executing lint process
 
+
+@public_method
 def EmptyList() -> List[Any]:
     return []
 

--- a/boa3_test/test_sc/import_test/FromImportTypingWithAlias.py
+++ b/boa3_test/test_sc/import_test/FromImportTypingWithAlias.py
@@ -1,5 +1,8 @@
 from typing import Any as Bar, List as Foo
 
+from boa3.builtin import public
 
+
+@public
 def EmptyList() -> Foo[Bar]:
     return []

--- a/boa3_test/test_sc/import_test/ImportTyping.py
+++ b/boa3_test/test_sc/import_test/ImportTyping.py
@@ -1,5 +1,8 @@
 import typing
 
+from boa3.builtin import public
 
+
+@public
 def Main():
     a: typing.List[typing.Any] = []

--- a/boa3_test/test_sc/import_test/ImportTypingWithAlias.py
+++ b/boa3_test/test_sc/import_test/ImportTypingWithAlias.py
@@ -1,5 +1,8 @@
 import typing as types
 
+from boa3.builtin import public
 
+
+@public
 def Main():
     a: types.List[types.Any] = []

--- a/boa3_test/test_sc/interop_test/contract/GasScriptHashCantAssign.py
+++ b/boa3_test/test_sc/interop_test/contract/GasScriptHashCantAssign.py
@@ -1,8 +1,13 @@
+from boa3.builtin import public
 from boa3.builtin.interop.contract import GAS
 from boa3.builtin.type import UInt160
 
 
+@public
 def Main(example: UInt160) -> UInt160:
-    global GAS
     GAS = example
     return GAS
+
+
+def interop_call():
+    x = GAS

--- a/boa3_test/test_sc/interop_test/contract/NeoScriptHashCantAssign.py
+++ b/boa3_test/test_sc/interop_test/contract/NeoScriptHashCantAssign.py
@@ -1,8 +1,13 @@
+from boa3.builtin import public
 from boa3.builtin.interop.contract import NEO
 from boa3.builtin.type import UInt160
 
 
+@public
 def Main(example: UInt160) -> UInt160:
-    global NEO
     NEO = example
     return NEO
+
+
+def interop_call():
+    x = NEO

--- a/boa3_test/test_sc/interop_test/runtime/BlockTimeCantAssign.py
+++ b/boa3_test/test_sc/interop_test/runtime/BlockTimeCantAssign.py
@@ -1,7 +1,12 @@
+from boa3.builtin import public
 from boa3.builtin.interop.runtime import time
 
 
+@public
 def Main(example: int) -> int:
-    global time
     time = example
     return time
+
+
+def interop_call():
+    x = time

--- a/boa3_test/test_sc/interop_test/runtime/CallingScriptHash.py
+++ b/boa3_test/test_sc/interop_test/runtime/CallingScriptHash.py
@@ -1,6 +1,8 @@
+from boa3.builtin import public
 from boa3.builtin.interop.runtime import calling_script_hash
 from boa3.builtin.type import UInt160
 
 
+@public
 def Main() -> UInt160:
     return calling_script_hash

--- a/boa3_test/test_sc/interop_test/runtime/CallingScriptHashCantAssign.py
+++ b/boa3_test/test_sc/interop_test/runtime/CallingScriptHashCantAssign.py
@@ -1,8 +1,13 @@
+from boa3.builtin import public
 from boa3.builtin.interop.runtime import calling_script_hash
 from boa3.builtin.type import UInt160
 
 
+@public
 def Main(example: UInt160) -> UInt160:
-    global calling_script_hash
     calling_script_hash = example
     return calling_script_hash
+
+
+def interop_call():
+    x = calling_script_hash

--- a/boa3_test/test_sc/interop_test/runtime/EntryScriptHash.py
+++ b/boa3_test/test_sc/interop_test/runtime/EntryScriptHash.py
@@ -1,6 +1,8 @@
+from boa3.builtin import public
 from boa3.builtin.interop.runtime import entry_script_hash
 from boa3.builtin.type import UInt160
 
 
+@public
 def main() -> UInt160:
     return entry_script_hash

--- a/boa3_test/test_sc/interop_test/runtime/EntryScriptHashCantAssign.py
+++ b/boa3_test/test_sc/interop_test/runtime/EntryScriptHashCantAssign.py
@@ -1,8 +1,13 @@
+from boa3.builtin import public
 from boa3.builtin.interop.runtime import entry_script_hash
 from boa3.builtin.type import UInt160
 
 
+@public
 def main(example: UInt160) -> UInt160:
-    global entry_script_hash
     entry_script_hash = example
     return entry_script_hash
+
+
+def interop_call():
+    x = entry_script_hash

--- a/boa3_test/test_sc/interop_test/runtime/ExecutingScriptHashCantAssign.py
+++ b/boa3_test/test_sc/interop_test/runtime/ExecutingScriptHashCantAssign.py
@@ -5,6 +5,9 @@ from boa3.builtin.type import UInt160
 
 @public
 def Main(example: UInt160) -> UInt160:
-    global executing_script_hash
     executing_script_hash = example
     return executing_script_hash
+
+
+def interop_call():
+    x = executing_script_hash

--- a/boa3_test/test_sc/interop_test/runtime/GasLeft.py
+++ b/boa3_test/test_sc/interop_test/runtime/GasLeft.py
@@ -1,5 +1,7 @@
+from boa3.builtin import public
 from boa3.builtin.interop.runtime import gas_left
 
 
+@public
 def Main() -> int:
     return gas_left

--- a/boa3_test/test_sc/interop_test/runtime/GasLeftCantAssign.py
+++ b/boa3_test/test_sc/interop_test/runtime/GasLeftCantAssign.py
@@ -1,6 +1,12 @@
+from boa3.builtin import public
 from boa3.builtin.interop.runtime import gas_left
 
 
+@public
 def Main(example: int) -> int:
     gas_left = example
     return gas_left
+
+
+def interop_call():
+    x = gas_left

--- a/boa3_test/test_sc/interop_test/runtime/InvocationCounter.py
+++ b/boa3_test/test_sc/interop_test/runtime/InvocationCounter.py
@@ -1,5 +1,7 @@
+from boa3.builtin import public
 from boa3.builtin.interop.runtime import invocation_counter
 
 
+@public
 def Main() -> int:
     return invocation_counter

--- a/boa3_test/test_sc/interop_test/runtime/InvocationCounterCantAssign.py
+++ b/boa3_test/test_sc/interop_test/runtime/InvocationCounterCantAssign.py
@@ -1,6 +1,12 @@
+from boa3.builtin import public
 from boa3.builtin.interop.runtime import invocation_counter
 
 
+@public
 def Main(example: int) -> int:
     invocation_counter = example
     return invocation_counter
+
+
+def interop_call():
+    x = invocation_counter

--- a/boa3_test/test_sc/interop_test/runtime/PlatformCantAssign.py
+++ b/boa3_test/test_sc/interop_test/runtime/PlatformCantAssign.py
@@ -1,7 +1,12 @@
+from boa3.builtin import public
 from boa3.builtin.interop.runtime import platform
 
 
+@public
 def main(example: str) -> str:
-    global platform
     platform = example
     return platform
+
+
+def interop_call():
+    x = platform

--- a/boa3_test/test_sc/interop_test/storage/StorageGetBytesKey.py
+++ b/boa3_test/test_sc/interop_test/storage/StorageGetBytesKey.py
@@ -1,5 +1,7 @@
+from boa3.builtin import public
 from boa3.builtin.interop.storage import get
 
 
+@public
 def Main(key: bytes) -> bytes:
     return get(key)

--- a/boa3_test/test_sc/list_test/BoolList.py
+++ b/boa3_test/test_sc/list_test/BoolList.py
@@ -1,2 +1,6 @@
+from boa3.builtin import public
+
+
+@public
 def Main():
     a = [True, True, False]

--- a/boa3_test/test_sc/list_test/ClearList.py
+++ b/boa3_test/test_sc/list_test/ClearList.py
@@ -1,6 +1,9 @@
 from typing import List
 
+from boa3.builtin import public
 
+
+@public
 def Main(op: str, args: list) -> List[int]:
     a = [1, 2, 3]
     a.clear()

--- a/boa3_test/test_sc/list_test/EmptyListAssignment.py
+++ b/boa3_test/test_sc/list_test/EmptyListAssignment.py
@@ -1,5 +1,8 @@
 from typing import List
 
+from boa3.builtin import public
 
+
+@public
 def Main():
     a: List[int] = []

--- a/boa3_test/test_sc/list_test/PopListLiteralArgument.py
+++ b/boa3_test/test_sc/list_test/PopListLiteralArgument.py
@@ -1,3 +1,7 @@
+from boa3.builtin import public
+
+
+@public
 def pop_test() -> int:
     a = [1, 2, 3, 4, 5]
     b = a.pop(2)

--- a/boa3_test/test_sc/list_test/PopListLiteralNegativeArgument.py
+++ b/boa3_test/test_sc/list_test/PopListLiteralNegativeArgument.py
@@ -1,3 +1,7 @@
+from boa3.builtin import public
+
+
+@public
 def pop_test() -> int:
     a = [1, 2, 3, 4, 5]
     b = a.pop(-2)

--- a/boa3_test/test_sc/list_test/PopListVariableArgument.py
+++ b/boa3_test/test_sc/list_test/PopListVariableArgument.py
@@ -1,3 +1,7 @@
+from boa3.builtin import public
+
+
+@public
 def pop_test(x: int) -> int:
     a = [1, 2, 3, 4, 5]
     b = a.pop(x)

--- a/boa3_test/test_sc/list_test/ReverseList.py
+++ b/boa3_test/test_sc/list_test/ReverseList.py
@@ -1,6 +1,9 @@
 from typing import List
 
+from boa3.builtin import public
 
+
+@public
 def Main() -> List[int]:
     a: List[int] = [1, 2, 3]
     a.reverse()

--- a/boa3_test/test_sc/list_test/StrList.py
+++ b/boa3_test/test_sc/list_test/StrList.py
@@ -1,2 +1,6 @@
+from boa3.builtin import public
+
+
+@public
 def Main():
     a = ['1', '2', '3']

--- a/boa3_test/test_sc/list_test/TypeHintAssignment.py
+++ b/boa3_test/test_sc/list_test/TypeHintAssignment.py
@@ -1,5 +1,8 @@
 from typing import List
 
+from boa3.builtin import public
 
+
+@public
 def Main():
     a: List[int] = [1, 2, 3]

--- a/boa3_test/test_sc/list_test/VariableList.py
+++ b/boa3_test/test_sc/list_test/VariableList.py
@@ -1,3 +1,7 @@
+from boa3.builtin import public
+
+
+@public
 def Main():
     a = 1
     b = 2

--- a/boa3_test/test_sc/metadata_test/MetadataInfoAuthor.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoAuthor.py
@@ -1,6 +1,7 @@
-from boa3.builtin import NeoMetadata, metadata
+from boa3.builtin import NeoMetadata, metadata, public
 
 
+@public
 def Main() -> int:
     return 5
 

--- a/boa3_test/test_sc/metadata_test/MetadataInfoDescription.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoDescription.py
@@ -1,6 +1,7 @@
-from boa3.builtin import NeoMetadata, metadata
+from boa3.builtin import NeoMetadata, metadata, public
 
 
+@public
 def Main() -> int:
     return 5
 

--- a/boa3_test/test_sc/metadata_test/MetadataInfoEmail.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoEmail.py
@@ -1,6 +1,7 @@
-from boa3.builtin import NeoMetadata, metadata
+from boa3.builtin import NeoMetadata, metadata, public
 
 
+@public
 def Main() -> int:
     return 5
 

--- a/boa3_test/test_sc/metadata_test/MetadataInfoExtras.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoExtras.py
@@ -1,6 +1,7 @@
-from boa3.builtin import NeoMetadata, metadata
+from boa3.builtin import NeoMetadata, metadata, public
 
 
+@public
 def Main() -> int:
     return 5
 

--- a/boa3_test/test_sc/metadata_test/MetadataInfoMethod.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoMethod.py
@@ -1,6 +1,7 @@
-from boa3.builtin import NeoMetadata, metadata
+from boa3.builtin import NeoMetadata, metadata, public
 
 
+@public
 def Main() -> int:
     return 5
 

--- a/boa3_test/test_sc/metadata_test/MetadataInfoMultipleMethod.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoMultipleMethod.py
@@ -1,6 +1,7 @@
-from boa3.builtin import NeoMetadata, metadata
+from boa3.builtin import NeoMetadata, metadata, public
 
 
+@public
 def Main() -> int:
     return 5
 

--- a/boa3_test/test_sc/metadata_test/MetadataInfoName.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoName.py
@@ -1,6 +1,7 @@
-from boa3.builtin import NeoMetadata, metadata
+from boa3.builtin import NeoMetadata, metadata, public
 
 
+@public
 def Main() -> int:
     return 5
 

--- a/boa3_test/test_sc/metadata_test/MetadataInfoNameDefault.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoNameDefault.py
@@ -1,6 +1,7 @@
-from boa3.builtin import NeoMetadata, metadata
+from boa3.builtin import NeoMetadata, metadata, public
 
 
+@public
 def Main() -> int:
     return 5
 

--- a/boa3_test/test_sc/metadata_test/MetadataInfoNewExtras.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoNewExtras.py
@@ -1,6 +1,7 @@
-from boa3.builtin import NeoMetadata, metadata
+from boa3.builtin import NeoMetadata, metadata, public
 
 
+@public
 def Main() -> int:
     return 5
 

--- a/boa3_test/test_sc/metadata_test/MetadataInfoPermissions.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoPermissions.py
@@ -1,6 +1,7 @@
-from boa3.builtin import NeoMetadata, metadata
+from boa3.builtin import NeoMetadata, metadata, public
 
 
+@public
 def Main() -> int:
     return 5
 

--- a/boa3_test/test_sc/metadata_test/MetadataInfoPermissionsDefault.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoPermissionsDefault.py
@@ -1,6 +1,7 @@
-from boa3.builtin import NeoMetadata, metadata
+from boa3.builtin import NeoMetadata, metadata, public
 
 
+@public
 def Main() -> int:
     return 5
 

--- a/boa3_test/test_sc/metadata_test/MetadataInfoPermissionsMismatchedType.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoPermissionsMismatchedType.py
@@ -1,6 +1,7 @@
-from boa3.builtin import NeoMetadata, metadata
+from boa3.builtin import NeoMetadata, metadata, public
 
 
+@public
 def Main() -> int:
     return 5
 

--- a/boa3_test/test_sc/metadata_test/MetadataInfoPermissionsWildcard.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoPermissionsWildcard.py
@@ -1,6 +1,7 @@
-from boa3.builtin import NeoMetadata, metadata
+from boa3.builtin import NeoMetadata, metadata, public
 
 
+@public
 def Main() -> int:
     return 5
 

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandards.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandards.py
@@ -1,6 +1,7 @@
-from boa3.builtin import NeoMetadata, metadata
+from boa3.builtin import NeoMetadata, metadata, public
 
 
+@public
 def Main() -> int:
     return 5
 

--- a/boa3_test/test_sc/metadata_test/MetadataInfoTrusts.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoTrusts.py
@@ -1,6 +1,7 @@
-from boa3.builtin import NeoMetadata, metadata
+from boa3.builtin import NeoMetadata, metadata, public
 
 
+@public
 def Main() -> int:
     return 5
 

--- a/boa3_test/test_sc/metadata_test/MetadataInfoTrustsDefault.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoTrustsDefault.py
@@ -1,6 +1,7 @@
-from boa3.builtin import NeoMetadata, metadata
+from boa3.builtin import NeoMetadata, metadata, public
 
 
+@public
 def Main() -> int:
     return 5
 

--- a/boa3_test/test_sc/metadata_test/MetadataInfoTrustsMismatchedTypes.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoTrustsMismatchedTypes.py
@@ -1,6 +1,7 @@
-from boa3.builtin import NeoMetadata, metadata
+from boa3.builtin import NeoMetadata, metadata, public
 
 
+@public
 def Main() -> int:
     return 5
 

--- a/boa3_test/test_sc/metadata_test/MetadataInfoTrustsWildcard.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoTrustsWildcard.py
@@ -1,6 +1,7 @@
-from boa3.builtin import NeoMetadata, metadata
+from boa3.builtin import NeoMetadata, metadata, public
 
 
+@public
 def Main() -> int:
     return 5
 

--- a/boa3_test/test_sc/none_test/NoneTuple.py
+++ b/boa3_test/test_sc/none_test/NoneTuple.py
@@ -1,2 +1,6 @@
+from boa3.builtin import public
+
+
+@public
 def Main():
     a = (None, None, None)

--- a/boa3_test/test_sc/none_test/VariableNone.py
+++ b/boa3_test/test_sc/none_test/VariableNone.py
@@ -1,2 +1,6 @@
+from boa3.builtin import public
+
+
+@public
 def Main():
     a = None

--- a/boa3_test/test_sc/optional_test/OptionalVariableReassign.py
+++ b/boa3_test/test_sc/optional_test/OptionalVariableReassign.py
@@ -1,6 +1,9 @@
 from typing import Optional
 
+from boa3.builtin import public
 
+
+@public
 def Main():
     a = 2
     b: Optional[int] = a

--- a/boa3_test/test_sc/tuple_test/BoolTuple.py
+++ b/boa3_test/test_sc/tuple_test/BoolTuple.py
@@ -1,2 +1,6 @@
+from boa3.builtin import public
+
+
+@public
 def Main():
     a = (True, True, False)

--- a/boa3_test/test_sc/tuple_test/EmptyTupleAssignment.py
+++ b/boa3_test/test_sc/tuple_test/EmptyTupleAssignment.py
@@ -1,5 +1,8 @@
 from typing import Tuple
 
+from boa3.builtin import public
 
+
+@public
 def Main():
     a: Tuple[int] = ()

--- a/boa3_test/test_sc/tuple_test/IntTuple.py
+++ b/boa3_test/test_sc/tuple_test/IntTuple.py
@@ -1,2 +1,6 @@
+from boa3.builtin import public
+
+
+@public
 def Main():
     a = (1, 2, 3)

--- a/boa3_test/test_sc/tuple_test/StrTuple.py
+++ b/boa3_test/test_sc/tuple_test/StrTuple.py
@@ -1,2 +1,6 @@
+from boa3.builtin import public
+
+
+@public
 def Main():
     a = ('1', '2', '3')

--- a/boa3_test/test_sc/tuple_test/VariableTuple.py
+++ b/boa3_test/test_sc/tuple_test/VariableTuple.py
@@ -1,3 +1,7 @@
+from boa3.builtin import public
+
+
+@public
 def Main():
     a = 1
     b = 2

--- a/boa3_test/test_sc/union_test/UnionVariableReassign.py
+++ b/boa3_test/test_sc/union_test/UnionVariableReassign.py
@@ -1,6 +1,9 @@
 from typing import Union
 
+from boa3.builtin import public
 
+
+@public
 def Main():
     a = 2
     b: Union[int, list] = a

--- a/boa3_test/test_sc/variable_test/ArgumentAssignment.py
+++ b/boa3_test/test_sc/variable_test/ArgumentAssignment.py
@@ -1,2 +1,6 @@
+from boa3.builtin import public
+
+
+@public
 def Main(a: str):
     a = 'unit_test'

--- a/boa3_test/test_sc/variable_test/AssignmentWithType.py
+++ b/boa3_test/test_sc/variable_test/AssignmentWithType.py
@@ -1,2 +1,6 @@
+from boa3.builtin import public
+
+
+@public
 def Main():
     a: str = 'unit_test'

--- a/boa3_test/test_sc/variable_test/AssignmentWithoutType.py
+++ b/boa3_test/test_sc/variable_test/AssignmentWithoutType.py
@@ -1,2 +1,6 @@
+from boa3.builtin import public
+
+
+@public
 def Main():
     a = 1

--- a/boa3_test/test_sc/variable_test/DeclarationWithType.py
+++ b/boa3_test/test_sc/variable_test/DeclarationWithType.py
@@ -1,2 +1,6 @@
+from boa3.builtin import public
+
+
+@public
 def Main():
     a: int

--- a/boa3_test/test_sc/variable_test/ManyAssignments.py
+++ b/boa3_test/test_sc/variable_test/ManyAssignments.py
@@ -1,3 +1,7 @@
+from boa3.builtin import public
+
+
+@public
 def Main():
     a = 0
     b = 1

--- a/boa3_test/test_sc/variable_test/MismatchedTypeAssignBinOp.py
+++ b/boa3_test/test_sc/variable_test/MismatchedTypeAssignBinOp.py
@@ -1,2 +1,6 @@
+from boa3.builtin import public
+
+
+@public
 def Main():
     a: str = 1 + 2

--- a/boa3_test/test_sc/variable_test/MismatchedTypeAssignMixedOp.py
+++ b/boa3_test/test_sc/variable_test/MismatchedTypeAssignMixedOp.py
@@ -1,2 +1,6 @@
+from boa3.builtin import public
+
+
+@public
 def Main(a: int, min: int, max: int):
     b: str = min <= a - 2 <= max

--- a/boa3_test/test_sc/variable_test/MismatchedTypeAssignSequenceGet.py
+++ b/boa3_test/test_sc/variable_test/MismatchedTypeAssignSequenceGet.py
@@ -1,5 +1,8 @@
 from typing import Tuple
 
+from boa3.builtin import public
 
+
+@public
 def Main(a: Tuple[int]):
     b: str = a[0]

--- a/boa3_test/test_sc/variable_test/MismatchedTypeAssignUnOp.py
+++ b/boa3_test/test_sc/variable_test/MismatchedTypeAssignUnOp.py
@@ -1,2 +1,6 @@
+from boa3.builtin import public
+
+
+@public
 def Main():
     a: str = -5

--- a/boa3_test/test_sc/variable_test/MismatchedTypeAssignValue.py
+++ b/boa3_test/test_sc/variable_test/MismatchedTypeAssignValue.py
@@ -1,2 +1,6 @@
+from boa3.builtin import public
+
+
+@public
 def Main():
     a: int = '1'

--- a/boa3_test/test_sc/variable_test/MismatchedTypeMultipleAssignments.py
+++ b/boa3_test/test_sc/variable_test/MismatchedTypeMultipleAssignments.py
@@ -1,3 +1,7 @@
+from boa3.builtin import public
+
+
+@public
 def Main():
     c = 'str'
     a = b = c = True

--- a/boa3_test/test_sc/variable_test/MultipleAssignments.py
+++ b/boa3_test/test_sc/variable_test/MultipleAssignments.py
@@ -1,2 +1,6 @@
+from boa3.builtin import public
+
+
+@public
 def Main():
     a = b = c = True

--- a/boa3_test/test_sc/variable_test/MultipleAssignmentsSetSequence.py
+++ b/boa3_test/test_sc/variable_test/MultipleAssignmentsSetSequence.py
@@ -1,3 +1,7 @@
+from boa3.builtin import public
+
+
+@public
 def Main():
     a = [1, 2, 3]
     c = a[2] = b = 2

--- a/boa3_test/test_sc/variable_test/MultipleAssignmentsSetSequenceLast.py
+++ b/boa3_test/test_sc/variable_test/MultipleAssignmentsSetSequenceLast.py
@@ -1,3 +1,7 @@
+from boa3.builtin import public
+
+
+@public
 def Main():
     a = [1, 2, 3]
     a[2] = c = b = 2

--- a/boa3_test/tests/compiler_tests/test_class.py
+++ b/boa3_test/tests/compiler_tests/test_class.py
@@ -1,7 +1,6 @@
 from boa3.boa3 import Boa3
 from boa3.exception import CompilerError
 from boa3.neo.cryptography import hash160
-from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.String import String
 from boa3_test.tests.boa_test import BoaTest
 from boa3_test.tests.test_classes.testengine import TestEngine
@@ -91,18 +90,12 @@ class TestClass(BoaTest):
         self.assertEqual({}, result[4])
 
     def test_user_class_empty(self):
-        expected_output = (
-            Opcode.INITSLOT
-            + b'\x00'
-            + b'\x01'
-            + Opcode.LDARG0
-            + Opcode.RET
-            + Opcode.NOP
-        )
-
+        # since 0.11.2 methods that are not public nor are called are not generated to optimize code
+        # this test generates an empty contract
         path = self.get_contract_path('UserClassEmpty.py')
-        output = Boa3.compile(path)
 
+        expected_output = b''
+        output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
     def test_user_class_with_static_method_from_class(self):

--- a/boa3_test/tests/compiler_tests/test_file_generation.py
+++ b/boa3_test/tests/compiler_tests/test_file_generation.py
@@ -128,7 +128,7 @@ class TestFileGeneration(BoaTest):
         abi = manifest['abi']
 
         self.assertIn('methods', abi)
-        self.assertEqual(0, len(abi['methods']))
+        self.assertEqual(1, len(abi['methods']))
 
         self.assertIn('events', abi)
         self.assertEqual(0, len(abi['events']))
@@ -490,20 +490,12 @@ class TestFileGeneration(BoaTest):
         self.assertEqual(0, len(abi['events']))
 
     def test_generate_without_main_and_public_methods(self):
+        # since 0.11.2 methods that are not public nor are called are not generated to optimize code
+        # this test generates an empty contract, which results in failing compilation
         path = self.get_contract_path('GenerationWithoutMainAndPublicMethods.py')
-        expected_manifest_output = path.replace('.py', '.manifest.json')
-        output, manifest = self.compile_and_save(path)
 
-        self.assertTrue(os.path.exists(expected_manifest_output))
-        self.assertIn('abi', manifest)
-        abi = manifest['abi']
-
-        self.assertNotIn('entryPoint', abi)
-        self.assertIn('methods', abi)
-        self.assertEqual(0, len(abi['methods']))
-
-        self.assertIn('events', abi)
-        self.assertEqual(0, len(abi['events']))
+        with self.assertRaises(NotLoadedException):
+            output, manifest = self.compile_and_save(path)
 
     def test_generate_manifest_file_abi_method_offset(self):
         path = self.get_contract_path('GenerationWithDecorator.py')

--- a/docs/source/conceptual-overview.rst
+++ b/docs/source/conceptual-overview.rst
@@ -3,7 +3,7 @@
 
 This project is part of the **Neo Python Framework**, aimed to allow the full development of dApps using Python alone.
 
-**Neo3-Boa** is a tool for creating **Neo Smart Contracts using Python**. It compiles ``.py`` files to ``.nef`` and ``.manisfest.json`` formats for usage in the **Neo Virtual Machine** which is used to execute contracts on the **Neo Blockchain**.
+**Neo3-Boa** is a tool for creating **Neo Smart Contracts using Python**. It compiles ``.py`` files to ``.nef`` and ``.manifest.json`` formats for usage in the **Neo Virtual Machine** which is used to execute contracts on the **Neo Blockchain**.
 
 3.1 Project Structure
 =====================

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -1,7 +1,7 @@
 1. Getting Started
 ##################
 
-**Neo3-Boa** is a tool for creating **Neo Smart Contracts using Python**. It compiles ``.py`` files to ``.nef`` and ``.manisfest.json`` formats for usage in the **Neo Virtual Machine** which is used to execute contracts on the **Neo Blockchain**.
+**Neo3-Boa** is a tool for creating **Neo Smart Contracts using Python**. It compiles ``.py`` files to ``.nef`` and ``.manifest.json`` formats for usage in the **Neo Virtual Machine** which is used to execute contracts on the **Neo Blockchain**.
 
 1.1 Installation
 ================


### PR DESCRIPTION
**Related issue**
#835

**Summary or solution description**
Changed the assembly code generation to not convert methods that are written in the smart contract but are not called, unless it's a public method to be included in the manifest.

**How to Reproduce**
In this example, `symbol` is the only method from `Nep17` class that is used. Instead of generating all the methods and including them in the `.nef`, only the called `symbol` is generated.
https://github.com/CityOfZion/neo3-boa/blob/70d5707470ec06e83a5aa87528413f5596dc8856/boa3_test/test_sc/contract_interface_test/ContractInterfaceCodeOptimization.py#L7-L35
https://github.com/CityOfZion/neo3-boa/blob/70d5707470ec06e83a5aa87528413f5596dc8856/boa3_test/tests/compiler_tests/test_contract_interface.py#L101-L113

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/70d5707470ec06e83a5aa87528413f5596dc8856/boa3_test/tests/compiler_tests/test_contract_interface.py#L90-L183

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7