### PR TITLE
Unresolved reference raised when importing a created module with from import

### DIFF
--- a/boa3/analyser/moduleanalyser.py
+++ b/boa3/analyser/moduleanalyser.py
@@ -442,7 +442,7 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
 
     def _build_import(self, origin: str, syntax_tree: ast.AST,
                       import_analyser: ImportAnalyser,
-                      imported_symbols: Dict[str, ISymbol] = None,) -> Import:
+                      imported_symbols: Dict[str, ISymbol] = None) -> Import:
 
         if import_analyser.is_builtin_import:
             return BuiltinImport(origin, syntax_tree, import_analyser, imported_symbols)
@@ -1038,7 +1038,8 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
         symbol = self.get_symbol(value, is_internal=is_internal, origin_node=subscript.value) if isinstance(value, str) else value
 
         if isinstance(subscript.ctx, ast.Load):
-            if isinstance(symbol, (Collection, MetaType)) and isinstance(subscript.value, (ast.Name, ast.NameConstant)):
+            if (isinstance(symbol, (Collection, MetaType))
+                    and isinstance(subscript.value, (ast.Name, ast.NameConstant, ast.Attribute))):
                 # for evaluating names like List[str], Dict[int, bool], etc
                 value = subscript.slice.value if isinstance(subscript.slice, ast.Index) else subscript.slice
                 values_type: Iterable[IType] = self.get_values_type(value)

--- a/boa3/compiler/codegenerator/codegenerator.py
+++ b/boa3/compiler/codegenerator/codegenerator.py
@@ -422,7 +422,7 @@ class CodeGenerator:
                 found_symbol = imports.builtin.get_internal_symbol(identifier)
                 if isinstance(found_symbol, ISymbol):
                     return identifier, found_symbol
-        return Type.none
+        return identifier, Type.none
 
     def initialize_static_fields(self) -> bool:
         """

--- a/boa3/compiler/codegenerator/codegenerator.py
+++ b/boa3/compiler/codegenerator/codegenerator.py
@@ -58,6 +58,7 @@ class CodeGenerator:
         import ast
         from boa3.compiler.codegenerator.codegeneratorvisitor import VisitorCodeGenerator
 
+        all_imports = CodeGenerator._find_all_imports(analyser)
         generator = CodeGenerator(analyser.symbol_table)
         deploy_method = (analyser.symbol_table[constants.DEPLOY_METHOD_ID]
                          if constants.DEPLOY_METHOD_ID in analyser.symbol_table
@@ -75,7 +76,7 @@ class CodeGenerator:
         generator.symbol_table.clear()
         generator.symbol_table.update(analyser.symbol_table.copy())
 
-        for symbol in [symbol for symbol in analyser.symbol_table.values() if isinstance(symbol, Import)]:
+        for symbol in all_imports.values():
             generator.symbol_table.update(symbol.all_symbols)
 
             if hasattr(deploy_method, 'origin') and deploy_method.origin in symbol.ast.body:
@@ -125,7 +126,25 @@ class CodeGenerator:
             generator.initialized_static_fields = True
 
         analyser.update_symbol_table(generator.symbol_table)
-        return generator.bytecode
+        bytecode = generator.bytecode
+        return bytecode
+
+    @staticmethod
+    def _find_all_imports(analyser: Analyser) -> Dict[str, Import]:
+        imports = {}
+        for key, symbol in analyser.symbol_table.copy().items():
+            if isinstance(symbol, Import):
+                importing = symbol
+            elif isinstance(symbol, Package) and isinstance(symbol.origin, Import):
+                importing = symbol.origin
+                analyser.symbol_table[symbol.origin.origin] = symbol.origin
+            else:
+                importing = None
+
+            if importing is not None and importing.origin not in imports:
+                imports[importing.origin] = importing
+
+        return imports
 
     def __init__(self, symbol_table: Dict[str, ISymbol]):
         self.symbol_table: Dict[str, ISymbol] = symbol_table.copy()
@@ -357,7 +376,7 @@ class CodeGenerator:
         return (self.last_code.opcode is Opcode.PUSHNULL or
                 (len(self._stack) > 0 and self._stack[-1] is Type.none))
 
-    def get_symbol(self, identifier: str, scope: Optional[ISymbol] = None, is_internal: bool = False) -> ISymbol:
+    def get_symbol(self, identifier: str, scope: Optional[ISymbol] = None, is_internal: bool = False) -> Tuple[str, ISymbol]:
         """
         Gets a symbol in the symbol table by its id
 
