### PR TITLE
`is not None` is not working properly

### DIFF
--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -710,12 +710,10 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
                                      and condition.func.id in is_instance_objs and len(condition.args) == 2)
 
             # verifies if condition is a identity condition (is None or is not None)
-            from boa3.model.operation.unary.noneidentity import NoneIdentity
-            from boa3.model.operation.unary.nonenotidentity import NoneNotIdentity
             identity_condition = isinstance(condition, ast.Compare) \
-                                 and isinstance(condition.ops[0], (NoneIdentity, NoneNotIdentity))
+                                 and isinstance(condition.ops[0], (type(BinaryOp.IsNone), type(BinaryOp.IsNotNone)))
 
-            if identity_condition and isinstance(condition.ops[0], NoneNotIdentity):
+            if identity_condition and isinstance(condition.ops[0], type(BinaryOp.IsNotNone)):
                 negate = True
 
             if is_instance_condition or identity_condition:
@@ -725,7 +723,7 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
 
                 else:
                     left_value = condition.left
-                    right_value = None
+                    right_value = Type.none
 
                 original = self.get_symbol(left_value)
                 if isinstance(original, Variable) and isinstance(left_value, ast.Name):

--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -705,22 +705,42 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
                 condition = condition.operand
                 negate = True
 
-            if (isinstance(condition, ast.Call) and isinstance(condition.func, ast.Name)
-                    and condition.func.id in is_instance_objs and len(condition.args) == 2):
-                original = self.get_symbol(condition.args[0])
-                if isinstance(original, Variable) and isinstance(condition.args[0], ast.Name):
-                    original_id = condition.args[0].id
+            # verifies if condition is an is_instance condition
+            is_instance_condition = (isinstance(condition, ast.Call) and isinstance(condition.func, ast.Name)
+                                     and condition.func.id in is_instance_objs and len(condition.args) == 2)
+
+            # verifies if condition is a identity condition (is None or is not None)
+            from boa3.model.operation.unary.noneidentity import NoneIdentity
+            from boa3.model.operation.unary.nonenotidentity import NoneNotIdentity
+            identity_condition = isinstance(condition, ast.Compare) \
+                                 and isinstance(condition.ops[0], (NoneIdentity, NoneNotIdentity))
+
+            if identity_condition and isinstance(condition.ops[0], NoneNotIdentity):
+                negate = True
+
+            if is_instance_condition or identity_condition:
+                if is_instance_condition:
+                    left_value = condition.args[0]
+                    right_value = condition.args[1]
+
+                else:
+                    left_value = condition.left
+                    right_value = None
+
+                original = self.get_symbol(left_value)
+                if isinstance(original, Variable) and isinstance(left_value, ast.Name):
+                    original_id = left_value.id
                     original_type = (original.type
                                      if original_id not in is_instance_symbols
                                      else is_instance_symbols[original_id])
 
-                    instance_obj = self.get_symbol(condition.func.id)
+                    instance_obj = self.get_symbol(condition.func.id) if is_instance_condition else None
                     if isinstance(instance_obj, type(Builtin.IsInstance)):
                         is_instance_type = instance_obj._instances_type
                         if isinstance(is_instance_type, list):
                             is_instance_type = Type.union.build(is_instance_type)
                     else:
-                        is_instance_type = self.get_type(condition.args[1])
+                        is_instance_type = self.get_type(right_value)
                     is_instance_type = is_instance_type.intersect_type(original_type)
                     negation = original_type.except_type(is_instance_type)
                     resulting_type = is_instance_type if not negate else negation
@@ -732,7 +752,9 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
 
                     if len(is_instance_symbols) == 1:
                         is_not_instance_symbols[original_id] = is_instance_type if negate else negation
-                    elif len(is_not_instance_symbols) > 1:
+                    elif len(is_not_instance_symbols) == 1:
+                        # if there is more than one isinstance it's not possible to determine in compiler time what is
+                        # the type of the variables on the else body
                         is_not_instance_symbols.clear()
 
         for key, value in is_instance_symbols.copy().items():

