### PR TITLE
Global variables don't initialize from modules that are not imported in the main file

### DIFF
--- a/boa3/analyser/analyser.py
+++ b/boa3/analyser/analyser.py
@@ -214,7 +214,7 @@ class Analyser:
             if file_path not in paths_already_imported:
                 import_analyser = ImportAnalyser(file_path, self.root,
                                                  already_imported_modules=imports,
-                                                 log=False)
+                                                 log=False, get_entry=True)
                 import_symbol = Import(file_path, analyser.ast_tree, import_analyser, {})
                 self.symbol_table[file_path] = import_symbol
 


### PR DESCRIPTION
**Summary or solution description**
Inner imports were raising InternalCompilerError because the returned symbol table was empty.
Solved by fixing the arguments when calling the ImportAnalyser

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.10.4