### PR TITLE
Unresolved reference 'Event'

### DIFF
--- a/boa3/analyser/moduleanalyser.py
+++ b/boa3/analyser/moduleanalyser.py
@@ -975,6 +975,8 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
         """
         var_id: str = self.visit(ann_assign.target)
         var_type: IType = self.visit_type(ann_assign.annotation)
+        if var_type is Builtin.Event:
+            self.visit(ann_assign.value)
 
         # TODO: check if the annotated type and the value type are the same
         return self.assign_value(var_id, var_type, source_node=ann_assign, assignment=ann_assign.value is not None)

--- a/boa3/builtin/contract/__init__.py
+++ b/boa3/builtin/contract/__init__.py
@@ -5,8 +5,8 @@ from boa3.builtin.type import ByteString, ECPoint, UInt160
 
 Nep5TransferEvent: Event = CreateNewEvent(
     [
-        ('from_addr', bytes),
-        ('to_addr', bytes),
+        ('from', bytes),
+        ('to', bytes),
         ('amount', int)
     ],
     'transfer'
@@ -20,8 +20,8 @@ addresses of the sender, receiver and the amount transferred.
 
 Nep11TransferEvent: Event = CreateNewEvent(
     [
-        ('from_addr', Union[UInt160, None]),
-        ('to_addr', Union[UInt160, None]),
+        ('from', Union[UInt160, None]),
+        ('to', Union[UInt160, None]),
         ('amount', int),
         ('tokenId', ByteString)
     ],
@@ -37,8 +37,8 @@ addresses of the sender, receiver, amount transferred and the id of the token.
 
 Nep17TransferEvent: Event = CreateNewEvent(
     [
-        ('from_addr', Union[UInt160, None]),
-        ('to_addr', Union[UInt160, None]),
+        ('from', Union[UInt160, None]),
+        ('to', Union[UInt160, None]),
         ('amount', int)
     ],
     'Transfer'

--- a/boa3/model/builtin/method/createeventmethod.py
+++ b/boa3/model/builtin/method/createeventmethod.py
@@ -38,7 +38,7 @@ class __EventType(IType):
     """
 
     def __init__(self):
-        identifier = 'event'
+        identifier = 'Event'
         super().__init__(identifier)
 
     @property

--- a/boa3_test/test_sc/event_test/EventNep11Transfer.py
+++ b/boa3_test/test_sc/event_test/EventNep11Transfer.py
@@ -1,0 +1,10 @@
+from boa3.builtin import public
+from boa3.builtin.contract import Nep11TransferEvent
+from boa3.builtin.type import UInt160
+
+transfer = Nep11TransferEvent
+
+
+@public
+def Main(from_addr: UInt160, to_addr: UInt160, amount: int, token_id: bytes):
+    transfer(from_addr, to_addr, amount, token_id)

--- a/boa3_test/test_sc/event_test/EventNep17TransferBuilt.py
+++ b/boa3_test/test_sc/event_test/EventNep17TransferBuilt.py
@@ -5,8 +5,8 @@ from boa3.builtin.type import UInt160
 
 transfer = CreateNewEvent(
     [
-        ('from_addr', Union[UInt160, None]),
-        ('to_addr', Union[UInt160, None]),
+        ('from', Union[UInt160, None]),
+        ('to', Union[UInt160, None]),
         ('amount', int)
     ],
     'Transfer'

--- a/boa3_test/test_sc/event_test/EventWithAnnotation.py
+++ b/boa3_test/test_sc/event_test/EventWithAnnotation.py
@@ -1,0 +1,13 @@
+from boa3.builtin import CreateNewEvent, Event, public
+
+on_example: Event = CreateNewEvent(
+    [
+        ('a', int)
+    ],
+    'example'
+)
+
+
+@public
+def Main():
+    on_example(10)


### PR DESCRIPTION
**Related issue**
#884

**Summary or solution description**
The issue was caused because the EventType identifier (`event`) was different from the actual implementation (`Event`) and because the annotated assignments node visitor didn't verify if the event was generated.
Also updated other small details related to events (i.e. the argument names of the built-in events)

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/13bb746d6d3f7e9a42091d1169bf925098e96132/boa3_test/test_sc/event_test/EventWithAnnotation.py#L1-L13

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/13bb746d6d3f7e9a42091d1169bf925098e96132/boa3_test/tests/compiler_tests/test_event.py#L96-L123

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7