### PR TITLE
#2kwg0wf Global variables don't initialize from modules that are not imported in the main file

### DIFF
--- a/boa3/analyser/analyser.py
+++ b/boa3/analyser/analyser.py
@@ -35,6 +35,8 @@ class Analyser:
         self.__include_builtins_symbols()
         self._errors = []
         self._warnings = []
+        self._imported_files: Dict[str, Analyser] = {}
+        self._included_imported_files: bool = False
 
         import os
         self.path: str = path
@@ -100,10 +102,14 @@ class Analyser:
 
     def copy(self) -> Analyser:
         copied = Analyser(ast_tree=self.ast_tree, path=self.path, project_root=self.root, log=self._log)
+
         copied.metadata = self.metadata
         copied.is_analysed = self.is_analysed
         copied.symbol_table = self.symbol_table.copy()
         copied.filename = self.filename
+        copied._imported_files = self._imported_files.copy()
+        copied._included_imported_files = self._included_imported_files
+
         return copied
 
     def __include_builtins_symbols(self):
@@ -139,6 +145,7 @@ class Analyser:
         self.symbol_table.update(module_analyser.global_symbols)
         self.ast_tree.body.extend(module_analyser.imported_nodes)
         self.__update_logs(module_analyser)
+        self._imported_files = module_analyser.analysed_files.copy()
         return not module_analyser.has_errors
 
     def __check_standards(self) -> bool:
@@ -188,3 +195,27 @@ class Analyser:
             if not isinstance(symbol, IdentifiedSymbol) or isinstance(symbol, UserClass):
                 if unique_id not in self.symbol_table:
                     self.symbol_table[unique_id] = symbol
+
+    def update_symbol_table_with_imports(self):
+        if self._included_imported_files:
+            return
+
+        import os
+        from boa3.analyser.importanalyser import ImportAnalyser
+        from boa3.model.imports.importsymbol import Import
+
+        imports = self._imported_files.copy()
+        paths_already_imported = [imported.origin for imported in self.symbol_table.values()
+                                  if isinstance(imported, Import) and isinstance(imported.origin, str)]
+        if isinstance(self.path, str):
+            paths_already_imported.append(self.path.replace(os.path.sep, constants.PATH_SEPARATOR))
+
+        for file_path, analyser in imports.items():
+            if file_path not in paths_already_imported:
+                import_analyser = ImportAnalyser(file_path, self.root,
+                                                 already_imported_modules=imports,
+                                                 log=False)
+                import_symbol = Import(file_path, analyser.ast_tree, import_analyser, {})
+                self.symbol_table[file_path] = import_symbol
+
+        self._included_imported_files = True

--- a/boa3/analyser/moduleanalyser.py
+++ b/boa3/analyser/moduleanalyser.py
@@ -136,6 +136,10 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
 
         return global_symbols
 
+    @property
+    def analysed_files(self) -> Dict[str, Any]:
+        return self._analysed_files.copy()
+
     def __include_variable(self, var_id: str, var_type_id: Union[str, IType],
                            source_node: ast.AST,
                            var_enumerate_type: IType = Type.none, assignment: bool = True):

--- a/boa3/compiler/codegenerator/codegenerator.py
+++ b/boa3/compiler/codegenerator/codegenerator.py
@@ -55,6 +55,7 @@ class CodeGenerator:
         :return: the Neo VM bytecode
         """
         VMCodeMapping.reset()
+        analyser.update_symbol_table_with_imports()
         import ast
         from boa3.compiler.codegenerator.codegeneratorvisitor import VisitorCodeGenerator
 

--- a/boa3/compiler/filegenerator.py
+++ b/boa3/compiler/filegenerator.py
@@ -22,7 +22,7 @@ class FileGenerator:
     def __init__(self, bytecode: bytes, analyser: Analyser, entry_file: str):
         import os
         self._metadata = analyser.metadata
-        self._symbols: Dict[str, ISymbol] = analyser.symbol_table
+        self._symbols: Dict[str, ISymbol] = analyser.symbol_table.copy()
 
         self._entry_file = entry_file
         self._entry_file_full_path = analyser.path.replace(os.sep, constants.PATH_SEPARATOR)

--- a/boa3_test/test_sc/import_test/ImportUserClassInnerFiles.py
+++ b/boa3_test/test_sc/import_test/ImportUserClassInnerFiles.py
@@ -1,8 +1,5 @@
 from boa3.builtin import public
 from boa3_test.test_sc.import_test.class_import import ImportUserClass
-# TODO: remove when the bug that doesn't initialize global variables from modules that are not imported in the main
-#  file is fixed
-import boa3_test.test_sc.import_test.class_import.example
 
 
 @public

--- a/boa3_test/test_sc/import_test/variable_import/VariableFromImportedModule.py
+++ b/boa3_test/test_sc/import_test/variable_import/VariableFromImportedModule.py
@@ -1,7 +1,4 @@
 import boa3_test.test_sc.import_test.variable_import.GenerateImportedVariable as OtherModule
-# TODO: remove when the bug that doesn't initialize global variables from modules that are not imported in the main
-#  file is fixed
-import boa3_test.test_sc.import_test.variable_import.StaticVariables as StaticVariables
 from boa3.builtin import public
 
 

--- a/boa3_test/tests/compiler_tests/test_import.py
+++ b/boa3_test/tests/compiler_tests/test_import.py
@@ -134,7 +134,6 @@ class TestImport(BoaTest):
 
     def test_variable_access_from_imported_module(self):
         path = self.get_contract_path('variable_import', 'VariableAccessFromImportedModule.py')
-        self.compile_and_save(path)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'get_foo', expected_result_type=bytes)


### PR DESCRIPTION
**Summary or solution description**
Refactored the importing process so that the Code Analyser of the entry file has access to all the imported files accessed during the compilation.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/014d6f7b4a704821b97bede84296409b6cafa870/boa3_test/test_sc/import_test/variable_import/VariableFromImportedModule.py#L1-L12
https://github.com/CityOfZion/neo3-boa/blob/014d6f7b4a704821b97bede84296409b6cafa870/boa3_test/test_sc/import_test/ImportUserClassInnerFiles.py#L1-L7

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/014d6f7b4a704821b97bede84296409b6cafa870/boa3_test/tests/compiler_tests/test_import.py#L125-L143
https://github.com/CityOfZion/neo3-boa/blob/014d6f7b4a704821b97bede84296409b6cafa870/boa3_test/tests/compiler_tests/test_import.py#L378-L388

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7