### PR TITLE
Compilation succeeds when it should raise an unresolved reference from importing #2ewe99p

### DIFF
--- a/boa3_test/test_sc/import_test/FromImportNotExistingMethod.py
+++ b/boa3_test/test_sc/import_test/FromImportNotExistingMethod.py
@@ -1,0 +1,8 @@
+from typing import Any, Dict
+from boa3.builtin import public
+from package_with_import import Module as imported_module
+
+
+@public
+def get_token_json(token_id: bytes) -> Dict[str, Any]:
+    return imported_module.get_token_json(token_id)  # this method doesn't exist in the imported module

--- a/boa3_test/test_sc/import_test/ImportNotExistingMethod.py
+++ b/boa3_test/test_sc/import_test/ImportNotExistingMethod.py
@@ -1,0 +1,8 @@
+from typing import Any, Dict
+from boa3.builtin import public
+import FromImportAll as imported_module
+
+
+@public
+def get_token_json(token_id: bytes) -> Dict[str, Any]:
+    return imported_module.get_token_json(token_id)  # this method doesn't exist in the imported module

--- a/boa3_test/tests/compiler_tests/test_import.py
+++ b/boa3_test/tests/compiler_tests/test_import.py
@@ -366,3 +366,11 @@ class TestImport(BoaTest):
 
         result = self.run_smart_contract(engine, path, 'build_example_object')
         self.assertEqual('42', result)
+
+    def test_from_import_not_existing_method(self):
+        path = self.get_contract_path('FromImportNotExistingMethod.py')
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+
+    def test_import_not_existing_method(self):
+        path = self.get_contract_path('ImportNotExistingMethod.py')
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)


### PR DESCRIPTION
**Related issue**
#865 

**Summary or solution description**
Added a condition to check if an attribute is a method and exists inside the origin.

**How to Reproduce**

https://github.com/CityOfZion/neo3-boa/blob/0ca6f1e265890bfe46e5badaf2d0a2f5ea68b0f3/boa3_test/test_sc/import_test/FromImportNotExistingMethod.py#L1-L8

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/0ca6f1e265890bfe46e5badaf2d0a2f5ea68b0f3/boa3_test/tests/compiler_tests/test_import.py#L370-L376

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8

