### PR TITLE
NEP-11 properties validator doesn't accept bytes or ByteString

### DIFF
--- a/boa3/model/standards/nep11standard.py
+++ b/boa3/model/standards/nep11standard.py
@@ -45,7 +45,7 @@ class Nep11Standard(INeoStandard):
                            return_type=type_iterator),
             StandardMethod('properties', safe=True,
                            args={
-                               'tokenId': Type.str,
+                               'tokenId': type_bytestring,
                            },
                            return_type=Type.dict),
         ]

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsMissingImplementationNEP11OptionalMethods.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsMissingImplementationNEP11OptionalMethods.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Dict
 
 from boa3.builtin import NeoMetadata, metadata, public
 from boa3.builtin.contract import Nep11TransferEvent
@@ -17,7 +17,7 @@ def standards_manifest() -> NeoMetadata:
 
 # this method has the same name as an NEP-11 optional method, but with a different signature
 @public(safe=True)
-def properties():
+def properties(token_id: str) -> Dict[Any, Any]:
     pass
 
 


### PR DESCRIPTION
**Related issue**
#864 

**Summary or solution description**
Corrected the `arg` type in `nep11standard`.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/037db9039baae75581dfae4c156e8accaa3f4f99/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsMissingImplementationNEP11OptionalMethods.py#L19-L21

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/037db9039baae75581dfae4c156e8accaa3f4f99/boa3_test/tests/compiler_tests/test_metadata.py#L191-L193

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8
