### PR TITLE
Runtime error raised when invoking user-created class constructor

### DIFF
--- a/boa3/analyser/importanalyser.py
+++ b/boa3/analyser/importanalyser.py
@@ -86,6 +86,14 @@ class ImportAnalyser(IAstAnalyser):
                        if symbol_id in identifiers and symbol is not None}
         return symbols
 
+    def update_external_analysed_files(self, external_files: dict):
+        if self.can_be_imported and self.path in self._imported_files and self.path not in external_files:
+            external_files[self.path] = self._imported_files[self.path]
+
+        for path, analyser in self._imported_files.items():
+            if path not in external_files and analyser.is_analysed:
+                external_files[path] = analyser
+
     def _find_package(self, module_origin: str, origin_file: Optional[str] = None):
         path: List[str] = module_origin.split(os.sep)
 
@@ -129,6 +137,8 @@ class ImportAnalyser(IAstAnalyser):
                                                     imported_files=self._imported_files,
                                                     import_stack=files, log=self._log)
 
+                        if analyser.is_analysed:
+                            self._imported_files[self.path] = analyser
                         self._include_inner_packages(analyser)
 
                     # include only imported symbols

--- a/boa3_test/test_sc/import_test/ImportUserClassInnerFiles.py
+++ b/boa3_test/test_sc/import_test/ImportUserClassInnerFiles.py
@@ -1,0 +1,10 @@
+from boa3.builtin import public
+from boa3_test.test_sc.import_test.class_import import ImportUserClass
+# TODO: remove when the bug that doesn't initialize global variables from modules that are not imported in the main
+#  file is fixed
+import boa3_test.test_sc.import_test.class_import.example
+
+
+@public
+def build_example_object() -> str:
+    return ImportUserClass.build_example_object().var_str

--- a/boa3_test/test_sc/import_test/class_import/ImportUserClass.py
+++ b/boa3_test/test_sc/import_test/class_import/ImportUserClass.py
@@ -1,0 +1,8 @@
+from boa3.builtin import public
+
+from boa3_test.test_sc.import_test.class_import.example import Example
+
+
+@public
+def build_example_object() -> Example:
+    return Example(42, '42')

--- a/boa3_test/test_sc/import_test/class_import/example.py
+++ b/boa3_test/test_sc/import_test/class_import/example.py
@@ -1,0 +1,9 @@
+class Example:
+    def __init__(self, id_: int, arg1: str):
+        self._var_int = id_
+        self.var_str = arg1
+
+    def export(self) -> dict:
+        return {
+            'text': self.var_str
+        }

--- a/boa3_test/tests/compiler_tests/test_import.py
+++ b/boa3_test/tests/compiler_tests/test_import.py
@@ -347,7 +347,6 @@ class TestImport(BoaTest):
 
     def test_import_module_with_init(self):
         path = self.get_contract_path('ImportModuleWithInit.py')
-        self.compile_and_save(path)
         engine = TestEngine()
 
         result = self.run_smart_contract(engine, path, 'call_imported_method')
@@ -355,3 +354,15 @@ class TestImport(BoaTest):
 
         result = self.run_smart_contract(engine, path, 'call_imported_variable')
         self.assertEqual(42, result)
+
+    def test_import_user_class_inner_files(self):
+        inner_path = self.get_contract_path('class_import', 'ImportUserClass.py')
+        path = self.get_contract_path('ImportUserClassInnerFiles.py')
+
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, inner_path, 'build_example_object')
+        self.assertEqual([42, '42'], result)
+
+        result = self.run_smart_contract(engine, path, 'build_example_object')
+        self.assertEqual('42', result)


### PR DESCRIPTION
**Summary or solution description**
Fixed the bug related to class constructors raising stack size errors during runtime.
The error only happened with classes that weren't imported by the main contract file.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/593eec45f39321727d303d970fdf295dbf1df5b8/boa3_test/test_sc/import_test/ImportUserClassInnerFiles.py#L2-L10
https://github.com/CityOfZion/neo3-boa/blob/593eec45f39321727d303d970fdf295dbf1df5b8/boa3_test/test_sc/import_test/class_import/ImportUserClass.py#L3-L8
https://github.com/CityOfZion/neo3-boa/blob/593eec45f39321727d303d970fdf295dbf1df5b8/boa3_test/test_sc/import_test/class_import/example.py#L1-L9

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/593eec45f39321727d303d970fdf295dbf1df5b8/boa3_test/tests/compiler_tests/test_import.py#L358-L368

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7