### PR TITLE
Invalid type for SETITEM: ByteString when assigning value at index in bytearray

### DIFF
--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -710,8 +710,8 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
                                      and condition.func.id in is_instance_objs and len(condition.args) == 2)
 
             # verifies if condition is a identity condition (is None or is not None)
-            identity_condition = isinstance(condition, ast.Compare) \
-                                 and isinstance(condition.ops[0], (type(BinaryOp.IsNone), type(BinaryOp.IsNotNone)))
+            identity_condition = (isinstance(condition, ast.Compare)
+                                  and isinstance(condition.ops[0], (type(BinaryOp.IsNone), type(BinaryOp.IsNotNone))))
 
             if identity_condition and isinstance(condition.ops[0], type(BinaryOp.IsNotNone)):
                 negate = True

--- a/boa3/compiler/codegenerator/codegenerator.py
+++ b/boa3/compiler/codegenerator/codegenerator.py
@@ -915,10 +915,10 @@ class CodeGenerator:
                 self._stack_append(Type.int)
                 self.convert_operation(UnaryOp.Negative)
             else:
-                array = Integer(value).to_byte_array(signed=True)
-                self.insert_push_data(array)
-                # cast the value to integer
-                self.convert_cast(Type.int)
+                opcode, data = Opcode.get_push_and_data(value)
+                op_info: OpcodeInformation = OpcodeInfo.get_info(opcode)
+                self.__insert1(op_info, data)
+                self._stack_append(Type.int)
 
     def convert_string_literal(self, value: str):
         """

--- a/boa3/model/builtin/method/bytearraymethod.py
+++ b/boa3/model/builtin/method/bytearraymethod.py
@@ -50,7 +50,8 @@ class ByteArrayMethod(IBuiltinMethod):
 
     @property
     def opcode(self) -> List[Tuple[Opcode, bytes]]:
-        return []
+        from boa3.neo.vm.type.StackItem import StackItemType
+        return [(Opcode.CONVERT, StackItemType.Buffer)]
 
     @property
     def is_supported(self) -> bool:

--- a/boa3/model/type/primitive/bytearraytype.py
+++ b/boa3/model/type/primitive/bytearraytype.py
@@ -3,6 +3,7 @@ from typing import Any
 from boa3.model.type.collection.sequence.mutable.mutablesequencetype import MutableSequenceType
 from boa3.model.type.itype import IType
 from boa3.model.type.primitive.bytestype import BytesType
+from boa3.neo.vm.type.StackItem import StackItemType
 
 
 class ByteArrayType(BytesType, MutableSequenceType):
@@ -13,6 +14,10 @@ class ByteArrayType(BytesType, MutableSequenceType):
     def __init__(self):
         super().__init__()
         self._identifier = 'bytearray'
+
+    @property
+    def stack_item(self) -> StackItemType:
+        return StackItemType.Buffer
 
     @property
     def default_value(self) -> Any:

--- a/boa3/neo/vm/opcode/Opcode.py
+++ b/boa3/neo/vm/opcode/Opcode.py
@@ -98,9 +98,9 @@ class Opcode(bytes, Enum):
         :return: the respective opcode and its required data
         :rtype: Tuple[Opcode, bytes]
         """
-        if -1 <= integer <= 16:
-            opcode_value: int = Integer.from_bytes(Opcode.PUSH0) + integer
-            return Opcode(Integer(opcode_value).to_byte_array()), b''
+        opcode = Opcode.get_literal_push(integer)
+        if isinstance(opcode, Opcode):
+            return opcode, b''
         else:
             data = Integer(integer).to_byte_array(signed=True, min_length=1)
             if len(data) == 1:

--- a/boa3_test/test_sc/bytes_test/BytearraySetValue.py
+++ b/boa3_test/test_sc/bytes_test/BytearraySetValue.py
@@ -2,6 +2,7 @@ from boa3.builtin import public
 
 
 @public
-def Main(a: bytearray) -> bytes:
+def Main(arg: bytes) -> bytes:
+    a = bytearray(arg)
     a[0] = 0x01  # raises runtime error if the value is out of range(256)
     return a

