### PR TITLE
Variable access from imported modules raises runtime errors

### DIFF
--- a/boa3/analyser/model/optimizer/__init__.py
+++ b/boa3/analyser/model/optimizer/__init__.py
@@ -88,5 +88,9 @@ class UndefinedType:
     def __init__(self):
         pass
 
+    @property
+    def identifier(self) -> str:
+        return 'undefined'
+
 
 Undefined = UndefinedType()

--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -197,6 +197,12 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
                 self._validate_return(function)
 
             method_scope = self.pop_local_scope()
+            for symbol_id, symbol in self._current_method.symbols.items():
+                if isinstance(symbol, Variable) and symbol.type is UndefinedType and symbol_id in method_scope:
+                    new_scope_symbol = method_scope[symbol_id]
+                    if hasattr(new_scope_symbol, 'type') and new_scope_symbol.type is not UndefinedType:
+                        symbol.set_type(new_scope_symbol.type)
+
             self._current_method = None
         elif (isinstance(method, Event)  # events don't have return
               and function.returns is not None):

--- a/boa3_test/test_sc/import_test/variable_import/VariableAccessFromImportedModule.py
+++ b/boa3_test/test_sc/import_test/variable_import/VariableAccessFromImportedModule.py
@@ -1,0 +1,13 @@
+
+from boa3.builtin import public
+import boa3_test.test_sc.import_test.variable_import.StaticVariables as StaticVariables
+
+
+@public
+def get_foo() -> bytes:
+    return StaticVariables.FOO
+
+
+@public
+def get_bar() -> str:
+    return StaticVariables.BAR

--- a/boa3_test/tests/compiler_tests/test_import.py
+++ b/boa3_test/tests/compiler_tests/test_import.py
@@ -132,6 +132,17 @@ class TestImport(BoaTest):
         result = self.run_smart_contract(engine, path, 'get_bar')
         self.assertEqual('bar', result)
 
+    def test_variable_access_from_imported_module(self):
+        path = self.get_contract_path('variable_import', 'VariableAccessFromImportedModule.py')
+        self.compile_and_save(path)
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'get_foo', expected_result_type=bytes)
+        self.assertEqual(b'Foo', result)
+
+        result = self.run_smart_contract(engine, path, 'get_bar')
+        self.assertEqual('bar', result)
+
     def test_typing_python_library(self):
         path = self.get_contract_path('ImportPythonLib.py')
         self.assertCompilerLogs(CompilerError.UnresolvedReference, path)


### PR DESCRIPTION
**Related issue**
#868

**Summary or solution description**
Aside from the module importing, which was also fixed by #874, there was another error related to variables where the type `UndefinedType` used in the ModuleAnalyser was propagated to `TypeAnalyser` and `CodeGenerator`.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/78320c7a77a0a52d1b6d2892f728cddc77e4e600/boa3_test/test_sc/import_test/variable_import/VariableAccessFromImportedModule.py#L3-L13

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/78320c7a77a0a52d1b6d2892f728cddc77e4e600/boa3_test/tests/compiler_tests/test_import.py#L135-L144

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
