### PR TITLE
Implement CryptoLib Native Contract method `murmur32` 

### DIFF
--- a/boa3/builtin/interop/crypto/__init__.py
+++ b/boa3/builtin/interop/crypto/__init__.py
@@ -96,3 +96,17 @@ def verify_with_ecdsa(message: Any, pubkey: ECPoint, signature: ByteString, curv
     :rtype: bool
     """
     pass
+
+
+def murmur32(data: ByteString, seed: int) -> ByteString:
+    """
+    Computes the hash value for the specified byte array using the murmur32 algorithm.
+
+    :param data: the input to compute the hash code for
+    :type data: ByteString
+    :param seed: the seed of the murmur32 hash function
+    :type seed: int
+    :return: the hash value
+    :rtype: ByteString
+    """
+    pass

--- a/boa3/builtin/nativecontract/cryptolib.py
+++ b/boa3/builtin/nativecontract/cryptolib.py
@@ -10,6 +10,20 @@ class CryptoLib:
     """
 
     @classmethod
+    def murmur32(cls, data: ByteString, seed: int) -> ByteString:
+        """
+        Computes the hash value for the specified byte array using the murmur32 algorithm.
+
+        :param data: the input to compute the hash code for
+        :type data: ByteString
+        :param seed: the seed of the murmur32 hash function
+        :type seed: int
+        :return: the hash value
+        :rtype: ByteString
+        """
+        pass
+
+    @classmethod
     def sha256(cls, key: Any) -> bytes:
         """
         Encrypts a key using SHA-256.

--- a/boa3/model/builtin/interop/crypto/__init__.py
+++ b/boa3/model/builtin/interop/crypto/__init__.py
@@ -2,6 +2,7 @@ __all__ = ['CheckMultisigMethod',
            'CheckSigMethod',
            'Hash160Method',
            'Hash256Method',
+           'Murmur32Method',
            'NamedCurveType',
            'Ripemd160Method',
            'Sha256Method',
@@ -12,6 +13,7 @@ from boa3.model.builtin.interop.crypto.checkmultisigmethod import CheckMultisigM
 from boa3.model.builtin.interop.crypto.checksigmethod import CheckSigMethod
 from boa3.model.builtin.interop.crypto.hash160method import Hash160Method
 from boa3.model.builtin.interop.crypto.hash256method import Hash256Method
+from boa3.model.builtin.interop.crypto.murmur32method import Murmur32Method
 from boa3.model.builtin.interop.crypto.namedcurvetype import NamedCurveType
 from boa3.model.builtin.interop.crypto.ripemd160method import Ripemd160Method
 from boa3.model.builtin.interop.crypto.sha256method import Sha256Method

--- a/boa3/model/builtin/interop/crypto/murmur32method.py
+++ b/boa3/model/builtin/interop/crypto/murmur32method.py
@@ -1,0 +1,17 @@
+from typing import Dict
+
+from boa3.model.builtin.interop.nativecontract import CryptoLibMethod
+from boa3.model.variable import Variable
+
+
+class Murmur32Method(CryptoLibMethod):
+    def __init__(self):
+        from boa3.model.type.type import Type
+        from boa3.model.type.primitive.bytestringtype import ByteStringType
+        identifier = 'murmur32'
+        native_identifier = 'murmur32'
+        args: Dict[str, Variable] = {
+            'data': Variable(ByteStringType.build()),
+            'seed': Variable(Type.int),
+        }
+        super().__init__(identifier, native_identifier, args, return_type=ByteStringType.build())

--- a/boa3/model/builtin/interop/interop.py
+++ b/boa3/model/builtin/interop/interop.py
@@ -105,6 +105,7 @@ class Interop:
     CheckSig = CheckSigMethod()
     Hash160 = Hash160Method()
     Hash256 = Hash256Method()
+    Murmur32 = Murmur32Method()
     Ripemd160 = Ripemd160Method()
     Sha256 = Sha256Method()
     VerifyWithECDsa = VerifyWithECDsaMethod()
@@ -245,6 +246,7 @@ class Interop:
                                      CheckSig,
                                      Hash160,
                                      Hash256,
+                                     Murmur32,
                                      Ripemd160,
                                      Sha256,
                                      VerifyWithECDsa,

--- a/boa3/model/builtin/native/cryptolibclass.py
+++ b/boa3/model/builtin/native/cryptolibclass.py
@@ -39,11 +39,12 @@ class CryptoLibClass(ClassArrayType):
     @property
     def class_methods(self) -> Dict[str, Method]:
         # avoid recursive import
-        from boa3.model.builtin.interop.crypto import (Sha256Method, Ripemd160Method,
+        from boa3.model.builtin.interop.crypto import (Murmur32Method, Sha256Method, Ripemd160Method,
                                                        VerifyWithECDsaMethod)
 
         if len(self._class_methods) == 0:
             self._class_methods = {
+                'murmur32': Murmur32Method(),
                 'sha256': Sha256Method(),
                 'ripemd160': Ripemd160Method(),
                 'verify_with_ecdsa': VerifyWithECDsaMethod(),

--- a/boa3_test/test_sc/interop_test/crypto/Murmur32.py
+++ b/boa3_test/test_sc/interop_test/crypto/Murmur32.py
@@ -1,0 +1,8 @@
+from boa3.builtin import public
+from boa3.builtin.nativecontract.cryptolib import CryptoLib
+from boa3.builtin.type import ByteString
+
+
+@public
+def main(data: ByteString, seed: int) -> ByteString:
+    return CryptoLib.murmur32(data, seed)

--- a/boa3_test/test_sc/native_test/cryptolib/Murmur32.py
+++ b/boa3_test/test_sc/native_test/cryptolib/Murmur32.py
@@ -1,0 +1,8 @@
+from boa3.builtin import public
+from boa3.builtin.nativecontract.cryptolib import CryptoLib
+from boa3.builtin.type import ByteString
+
+
+@public
+def main(data: ByteString, seed: int) -> ByteString:
+    return CryptoLib.murmur32(data, seed)

--- a/boa3_test/tests/compiler_tests/test_interop/test_crypto.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_crypto.py
@@ -567,3 +567,30 @@ class TestCryptoInterop(BoaTest):
         expected_result = hashlib.new('ripemd160', (hashlib.sha256(b'unit test').digest())).digest()
         result = self.run_smart_contract(engine, path, 'main', 'unit test')
         self.assertEqual(expected_result, result)
+
+    def test_murmur32(self):
+        function_id = String(Interop.Murmur32._sys_call).to_bytes()
+        call_flag = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
+
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x00'
+            + b'\x02'
+            + Opcode.LDARG1
+            + Opcode.LDARG0
+            + Opcode.PUSH2
+            + Opcode.PACK
+            + Opcode.PUSHDATA1
+            + Integer(len(call_flag)).to_byte_array() + call_flag
+            + Opcode.PUSHDATA1
+            + Integer(len(function_id)).to_byte_array() + function_id
+            + Opcode.PUSHDATA1
+            + Integer(len(constants.CRYPTO_SCRIPT)).to_byte_array() + constants.CRYPTO_SCRIPT
+            + Opcode.SYSCALL
+            + Interop.CallContract.interop_method_hash
+            + Opcode.RET
+        )
+
+        path = self.get_contract_path('Murmur32.py')
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)

--- a/boa3_test/tests/compiler_tests/test_native/test_cryptolib.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_cryptolib.py
@@ -418,3 +418,30 @@ class TestCryptoLibClass(BoaTest):
     def test_verify_with_ecdsa_secp256k1_mismatched_type(self):
         path = self.get_contract_path('VerifyWithECDsaSecp256k1MismatchedType.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+
+    def test_murmur32(self):
+        function_id = String(Interop.Murmur32._sys_call).to_bytes()
+        call_flag = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
+
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x00'
+            + b'\x02'
+            + Opcode.LDARG1
+            + Opcode.LDARG0
+            + Opcode.PUSH2
+            + Opcode.PACK
+            + Opcode.PUSHDATA1
+            + Integer(len(call_flag)).to_byte_array() + call_flag
+            + Opcode.PUSHDATA1
+            + Integer(len(function_id)).to_byte_array() + function_id
+            + Opcode.PUSHDATA1
+            + Integer(len(constants.CRYPTO_SCRIPT)).to_byte_array() + constants.CRYPTO_SCRIPT
+            + Opcode.SYSCALL
+            + Interop.CallContract.interop_method_hash
+            + Opcode.RET
+        )
+
+        path = self.get_contract_path('Murmur32.py')
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)


### PR DESCRIPTION
**Summary or solution description**
Added the `murmur32` method to crypto and cryptoLib

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/acb02972f2fd25cec9f6b5292d6fdaf0421dd46d/boa3_test/test_sc/interop_test/crypto/Murmur32.py#L1-L8

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/acb02972f2fd25cec9f6b5292d6fdaf0421dd46d/boa3_test/tests/compiler_tests/test_interop/test_crypto.py#L564-L596

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
