### PR TITLE
Only boa3.builtin package should be imported by contracts

### DIFF
--- a/boa3/analyser/importanalyser.py
+++ b/boa3/analyser/importanalyser.py
@@ -135,7 +135,8 @@ class ImportAnalyser(IAstAnalyser):
             self.is_builtin_import = True
             return
 
-        if not ('boa3' in path and constants.PATH_SEPARATOR.join(path[path.index('boa3'):]).startswith('boa3/builtin')):
+        if (os.path.commonpath([self.path, constants.BOA_PACKAGE_PATH]) != constants.BOA_PACKAGE_PATH or
+                ('boa3' in path and constants.PATH_SEPARATOR.join(path[path.index('boa3'):]).startswith('boa3/builtin'))):
             # doesn't analyse boa3.builtin packages that aren't included in the imports.builtin as an user module
             # TODO: refactor when importing from user modules is accepted
             import re

--- a/boa3/constants.py
+++ b/boa3/constants.py
@@ -1,12 +1,22 @@
+import os
 import platform
 import sys
 
 from boa3 import __version__ as boa_version
 from boa3.neo import from_hex_str
 
+ENCODING = 'utf-8'
+BYTEORDER = 'little'
+
+ATTRIBUTE_NAME_SEPARATOR = '.'
+VARIABLE_NAME_SEPARATOR = ','
+PATH_SEPARATOR = '/'
+IMPORT_WILDCARD = '*'
+
 SYS_VERSION_INFO = sys.version_info
 SYS_VERSION = platform.python_version()
 BOA_VERSION = boa_version
+BOA_PACKAGE_PATH = os.path.abspath(f'{__file__}/..')
 
 ONE_BYTE_MAX_VALUE = 255
 TWO_BYTES_MAX_VALUE = 256 ** 2 - 1
@@ -17,14 +27,6 @@ SIZE_OF_INT160 = 20
 SIZE_OF_ECPOINT = 33
 DEFAULT_UINT32 = 0
 GAS_DECIMALS = 8
-
-ENCODING = 'utf-8'
-BYTEORDER = 'little'
-
-ATTRIBUTE_NAME_SEPARATOR = '.'
-VARIABLE_NAME_SEPARATOR = ','
-PATH_SEPARATOR = '/'
-IMPORT_WILDCARD = '*'
 
 INIT_METHOD_ID = '__init__'
 INITIALIZE_METHOD_ID = '_initialize'

--- a/boa3_test/test_sc/import_test/ImportBoaInvalidPackage.py
+++ b/boa3_test/test_sc/import_test/ImportBoaInvalidPackage.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.neo import to_script_hash  # should not be imported
+
+
+@public
+def Main() -> bytes:
+    return to_script_hash(b'42')

--- a/boa3_test/tests/compiler_tests/test_import.py
+++ b/boa3_test/tests/compiler_tests/test_import.py
@@ -395,3 +395,7 @@ class TestImport(BoaTest):
     def test_import_not_existing_method(self):
         path = self.get_contract_path('ImportNotExistingMethod.py')
         self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+
+    def test_import_boa_invalid_package(self):
+        path = self.get_contract_path('ImportBoaInvalidPackage.py')
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)


### PR DESCRIPTION
**Related issue**
#895

**Summary or solution description**
The only package in `boa3` package designed to be used in smart contracts is the `boa3.builtin` package.
The compiler was using the same process used to validate user-created modules to try to import the other `boa3` packages.
Included a filter to ignore these packages and always rais `UnresolvedReference` error.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/35dbab129377f62d708bb68622d74f55af8ab3b5/boa3_test/test_sc/import_test/ImportBoaInvalidPackage.py#L1-L7

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/35dbab129377f62d708bb68622d74f55af8ab3b5/boa3_test/tests/compiler_tests/test_import.py#L399-L401

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7

**(Optional) Additional context**
The messages reported as Infinite loop are actually the compiler trying to read the file and finding many features that are not supported
