### PR TITLE
Implement Ledger Native Contract method `getTransactionVMState`

### DIFF
--- a/boa3/builtin/interop/blockchain/__init__.py
+++ b/boa3/builtin/interop/blockchain/__init__.py
@@ -2,6 +2,7 @@ from typing import Union
 
 from boa3.builtin.interop.blockchain.block import Block
 from boa3.builtin.interop.blockchain.transaction import Transaction
+from boa3.builtin.interop.blockchain.vmstate import VMState
 from boa3.builtin.interop.contract import Contract
 from boa3.builtin.type import UInt160, UInt256
 
@@ -63,6 +64,17 @@ def get_transaction_height(hash_: UInt256) -> int:
     :param hash_: hash identifier of the transaction
     :type hash_: UInt256
     :return: height of the transaction
+    """
+    pass
+
+
+def get_transaction_vm_state(hash_: UInt256) -> VMState:
+    """
+    Gets the VM state of a transaction.
+
+    :param hash_: hash identifier of the transaction
+    :type hash_: UInt256
+    :return: VM state of the transaction
     """
     pass
 

--- a/boa3/builtin/interop/blockchain/vmstate.py
+++ b/boa3/builtin/interop/blockchain/vmstate.py
@@ -1,0 +1,3 @@
+from boa3.neo3.vm import VMState
+
+__all__ = ['VMState']

--- a/boa3/builtin/nativecontract/ledger.py
+++ b/boa3/builtin/nativecontract/ledger.py
@@ -1,6 +1,6 @@
 from typing import Union
 
-from boa3.builtin.interop.blockchain import Block, Transaction
+from boa3.builtin.interop.blockchain import Block, Transaction, VMState
 from boa3.builtin.type import UInt256
 
 
@@ -63,5 +63,16 @@ class Ledger:
         :param hash_: hash identifier of the transaction
         :type hash_: UInt256
         :return: height of the transaction
+        """
+        pass
+
+    @classmethod
+    def get_transaction_vm_state(cls, hash_: UInt256) -> VMState:
+        """
+        Gets the VM state of a transaction.
+
+        :param hash_: hash identifier of the transaction
+        :type hash_: UInt256
+        :return: VM state of the transaction
         """
         pass

--- a/boa3/model/builtin/interop/blockchain/__init__.py
+++ b/boa3/model/builtin/interop/blockchain/__init__.py
@@ -7,7 +7,9 @@ __all__ = ['BlockType',
            'GetTransactionMethod',
            'GetTransactionFromBlockMethod',
            'GetTransactionHeightMethod',
-           'TransactionType'
+           'GetTransactionVMStateMethod',
+           'TransactionType',
+           'VMStateType'
            ]
 
 from boa3.model.builtin.interop.blockchain.blocktype import BlockType
@@ -18,4 +20,6 @@ from boa3.model.builtin.interop.blockchain.getcontractmethod import GetContractM
 from boa3.model.builtin.interop.blockchain.gettransactionfromblockmethod import GetTransactionFromBlockMethod
 from boa3.model.builtin.interop.blockchain.gettransactionheightmethod import GetTransactionHeightMethod
 from boa3.model.builtin.interop.blockchain.gettransactionmethod import GetTransactionMethod
+from boa3.model.builtin.interop.blockchain.gettransactionvmstatemethod import GetTransactionVMStateMethod
 from boa3.model.builtin.interop.blockchain.transactiontype import TransactionType
+from boa3.model.builtin.interop.blockchain.vmstatetype import VMStateType

--- a/boa3/model/builtin/interop/blockchain/gettransactionvmstatemethod.py
+++ b/boa3/model/builtin/interop/blockchain/gettransactionvmstatemethod.py
@@ -1,0 +1,16 @@
+from typing import Dict
+
+from boa3.model.builtin.interop.blockchain.vmstatetype import VMStateType
+from boa3.model.builtin.interop.nativecontract import LedgerMethod
+from boa3.model.variable import Variable
+
+
+class GetTransactionVMStateMethod(LedgerMethod):
+
+    def __init__(self, vm_state_type: VMStateType):
+        from boa3.model.type.collection.sequence.uint256type import UInt256Type
+
+        identifier = 'get_transaction_vm_state'
+        syscall = 'getTransactionVMState'
+        args: Dict[str, Variable] = {'hash_': Variable(UInt256Type.build())}
+        super().__init__(identifier, syscall, args, return_type=vm_state_type)