--- a/boa3_test/examples/amm.py
+++ b/boa3_test/examples/amm.py
@@ -229,9 +229,9 @@ def post_transfer(from_address: Union[UInt160, None], to_address: Union[UInt160,
     :param data: any pertinent data that might validate the transaction
     :type data: Any
     """
-    if not isinstance(to_address, None):    # TODO: change to 'is not None' when `is` semantic is implemented
+    if to_address is not None:
         contract = ContractManagement.get_contract(to_address)
-        if not isinstance(contract, None):      # TODO: change to 'is not None' when `is` semantic is implemented
+        if contract is not None:
             call_contract(to_address, 'onNEP17Payment', [from_address, amount, data])
 
 

--- a/boa3_test/examples/htlc.py
+++ b/boa3_test/examples/htlc.py
@@ -134,12 +134,12 @@ def onNEP17Payment(from_address: UInt160, amount: int, data: Any):
     :raise AssertionError: raised if `from_address` length is not 20
     """
     # the parameters from and to should be 20-byte addresses. If not, this method should throw an exception.
-    aux_var = from_address is not None  # TODO: remove this variable when type checking the values after the if is fixed
+    aux_var = from_address is not None  # TODO: using identity operators or isinstance as a condition of an if is bugged
     if aux_var:
         assert len(from_address) == 20
 
     # this validation will verify if Neo is trying to mint GAS to this smart contract
-    aux_var = from_address is None      # TODO: remove this variable when type checking the values after the if is fixed
+    aux_var = from_address is None      # TODO: using identity operators or isinstance as a condition of an if is bugged
     if aux_var and runtime.calling_script_hash == GAS_SCRIPT:
         return
 

--- a/boa3_test/examples/htlc.py
+++ b/boa3_test/examples/htlc.py
@@ -134,11 +134,13 @@ def onNEP17Payment(from_address: UInt160, amount: int, data: Any):
     :raise AssertionError: raised if `from_address` length is not 20
     """
     # the parameters from and to should be 20-byte addresses. If not, this method should throw an exception.
-    if from_address is not None:
+    aux_var = from_address is not None  # TODO: remove this variable when type checking the values after the if is fixed
+    if aux_var:
         assert len(from_address) == 20
 
     # this validation will verify if Neo is trying to mint GAS to this smart contract
-    if from_address is None and runtime.calling_script_hash == GAS_SCRIPT:
+    aux_var = from_address is None      # TODO: remove this variable when type checking the values after the if is fixed
+    if aux_var and runtime.calling_script_hash == GAS_SCRIPT:
         return
 
     if not storage.get(NOT_INITIALIZED).to_bool():

--- a/boa3_test/examples/ico.py
+++ b/boa3_test/examples/ico.py
@@ -305,9 +305,9 @@ def post_transfer(from_address: Union[UInt160, None], to_address: Union[UInt160,
     :param data: any pertinent data that might validate the transaction
     :type data: Any
     """
-    if not isinstance(to_address, None):  # TODO: change to 'is not None' when `is` semantic is implemented
+    if to_address is not None:
         contract = ContractManagement.get_contract(to_address)
-        if not isinstance(contract, None):  # TODO: change to 'is not None' when `is` semantic is implemented
+        if contract is not None:
             call_contract(to_address, 'onNEP17Payment', [from_address, amount, data])
 
 

--- a/boa3_test/examples/nep17.py
+++ b/boa3_test/examples/nep17.py
@@ -186,9 +186,9 @@ def post_transfer(from_address: Union[UInt160, None], to_address: Union[UInt160,
     :param data: any pertinent data that might validate the transaction
     :type data: Any
     """
-    if not isinstance(to_address, None):  # TODO: change to 'is not None' when `is` semantic is implemented
+    if to_address is not None:
         contract = ContractManagement.get_contract(to_address)
-        if not isinstance(contract, None):  # TODO: change to 'is not None' when `is` semantic is implemented
+        if contract is not None:
             call_contract(to_address, 'onNEP17Payment', [from_address, amount, data])
 
 

--- a/boa3_test/examples/wrapped_gas.py
+++ b/boa3_test/examples/wrapped_gas.py
@@ -302,9 +302,9 @@ def post_transfer(from_address: Union[UInt160, None], to_address: Union[UInt160,
     :type call_onPayment: bool
     """
     if call_onPayment:
-        if not isinstance(to_address, None):  # TODO: change to 'is not None' when `is` semantic is implemented
+        if to_address is not None:
             contract = ContractManagement.get_contract(to_address)
-            if not isinstance(contract, None):  # TODO: change to 'is not None' when `is` semantic is implemented
+            if contract is not None:
                 call_contract(to_address, 'onNEP17Payment', [from_address, amount, data])
 
 

--- a/boa3_test/examples/wrapped_neo.py
+++ b/boa3_test/examples/wrapped_neo.py
@@ -301,9 +301,9 @@ def post_transfer(from_address: Union[UInt160, None], to_address: Union[UInt160,
     :type call_onPayment: bool
     """
     if call_onPayment:
-        if not isinstance(to_address, None):  # TODO: change to 'is not None' when `is` semantic is implemented
+        if to_address is not None:
             contract = ContractManagement.get_contract(to_address)
-            if not isinstance(contract, None):  # TODO: change to 'is not None' when `is` semantic is implemented
+            if contract is not None:
                 call_contract(to_address, 'onNEP17Payment', [from_address, amount, data])
 
 

--- a/boa3_test/test_sc/if_test/IfIsNone.py
+++ b/boa3_test/test_sc/if_test/IfIsNone.py
@@ -1,0 +1,15 @@
+from typing import Union
+
+from boa3.builtin import public
+
+
+@public
+def main(a: Union[int, None]) -> bool:
+    if a is None:
+        return True
+    else:
+        return some_function(a)
+
+
+def some_function(var: int) -> bool:
+    return False

--- a/boa3_test/test_sc/if_test/IfIsNotNone.py
+++ b/boa3_test/test_sc/if_test/IfIsNotNone.py
@@ -1,0 +1,15 @@
+from typing import Union
+
+from boa3.builtin import public
+
+
+@public
+def main(a: Union[int, None]) -> bool:
+    if a is not None:
+        return some_function(a)
+    else:
+        return False
+
+
+def some_function(var: int) -> bool:
+    return True

--- a/boa3_test/tests/compiler_tests/test_if.py
+++ b/boa3_test/tests/compiler_tests/test_if.py
@@ -670,3 +670,21 @@ class TestIf(BoaTest):
 
         result = self.run_smart_contract(engine, path, 'main', True)
         self.assertEqual(result, 0)
+
+    def test_if_is_none(self):
+        path = self.get_contract_path('IfIsNone.py')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'main', 123)
+        self.assertEqual(False, result)
+        result = self.run_smart_contract(engine, path, 'main', None)
+        self.assertEqual(True, result)
+
+    def test_if_is_not_none(self):
+        path = self.get_contract_path('IfIsNotNone.py')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'main', 123)
+        self.assertEqual(True, result)
+        result = self.run_smart_contract(engine, path, 'main', None)
+        self.assertEqual(False, result)

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -461,11 +461,13 @@ All of the examples presented here can be found in the `examples folder of the N
         :raise AssertionError: raised if `from_address` length is not 20
         """
         # the parameters from and to should be 20-byte addresses. If not, this method should throw an exception.
-        if from_address is not None:
+        aux_var = from_address is not None  # TODO: using identity operators or isinstance as a condition of an if is bugged
+        if aux_var:
             assert len(from_address) == 20
 
         # this validation will verify if Neo is trying to mint GAS to this smart contract
-        if from_address is None and runtime.calling_script_hash == GAS_SCRIPT:
+        aux_var = from_address is None      # TODO: using identity operators or isinstance as a condition of an if is bugged
+        if aux_var and runtime.calling_script_hash == GAS_SCRIPT:
             return
 
         if not storage.get(NOT_INITIALIZED).to_bool():

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -233,9 +233,9 @@ All of the examples presented here can be found in the `examples folder of the N
         :param data: any pertinent data that might validate the transaction
         :type data: Any
         """
-        if not isinstance(to_address, None):  # TODO: change to 'is not None' when `is` semantic is implemented
+        if to_address is not None:
             contract = ContractManagement.get_contract(to_address)
-            if not isinstance(contract, None):  # TODO: change to 'is not None' when `is` semantic is implemented
+            if contract is not None:
                 call_contract(to_address, 'onNEP17Payment', [from_address, amount, data])
 
 
@@ -874,9 +874,9 @@ All of the examples presented here can be found in the `examples folder of the N
         :param data: any pertinent data that might validate the transaction
         :type data: Any
         """
-        if not isinstance(to_address, None):  # TODO: change to 'is not None' when `is` semantic is implemented
+        if to_address is not None:
             contract = ContractManagement.get_contract(to_address)
-            if not isinstance(contract, None):  # TODO: change to 'is not None' when `is` semantic is implemented
+            if contract is not None:
                 call_contract(to_address, 'onNEP17Payment', [from_address, amount, data])
 
 
@@ -1353,9 +1353,9 @@ All of the examples presented here can be found in the `examples folder of the N
         :type call_onPayment: bool
         """
         if call_onPayment:
-            if not isinstance(to_address, None):  # TODO: change to 'is not None' when `is` semantic is implemented
+            if to_address is not None:
                 contract = ContractManagement.get_contract(to_address)
-                if not isinstance(contract, None):  # TODO: change to 'is not None' when `is` semantic is implemented
+                if contract is not None:
                     call_contract(to_address, 'onNEP17Payment', [from_address, amount, data])
 
 


### PR DESCRIPTION
**Summary or solution description**
Made `x is None` and `x is not None` have the same behaviour as `isinstance(x, None)` and `not isinstance(x, None)`.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/3d55492bb6ee826e2dcd1dfe08a923f579c56fff/boa3_test/test_sc/if_test/IfIsNone.py#L1-L15
https://github.com/CityOfZion/neo3-boa/blob/3d55492bb6ee826e2dcd1dfe08a923f579c56fff/boa3_test/test_sc/if_test/IfIsNotNone.py#L1-L15

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/3d55492bb6ee826e2dcd1dfe08a923f579c56fff/boa3_test/tests/compiler_tests/test_if.py#L674-L690

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7

**(Optional) Additional context**
Bugs regarding `isinstance(x, None)` and `not isinstance(x, None)` were not fixed and identity operations now have the same problems.
E.g.: it was necessary to replace the identity operation inside the `if` with another variable outside. Changing `if from_address is not None:` to `if not isinstance(from_address)` on the dev branch results in the same error.
https://github.com/CityOfZion/neo3-boa/blob/3d55492bb6ee826e2dcd1dfe08a923f579c56fff/boa3_test/examples/htlc.py#L136-L144