### PR TITLE
Implement manifest groups

### DIFF
--- a/boa3/builtin/__init__.py
+++ b/boa3/builtin/__init__.py
@@ -109,6 +109,7 @@ class NeoMetadata:
         self.supported_standards: List[str] = []
         self._trusts: List[str] = []
         self._permissions: List[dict] = []
+        self._groups: List[dict] = []
 
     @property
     def extras(self) -> Dict[str, Any]:
@@ -141,6 +142,10 @@ class NeoMetadata:
     def permissions(self) -> List[dict]:
         return self._permissions.copy()
 
+    @property
+    def groups(self) -> List[dict]:
+        return self._groups.copy()
+
     def add_trusted_source(self, hash_or_address: str):
         """
         Adds a valid contract hash, valid group public key, or the '*' wildcard to trusts.
@@ -167,6 +172,31 @@ class NeoMetadata:
         elif self._verify_is_valid_public_key(hash_or_address):
             if hash_or_address not in self._trusts:
                 self._trusts.append(hash_or_address.lower())
+
+    def add_group(self, pub_key: str, signature: str):
+        """
+        Adds a pair of public key and signature to the groups in the manifest.
+
+        :param pub_key: public key of the group
+        :type pub_key: str
+        :param signature: signature of the contract hash encoded in Base64
+        :type signature: str
+        """
+
+        if not isinstance(pub_key, str) or not isinstance(signature, str):
+            return
+
+        # verifies if pub_key is a valid value
+        if not self._verify_is_valid_public_key(pub_key):
+            return
+
+        new_group = {
+            'pubkey': pub_key.lower(),
+            'signature': signature,
+        }
+
+        if new_group not in self._permissions:
+            self._groups.append(new_group)
 
     def add_permission(self, *, contract: str = IMPORT_WILDCARD, methods: Union[List[str], str] = IMPORT_WILDCARD):
         """

--- a/boa3/compiler/filegenerator.py
+++ b/boa3/compiler/filegenerator.py
@@ -227,7 +227,7 @@ class FileGenerator:
         # TODO: fill the information of the manifest
         return {
             "name": self._get_name(),
-            "groups": [],
+            "groups": self._get_groups(),
             "abi": self._get_abi_info(),
             "permissions": self._get_permissions(),
             "trusts": self._metadata.trusts,
@@ -253,6 +253,14 @@ class FileGenerator:
         """
         return self._metadata.permissions if self._metadata.permissions else [{"contract": constants.IMPORT_WILDCARD,
                                                                                "methods": constants.IMPORT_WILDCARD}]
+
+    def _get_groups(self) -> List[Dict[str, Any]]:
+        """
+        Gets the group information in a dictionary format.
+
+        :return: a dictionary with the groups information
+        """
+        return self._metadata.groups
 
     def _get_abi_info(self) -> Dict[str, Any]:
         """

--- a/boa3_test/test_sc/metadata_test/MetadataInfoGroups.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoGroups.py
@@ -1,0 +1,16 @@
+from boa3.builtin import NeoMetadata, metadata, public
+
+
+@public
+def main() -> int:
+    return 5
+
+
+@metadata
+def permissions_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+
+    meta.add_group("031f64da8a38e6c1e5423a72ddd6d4fc4a777abe537e5cb5aa0425685cda8e063b",
+                   "gC+8ybKTjuQxBgPaFD/R+SrlZlERMK7aDe6+99XUulv/nD2Mco4pEbrESMa6Sc6WtjmSsRiI9ILf7LGRGQCmGA==")
+
+    return meta

--- a/boa3_test/test_sc/metadata_test/MetadataInfoGroupsDefault.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoGroupsDefault.py
@@ -1,0 +1,13 @@
+from boa3.builtin import NeoMetadata, metadata, public
+
+
+@public
+def main() -> int:
+    return 5
+
+
+@metadata
+def permissions_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+
+    return meta

--- a/boa3_test/tests/test_classes/contract/neomanifeststruct.py
+++ b/boa3_test/tests/test_classes/contract/neomanifeststruct.py
@@ -32,7 +32,7 @@ class NeoManifestStruct(NeoStruct):
 
         struct = cls()
         struct.append(json[cls._name_field])
-        struct.append(json[cls._groups_field])  # TODO: groups aren't implemented yet
+        struct.append(json[cls._groups_field])
         struct.append({})  # TODO: features aren't implemented yet
         struct.append(json[cls._supported_standards_field])
         struct.append(NeoAbiStruct.from_json(json[cls._abi_field]))


### PR DESCRIPTION
**Summary or solution description**
Added a NeoMetadata method to add groups in the metadata.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/5d2116fb02eccf3c1b34ac6d2ee94c9eca67be49/boa3_test/test_sc/metadata_test/MetadataInfoGroups.py#L1-L16

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/5d2116fb02eccf3c1b34ac6d2ee94c9eca67be49/boa3_test/tests/compiler_tests/test_metadata.py#L313-L355

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7

**(Optional) Additional context**
The Csharp version doesn't seem to have a way to add groups in the metadata using the smart contract, it's only done manually.