### PR TITLE
Fix standard name changing during compilation

### DIFF
--- a/boa3/analyser/supportedstandard/standardanalyser.py
+++ b/boa3/analyser/supportedstandard/standardanalyser.py
@@ -44,7 +44,7 @@ class StandardAnalyser(IAstAnalyser):
         for standard in self.standards:
             standard = standard.strip()
             if standard.upper().startswith('NEP'):
-                rebab_case = re.sub(r'([A-Z]+|(\d+\.\d+))[^a-zA-Z\d]?', r'\g<1>-', standard.upper())
+                rebab_case = re.sub(r'([A-Z]+|(.\d+)+|\d+)[^a-zA-Z\d]?', r'\g<1>-', standard.upper())
                 if rebab_case.endswith('-'):
                     rebab_case = rebab_case[:-1]
                 standard = rebab_case

--- a/boa3/analyser/supportedstandard/standardanalyser.py
+++ b/boa3/analyser/supportedstandard/standardanalyser.py
@@ -38,15 +38,18 @@ class StandardAnalyser(IAstAnalyser):
 
     def _filter_standards_names(self):
         """
-        Converts all the standards names to upper kebab case
+        Converts all the Neo standards names to upper kebab case
         """
         filtered_standards = set()
         for standard in self.standards:
-            rebab_case = re.sub(r'([a-z]+|[A-Z]+[a-z]*|\d+)[^a-zA-Z\d]?', r'\g<1>-', standard)
-            if rebab_case.endswith('-'):
-                rebab_case = rebab_case[:-1]
-            rebab_case = rebab_case.upper()
-            filtered_standards.add(rebab_case)
+            standard = standard.strip()
+            if standard.upper().startswith('NEP'):
+                rebab_case = re.sub(r'([A-Z]+|(\d+\.\d+))[^a-zA-Z\d]?', r'\g<1>-', standard.upper())
+                if rebab_case.endswith('-'):
+                    rebab_case = rebab_case[:-1]
+                standard = rebab_case
+
+            filtered_standards.add(standard)
 
         self.standards.clear()
         self.standards.extend(filtered_standards)

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsFilter.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsFilter.py
@@ -1,0 +1,44 @@
+from typing import Any
+
+from boa3.builtin import NeoMetadata, metadata, public
+from boa3.builtin.contract import Nep17TransferEvent
+from boa3.builtin.type import UInt160
+
+on_transfer = Nep17TransferEvent
+
+
+@public
+def Main() -> int:
+    return 5
+
+
+@metadata
+def standards_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+    meta.supported_standards = ['NEP-17', 'NEP-17.1', 'nep 100', 'nEP101', 'Nep-102', 'not neo standard 1']
+    return meta
+
+
+@public(safe=True)
+def symbol() -> str:
+    pass
+
+
+@public(safe=True)
+def decimals() -> int:
+    pass
+
+
+@public(name='totalSupply', safe=True)
+def total_supply() -> int:
+    pass
+
+
+@public(name='balanceOf', safe=True)
+def balance_of(account: UInt160) -> int:
+    pass
+
+
+@public
+def transfer(from_address: UInt160, to_address: UInt160, amount: int, data: Any) -> bool:
+    pass

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsFilter.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsFilter.py
@@ -15,7 +15,10 @@ def Main() -> int:
 @metadata
 def standards_manifest() -> NeoMetadata:
     meta = NeoMetadata()
-    meta.supported_standards = ['NEP-17', 'NEP-17.1', 'nep 100', 'nEP101', 'Nep-102', 'not neo standard 1']
+    meta.supported_standards = [
+        'NEP-17', 'NEP-17.1', 'NEP-17.1.2', 'NEP-17.1.3.5.7.9.11.13',
+        'nep 100', 'nEP101', 'Nep-102', 'not neo standard 1'
+    ]
     return meta
 
 

--- a/boa3_test/tests/compiler_tests/test_metadata.py
+++ b/boa3_test/tests/compiler_tests/test_metadata.py
@@ -208,6 +208,8 @@ class TestMetadata(BoaTest):
 
         # Using a dot is permitted and won't be removed by the filter
         self.assertIn('NEP-17.1', manifest['supportedstandards'])
+        self.assertIn('NEP-17.1.2', manifest['supportedstandards'])
+        self.assertIn('NEP-17.1.3.5.7.9.11.13', manifest['supportedstandards'])     # possible to use more than 1 dot
 
         # Every NEP needs to be in uppercase and be separated by a dash
         self.assertIn('NEP-100', manifest['supportedstandards'])

--- a/boa3_test/tests/compiler_tests/test_metadata.py
+++ b/boa3_test/tests/compiler_tests/test_metadata.py
@@ -197,6 +197,26 @@ class TestMetadata(BoaTest):
         self.assertIn('name', abi['events'][0])
         self.assertEqual('Transfer', abi['events'][0]['name'])
 
+    def test_metadata_info_supported_standards_filter(self):
+        path = self.get_contract_path('MetadataInfoSupportedStandardsFilter.py')
+        output, manifest = self.compile_and_save(path)
+
+        self.assertIn('supportedstandards', manifest)
+        self.assertIsInstance(manifest['supportedstandards'], list)
+        self.assertGreater(len(manifest['supportedstandards']), 0)
+        self.assertIn('NEP-17', manifest['supportedstandards'])
+
+        # Using a dot is permitted and won't be removed by the filter
+        self.assertIn('NEP-17.1', manifest['supportedstandards'])
+
+        # Every NEP needs to be in uppercase and be separated by a dash
+        self.assertIn('NEP-100', manifest['supportedstandards'])
+        self.assertIn('NEP-101', manifest['supportedstandards'])
+        self.assertIn('NEP-102', manifest['supportedstandards'])
+
+        # Standards that doesn't begin with NEP will not the filtered
+        self.assertIn('not neo standard 1', manifest['supportedstandards'])
+
     def test_metadata_info_supported_standards_missing_implementations_nep17(self):
         path = self.get_contract_path('MetadataInfoSupportedStandardsMissingImplementationNEP17.py')
         self.assertCompilerLogs(CompilerError.MissingStandardDefinition, path)


### PR DESCRIPTION
**Summary or solution description**
Changed the regex to permit using standards like `NEP-17.1`

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/ca3b7994d1fd83d88fab0edf251fb3bc86ad8f7d/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsFilter.py#L15-L19

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/ca3b7994d1fd83d88fab0edf251fb3bc86ad8f7d/boa3_test/tests/compiler_tests/test_metadata.py#L200-L218

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
