### PR TITLE
Convert the result to the return type of the function in the manifest

### DIFF
--- a/boa3/model/builtin/classmethod/__init__.py
+++ b/boa3/model/builtin/classmethod/__init__.py
@@ -43,8 +43,8 @@ from boa3.model.builtin.classmethod.joinmethod import JoinMethod
 from boa3.model.builtin.classmethod.lowermethod import LowerMethod
 from boa3.model.builtin.classmethod.mapkeysmethod import MapKeysMethod
 from boa3.model.builtin.classmethod.mapvaluesmethod import MapValuesMethod
-from boa3.model.builtin.classmethod.popdictmethod import PopDictMethod
 from boa3.model.builtin.classmethod.popdictdefaultmethod import PopDictDefaultMethod
+from boa3.model.builtin.classmethod.popdictmethod import PopDictMethod
 from boa3.model.builtin.classmethod.popsequencemethod import PopSequenceMethod
 from boa3.model.builtin.classmethod.removemethod import RemoveMethod
 from boa3.model.builtin.classmethod.reversemethod import ReverseMethod

--- a/boa3/model/operation/unary/logicnot.py
+++ b/boa3/model/operation/unary/logicnot.py
@@ -29,7 +29,7 @@ class LogicNot(UnaryOperation):
 
     def _get_result(self, operand: IType) -> IType:
         if self.validate_type(operand):
-            return operand
+            return Type.int
         else:
             return Type.none
 

