### PR TITLE
Error using Python 3.10

### DIFF
--- a/boa3/neo3/core/utils.py
+++ b/boa3/neo3/core/utils.py
@@ -1,6 +1,6 @@
 # type: ignore
 
-from collections import Iterable
+from typing import Iterable
 from enum import Enum
 
 from boa3.neo3.core import Size, serialization

--- a/boa3_test/tests/test_classes/contract/neopermissionsstruct.py
+++ b/boa3_test/tests/test_classes/contract/neopermissionsstruct.py
@@ -26,7 +26,7 @@ class NeoPermissionsStruct(NeoStruct):
     def _is_wildcard(cls, value: Any) -> bool:
         if value is None:
             return True
-        return value is '*'
+        return value == '*'
 
     @classmethod
     def get_contract(cls, value: Any) -> Optional[UInt160]:


### PR DESCRIPTION
**Summary or solution description**
The issue was an import that doesn't exist in Python 3.10 anymore.
There is a SyntaxWarning as well that is raised by Python 3.10 only that was fixed.

**Tests**
Run the unit tests using Python 3.10

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.10.4

**(Optional) Additional context**
We're going to include Python 3.10 in the CircleCI workflow in another pull request
