### PR TITLE
Arithmetic augmented assignment operator not working on instance methods

### DIFF
--- a/boa3/compiler/codegenerator/codegeneratorvisitor.py
+++ b/boa3/compiler/codegenerator/codegeneratorvisitor.py
@@ -437,6 +437,9 @@ class VisitorCodeGenerator(IAstAnalyser):
                 and isinstance(aug_assign.origin, ast.AST)):
             var_id = self._get_unique_name(var_id, aug_assign.origin)
 
+        if isinstance(var_data.type, UserClass):
+            self.generator.duplicate_stack_top_item()
+
         self.generator.convert_load_symbol(var_id)
         value_address = self.generator.bytecode_size
         self.visit_to_generate(aug_assign.value)

--- a/boa3_test/test_sc/class_test/UserClassWithAugmentedAssignmentOperatorWithVariable.py
+++ b/boa3_test/test_sc/class_test/UserClassWithAugmentedAssignmentOperatorWithVariable.py
@@ -1,0 +1,83 @@
+from boa3.builtin import public
+
+
+class Example:
+    def __init__(self, value: int = 0):
+        self.value = value
+
+    def increase(self):
+        self.value += 1
+
+    def decrease(self):
+        self.value -= 1
+
+    def multiply(self):
+        self.value *= 2
+
+    def divide(self):
+        self.value //= 2
+
+    def modulo(self):
+        self.value %= 2
+
+
+@public
+def add() -> int:
+    var = Example()
+
+    var.increase()  # 0 + 1 = 1
+    var.increase()  # 1 + 1 = 2
+
+    return var.value
+
+
+@public
+def sub() -> int:
+    var = Example()
+
+    var.decrease()  # 0 - 1 = -1
+    var.decrease()  # -1 - 1 = -2
+
+    return var.value
+
+
+@public
+def mult() -> int:
+    var = Example(4)
+
+    var.multiply()  # 4 * 2 = 8
+    var.multiply()  # 8 * 2 = 16
+
+    return var.value
+
+
+@public
+def div() -> int:
+    var = Example(8)
+
+    var.divide()    # 8 // 2 = 4
+    var.divide()    # 4 // 2 = 2
+
+    return var.value
+
+
+@public
+def mod() -> int:
+    var = Example(9)
+
+    var.modulo()    # 9 % 2 = 1
+
+    return var.value
+
+
+@public
+def mix() -> int:
+    var = Example(10)
+
+    var.increase()  # 10 + 1 = 11
+    var.multiply()  # 11 * 2 = 22
+    var.decrease()  # 22 - 1 = 21
+    var.modulo()    # 21 % 2 = 1
+    var.divide()    # 1 // 2 = 0
+
+    return var.value

--- a/boa3_test/tests/compiler_tests/test_class.py
+++ b/boa3_test/tests/compiler_tests/test_class.py
@@ -477,3 +477,25 @@ class TestClass(BoaTest):
     def test_user_class_with_property_without_self(self):
         path = self.get_contract_path('UserClassWithPropertyWithoutSelf.py')
         self.assertCompilerLogs(CompilerError.SelfArgumentError, path)
+
+    def test_user_class_with_augmented_assignment_operator_with_variable(self):
+        path = self.get_contract_path('UserClassWithAugmentedAssignmentOperatorWithVariable.py')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'add')
+        self.assertEqual(2, result)
+
+        result = self.run_smart_contract(engine, path, 'sub')
+        self.assertEqual(-2, result)
+
+        result = self.run_smart_contract(engine, path, 'mult')
+        self.assertEqual(16, result)
+
+        result = self.run_smart_contract(engine, path, 'div')
+        self.assertEqual(2, result)
+
+        result = self.run_smart_contract(engine, path, 'mod')
+        self.assertEqual(1, result)
+
+        result = self.run_smart_contract(engine, path, 'mix')
+        self.assertEqual(0, result)


### PR DESCRIPTION
**Related issue**
#854 

**Summary or solution description**
Added an `if` in `visit_AugAssign` to verify if the augmented assignment is being used with an instance variable. If it is then the object is duplicated in the stack.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/f976bf6c006bf63c6422e20493c7c1f835d88622/boa3_test/test_sc/class_test/UserClassWithAugmentedAssignmentOperatorWithVariable.py#L1-L83

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/f976bf6c006bf63c6422e20493c7c1f835d88622/boa3_test/tests/compiler_tests/test_class.py#L481-L501

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