--- a/boa3_test/test_sc/bytes_test/BytearraySetValueNegativeIndex.py
+++ b/boa3_test/test_sc/bytes_test/BytearraySetValueNegativeIndex.py
@@ -2,6 +2,7 @@ from boa3.builtin import public
 
 
 @public
-def Main(a: bytearray) -> bytes:
+def Main(arg: bytes) -> bytes:
+    a = bytearray(arg)
     a[-1] = 0x01  # raises runtime error if the value is out of range(256)
     return a

--- a/boa3_test/test_sc/contract_interface_test/ContractInterfaceCodeOptimization.py
+++ b/boa3_test/test_sc/contract_interface_test/ContractInterfaceCodeOptimization.py
@@ -4,7 +4,7 @@ from boa3.builtin import contract, display_name, public
 from boa3.builtin.type import UInt160
 
 
-@contract('0xa34afa0e5414255d1093e92a1a6f1f505c82cd3f')
+@contract('0x21f19f84e144f91abe755efb21a6798ac95c2e70')
 class Nep17:
 
     @staticmethod

--- a/boa3_test/test_sc/contract_interface_test/Nep17Interface.py
+++ b/boa3_test/test_sc/contract_interface_test/Nep17Interface.py
@@ -4,7 +4,7 @@ from boa3.builtin import contract, display_name, public
 from boa3.builtin.type import UInt160
 
 
-@contract('0xa34afa0e5414255d1093e92a1a6f1f505c82cd3f')
+@contract('0x21f19f84e144f91abe755efb21a6798ac95c2e70')
 class Nep17:
 
     @staticmethod

--- a/boa3_test/test_sc/contract_interface_test/Nep17InterfaceWithDisplayName.py
+++ b/boa3_test/test_sc/contract_interface_test/Nep17InterfaceWithDisplayName.py
@@ -4,7 +4,7 @@ from boa3.builtin import contract, display_name, public
 from boa3.builtin.type import UInt160
 
 
-@contract('0xa34afa0e5414255d1093e92a1a6f1f505c82cd3f')
+@contract('0x21f19f84e144f91abe755efb21a6798ac95c2e70')
 class Nep17:
 
     @staticmethod

--- a/boa3_test/tests/compiler_tests/test_builtin_method.py
+++ b/boa3_test/tests/compiler_tests/test_builtin_method.py
@@ -1,5 +1,3 @@
-import unittest
-
 from boa3.boa3 import Boa3
 from boa3.exception import CompilerError
 from boa3.model.type.type import Type
@@ -336,7 +334,6 @@ class TestBuiltinMethod(BoaTest):
         result = self.run_smart_contract(engine, path, 'Main')
         self.assertEqual([3, 2, 1], result)
 
-    @unittest.skip("reverse items doesn't work with bytestring")
     def test_reverse_mutable_sequence_with_builtin(self):
         path = self.get_contract_path('ReverseMutableSequenceBuiltinCall.py')
         output = Boa3.compile(path)

--- a/boa3_test/tests/compiler_tests/test_constant.py
+++ b/boa3_test/tests/compiler_tests/test_constant.py
@@ -44,11 +44,8 @@ class TestConstant(BoaTest):
         input = -100
         byte_input = Integer(input).to_byte_array()
         expected_output = (
-            Opcode.PUSHDATA1            # push the bytes
-            + Integer(len(byte_input)).to_byte_array()
+            Opcode.PUSHINT8             # push the bytes
             + byte_input
-            + Opcode.CONVERT            # convert to integer
-            + Type.int.stack_item
         )
 
         generator = self.build_code_generator()
@@ -61,11 +58,8 @@ class TestConstant(BoaTest):
         input = 42
         byte_input = Integer(input).to_byte_array()
         expected_output = (
-            Opcode.PUSHDATA1            # push the bytes
-            + Integer(len(byte_input)).to_byte_array(min_length=1)
+            Opcode.PUSHINT8             # push the bytes
             + byte_input
-            + Opcode.CONVERT            # convert to integer
-            + Type.int.stack_item
         )
 
         generator = self.build_code_generator()