--- a/boa3/model/builtin/interop/blockchain/vmstatetype.py
+++ b/boa3/model/builtin/interop/blockchain/vmstatetype.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from boa3.model.symbol import ISymbol
+from boa3.model.type.primitive.inttype import IntType
+from boa3.neo3.vm import VMState
+
+
+class VMStateType(IntType):
+    """
+    A class used to represent Neo interop VMState type
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._identifier = 'VMState'
+
+    @property
+    def default_value(self) -> Any:
+        return VMState.NONE
+
+    @classmethod
+    def build(cls, value: Any = None) -> VMStateType:
+        if value is None or cls._is_type_of(value):
+            return _VMState
+
+    @classmethod
+    def _is_type_of(cls, value: Any = None):
+        return isinstance(value, (VMState, VMStateType))
+
+    @property
+    def symbols(self) -> Dict[str, ISymbol]:
+        """
+        Gets the class symbols of this type
+
+        :return: a dictionary that maps each symbol in the module with its name
+        """
+        from boa3.model.variable import Variable
+
+        _symbols = super().symbols
+        _symbols.update({name: Variable(self) for name in VMState.__members__.keys()})
+
+        return _symbols
+
+    def get_value(self, symbol_id) -> Any:
+        """
+        Gets the literal value of a symbol
+
+        :return: the value if this type has this symbol. None otherwise.
+        """
+        if symbol_id in self.symbols:
+            return VMState.__members__[symbol_id]
+
+        return None
+
+
+_VMState = VMStateType()

--- a/boa3/model/builtin/interop/interop.py
+++ b/boa3/model/builtin/interop/interop.py
@@ -71,6 +71,7 @@ class Interop:
     StorageMapType = StorageMapType.build()
     TransactionType = TransactionType.build()
     TriggerType = TriggerType()
+    VMStateType = VMStateType.build()
 
     # Blockchain Interops
     CurrentHash = CurrentHashProperty()
@@ -80,6 +81,7 @@ class Interop:
     GetTransaction = GetTransactionMethod(TransactionType)
     GetTransactionFromBlock = GetTransactionFromBlockMethod(TransactionType)
     GetTransactionHeight = GetTransactionHeightMethod()
+    GetTransactionVMState = GetTransactionVMStateMethod(VMStateType)
 
     # Contract Interops
     CallContract = CallMethod()
@@ -179,9 +181,14 @@ class Interop:
                                 types=[TransactionType]
                                 )
 
+    VMStateModule = Package(identifier=VMStateType.identifier.lower(),
+                            types=[VMStateType]
+                            )
+
     BlockchainPackage = Package(identifier=InteropPackage.Blockchain,
                                 types=[BlockType,
-                                       TransactionType
+                                       TransactionType,
+                                       VMStateType
                                        ],
                                 methods=[CurrentHash,
                                          CurrentIndex,
@@ -189,10 +196,12 @@ class Interop:
                                          GetContract,
                                          GetTransaction,
                                          GetTransactionFromBlock,
-                                         GetTransactionHeight
+                                         GetTransactionHeight,
+                                         GetTransactionVMState
                                          ],
                                 packages=[BlockModule,
-                                          TransactionModule
+                                          TransactionModule,
+                                          VMStateModule
                                           ]
                                 )
 

--- a/boa3/model/builtin/native/ledgerclass.py
+++ b/boa3/model/builtin/native/ledgerclass.py
@@ -41,15 +41,18 @@ class LedgerClass(ClassArrayType):
         # avoid recursive import
         from boa3.model.builtin.interop.blockchain import (BlockType, GetBlockMethod, GetCurrentIndexMethod,
                                                            GetTransactionMethod, GetTransactionFromBlockMethod,
-                                                           GetTransactionHeightMethod, TransactionType)
+                                                           GetTransactionHeightMethod, GetTransactionVMStateMethod,
+                                                           TransactionType, VMStateType)
 
         if len(self._class_methods) == 0:
+            tx_type = TransactionType.build()
             self._class_methods = {
-                'get_block': GetBlockMethod(BlockType()),
+                'get_block': GetBlockMethod(BlockType.build()),
                 'get_current_index': GetCurrentIndexMethod(),
-                'get_transaction': GetTransactionMethod(TransactionType()),
-                'get_transaction_from_block': GetTransactionFromBlockMethod(TransactionType()),
-                'get_transaction_height': GetTransactionHeightMethod()
+                'get_transaction': GetTransactionMethod(tx_type),
+                'get_transaction_from_block': GetTransactionFromBlockMethod(tx_type),
+                'get_transaction_height': GetTransactionHeightMethod(),
+                'get_transaction_vm_state': GetTransactionVMStateMethod(VMStateType.build())
             }
         return self._class_methods
 

--- a/boa3/neo3/vm/vmstate.py
+++ b/boa3/neo3/vm/vmstate.py
@@ -12,9 +12,9 @@ class VMState(IntEnum):
     FAULT = 2
     BREAK = 4
 
-    @classmethod
-    def get_vm_state(cls, state_name: str) -> VMState:
-        try:
-            return VMState[state_name]
-        except BaseException:
-            return VMState.NONE
+
+def get_vm_state(state_name: str) -> VMState:
+    try:
+        return VMState[state_name]
+    except BaseException:
+        return VMState.NONE

--- a/boa3_test/test_sc/interop_test/blockchain/GetTransactionVMState.py
+++ b/boa3_test/test_sc/interop_test/blockchain/GetTransactionVMState.py
@@ -1,0 +1,8 @@
+from boa3.builtin import public
+from boa3.builtin.interop.blockchain import VMState, get_transaction_vm_state
+from boa3.builtin.type import UInt256
+
+
+@public
+def main(hash_: UInt256) -> VMState:
+    return get_transaction_vm_state(hash_)

--- a/boa3_test/test_sc/interop_test/blockchain/GetTransactionVMStateMismatchedType.py
+++ b/boa3_test/test_sc/interop_test/blockchain/GetTransactionVMStateMismatchedType.py
@@ -1,0 +1,5 @@
+from boa3.builtin.interop.blockchain import VMState, get_transaction_vm_state
+
+
+def main() -> VMState:
+    return get_transaction_vm_state(123)

--- a/boa3_test/test_sc/native_test/ledger/GetTransactionVMState.py
+++ b/boa3_test/test_sc/native_test/ledger/GetTransactionVMState.py
@@ -1,0 +1,9 @@
+from boa3.builtin import public
+from boa3.builtin.interop.blockchain import VMState
+from boa3.builtin.nativecontract.ledger import Ledger
+from boa3.builtin.type import UInt256
+
+
+@public
+def main(hash_: UInt256) -> VMState:
+    return Ledger.get_transaction_vm_state(hash_)

--- a/boa3_test/test_sc/native_test/ledger/GetTransactionVMStateMismatchedType.py
+++ b/boa3_test/test_sc/native_test/ledger/GetTransactionVMStateMismatchedType.py
@@ -1,0 +1,6 @@
+from boa3.builtin.interop.blockchain import VMState
+from boa3.builtin.nativecontract.ledger import Ledger
+
+
+def main() -> VMState:
+    return Ledger.get_transaction_vm_state(123)

--- a/boa3_test/tests/compiler_tests/test_native/test_ledger.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_ledger.py
@@ -285,6 +285,53 @@ class TestLedgerContract(BoaTest):
         path = self.get_contract_path('GetTransactionHeightMismatchedType.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
+    def test_get_transaction_vm_state(self):
+        call_flags = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
+        method = String('getTransactionVMState').to_bytes()
+
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x00\x01'
+            + Opcode.LDARG0
+            + Opcode.PUSH1
+            + Opcode.PACK
+            + Opcode.PUSHDATA1
+            + Integer(len(call_flags)).to_byte_array()
+            + call_flags
+            + Opcode.PUSHDATA1
+            + Integer(len(method)).to_byte_array()
+            + method
+            + Opcode.PUSHDATA1
+            + Integer(len(constants.LEDGER_SCRIPT)).to_byte_array()
+            + constants.LEDGER_SCRIPT
+            + Opcode.SYSCALL
+            + Interop.CallContract.interop_method_hash
+            + Opcode.RET
+        )
+        path = self.get_contract_path('GetTransactionVMState.py')
+        output, manifest = self.get_output(path)
+        self.assertEqual(expected_output, output)
+
+        path_burn_gas = self.get_contract_path('../../interop_test/runtime', 'BurnGas.py')
+        engine = TestEngine()
+        from boa3.neo3.vm import VMState
+
+        self.run_smart_contract(engine, path_burn_gas, 'main', 1000)
+        expected_vm_state = engine.vm_state.value
+
+        txs = engine.get_transactions()
+        self.assertGreater(len(txs), 0)
+        hash_ = txs[0].hash
+        engine.increase_block()
+
+        result = self.run_smart_contract(engine, path, 'main', hash_)
+        # TODO: TestEngine does not save the state of previous transactions
+        self.assertEqual(VMState.NONE, result)
+
+    def test_get_transaction_vm_state_mismatched_type(self):
+        path = self.get_contract_path('GetTransactionVMStateMismatchedType.py')
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+
     def test_get_current_index(self):
         path = self.get_contract_path('GetCurrentIndex.py')
         engine = TestEngine()

--- a/boa3_test/tests/test_classes/testengine.py
+++ b/boa3_test/tests/test_classes/testengine.py
@@ -7,7 +7,7 @@ from boa3.neo.smart_contract.notification import Notification
 from boa3.neo.utils import contract_parameter_to_json, stack_item_from_json
 from boa3.neo.vm.type.String import String
 from boa3.neo3.core.types import UInt160
-from boa3.neo3.vm import VMState
+from boa3.neo3.vm import VMState, vmstate
 from boa3_test.tests.test_classes.block import Block
 from boa3_test.tests.test_classes.signer import Signer
 from boa3_test.tests.test_classes.storage import Storage
@@ -286,7 +286,7 @@ class TestEngine:
             self._error_message = result['error'] if 'error' in result else None
 
             if 'vmstate' in result:
-                self._vm_state = VMState.get_vm_state(result['vmstate'])
+                self._vm_state = vmstate.get_vm_state(result['vmstate'])
 
             if 'executedscripthash' in result:
                 self._executed_script_hash = UInt160.from_string(result['executedscripthash'])

--- a/test_runner/neo_test_runner.py
+++ b/test_runner/neo_test_runner.py
@@ -8,7 +8,7 @@ from boa3.neo import utils as neo_utils
 from boa3.neo.smart_contract.VoidType import VoidType
 from boa3.neo.vm.type.String import String
 from boa3.neo3.core.types import UInt160
-from boa3.neo3.vm import VMState
+from boa3.neo3.vm import VMState, vmstate
 from test_runner import neoxp_utils
 from test_runner.blockchain import *
 from test_runner.blockchain.contractcollection import ContractCollection
@@ -220,7 +220,7 @@ class NeoTestRunner:
         self._error_message = result['exception'] if 'exception' in result else None
 
         if 'state' in result:
-            self._vm_state = VMState.get_vm_state(result['state'])
+            self._vm_state = vmstate.get_vm_state(result['state'])
 
         if 'gasconsumed' in result:
             self._gas_consumed = int(float(result['gasconsumed']) * 10 ** constants.GAS_DECIMALS)


### PR DESCRIPTION
**Summary or solution description**
Implemented Ledger native contract method getTransactionVMState
https://github.com/CityOfZion/neo3-boa/blob/da94d291e3eecb02e25e27ad75ffe14378595af3/boa3/builtin/nativecontract/ledger.py#L70-L78
Also accessible in `boa3.builtin.interop.blockchain`
https://github.com/CityOfZion/neo3-boa/blob/da94d291e3eecb02e25e27ad75ffe14378595af3/boa3/builtin/interop/blockchain/__init__.py#L71-L79


**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/da94d291e3eecb02e25e27ad75ffe14378595af3/boa3_test/test_sc/native_test/ledger/GetTransactionVMState.py#L8-L9
https://github.com/CityOfZion/neo3-boa/blob/da94d291e3eecb02e25e27ad75ffe14378595af3/boa3_test/test_sc/interop_test/blockchain/GetTransactionVMState.py#L7-L8


**Tests**
https://github.com/CityOfZion/neo3-boa/blob/da94d291e3eecb02e25e27ad75ffe14378595af3/boa3_test/tests/compiler_tests/test_native/test_ledger.py#L288-L333


**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
