### PR TITLE
Global variable not working in class methods

### DIFF
--- a/boa3/analyser/astanalyser.py
+++ b/boa3/analyser/astanalyser.py
@@ -258,7 +258,7 @@ class IAstAnalyser(ABC, ast.NodeVisitor):
         clone._attributes = node._attributes
         clone._fields = node._fields
 
-        for attr in node._attributes + node._fields:
+        for attr in node.__dict__:
             clone.__setattr__(attr, node.__getattribute__(attr))
 
         return clone

--- a/boa3_test/test_sc/variable_test/GlobalVariableInClassMethod.py
+++ b/boa3_test/test_sc/variable_test/GlobalVariableInClassMethod.py
@@ -13,11 +13,11 @@ class Example:
         return {
             'val1': self.val1,
             'val2': self.val2,
-            'bar': GLOBAL_TEST  # without this, it works
+            'bar': GLOBAL_TEST
         }
 
     def get_constant(self) -> int:
-        return GLOBAL_TEST  # this works as expected
+        return GLOBAL_TEST
 
 
 @public

--- a/boa3_test/test_sc/variable_test/GlobalVariableInClassMethod.py
+++ b/boa3_test/test_sc/variable_test/GlobalVariableInClassMethod.py
@@ -1,0 +1,30 @@
+from boa3.builtin import public
+
+GLOBAL_TEST = 42
+
+
+class Example:
+    val1 = 1
+
+    def __init__(self):
+        self.val2 = 2
+
+    def export(self) -> dict:
+        return {
+            'val1': self.val1,
+            'val2': self.val2,
+            'bar': GLOBAL_TEST  # without this, it works
+        }
+
+    def get_constant(self) -> int:
+        return GLOBAL_TEST  # this works as expected
+
+
+@public
+def use_variable_in_map() -> dict:
+    return Example().export()
+
+
+@public
+def use_variable_in_func() -> int:
+    return Example().get_constant()

--- a/boa3_test/tests/compiler_tests/test_variable.py
+++ b/boa3_test/tests/compiler_tests/test_variable.py
@@ -576,6 +576,16 @@ class TestVariable(BoaTest):
         result = self.run_smart_contract(engine, path, 'example')
         self.assertEqual(5, result)
 
+    def test_global_variable_in_class_method(self):
+        path = self.get_contract_path('GlobalVariableInClassMethod.py')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'use_variable_in_func')
+        self.assertEqual(42, result)
+
+        result = self.run_smart_contract(engine, path, 'use_variable_in_map')
+        self.assertEqual({'val1': 1, 'val2': 2, 'bar': 42}, result)
+
     def test_get_global_variable_value_written_after(self):
         expected_output = (
             Opcode.LDSFLD + b'\x07'


### PR DESCRIPTION
**Summary or solution description**
Using global variable in class methods were not working as expected when both the variable and the class are written in the same file. Fixed by keeping the reference to the original file during code generation.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/adfdf01fc67c1a46cdd5fc77fe353234fa46fac0/boa3_test/test_sc/variable_test/GlobalVariableInClassMethod.py#L3-L21

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/adfdf01fc67c1a46cdd5fc77fe353234fa46fac0/boa3_test/tests/compiler_tests/test_variable.py#L579-L587

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7