### PR TITLE
Standard validators don't recognize imported events #866

### DIFF
--- a/boa3/builtin/__init__.py
+++ b/boa3/builtin/__init__.py
@@ -32,7 +32,9 @@ def public(name: str = None, safe: bool = True, *args, **kwargs):
     :param safe: Whether this method is an abi safe method. False by default
     :type safe: bool
     """
-    pass
+    def decorator_wrapper(*args, **kwargs):
+        pass
+    return decorator_wrapper
 
 
 def metadata(*args):

--- a/boa3/model/imports/importsymbol.py
+++ b/boa3/model/imports/importsymbol.py
@@ -63,3 +63,10 @@ class Import(ISymbol):
         symbol = self.symbols.copy()
         symbol.update(self._symbols_not_imported)
         return symbol
+
+
+class BuiltinImport(Import):
+    """
+    A class used to differentiate built-in importings
+    """
+    pass

--- a/boa3_test/test_sc/generation_test/GenerationWithImportedEvent.py
+++ b/boa3_test/test_sc/generation_test/GenerationWithImportedEvent.py
@@ -1,0 +1,10 @@
+from boa3.builtin import public
+from boa3_test.examples.nep17 import on_transfer
+
+
+imported_transfer = on_transfer  # all events should be mapped in the manifest
+
+
+@public
+def Main(a: int, b: int) -> int:
+    return a + b

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsImportedEvent.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsImportedEvent.py
@@ -1,0 +1,37 @@
+from typing import Any
+
+import boa3_test.examples.nep17 as nep17
+from boa3.builtin import NeoMetadata, metadata, public
+from boa3.builtin.type import UInt160
+
+
+@metadata
+def standards_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+    meta.supported_standards = ['NEP-17']
+    return meta
+
+
+@public(safe=True)
+def symbol() -> str:
+    return nep17.symbol()
+
+
+@public(safe=True)
+def decimals() -> int:
+    return nep17.decimals()
+
+
+@public(name='totalSupply', safe=True)
+def total_supply() -> int:
+    return nep17.total_supply()
+
+
+@public(name='balanceOf', safe=True)
+def balance_of(account: UInt160) -> int:
+    return nep17.balance_of(account)
+
+
+@public
+def transfer(from_address: UInt160, to_address: UInt160, amount: int, data: Any) -> bool:
+    return nep17.transfer(from_address, to_address, amount, data)

--- a/boa3_test/tests/compiler_tests/test_file_generation.py
+++ b/boa3_test/tests/compiler_tests/test_file_generation.py
@@ -203,6 +203,39 @@ class TestFileGeneration(BoaTest):
                 self.assertEqual(event_args[event_param['name']].type.abi_type,
                                  event_param['type'])
 
+    def test_generate_manifest_file_with_imported_event(self):
+        path = self.get_contract_path('GenerationWithImportedEvent.py')
+        expected_manifest_output = path.replace('.py', '.manifest.json')
+        compiler = Compiler()
+        compiler.compile_and_save(path, path.replace('.py', '.nef'))
+        events: Dict[str, Event] = {}
+        for name, method in self.get_compiler_analyser(compiler).symbol_table.items():
+            if isinstance(method, Event):
+                events[name] = method
+                if method.name not in events:
+                    events[method.name] = method
+
+        output, manifest = self.get_output(path)
+        self.assertTrue(os.path.exists(expected_manifest_output))
+        self.assertIn('abi', manifest)
+        abi = manifest['abi']
+
+        self.assertIn('events', abi)
+        self.assertEqual(1, len(abi['events']))
+
+        for abi_event in abi['events']:
+            self.assertIn('name', abi_event)
+            self.assertIn(abi_event['name'], events)
+            self.assertIn('parameters', abi_event)
+
+            event_args = events[abi_event['name']].args
+            for event_param in abi_event['parameters']:
+                self.assertIn('name', event_param)
+                self.assertIn(event_param['name'], event_args)
+                self.assertIn('type', event_param)
+                self.assertEqual(event_args[event_param['name']].type.abi_type,
+                                 event_param['type'])
+
     def test_generate_manifest_file_with_public_name_decorator_kwarg(self):
         path = self.get_contract_path('MetadataMethodName.py')
         expected_manifest_output = path.replace('.py', '.manifest.json')
@@ -639,7 +672,7 @@ class TestFileGeneration(BoaTest):
         self.assertEqual(2, len(abi['methods']))
 
         self.assertIn('events', abi)
-        self.assertEqual(0, len(abi['events']))
+        self.assertEqual(1, len(abi['events']))
 
     def test_generate_with_user_module_import_with_project_root(self):
         path = self.get_contract_path('project_path', 'GenerationWithUserModuleImportsFromProjectRoot.py')
@@ -657,7 +690,7 @@ class TestFileGeneration(BoaTest):
         self.assertEqual(2, len(abi['methods']))
 
         self.assertIn('events', abi)
-        self.assertEqual(0, len(abi['events']))
+        self.assertEqual(1, len(abi['events']))
 
     def test_compiler_error(self):
         path = self.get_contract_path('test_sc/built_in_methods_test', 'ClearTooManyParameters.py')

--- a/boa3_test/tests/compiler_tests/test_metadata.py
+++ b/boa3_test/tests/compiler_tests/test_metadata.py
@@ -167,6 +167,19 @@ class TestMetadata(BoaTest):
         self.assertGreater(len(manifest['supportedstandards']), 0)
         self.assertIn('NEP-5', manifest['supportedstandards'])
 
+    def test_metadata_info_supported_standards_with_imported_event(self):
+        path = self.get_contract_path('MetadataInfoSupportedStandardsImportedEvent.py')
+        output, manifest = self.get_output(path)
+
+        self.assertIn('abi', manifest)
+        abi = manifest['abi']
+
+        self.assertIn('events', abi)
+        self.assertEqual(1, len(abi['events']))
+
+        self.assertIn('name', abi['events'][0])
+        self.assertEqual('Transfer', abi['events'][0]['name'])
+
     def test_metadata_info_supported_standards_missing_implementations_nep17(self):
         path = self.get_contract_path('MetadataInfoSupportedStandardsMissingImplementationNEP17.py')
         self.assertCompilerLogs(CompilerError.MissingStandardDefinition, path)


### PR DESCRIPTION
**Related issue**
#866

**Summary or solution description**
Changed to include all events in the manifest, even the ones that are not imported in the smart contract main file.
Also changed the standard validators to check imported events.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/205cacc5226477cf85aebb5575614fcb7a3ab621/boa3_test/test_sc/generation_test/GenerationWithImportedEvent.py#L1-L10

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/205cacc5226477cf85aebb5575614fcb7a3ab621/boa3_test/tests/compiler_tests/test_file_generation.py#L206-L237

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7