--- a/boa3_test/test_sc/dict_test/DictPopDefault.py
+++ b/boa3_test/test_sc/dict_test/DictPopDefault.py
@@ -8,4 +8,3 @@ def main(dict_: Dict[Any, Any], key: Any, default: Any) -> Tuple[Dict[Any, Any],
     value = dict_.pop(key, default)
     new_dict_and_value = (dict_, value)
     return new_dict_and_value
-

--- a/boa3_test/test_sc/logical_test/LogicNotBool.py
+++ b/boa3_test/test_sc/logical_test/LogicNotBool.py
@@ -2,5 +2,5 @@ from boa3.builtin import public
 
 
 @public
-def Main(a: bool) -> bool:
+def Main(a: bool) -> int:
     return ~a

--- a/boa3_test/tests/compiler_tests/test_interop/test_blockchain.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_blockchain.py
@@ -497,12 +497,9 @@ class TestBlockchainInterop(BoaTest):
 
         engine.increase_block()
 
-        result = self.run_smart_contract(engine, path, 'main')
-        if isinstance(result, str):
-            result = String(result).to_bytes()
+        result = self.run_smart_contract(engine, path, 'main', expected_result_type=bytes)
 
         block = engine.current_block
-
         self.assertEqual(block.hash, result)
 
     def test_current_index(self):

--- a/boa3_test/tests/compiler_tests/test_native/test_neo.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_neo.py
@@ -187,7 +187,7 @@ class TestNeoClass(BoaTest):
         self.assertEqual(0, result[0][1])
 
         # voting for candidate again
-        result = self.run_smart_contract(engine, path, 'main', account, candidate_pubkey, signer_accounts=[account])
+        self.run_smart_contract(engine, path, 'main', account, candidate_pubkey, signer_accounts=[account])
         result = self.run_smart_contract(engine, path_get, 'main')
         self.assertEqual(n_votes, result[0][1])
 

--- a/boa3_test/tests/test_classes/contractcollection.py
+++ b/boa3_test/tests/test_classes/contractcollection.py
@@ -1,0 +1,49 @@
+from typing import List
+
+from boa3 import constants
+from boa3_test.tests.test_classes.testcontract import TestContract
+
+
+class ContractCollection:
+    def __init__(self):
+        self._internal_list: List[TestContract] = []
+
+    def append(self, new_contract: TestContract):
+        return self._internal_list.append(new_contract)
+
+    def remove(self, contract: TestContract):
+        return self._internal_list.remove(contract)
+
+    def pop(self, index: int):
+        return self._internal_list.pop(index)
+
+    def clear(self):
+        return self._internal_list.clear()
+
+    def copy(self):
+        collection_copy = ContractCollection()
+        collection_copy._internal_list = self._internal_list.copy()
+        return collection_copy
+
+    def __len__(self):
+        return len(self._internal_list)
+
+    def __contains__(self, item) -> bool:
+        return any(contract.is_valid_identifier(item) for contract in self._internal_list)
+
+    def __getitem__(self, item) -> TestContract:
+        from boa3.neo3.core.types import UInt160
+        if isinstance(item, UInt160):
+            item = str(item)
+        elif isinstance(item, bytes) and len(item) == constants.SIZE_OF_INT160:
+            item = str(UInt160(item))
+        return next((contract for contract in self._internal_list if contract.is_valid_identifier(item)), None)
+
+    def __iter__(self):
+        return self._internal_list.__iter__()
+
+    def __str__(self):
+        return str(self._internal_list)
+
+    def __repr__(self):
+        return self._internal_list.__repr__()

--- a/boa3_test/tests/test_classes/testcontract.py
+++ b/boa3_test/tests/test_classes/testcontract.py
@@ -2,12 +2,15 @@ import os
 from typing import Optional
 
 from boa3.neo import to_hex_str
+from boa3.neo.vm.type.StackItem import StackItemType
 
 
 class TestContract:
-    def __init__(self, file_path: str):
+    def __init__(self, file_path: str, manifest_path: str):
         self._nef_path: str = file_path
+        self._manifest_path: str = manifest_path
         self._script_hash: Optional[bytes] = self._get_script_hash()
+        self._manifest: dict = self._read_manifest()
 
     def _get_script_hash(self) -> bytes:
         file_path = self._nef_path
@@ -16,6 +19,16 @@ class TestContract:
                 file = nef.read()
             from boa3.neo.contracts.neffile import NefFile
             return NefFile.deserialize(file).script_hash
+
+    def _read_manifest(self) -> dict:
+        try:
+            with open(self._manifest_path) as manifest_output:
+                import json
+                manifest = json.loads(manifest_output.read())
+        except:
+            manifest = {}
+
+        return manifest
 
     @property
     def path(self) -> str:
@@ -36,3 +49,19 @@ class TestContract:
         return (item == self._nef_path
                 or item == self._script_hash
                 or item == to_hex_str(self._script_hash))
+
+    def get_method_return_type(self, called_method: str) -> StackItemType:
+        cur_json = self._manifest
+        return_type = StackItemType.Any
+
+        if 'abi' in cur_json:
+            cur_json = cur_json['abi']
+            if 'methods' in cur_json:
+                cur_json = cur_json['methods']
+                method_json = next((node for node in cur_json
+                                    if 'name' in node and node['name'] == called_method),
+                                   {})
+                if 'returntype' in method_json:
+                    return_type = StackItemType.get_stack_item_type(method_json['returntype'])
+
+        return return_type

--- a/boa3_test/tests/test_classes/testengine.py
+++ b/boa3_test/tests/test_classes/testengine.py
@@ -5,10 +5,13 @@ from boa3 import constants
 from boa3.neo.smart_contract.VoidType import VoidType
 from boa3.neo.smart_contract.notification import Notification
 from boa3.neo.utils import contract_parameter_to_json, stack_item_from_json
+from boa3.neo.vm.type.Integer import Integer
+from boa3.neo.vm.type.StackItem import StackItemType
 from boa3.neo.vm.type.String import String
 from boa3.neo3.core.types import UInt160
 from boa3.neo3.vm import VMState, vmstate
 from boa3_test.tests.test_classes.block import Block
+from boa3_test.tests.test_classes.contractcollection import ContractCollection
 from boa3_test.tests.test_classes.signer import Signer
 from boa3_test.tests.test_classes.storage import Storage
 from boa3_test.tests.test_classes.testcontract import TestContract
@@ -43,7 +46,7 @@ class TestEngine:
 
         self._current_tx: Optional[Transaction] = None
         self._accounts: List[Signer] = []
-        self._contract_paths: List[TestContract] = []
+        self._contract_paths: ContractCollection = ContractCollection()
 
         self._error_message: Optional[str] = None
         self._neo_balance_prefix: bytes = b'\x14'
@@ -149,7 +152,10 @@ class TestEngine:
 
     def add_contract(self, contract_nef_path: str):
         if contract_nef_path.endswith('.nef') and contract_nef_path not in self._contract_paths:
-            self._contract_paths.append(TestContract(contract_nef_path))
+            manifest_path = contract_nef_path.replace('.nef', '.manifest.json')
+            if not path.exists(manifest_path):
+                raise FileNotFoundError(manifest_path)
+            self._contract_paths.append(TestContract(contract_nef_path, manifest_path))
 
     def remove_contract(self, contract_index_or_path: Union[int, str]):
         if isinstance(contract_index_or_path, str):
@@ -342,8 +348,9 @@ class TestEngine:
         except BaseException as e:
             self._error_message = str(e)
 
-        # TODO: convert the result to the return type of the function in the manifest
-        return self._result_stack[-1] if len(self._result_stack) > 0 else VoidType
+        if len(self._result_stack) > 0:
+            return self._filter_result(self._result_stack[0], method, contract_id)
+        return VoidType
 
     def reset_state(self):
         self._vm_state = VMState.NONE
@@ -358,6 +365,36 @@ class TestEngine:
         self.reset_state()
         self._notifications.clear()
         self._storage.clear()
+
+    def _filter_result(self, value: Any, called_method: str, contract_id=None):
+        if contract_id is None:
+            contract_id = self._executed_script_hash
+
+        called_contract = self._contract_paths[contract_id]
+        if not isinstance(called_contract, TestContract):
+            return value
+
+        converted_value = value
+        expected_return_type = called_contract.get_method_return_type(called_method)
+
+        if expected_return_type is StackItemType.Boolean:
+            converted_value = bool(value)
+        elif expected_return_type is StackItemType.Integer:
+            if isinstance(value, str):
+                converted_value = String(value).to_bytes(min_length=1)
+
+            if isinstance(converted_value, bytes):
+                converted_value = Integer.from_bytes(value)
+            else:
+                try:
+                    converted_value = int(value)
+                except:
+                    converted_value = value
+        elif expected_return_type is StackItemType.ByteString:
+            if isinstance(value, int):
+                converted_value = Integer(value).to_byte_array(min_length=1)
+
+        return converted_value
 
     def to_json(self, contract_id: Union[str, UInt160], method: str, *args: Any) -> Dict[str, Any]:
         json = {


### PR DESCRIPTION
**Summary or solution description**
Updated TestEngine interface to convert the execution result to the expected type given the contract manifest.

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7