@@ -371,38 +390,38 @@ class CodeGenerator:
         if len(self._scope_stack) > 0:
             for symbol_scope in self._scope_stack:
                 if identifier in symbol_scope:
-                    return symbol_scope[identifier]
+                    return identifier, symbol_scope[identifier]
 
         if scope is not None and hasattr(scope, 'symbols') and isinstance(scope.symbols, dict):
             if identifier in scope.symbols and isinstance(scope.symbols[identifier], ISymbol):
-                return scope.symbols[identifier]
+                return identifier, scope.symbols[identifier]
         else:
             if self._current_method is not None and identifier in self._current_method.symbols:
-                return self._current_method.symbols[identifier]
+                return identifier, self._current_method.symbols[identifier]
             elif identifier in cur_symbol_table:
-                return cur_symbol_table[identifier]
+                return identifier, cur_symbol_table[identifier]
 
             # the symbol may be a built in. If not, returns None
             symbol = Builtin.get_symbol(identifier)
             if symbol is not None:
-                return symbol
+                return identifier, symbol
 
             if not isinstance(identifier, str):
-                return symbol
+                return identifier, symbol
             split = identifier.split(constants.ATTRIBUTE_NAME_SEPARATOR)
             if len(split) > 1:
                 attribute, symbol_id = constants.ATTRIBUTE_NAME_SEPARATOR.join(split[:-1]), split[-1]
-                attr = self.get_symbol(attribute, is_internal=is_internal)
+                another_attr_id, attr = self.get_symbol(attribute, is_internal=is_internal)
                 if hasattr(attr, 'symbols') and symbol_id in attr.symbols:
-                    return attr.symbols[symbol_id]
+                    return symbol_id, attr.symbols[symbol_id]
                 elif isinstance(attr, Package) and symbol_id in attr.inner_packages:
-                    return attr.inner_packages[symbol_id]
+                    return symbol_id, attr.inner_packages[symbol_id]
 
             if is_internal:
                 from boa3.model import imports
                 found_symbol = imports.builtin.get_internal_symbol(identifier)
                 if isinstance(found_symbol, ISymbol):
-                    return found_symbol
+                    return identifier, found_symbol
         return Type.none
 
     def initialize_static_fields(self) -> bool:
@@ -1481,7 +1500,7 @@ class CodeGenerator:
         if class_type is None and len(self._stack) > 0 and isinstance(self._stack[-1], UserClass):
             class_type = self._stack[-1]
 
-        symbol = self.get_symbol(symbol_id, is_internal=is_internal)
+        another_symbol_id, symbol = self.get_symbol(symbol_id, is_internal=is_internal)
 
         if class_type is not None and symbol_id in class_type.symbols:
             symbol = class_type.symbols[symbol_id]
@@ -1497,6 +1516,7 @@ class CodeGenerator:
                 params_addresses = []
 
             if isinstance(symbol, Variable):
+                symbol_id = another_symbol_id
                 self.convert_load_variable(symbol_id, symbol, class_type)
             elif isinstance(symbol, IBuiltinMethod) and symbol.body is None:
                 self.convert_builtin_method_call(symbol, params_addresses)
@@ -1533,7 +1553,7 @@ class CodeGenerator:
                 self.convert_literal(value)
 
         elif var_id in self._globals:
-            var = self.get_symbol(var_id)
+            another_var_id, var = self.get_symbol(var_id)
             storage_key = codegenerator.get_storage_key_for_variable(var)
             self._convert_builtin_storage_get_or_put(True, storage_key)
 