@@ -78,11 +72,8 @@ class TestConstant(BoaTest):
         byte_input = bytes(300) + b'\x01'
         input = Integer.from_bytes(byte_input)
         expected_output = (
-            Opcode.PUSHDATA2            # push the bytes
-            + Integer(len(byte_input)).to_byte_array(min_length=2)
-            + byte_input
-            + Opcode.CONVERT            # convert to integer
-            + Type.int.stack_item
+            Opcode.PUSHINT256           # push the bytes
+            + byte_input[:32]
         )
 
         generator = self.build_code_generator()
@@ -95,11 +86,8 @@ class TestConstant(BoaTest):
         byte_input = bytes(100000) + b'\x01'
         input = Integer.from_bytes(byte_input)
         expected_output = (
-            Opcode.PUSHDATA4            # push the bytes
-            + Integer(len(byte_input)).to_byte_array(min_length=4)
-            + byte_input
-            + Opcode.CONVERT            # convert to integer
-            + Type.int.stack_item
+            Opcode.PUSHINT256           # push the bytes
+            + byte_input[:32]
         )
 
         generator = self.build_code_generator()
@@ -114,14 +102,11 @@ class TestConstant(BoaTest):
         signed = Integer.from_bytes(byte_input, signed=True)
         self.assertNotEqual(unsigned, signed)
 
-        unsigned_byte_input = Integer(unsigned).to_byte_array(signed=True)
+        unsigned_byte_input = Integer(unsigned).to_byte_array(signed=True, min_length=4)
         self.assertNotEqual(byte_input, unsigned_byte_input)
         unsigned_expected_output = (
-            Opcode.PUSHDATA1            # push the bytes
-            + Integer(len(unsigned_byte_input)).to_byte_array(min_length=1)
+            Opcode.PUSHINT32            # push the bytes
             + unsigned_byte_input
-            + Opcode.CONVERT            # convert to integer
-            + Type.int.stack_item
         )
 
         generator = self.build_code_generator()
@@ -130,14 +115,11 @@ class TestConstant(BoaTest):
 
         self.assertEqual(unsigned_expected_output, output)
 
-        signed_byte_input = Integer(signed).to_byte_array(signed=True)
+        signed_byte_input = Integer(signed).to_byte_array(signed=True, min_length=2)
         self.assertEqual(byte_input, signed_byte_input)
         signed_expected_output = (
-            Opcode.PUSHDATA1            # push the bytes
-            + Integer(len(signed_byte_input)).to_byte_array(min_length=1)
+            Opcode.PUSHINT16           # push the bytes
             + signed_byte_input
-            + Opcode.CONVERT            # convert to integer
-            + Type.int.stack_item
         )
 
         generator = self.build_code_generator()

--- a/boa3_test/tests/compiler_tests/test_contract_interface.py
+++ b/boa3_test/tests/compiler_tests/test_contract_interface.py
@@ -96,7 +96,7 @@ class TestContractInterface(BoaTest):
 
         external_contract_name = 'symbol'
         function_name_bytes = String(external_contract_name).to_bytes()
