### PR TITLE
Implement manifest trusts

### DIFF
--- a/boa3_test/test_sc/metadata_test/MetadataInfoTrusts.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoTrusts.py
@@ -13,13 +13,13 @@ def trusts_manifest() -> NeoMetadata:
     # values added to manifest
     meta.add_trusted_source("0x1234567890123456789012345678901234567890")
     meta.add_trusted_source("0x1234567890123456789012345678901234abcdef")
-    meta.add_trusted_source("030000123456789012345678901234567890123456789012345678901234abcdef")
-    meta.add_trusted_source("020000123456789012345678901234567890123456789012345678901234abcdef")
+    meta.add_trusted_source("035a928f201639204e06b4368b1a93365462a8ebbff0b8818151b74faab3a2b61a")
+    meta.add_trusted_source("03cdb067d930fd5adaa6c68545016044aaddec64ba39e548250eaea551172e535c")
 
     # values not added to manifest
     meta.add_trusted_source("0x123456789012345678901234567890123abcdefg")   # only hex values are valid
     meta.add_trusted_source("0x1234567890123456789012345678901234567890")   # can't repeat values
-    meta.add_trusted_source("030000123456789012345678901234567890123456789012345678901234abcdef")   # can't repeat values
+    meta.add_trusted_source("03cdb067d930fd5adaa6c68545016044aaddec64ba39e548250eaea551172e535c")   # can't repeat values
     meta.add_trusted_source("03000012345678901234567890123456789012345678901234567890123abcdefg")   # only hex values are valid
     meta.add_trusted_source("000000123456789012345678901234567890123456789012345678901234567890")   # public keys must begin with 03 or 02
 

--- a/boa3_test/tests/compiler_tests/test_metadata.py
+++ b/boa3_test/tests/compiler_tests/test_metadata.py
@@ -2,6 +2,8 @@ from boa3.constants import IMPORT_WILDCARD
 from boa3.exception import CompilerError, CompilerWarning
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3_test.tests.boa_test import BoaTest
+from boa3_test.tests.test_classes.contract.neomanifeststruct import NeoManifestStruct
+from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestMetadata(BoaTest):
@@ -167,7 +169,6 @@ class TestMetadata(BoaTest):
         self.assertGreater(len(manifest['supportedstandards']), 0)
         self.assertIn('NEP-17', manifest['supportedstandards'])
 
-        from boa3_test.tests.test_classes.testengine import TestEngine
         engine = TestEngine()
         # verify using NeoManifestStruct
         nef, manifest = self.get_bytes_output(path)
@@ -180,7 +181,6 @@ class TestMetadata(BoaTest):
         engine.add_contract(path)
 
         result = self.run_smart_contract(engine, get_contract_path, 'main', call_hash)
-        from boa3_test.tests.test_classes.contract.neomanifeststruct import NeoManifestStruct
         manifest_struct = NeoManifestStruct.from_json(manifest)
         self.assertEqual(manifest_struct, result[4])
 
@@ -222,8 +222,38 @@ class TestMetadata(BoaTest):
         self.assertEqual(len(manifest['trusts']), 4)
         self.assertIn('0x1234567890123456789012345678901234567890', manifest['trusts'])
         self.assertIn('0x1234567890123456789012345678901234abcdef', manifest['trusts'])
-        self.assertIn('030000123456789012345678901234567890123456789012345678901234abcdef', manifest['trusts'])
-        self.assertIn('020000123456789012345678901234567890123456789012345678901234abcdef', manifest['trusts'])
+        self.assertIn('035a928f201639204e06b4368b1a93365462a8ebbff0b8818151b74faab3a2b61a', manifest['trusts'])
+        self.assertIn('03cdb067d930fd5adaa6c68545016044aaddec64ba39e548250eaea551172e535c', manifest['trusts'])
+
+        engine = TestEngine()
+        # verify using NeoManifestStruct
+        nef, manifest = self.get_bytes_output(path)
+        self.run_smart_contract(engine, path, 'Main')
+        call_hash = engine.executed_script_hash.to_array()
+        path = path.replace('.py', '.nef')
+
+        get_contract_path = self.get_contract_path('test_sc/native_test/contractmanagement', 'GetContract.py')
+        engine = TestEngine()
+        engine.add_contract(path)
+
+        result = self.run_smart_contract(engine, get_contract_path, 'main', call_hash)
+        manifest_struct = NeoManifestStruct.from_json(manifest)
+
+        result_trusts = result[4][6]
+
+        # transform the str values to bytes values
+        manifest_struct_trusts = []
+        for item in manifest_struct[6]:
+            if isinstance(item, str):
+                if len(item) == 42:
+                    from boa3.neo3.core.types import UInt160
+                    item = UInt160.from_string(item).to_array()
+                elif len(item) == 66:
+                    item = bytes.fromhex(item)
+            manifest_struct_trusts.append(item)
+
+        # compare result from GetContract and NeoManifestStruct
+        self.assertEqual(manifest_struct_trusts, result_trusts)
 
     def test_metadata_info_trusts_wildcard(self):
         path = self.get_contract_path('MetadataInfoTrustsWildcard.py')
@@ -233,6 +263,25 @@ class TestMetadata(BoaTest):
         self.assertIsInstance(manifest['trusts'], list)
         self.assertEqual(len(manifest['trusts']), 1)
         self.assertIn(IMPORT_WILDCARD, manifest['trusts'])
+
+        engine = TestEngine()
+        # verify using NeoManifestStruct
+        nef, manifest = self.get_bytes_output(path)
+        self.run_smart_contract(engine, path, 'Main')
+        call_hash = engine.executed_script_hash.to_array()
+        path = path.replace('.py', '.nef')
+
+        get_contract_path = self.get_contract_path('test_sc/native_test/contractmanagement', 'GetContract.py')
+        engine = TestEngine()
+        engine.add_contract(path)
+
+        result = self.run_smart_contract(engine, get_contract_path, 'main', call_hash)
+        manifest_struct = NeoManifestStruct.from_json(manifest)
+
+        result_trusts = result[4][6]
+
+        # TODO: change when TestEngine is updated
+        self.assertEqual([''], result_trusts)
 
     def test_metadata_info_trusts_mismatched_types(self):
         path = self.get_contract_path('MetadataInfoTrustsMismatchedTypes.py')

--- a/boa3_test/tests/test_classes/contract/neomanifeststruct.py
+++ b/boa3_test/tests/test_classes/contract/neomanifeststruct.py
@@ -37,7 +37,7 @@ class NeoManifestStruct(NeoStruct):
         struct.append(json[cls._supported_standards_field])
         struct.append(NeoAbiStruct.from_json(json[cls._abi_field]))
         struct.append([NeoPermissionsStruct.from_json(permission) for permission in json[cls._permissions_field]])
-        struct.append(json[cls._trusts_field])  # TODO: trusts aren't implemented
+        struct.append(json[cls._trusts_field])
         extras = json[cls._extra_field]
         struct.append(extras if extras is not None else "null")
 


### PR DESCRIPTION
**Summary or solution description**
Added tests to verify NeoManifestStruct trusts

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/0af0f65d5c5e4b6bb64e3992c24bf7d8a8ab6139/boa3_test/test_sc/metadata_test/MetadataInfoTrusts.py#L1-L26

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/0af0f65d5c5e4b6bb64e3992c24bf7d8a8ab6139/boa3_test/tests/compiler_tests/test_metadata.py#L216-L284

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7

**(Optional) Additional context**
The TestEngine is probably not returning the correct value when the wildcard is being used