@@ -1591,14 +1611,14 @@ class CodeGenerator:
                 from boa3.analyser.model.optimizer import UndefinedType
                 if (var_id in self._current_scope.symbols or
                         (var_id in self._locals and self._current_method.locals[var_id].type is UndefinedType)):
-                    symbol = self.get_symbol(var_id)
+                    another_symbol_id, symbol = self.get_symbol(var_id)
                     if isinstance(symbol, Variable):
                         var = symbol.copy()
                         var.set_type(stored_type)
                         self._current_scope.include_symbol(var_id, var)
 
         elif var_id in self._globals:
-            var = self.get_symbol(var_id)
+            another_var_id, var = self.get_symbol(var_id)
             storage_key = codegenerator.get_storage_key_for_variable(var)
             if value_start_address is None:
                 value_start_address = self.bytecode_size

--- a/boa3/compiler/codegenerator/codegeneratorvisitor.py
+++ b/boa3/compiler/codegenerator/codegeneratorvisitor.py
@@ -127,12 +127,15 @@ class VisitorCodeGenerator(IAstAnalyser):
                     is_internal = hasattr(node, 'is_internal_call') and node.is_internal_call
                     class_type = result.type
 
-                    if (self.is_implemented_class_type(result.type)
+                    if ((self.is_implemented_class_type(result.type))
                             and len(result.symbol_id.split(constants.ATTRIBUTE_NAME_SEPARATOR)) > 1):
                         # if the symbol id has the attribute separator and the top item on the stack is a user class,
                         # then this value is an attribute from that class
                         # change the id for correct generation
                         result.symbol_id = result.symbol_id.split(constants.ATTRIBUTE_NAME_SEPARATOR)[-1]
+
+                    elif isinstance(result.index, Package):
+                        class_type = None
 
                     self.generator.convert_load_symbol(result.symbol_id, is_internal=is_internal, class_type=class_type)
 
@@ -927,6 +930,7 @@ class VisitorCodeGenerator(IAstAnalyser):
         attr = self.generator.get_symbol(attribute.attr)
         value = attribute.value
         value_symbol = None
+        value_type = None
         value_data = self.visit(value)
         need_to_visit_again = True
 
@@ -960,7 +964,8 @@ class VisitorCodeGenerator(IAstAnalyser):
                                if self.is_implemented_class_type(value_symbol)
                                else value_data.symbol_id)
             attribute_id = f'{value_symbol_id}{constants.ATTRIBUTE_NAME_SEPARATOR}{attribute.attr}'
-            return self.build_data(attribute, symbol_id=attribute_id, symbol=attr)
+            index = value_type if isinstance(value_type, Package) else None
+            return self.build_data(attribute, symbol_id=attribute_id, symbol=attr, index=index)
 
         if isinstance(value, ast.Attribute):
             value_data = self.visit(value)

--- a/boa3/compiler/codegenerator/codegeneratorvisitor.py
+++ b/boa3/compiler/codegenerator/codegeneratorvisitor.py
@@ -80,7 +80,7 @@ class VisitorCodeGenerator(IAstAnalyser):
             if symbol_id in self._symbols:
                 found_symbol = self._symbols[symbol_id]
             else:
-                found_symbol = self.generator.get_symbol(symbol_id)
+                _, found_symbol = self.generator.get_symbol(symbol_id)
                 if found_symbol is Type.none:
                     # generator get_symbol returns Type.none if the symbol is not found
                     found_symbol = None
@@ -127,7 +127,7 @@ class VisitorCodeGenerator(IAstAnalyser):
                     is_internal = hasattr(node, 'is_internal_call') and node.is_internal_call
                     class_type = result.type
 
