### PR TITLE
Method call is falling when calling other methods as arguments

### DIFF
--- a/boa3/compiler/codegenerator/codegenerator.py
+++ b/boa3/compiler/codegenerator/codegenerator.py
@@ -1768,7 +1768,9 @@ class CodeGenerator:
                 self._stack_pop()  # remove call contract 'any' result from the stack
         else:
             from boa3.neo.vm.CallCode import CallCode
-            self.__insert_code(CallCode(function))
+            call_code = CallCode(function)
+            self.__insert_code(call_code)
+            self._update_codes_with_target(call_code)
 
         for arg in range(num_args):
             self._stack_pop()

--- a/boa3/model/builtin/classmethod/tobytesmethod.py
+++ b/boa3/model/builtin/classmethod/tobytesmethod.py
@@ -112,7 +112,7 @@ class IntToBytesMethod(ToBytesMethod):
         return (
             verify_number_is_zero +
             number_is_not_zero +
-            number_is_zero + [(Opcode.NOP, b'')]    # TODO: change this when refactoring calling methods with methods as args
+            number_is_zero
         )
 
 

--- a/boa3_test/test_sc/function_test/FunctionAsArg.py
+++ b/boa3_test/test_sc/function_test/FunctionAsArg.py
@@ -1,0 +1,12 @@
+from boa3.builtin import public
+
+
+@public
+def main(value: int) -> int:
+    var = return_int(value.to_bytes())
+
+    return var
+
+
+def return_int(arg1: bytes) -> int:
+    return arg1.to_int()

--- a/boa3_test/test_sc/function_test/FunctionWithArgAsArg.py
+++ b/boa3_test/test_sc/function_test/FunctionWithArgAsArg.py
@@ -1,0 +1,14 @@
+from typing import List
+
+from boa3.builtin import public
+
+
+@public
+def main(a: List[int], value: int) -> int:
+    var = return_same(a.index(value))
+
+    return var
+
+
+def return_same(arg: int) -> int:
+    return arg

--- a/boa3_test/test_sc/function_test/FunctionWithArgsAsArg.py
+++ b/boa3_test/test_sc/function_test/FunctionWithArgsAsArg.py
@@ -1,0 +1,14 @@
+from typing import List
+
+from boa3.builtin import public
+
+
+@public
+def main(a: List[int], value: int, start: int, end: int) -> int:
+    var = return_same(a.index(value, start, end))
+
+    return var
+
+
+def return_same(arg: int) -> int:
+    return arg

--- a/boa3_test/tests/compiler_tests/test_function.py
+++ b/boa3_test/tests/compiler_tests/test_function.py
@@ -1071,3 +1071,30 @@ class TestFunction(BoaTest):
     def test_functions_with_duplicated_name(self):
         path = self.get_contract_path('FunctionsWithDuplicatedName.py')
         self.assertCompilerLogs(CompilerError.DuplicatedIdentifier, path)
+
+    def test_function_as_arg(self):
+        path = self.get_contract_path('FunctionAsArg.py')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'main', 123)
+        self.assertEqual(123, result)
+
+    def test_function_with_arg_as_arg(self):
+        path = self.get_contract_path('FunctionWithArgAsArg.py')
+        engine = TestEngine()
+
+        list_int = [123, 456, 789]
+        value = 123
+        result = self.run_smart_contract(engine, path, 'main', list_int, value)
+        self.assertEqual(list_int.index(value), result)
+
+    def test_function_with_args_as_arg(self):
+        path = self.get_contract_path('FunctionWithArgsAsArg.py')
+        engine = TestEngine()
+
+        list_int = [123, 456, 789]
+        value = 123
+        start = 0
+        end = 5
+        result = self.run_smart_contract(engine, path, 'main', list_int, value, start, end)
+        self.assertEqual(list_int.index(value, start, end), result)


### PR DESCRIPTION
**Summary or solution description**
Added a `_update_codes_with_target` on `convert_method_call`.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/111a0417ae212c1cb4abb0a860a92cdcb75afaea/boa3_test/test_sc/function_test/FunctionAsArg.py#L1-L12

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/111a0417ae212c1cb4abb0a860a92cdcb75afaea/boa3_test/tests/compiler_tests/test_function.py#L1075-L1080

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