-        contract_script_bytes = UInt160.from_string('a34afa0e5414255d1093e92a1a6f1f505c82cd3f').to_array()
+        contract_script_bytes = UInt160.from_string('21f19f84e144f91abe755efb21a6798ac95c2e70').to_array()
 
         expected_output = (
             Opcode.NEWARRAY0    # arguments list
@@ -132,7 +132,7 @@ class TestContractInterface(BoaTest):
 
         external_contract_name = 'symbol'
         function_name_bytes = String(external_contract_name).to_bytes()
-        contract_script_bytes = UInt160.from_string('a34afa0e5414255d1093e92a1a6f1f505c82cd3f').to_array()
+        contract_script_bytes = UInt160.from_string('21f19f84e144f91abe755efb21a6798ac95c2e70').to_array()
 
         expected_output = (
             # start public method

--- a/boa3_test/tests/compiler_tests/test_if.py
+++ b/boa3_test/tests/compiler_tests/test_if.py
@@ -1,6 +1,5 @@
 from boa3.boa3 import Boa3
 from boa3.exception import CompilerWarning
-from boa3.model.type.type import Type
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.StackItem import StackItemType
@@ -236,42 +235,38 @@ class TestIf(BoaTest):
             + Opcode.LT
             + Opcode.JMPIFNOT       # if arg0 < 0
             + Integer(6).to_byte_array(min_length=1)
-            + Opcode.PUSH0          # a = 0
+            + Opcode.PUSH0              # a = 0
             + Opcode.STLOC0
             + Opcode.JMP
-            + Integer(35).to_byte_array(min_length=1)
+            + Integer(32).to_byte_array(min_length=1)
             + Opcode.LDARG0
             + Opcode.PUSH5
             + Opcode.LT
             + Opcode.JMPIFNOT       # elif arg0 < 5
             + Integer(6).to_byte_array(min_length=1)
-            + Opcode.PUSH5          # a = 5
+            + Opcode.PUSH5              # a = 5
             + Opcode.STLOC0
             + Opcode.JMP
-            + Integer(26).to_byte_array(min_length=1)
+            + Integer(23).to_byte_array(min_length=1)
             + Opcode.LDARG0
             + Opcode.PUSH10
             + Opcode.LT
             + Opcode.JMPIFNOT       # elif arg0 < 10
             + Integer(6).to_byte_array(min_length=1)
-            + Opcode.PUSH10         # a = 10
+            + Opcode.PUSH10             # a = 10
             + Opcode.STLOC0
             + Opcode.JMP
-            + Integer(17).to_byte_array(min_length=1)
+            + Integer(14).to_byte_array(min_length=1)
             + Opcode.LDARG0
             + Opcode.PUSH15
             + Opcode.LT
             + Opcode.JMPIFNOT       # elif arg0 < 15
             + Integer(6).to_byte_array(min_length=1)
-            + Opcode.PUSH15         # a = 15
+            + Opcode.PUSH15             # a = 15
             + Opcode.STLOC0
             + Opcode.JMP            # else
-            + Integer(8).to_byte_array(min_length=1)
-            + Opcode.PUSHDATA1      # a = 20
-            + Integer(len(twenty)).to_byte_array()
-            + twenty
-            + Opcode.CONVERT
-            + Type.int.stack_item
+            + Integer(5).to_byte_array(min_length=1)
+            + Opcode.PUSHINT8 + twenty  # a = 20
             + Opcode.STLOC0
             + Opcode.LDLOC0     # return a
             + Opcode.RET
@@ -455,7 +450,7 @@ class TestIf(BoaTest):
         self.assertEqual(False, result)
 
         result = self.run_smart_contract(engine, path, 'main', 2)
-        self.assertEqual(True, result)
+        self.assertEqual(False, result)
 
         result = self.run_smart_contract(engine, path, 'main', 3)
         self.assertEqual(False, result)

--- a/boa3_test/tests/compiler_tests/test_interop/test_crypto.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_crypto.py
@@ -257,10 +257,7 @@ class TestCryptoInterop(BoaTest):
         call_flag = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
 
         expected_output = (
-            Opcode.PUSHDATA1
-            + Integer(len(named_curve)).to_byte_array(min_length=1)
-            + named_curve
-            + Opcode.CONVERT + Type.int.stack_item
+            Opcode.PUSHINT8 + named_curve
             + Opcode.PUSHDATA1
             + Integer(len(byte_input2)).to_byte_array(min_length=1)
             + byte_input2
@@ -298,10 +295,7 @@ class TestCryptoInterop(BoaTest):
         call_flag = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
 
         expected_output = (
-            Opcode.PUSHDATA1
-            + Integer(len(named_curve)).to_byte_array(min_length=1)
-            + named_curve
-            + Opcode.CONVERT + Type.int.stack_item
+            Opcode.PUSHINT8 + named_curve
             + Opcode.PUSHDATA1
             + Integer(len(byte_input2)).to_byte_array(min_length=1)
             + byte_input2
@@ -338,10 +332,7 @@ class TestCryptoInterop(BoaTest):
         call_flag = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
 
         expected_output = (
-            Opcode.PUSHDATA1
-            + Integer(len(named_curve)).to_byte_array(min_length=1)
-            + named_curve
-            + Opcode.CONVERT + Type.int.stack_item
+            Opcode.PUSHINT8 + named_curve
             + Opcode.PUSHDATA1
             + Integer(len(byte_input2)).to_byte_array(min_length=1)
             + byte_input2
@@ -378,10 +369,7 @@ class TestCryptoInterop(BoaTest):
         call_flag = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
 
         expected_output = (
-            Opcode.PUSHDATA1
-            + Integer(len(named_curve)).to_byte_array(min_length=1)
-            + named_curve
-            + Opcode.CONVERT + Type.int.stack_item
+            Opcode.PUSHINT8 + named_curve
             + Opcode.PUSHDATA1
             + Integer(len(byte_input2)).to_byte_array(min_length=1)
             + byte_input2
@@ -424,10 +412,7 @@ class TestCryptoInterop(BoaTest):
         call_flag = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
 
         expected_output = (
-            Opcode.PUSHDATA1
-            + Integer(len(named_curve)).to_byte_array(min_length=1)
-            + named_curve
-            + Opcode.CONVERT + Type.int.stack_item
+            Opcode.PUSHINT8 + named_curve
             + Opcode.PUSHDATA1
             + Integer(len(byte_input2)).to_byte_array(min_length=1)
             + byte_input2
@@ -464,10 +449,7 @@ class TestCryptoInterop(BoaTest):
         call_flag = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
 
         expected_output = (
-            Opcode.PUSHDATA1
-            + Integer(len(named_curve)).to_byte_array(min_length=1)
-            + named_curve
-            + Opcode.CONVERT + Type.int.stack_item
+            Opcode.PUSHINT8 + named_curve
             + Opcode.PUSHDATA1
             + Integer(len(byte_input2)).to_byte_array(min_length=1)
             + byte_input2
@@ -503,10 +485,7 @@ class TestCryptoInterop(BoaTest):
         call_flag = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
 
         expected_output = (
-            Opcode.PUSHDATA1
-            + Integer(len(named_curve)).to_byte_array(min_length=1)
-            + named_curve
-            + Opcode.CONVERT + Type.int.stack_item
+            Opcode.PUSHINT8 + named_curve
             + Opcode.PUSHDATA1
             + Integer(len(byte_input2)).to_byte_array(min_length=1)
             + byte_input2
@@ -542,10 +521,7 @@ class TestCryptoInterop(BoaTest):
         call_flag = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
 
         expected_output = (
-            Opcode.PUSHDATA1
-            + Integer(len(named_curve)).to_byte_array(min_length=1)
-            + named_curve
-            + Opcode.CONVERT + Type.int.stack_item
+            Opcode.PUSHINT8 + named_curve
             + Opcode.PUSHDATA1
             + Integer(len(byte_input2)).to_byte_array(min_length=1)
             + byte_input2

--- a/boa3_test/tests/compiler_tests/test_interop/test_runtime.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_runtime.py
@@ -1,7 +1,6 @@
 from boa3.boa3 import Boa3
 from boa3.exception import CompilerError, CompilerWarning
 from boa3.model.builtin.interop.interop import Interop
-from boa3.model.type.type import Type
 from boa3.neo import to_script_hash
 from boa3.neo.cryptography import hash160
 from boa3.neo.vm.opcode.Opcode import Opcode
@@ -265,11 +264,7 @@ class TestRuntimeInterop(BoaTest):
         expected_output = (
             Opcode.SYSCALL
             + Interop.GetTrigger.interop_method_hash
-            + Opcode.PUSHDATA1
-            + Integer(len(application)).to_byte_array(min_length=1)
-            + application
-            + Opcode.CONVERT
-            + Type.int.stack_item
+            + Opcode.PUSHINT8 + application
             + Opcode.NUMEQUAL
             + Opcode.RET
         )
@@ -287,11 +282,7 @@ class TestRuntimeInterop(BoaTest):
         expected_output = (
             Opcode.SYSCALL
             + Interop.GetTrigger.interop_method_hash
-            + Opcode.PUSHDATA1
-            + Integer(len(verification)).to_byte_array(min_length=1)
-            + verification
-            + Opcode.CONVERT
-            + Type.int.stack_item
+            + Opcode.PUSHINT8 + verification
             + Opcode.NUMEQUAL
             + Opcode.RET
         )

--- a/boa3_test/tests/compiler_tests/test_interop/test_storage.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_storage.py
@@ -121,15 +121,9 @@ class TestStorageInterop(BoaTest):
             Opcode.INITSLOT
             + b'\x01'
             + b'\x01'
-            + Opcode.PUSHDATA1
-            + Integer(len(value)).to_byte_array(min_length=1, signed=True)
-            + value
-            + Opcode.CONVERT + Type.int.stack_item
+            + Opcode.PUSHINT8 + value
             + Opcode.STLOC0
-            + Opcode.PUSHDATA1
-            + Integer(len(value)).to_byte_array(min_length=1, signed=True)
-            + value
-            + Opcode.CONVERT + Type.int.stack_item
+            + Opcode.PUSHINT8 + value
             + Opcode.LDARG0
             + Opcode.SYSCALL
             + Interop.StorageGetContext.interop_method_hash
@@ -251,15 +245,9 @@ class TestStorageInterop(BoaTest):
             Opcode.INITSLOT
             + b'\x01'
             + b'\x01'
-            + Opcode.PUSHDATA1
-            + Integer(len(value)).to_byte_array(min_length=1, signed=True)
-            + value
-            + Opcode.CONVERT + Type.int.stack_item
+            + Opcode.PUSHINT8 + value
             + Opcode.STLOC0
-            + Opcode.PUSHDATA1
-            + Integer(len(value)).to_byte_array(min_length=1, signed=True)
-            + value
-            + Opcode.CONVERT + Type.int.stack_item
+            + Opcode.PUSHINT8 + value
             + Opcode.LDARG0
             + Opcode.SYSCALL
             + Interop.StorageGetContext.interop_method_hash

--- a/boa3_test/tests/compiler_tests/test_native/test_cryptolib.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_cryptolib.py
@@ -122,10 +122,7 @@ class TestCryptoLibClass(BoaTest):
         call_flag = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
 
         expected_output = (
-            Opcode.PUSHDATA1
-            + Integer(len(named_curve)).to_byte_array(min_length=1)
-            + named_curve
-            + Opcode.CONVERT + Type.int.stack_item
+            Opcode.PUSHINT8 + named_curve
             + Opcode.PUSHDATA1
             + Integer(len(byte_input2)).to_byte_array(min_length=1)
             + byte_input2
@@ -163,10 +160,7 @@ class TestCryptoLibClass(BoaTest):
         call_flag = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
 
         expected_output = (
-            Opcode.PUSHDATA1
-            + Integer(len(named_curve)).to_byte_array(min_length=1)
-            + named_curve
-            + Opcode.CONVERT + Type.int.stack_item
+            Opcode.PUSHINT8 + named_curve
             + Opcode.PUSHDATA1
             + Integer(len(byte_input2)).to_byte_array(min_length=1)
             + byte_input2
@@ -203,10 +197,7 @@ class TestCryptoLibClass(BoaTest):
         call_flag = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
 
         expected_output = (
-            Opcode.PUSHDATA1
-            + Integer(len(named_curve)).to_byte_array(min_length=1)
-            + named_curve
-            + Opcode.CONVERT + Type.int.stack_item
+            Opcode.PUSHINT8 + named_curve
             + Opcode.PUSHDATA1
             + Integer(len(byte_input2)).to_byte_array(min_length=1)
             + byte_input2
@@ -243,10 +234,7 @@ class TestCryptoLibClass(BoaTest):
         call_flag = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
 
         expected_output = (
-            Opcode.PUSHDATA1
-            + Integer(len(named_curve)).to_byte_array(min_length=1)
-            + named_curve
-            + Opcode.CONVERT + Type.int.stack_item
+            Opcode.PUSHINT8 + named_curve
             + Opcode.PUSHDATA1
             + Integer(len(byte_input2)).to_byte_array(min_length=1)
             + byte_input2
@@ -289,10 +277,7 @@ class TestCryptoLibClass(BoaTest):
         call_flag = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
 
         expected_output = (
-            Opcode.PUSHDATA1
-            + Integer(len(named_curve)).to_byte_array(min_length=1)
-            + named_curve
-            + Opcode.CONVERT + Type.int.stack_item
+            Opcode.PUSHINT8 + named_curve
             + Opcode.PUSHDATA1
             + Integer(len(byte_input2)).to_byte_array(min_length=1)
             + byte_input2
@@ -329,10 +314,7 @@ class TestCryptoLibClass(BoaTest):
         call_flag = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
 
         expected_output = (
-            Opcode.PUSHDATA1
-            + Integer(len(named_curve)).to_byte_array(min_length=1)
-            + named_curve
-            + Opcode.CONVERT + Type.int.stack_item
+            Opcode.PUSHINT8 + named_curve
             + Opcode.PUSHDATA1
             + Integer(len(byte_input2)).to_byte_array(min_length=1)
             + byte_input2
@@ -368,10 +350,7 @@ class TestCryptoLibClass(BoaTest):
         call_flag = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
 
         expected_output = (
-            Opcode.PUSHDATA1
-            + Integer(len(named_curve)).to_byte_array(min_length=1)
-            + named_curve
-            + Opcode.CONVERT + Type.int.stack_item
+            Opcode.PUSHINT8 + named_curve
             + Opcode.PUSHDATA1
             + Integer(len(byte_input2)).to_byte_array(min_length=1)
             + byte_input2
@@ -407,10 +386,7 @@ class TestCryptoLibClass(BoaTest):
         call_flag = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
 
         expected_output = (
-            Opcode.PUSHDATA1
-            + Integer(len(named_curve)).to_byte_array(min_length=1)
-            + named_curve
-            + Opcode.CONVERT + Type.int.stack_item
+            Opcode.PUSHINT8 + named_curve
             + Opcode.PUSHDATA1
             + Integer(len(byte_input2)).to_byte_array(min_length=1)
             + byte_input2

--- a/boa3_test/tests/compiler_tests/test_relational.py
+++ b/boa3_test/tests/compiler_tests/test_relational.py
@@ -416,7 +416,7 @@ class TestRelational(BoaTest):
         self.assertEqual(False, result)
 
         result = self.run_smart_contract(engine, path, 'main', 2)
-        self.assertEqual(True, result)
+        self.assertEqual(False, result)
 
         result = self.run_smart_contract(engine, path, 'main', 3)
         self.assertEqual(True, result)

--- a/boa3_test/tests/compiler_tests/test_union.py
+++ b/boa3_test/tests/compiler_tests/test_union.py
@@ -1,5 +1,4 @@
 from boa3.boa3 import Boa3
-from boa3.model.type.type import Type
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.String import String
@@ -19,12 +18,8 @@ class TestUnion(BoaTest):
             + b'\x01'
             + Opcode.LDARG0
             + Opcode.JMPIFNOT
-            + Integer(8).to_byte_array(signed=True, min_length=1)
-            + Opcode.PUSHDATA1  # return 42
-            + Integer(len(integer)).to_byte_array(min_length=1)
-            + integer
-            + Opcode.CONVERT
-            + Type.int.stack_item
+            + Integer(5).to_byte_array(signed=True, min_length=1)
+            + Opcode.PUSHINT8 + integer  # return 42
             + Opcode.RET
             + Opcode.PUSHDATA1  # a = b'\x01\x02\x03'
             + Integer(len(string)).to_byte_array(min_length=1)


### PR DESCRIPTION
**Related issue**
#903

**Summary or solution description**
`bytearray` is being generated as a `ByteString` instead of `Buffer` and this is causing errors in the Neo VM.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/8bd1e207f883ecadb3c66968158fe6159497b7cc/boa3_test/test_sc/bytes_test/BytearraySetValue.py#L5-L8

**Tests**
The unit tests already existed, but they were being skipped in the test workflow
https://github.com/CityOfZion/neo3-boa/blob/8bd1e207f883ecadb3c66968158fe6159497b7cc/boa3_test/tests/compiler_tests/test_bytes.py#L570-L576

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7