-                    if ((self.is_implemented_class_type(result.type))
+                    if (self.is_implemented_class_type(result.type)
                             and len(result.symbol_id.split(constants.ATTRIBUTE_NAME_SEPARATOR)) > 1):
                         # if the symbol id has the attribute separator and the top item on the stack is a user class,
                         # then this value is an attribute from that class
@@ -778,7 +778,7 @@ class VisitorCodeGenerator(IAstAnalyser):
 
         if not isinstance(symbol, Method):
             is_internal = hasattr(call, 'is_internal_call') and call.is_internal_call
-            symbol = self.generator.get_symbol(function_id, is_internal=is_internal)
+            _, symbol = self.generator.get_symbol(function_id, is_internal=is_internal)
 
         if self.is_implemented_class_type(symbol):
             self.generator.convert_init_user_class(symbol)
@@ -927,7 +927,7 @@ class VisitorCodeGenerator(IAstAnalyser):
         last_address = VMCodeMapping.instance().bytecode_size
         last_stack = self.generator.stack_size
 
-        attr = self.generator.get_symbol(attribute.attr)
+        _, attr = self.generator.get_symbol(attribute.attr)
         value = attribute.value
         value_symbol = None
         value_type = None
@@ -936,9 +936,10 @@ class VisitorCodeGenerator(IAstAnalyser):
 
         if value_data.symbol_id is not None and not value_data.already_generated:
             value_id = value_data.symbol_id
-            value_symbol = (value_data.symbol
-                            if value_data.symbol is not None
-                            else self.generator.get_symbol(value_id))
+            if value_data.symbol is not None:
+                value_symbol = value_data.symbol
+            else:
+                _, value_symbol = self.generator.get_symbol(value_id)
             value_type = value_symbol.type if hasattr(value_symbol, 'type') else value_symbol
 
             if hasattr(value_type, 'symbols') and attribute.attr in value_type.symbols:
@@ -977,7 +978,7 @@ class VisitorCodeGenerator(IAstAnalyser):
             result = value_data.type
             generation_result = value_data.symbol
             if result is None and value_data.symbol_id is not None:
-                result = self.generator.get_symbol(value_data.symbol_id)
+                _, result = self.generator.get_symbol(value_data.symbol_id)
                 if isinstance(result, IExpression):
                     generation_result = result
                     result = result.type

--- a/boa3_test/test_sc/import_test/ImportModuleWithInit.py
+++ b/boa3_test/test_sc/import_test/ImportModuleWithInit.py
@@ -1,0 +1,14 @@
+from boa3.builtin import public
+
+from boa3_test.test_sc.import_test.package_with_import import Module
+
+
+@public
+def call_imported_method() -> list:
+    a: Module.List[Module.Any] = Module.EmptyList()
+    return a
+
+
+@public
+def call_imported_variable() -> int:
+    return Module.default_number

--- a/boa3_test/test_sc/import_test/package_with_import/Module.py
+++ b/boa3_test/test_sc/import_test/package_with_import/Module.py
@@ -1,0 +1,8 @@
+from typing import Any, List
+
+
+def EmptyList() -> List[Any]:
+    return []
+
+
+default_number = 42

--- a/boa3_test/tests/compiler_tests/test_import.py
+++ b/boa3_test/tests/compiler_tests/test_import.py
@@ -344,3 +344,14 @@ class TestImport(BoaTest):
 
         result = self.run_smart_contract(engine, path, 'main')
         self.assertEqual(3, result)
+
+    def test_import_module_with_init(self):
+        path = self.get_contract_path('ImportModuleWithInit.py')
+        self.compile_and_save(path)
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'call_imported_method')
+        self.assertEqual([], result)
+
+        result = self.run_smart_contract(engine, path, 'call_imported_variable')
+        self.assertEqual(42, result)


### PR DESCRIPTION
**Related issue**
#863

**Summary or solution description**
Fixed the incorrect error raised when using symbols from an imported module.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/43642e351f9c4d9842d52044e1762f613410abf7/boa3_test/test_sc/import_test/ImportModuleWithInit.py#L3-L14
https://github.com/CityOfZion/neo3-boa/blob/43642e351f9c4d9842d52044e1762f613410abf7/boa3_test/test_sc/import_test/package_with_import/Module.py#L1-L8

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/43642e351f9c4d9842d52044e1762f613410abf7/boa3_test/tests/compiler_tests/test_import.py#L348-L357

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7