### PR TITLE
Add default argument to dict.pop() method | #2kq1z1b

### DIFF
--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -87,6 +87,7 @@ class Builtin:
     StrIndex = IndexStrMethod()
     DictKeys = MapKeysMethod()
     DictPop = PopDictMethod()
+    DictPopDefault = PopDictDefaultMethod()
     DictValues = MapValuesMethod()
 
     # custom class methods

--- a/boa3/model/builtin/classmethod/__init__.py
+++ b/boa3/model/builtin/classmethod/__init__.py
@@ -14,6 +14,7 @@ __all__ = ['AppendMethod',
            'MapKeysMethod',
            'MapValuesMethod',
            'PopDictMethod',
+           'PopDictDefaultMethod',
            'PopSequenceMethod',
            'RemoveMethod',
            'ReverseMethod',
@@ -43,6 +44,7 @@ from boa3.model.builtin.classmethod.lowermethod import LowerMethod
 from boa3.model.builtin.classmethod.mapkeysmethod import MapKeysMethod
 from boa3.model.builtin.classmethod.mapvaluesmethod import MapValuesMethod
 from boa3.model.builtin.classmethod.popdictmethod import PopDictMethod
+from boa3.model.builtin.classmethod.popdictdefaultmethod import PopDictDefaultMethod
 from boa3.model.builtin.classmethod.popsequencemethod import PopSequenceMethod
 from boa3.model.builtin.classmethod.removemethod import RemoveMethod
 from boa3.model.builtin.classmethod.reversemethod import ReverseMethod

--- a/boa3/model/builtin/classmethod/popdictdefaultmethod.py
+++ b/boa3/model/builtin/classmethod/popdictdefaultmethod.py
@@ -1,0 +1,87 @@
+from typing import Dict, List, Optional, Tuple
+
+from boa3.model.builtin.classmethod.popmethod import PopMethod
+from boa3.model.type.itype import IType
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class PopDictDefaultMethod(PopMethod):
+
+    def __init__(self, arg_value: Optional[IType] = None):
+        from boa3.model.type.type import Type
+
+        if not Type.dict.is_type_of(arg_value):
+            arg_value = Type.dict
+
+        args: Dict[str, Variable] = {
+            'self': Variable(arg_value),
+            'key': Variable(arg_value.valid_key),
+            'default': Variable(Type.any)
+        }
+
+        super().__init__(args, return_type=arg_value.value_type)
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        from boa3.neo.vm.type.Integer import Integer
+        from boa3.compiler.codegenerator import get_bytes_count
+
+        jmp_place_holder = (Opcode.JMP, b'\x01')
+
+        put_default_at_bottom = [
+            (Opcode.REVERSE3, b''),
+            (Opcode.SWAP, b''),
+            (Opcode.REVERSE3, b''),
+        ]
+
+        prepare_values = [
+            (Opcode.DUP, b''),
+            (Opcode.SIGN, b''),
+            (Opcode.PUSHM1, b''),
+            (Opcode.JMPNE, Integer(5).to_byte_array(min_length=1, signed=True)),
+            (Opcode.OVER, b''),
+            (Opcode.SIZE, b''),
+            (Opcode.ADD, b''),
+            (Opcode.OVER, b''),
+            (Opcode.OVER, b''),
+        ]
+
+        verify_has_key = [
+            (Opcode.HASKEY, b''),
+            jmp_place_holder
+        ]
+
+        pick_from_dict = [
+            (Opcode.OVER, b''),
+            (Opcode.OVER, b''),
+            (Opcode.PICKITEM, b''),
+            (Opcode.REVERSE3, b''),
+            (Opcode.SWAP, b''),
+        ]
+
+        pop_from_dict = [
+            (Opcode.REMOVE, b''),
+            (Opcode.NIP, b''),
+            jmp_place_holder
+        ]
+
+        return_default = [
+            (Opcode.DROP, b''),
+            (Opcode.DROP, b''),
+        ]
+
+        num_jmp_code = get_bytes_count(return_default)
+        pop_from_dict[-1] = Opcode.get_jump_and_data(Opcode.JMP, num_jmp_code, True)
+
+        num_jmp_code = get_bytes_count(pick_from_dict + pop_from_dict)
+        verify_has_key[-1] = Opcode.get_jump_and_data(Opcode.JMPIFNOT, num_jmp_code, True)
+
+        return (
+            put_default_at_bottom +
+            prepare_values +
+            verify_has_key +
+            pick_from_dict +
+            pop_from_dict +
+            return_default
+        )

--- a/boa3/model/builtin/classmethod/popdictmethod.py
+++ b/boa3/model/builtin/classmethod/popdictmethod.py
@@ -16,7 +16,6 @@ class PopDictMethod(PopMethod):
         args: Dict[str, Variable] = {
             'self': Variable(arg_value),
             'key': Variable(arg_value.valid_key)
-            # TODO: Add default parameter
         }
 
         super().__init__(args, return_type=arg_value.value_type)

--- a/boa3/model/builtin/classmethod/popmethod.py
+++ b/boa3/model/builtin/classmethod/popmethod.py
@@ -24,8 +24,13 @@ class PopMethod(IBuiltinMethod):
         if self._arg_self.type is Type.mutableSequence:
             return self._identifier
 
-        if self._arg_self.type is Type.dict:
-            return '-{0}_{1}'.format(self._identifier, Type.dict.identifier)
+        if Type.dict.is_type_of(self._arg_self.type):
+
+            if len(self.args) == 2:
+                return '-{0}_{1}'.format(self._identifier, Type.dict.identifier)
+
+            elif len(self.args) == 3:
+                return '-{0}_{1}_{2}'.format(self._identifier, Type.dict.identifier, 'default')
 
         if Type.mutableSequence.is_type_of(self._arg_self.type):
             return '-{0}_{1}'.format(self._identifier, Type.mutableSequence.identifier)
@@ -83,15 +88,17 @@ class PopMethod(IBuiltinMethod):
         return None
 
     def build(self, value: Any) -> IBuiltinMethod:
-        if isinstance(value, list) and len(value) > 0:
-            if len(value) == 2:
-                value = value[0]
+        if not isinstance(value, list):
+            value = [value]
 
         from boa3.model.builtin.classmethod.popdictmethod import PopDictMethod
         from boa3.model.builtin.classmethod.popsequencemethod import PopSequenceMethod
         from boa3.model.type.type import Type
 
-        if Type.dict.is_type_of(value):
-            return PopDictMethod(value)
+        if Type.dict.is_type_of(value[0]):
+            if len(value) == 3:
+                from boa3.model.builtin.classmethod.popdictdefaultmethod import PopDictDefaultMethod
+                return PopDictDefaultMethod(value[0])
+            return PopDictMethod(value[0])
 
-        return PopSequenceMethod(value)
+        return PopSequenceMethod(value[0])

--- a/boa3/model/type/collection/mapping/mutable/dicttype.py
+++ b/boa3/model/type/collection/mapping/mutable/dicttype.py
@@ -31,6 +31,7 @@ class DictType(MutableMappingType):
         instance_methods = [Builtin.DictKeys,
                             Builtin.DictValues,
                             Builtin.DictPop,
+                            Builtin.DictPopDefault,
                             ]
 
         for instance_method in instance_methods:

--- a/boa3_test/test_sc/dict_test/DictPopDefault.py
+++ b/boa3_test/test_sc/dict_test/DictPopDefault.py
@@ -1,0 +1,11 @@
+from typing import Any, Dict, Tuple
+
+from boa3.builtin import public
+
+
+@public
+def main(dict_: Dict[Any, Any], key: Any, default: Any) -> Tuple[Dict[Any, Any], Any]:
+    value = dict_.pop(key, default)
+    new_dict_and_value = (dict_, value)
+    return new_dict_and_value
+

--- a/boa3_test/tests/compiler_tests/test_dict.py
+++ b/boa3_test/tests/compiler_tests/test_dict.py
@@ -547,6 +547,38 @@ class TestDict(BoaTest):
         with self.assertRaisesRegex(TestExecutionException, self.MAP_KEY_NOT_FOUND_ERROR_MSG):
             self.run_smart_contract(engine, path, 'main', dict_, key)
 
+    def test_dict_pop_default(self):
+        path = self.get_contract_path('DictPopDefault.py')
+        engine = TestEngine()
+
+        dict_ = {'a': 1, 'b': 2, 'c': 3, 'd': 4}
+        key = 'a'
+        default = 'test'
+        result = self.run_smart_contract(engine, path, 'main', dict_, key, default)
+        value = dict_.pop(key, default)
+        self.assertEqual((dict_, value), tuple(result))
+
+        dict_ = {'a': 1, 'b': 2, 'c': 3, 'd': 4}
+        key = 'd'
+        default = 'test'
+        result = self.run_smart_contract(engine, path, 'main', dict_, key, default)
+        value = dict_.pop(key, default)
+        self.assertEqual((dict_, value), tuple(result))
+
+        dict_ = {'a': 1, 'b': 2, 'c': 3, 'd': 4}
+        key = 'not inside'
+        default = 'test'
+        result = self.run_smart_contract(engine, path, 'main', dict_, key, default)
+        value = dict_.pop(key, default)
+        self.assertEqual((dict_, value), tuple(result))
+
+        dict_ = {'a': 1, 'b': 2, 'c': 3, 'd': 4}
+        key = 'not inside'
+        default = 123456
+        result = self.run_smart_contract(engine, path, 'main', dict_, key, default)
+        value = dict_.pop(key, default)
+        self.assertEqual((dict_, value), tuple(result))
+
     def test_dict_copy(self):
         path = self.get_contract_path('DictCopy.py')
         engine = TestEngine()


### PR DESCRIPTION
**Summary or solution description**
Added another variation of pop for dict with 3 args instead of 2.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/1d3f3710f290aa73cd5e8b6c77ba7e8d368c77e6/boa3_test/test_sc/dict_test/DictPopDefault.py#L1-L10

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/1d3f3710f290aa73cd5e8b6c77ba7e8d368c77e6/boa3_test/tests/compiler_tests/test_dict.py#L550-L580


**Platform:**
 - OS:  Windows 10 x64
 - Python version: Python 3.7