### PR TITLE
Directly importing variables from custom module is not working in runtime #869

### DIFF
--- a/boa3/compiler/codegenerator/codegeneratorvisitor.py
+++ b/boa3/compiler/codegenerator/codegeneratorvisitor.py
@@ -228,6 +228,7 @@ class VisitorCodeGenerator(IAstAnalyser):
                         class_non_static_stmts.append(cls_fun)
 
             # to generate the 'initialize' method for Neo
+            self._log_info(f"Compiling '{constants.INITIALIZE_METHOD_ID}' function")
             self._is_generating_initialize = True
             for stmt in global_stmts:
                 cur_filename = self.filename
@@ -391,7 +392,9 @@ class VisitorCodeGenerator(IAstAnalyser):
         var_data = self.visit(ann_assign.target)
         var_id = var_data.symbol_id
         # filter to find the imported variables
-        if var_id not in self._symbols and hasattr(ann_assign, 'origin') and isinstance(ann_assign.origin, ast.AST):
+        if (var_id not in self.generator.symbol_table
+                and hasattr(ann_assign, 'origin')
+                and isinstance(ann_assign.origin, ast.AST)):
             var_id = self._get_unique_name(var_id, ann_assign.origin)
         self.store_variable((var_id, None, var_value_address), value=ann_assign.value)
         return self.build_data(ann_assign)
@@ -411,7 +414,9 @@ class VisitorCodeGenerator(IAstAnalyser):
             var_index = target_data.index
 
             # filter to find the imported variables
-            if var_id not in self._symbols and hasattr(assign, 'origin') and isinstance(assign.origin, ast.AST):
+            if (var_id not in self.generator.symbol_table
+                    and hasattr(assign, 'origin')
+                    and isinstance(assign.origin, ast.AST)):
                 var_id = self._get_unique_name(var_id, assign.origin)
             vars_ids.append((var_id, var_index, var_value_address))
 
@@ -427,7 +432,9 @@ class VisitorCodeGenerator(IAstAnalyser):
         var_data = self.visit(aug_assign.target)
         var_id = var_data.symbol_id
         # filter to find the imported variables
-        if var_id not in self._symbols and hasattr(aug_assign, 'origin') and isinstance(aug_assign.origin, ast.AST):
+        if (var_id not in self.generator.symbol_table
+                and hasattr(aug_assign, 'origin')
+                and isinstance(aug_assign.origin, ast.AST)):
             var_id = self._get_unique_name(var_id, aug_assign.origin)
 
         self.generator.convert_load_symbol(var_id)

--- a/boa3_test/test_sc/import_test/variable_import/GenerateImportedVariable.py
+++ b/boa3_test/test_sc/import_test/variable_import/GenerateImportedVariable.py
@@ -1,0 +1,9 @@
+from boa3_test.test_sc.import_test.variable_import.StaticVariables import BAR, FOO
+
+
+def foo() -> bytes:
+    return FOO
+
+
+def bar() -> str:
+    return BAR

--- a/boa3_test/test_sc/import_test/variable_import/StaticVariables.py
+++ b/boa3_test/test_sc/import_test/variable_import/StaticVariables.py
@@ -1,0 +1,2 @@
+FOO = b'Foo'
+BAR: str = 'bar'

--- a/boa3_test/test_sc/import_test/variable_import/VariableFromImportedModule.py
+++ b/boa3_test/test_sc/import_test/variable_import/VariableFromImportedModule.py
@@ -1,0 +1,15 @@
+import boa3_test.test_sc.import_test.variable_import.GenerateImportedVariable as OtherModule
+# TODO: remove when the bug that doesn't initialize global variables from modules that are not imported in the main
+#  file is fixed
+import boa3_test.test_sc.import_test.variable_import.StaticVariables as StaticVariables
+from boa3.builtin import public
+
+
+@public
+def get_foo() -> bytes:
+    return OtherModule.foo()
+
+
+@public
+def get_bar() -> str:
+    return OtherModule.bar()

--- a/boa3_test/tests/compiler_tests/test_import.py
+++ b/boa3_test/tests/compiler_tests/test_import.py
@@ -122,6 +122,16 @@ class TestImport(BoaTest):
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([], result)
 
+    def test_variable_from_imported_module(self):
+        path = self.get_contract_path('variable_import', 'VariableFromImportedModule.py')
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'get_foo', expected_result_type=bytes)
+        self.assertEqual(b'Foo', result)
+
+        result = self.run_smart_contract(engine, path, 'get_bar')
+        self.assertEqual('bar', result)
+
     def test_typing_python_library(self):
         path = self.get_contract_path('ImportPythonLib.py')
         self.assertCompilerLogs(CompilerError.UnresolvedReference, path)


### PR DESCRIPTION
**Related issue**
#869

**Summary or solution description**
A clear and concise description of what you made in this change.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/7fb60af5ced06032cb5e9b8c5109f65591269f8f/boa3_test/test_sc/import_test/variable_import/StaticVariables.py#L1-L2
https://github.com/CityOfZion/neo3-boa/blob/7fb60af5ced06032cb5e9b8c5109f65591269f8f/boa3_test/test_sc/import_test/variable_import/GenerateImportedVariable.py#L1-L9
https://github.com/CityOfZion/neo3-boa/blob/7fb60af5ced06032cb5e9b8c5109f65591269f8f/boa3_test/test_sc/import_test/variable_import/VariableFromImportedModule.py#L1-L15

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/7fb60af5ced06032cb5e9b8c5109f65591269f8f/boa3_test/tests/compiler_tests/test_import.py#L125-L133

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7

**(Optional) Additional context**
The bug annotated as a TODO in the test contract is probably related to #863
