### PR TITLE
Implement the optional keyword `else` when handling exceptions/errors in optimization

### DIFF
--- a/boa3/analyser/astoptimizer.py
+++ b/boa3/analyser/astoptimizer.py
@@ -383,13 +383,21 @@ class AstOptimizer(IAstAnalyser, ast.NodeTransformer):
 
                 except_scopes.append(except_scope)
 
+        if len(node.orelse) > 0:
+            else_scope = outer_scope.new_scope()
+            self.current_scope = else_scope
+
+            for stmt in node.orelse:
+                self.visit(stmt)
+
+            except_scopes.append(else_scope)
+
         self.current_scope = self.current_scope.previous_scope()
         self.current_scope.update_values(try_scope, *except_scopes)
 
         for stmt in node.finalbody:
             self.visit(stmt)
 
-        # TODO: include else scope
         return node
 
     def visit_Name(self, node: ast.Name) -> ast.AST:

--- a/boa3_test/test_sc/interop_test/runtime/AddressVersionCantAssign.py
+++ b/boa3_test/test_sc/interop_test/runtime/AddressVersionCantAssign.py
@@ -6,3 +6,7 @@ from boa3.builtin.interop.runtime import address_version
 def main() -> int:
     address_version = 123
     return address_version
+
+
+def interop_call():
+    x = address_version

--- a/boa3_test/tests/compiler_tests/test_interop/test_runtime.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_runtime.py
@@ -666,4 +666,4 @@ class TestRuntimeInterop(BoaTest):
 
     def test_address_version_cant_assign(self):
         path = self.get_contract_path('AddressVersionCantAssign.py')
-        output = self.assertCompilerLogs(CompilerWarning.NameShadowing, path)
+        self.assertCompilerLogs(CompilerWarning.NameShadowing, path)


### PR DESCRIPTION
**Summary or solution description**
The ast visitor implement for optimizations wasn't checking `else` branches of `try except`

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/84d2a06393003d4ee5f5d9b885b4fd53785c5436/boa3_test/test_sc/exception_test/TryExceptElse.py#L5-L13

**Tests**
Rerun all `except` unit tests
https://github.com/CityOfZion/neo3-boa/blob/84d2a06393003d4ee5f5d9b885b4fd53785c5436/boa3_test/tests/compiler_tests/test_exception.py#L192-L415

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7