### PR TITLE
Add support to Bytes index method

### DIFF
--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -68,6 +68,7 @@ class Builtin:
     Super = SuperMethod()
 
     # python class method
+    BytesStringIndex = IndexBytesStringMethod()
     BytesStringIsDigit = IsDigitMethod()
     BytesStringJoin = JoinMethod()
     BytesStringLower = LowerMethod()
@@ -85,7 +86,6 @@ class Builtin:
     SequencePop = PopSequenceMethod()
     SequenceRemove = RemoveMethod()
     SequenceReverse = ReverseMethod()
-    StrIndex = IndexStrMethod()
     DictKeys = MapKeysMethod()
     DictPop = PopDictMethod()
     DictPopDefault = PopDictDefaultMethod()
@@ -106,6 +106,7 @@ class Builtin:
     _python_builtins: List[IdentifiedSymbol] = [Abs,
                                                 ByteArray,
                                                 ByteArrayEncoding,
+                                                BytesStringIndex,
                                                 BytesStringIsDigit,
                                                 BytesStringJoin,
                                                 BytesStringLower,
@@ -142,7 +143,6 @@ class Builtin:
                                                 SequenceRemove,
                                                 SequenceReverse,
                                                 StaticMethodDecorator,
-                                                StrIndex,
                                                 StrSplit,
                                                 Sum,
                                                 Super,

--- a/boa3/model/builtin/classmethod/__init__.py
+++ b/boa3/model/builtin/classmethod/__init__.py
@@ -5,8 +5,8 @@ __all__ = ['AppendMethod',
            'CountSequenceMethod',
            'CountStrMethod',
            'ExtendMethod',
+           'IndexBytesStringMethod',
            'IndexSequenceMethod',
-           'IndexStrMethod',
            'InsertMethod',
            'IsDigitMethod',
            'JoinMethod',
@@ -36,7 +36,7 @@ from boa3.model.builtin.classmethod.countsequencemethod import CountSequenceMeth
 from boa3.model.builtin.classmethod.countstrmethod import CountStrMethod
 from boa3.model.builtin.classmethod.extendmethod import ExtendMethod
 from boa3.model.builtin.classmethod.indexsequencemethod import IndexSequenceMethod
-from boa3.model.builtin.classmethod.indexstrmethod import IndexStrMethod
+from boa3.model.builtin.classmethod.indexbytesstringmethod import IndexBytesStringMethod
 from boa3.model.builtin.classmethod.insertmethod import InsertMethod
 from boa3.model.builtin.classmethod.isdigitmethod import IsDigitMethod
 from boa3.model.builtin.classmethod.joinmethod import JoinMethod

--- a/boa3/model/builtin/classmethod/indexmethod.py
+++ b/boa3/model/builtin/classmethod/indexmethod.py
@@ -63,8 +63,8 @@ class IndexMethod(IBuiltinMethod):
             return IndexSequenceMethod(value[0], value[1])
 
         from boa3.model.type.type import Type
-        if len(value) > 0 and Type.str.is_type_of(value[0]):
-            from boa3.model.builtin.classmethod.indexstrmethod import IndexStrMethod
-            return IndexStrMethod(value[0])
+        if len(value) > 0 and (Type.str.is_type_of(value[0]) or Type.bytes.is_type_of(value[0])):
+            from boa3.model.builtin.classmethod.indexbytesstringmethod import IndexBytesStringMethod
+            return IndexBytesStringMethod(value[0])
 
         return super().build(value)

--- a/boa3/model/type/primitive/strtype.py
+++ b/boa3/model/type/primitive/strtype.py
@@ -29,7 +29,7 @@ class StrType(IByteStringType):
 
         instance_methods = [Builtin.ConvertToBytes,
                             Builtin.StrSplit,
-                            Builtin.StrIndex,
+                            Builtin.BytesStringIndex,
                             ]
 
         for instance_method in instance_methods:

--- a/boa3_test/test_sc/bytes_test/IndexBytes.py
+++ b/boa3_test/test_sc/bytes_test/IndexBytes.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main(a: bytes, value: bytes, start: int, end: int) -> int:
+    return a.index(value, start, end)

--- a/boa3_test/test_sc/bytes_test/IndexBytesDefaults.py
+++ b/boa3_test/test_sc/bytes_test/IndexBytesDefaults.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main(a: bytes, value: bytes) -> int:
+    return a.index(value)

--- a/boa3_test/test_sc/bytes_test/IndexBytesEndDefault.py
+++ b/boa3_test/test_sc/bytes_test/IndexBytesEndDefault.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def main(a: bytes, value: bytes, start: int) -> int:
+    return a.index(value, start)

--- a/boa3_test/test_sc/bytes_test/IndexBytesMismatchedType.py
+++ b/boa3_test/test_sc/bytes_test/IndexBytesMismatchedType.py
@@ -1,0 +1,2 @@
+def main(a: bytes, value: int) -> int:
+    return a.index(value)

--- a/boa3_test/tests/compiler_tests/test_bytes.py
+++ b/boa3_test/tests/compiler_tests/test_bytes.py
@@ -12,6 +12,8 @@ from boa3_test.tests.test_classes.testengine import TestEngine
 class TestBytes(BoaTest):
     default_folder: str = 'test_sc/bytes_test'
 
+    SUBSEQUENCE_NOT_FOUND_MSG = 'subsequence of bytes not found'
+
     def test_bytes_literal_value(self):
         data = b'\x01\x02\x03'
         expected_output = (
@@ -1160,3 +1162,101 @@ class TestBytes(BoaTest):
         result = self.run_smart_contract(engine, path, 'main', bytes_value, dictionary,
                                          expected_result_type=bytes)
         self.assertEqual(bytes_value.join(dictionary), result)
+
+    def test_bytes_index(self):
+        path = self.get_contract_path('IndexBytes.py')
+        engine = TestEngine()
+
+        bytes_ = b'unit test'
+        subsequence = b'i'
+        start = 0
+        end = 4
+        result = self.run_smart_contract(engine, path, 'main', bytes_, subsequence, start, end)
+        self.assertEqual(bytes_.index(subsequence, start, end), result)
+
+        bytes_ = b'unit test'
+        bytes_sequence = b'i'
+        start = 2
+        end = 4
+        result = self.run_smart_contract(engine, path, 'main', bytes_, bytes_sequence, start, end)
+        self.assertEqual(bytes_.index(bytes_sequence, start, end), result)
+
+        with self.assertRaisesRegex(TestExecutionException, f'{self.SUBSEQUENCE_NOT_FOUND_MSG}$'):
+            self.run_smart_contract(engine, path, 'main', 'unit test', 'i', 3, 4)
+
+        with self.assertRaisesRegex(TestExecutionException, f'{self.SUBSEQUENCE_NOT_FOUND_MSG}$'):
+            self.run_smart_contract(engine, path, 'main', 'unit test', 'i', 4, -1)
+
+        with self.assertRaisesRegex(TestExecutionException, f'{self.SUBSEQUENCE_NOT_FOUND_MSG}$'):
+            self.run_smart_contract(engine, path, 'main', 'unit test', 'i', 0, -99)
+
+        bytes_ = b'unit test'
+        bytes_sequence = b'i'
+        start = 0
+        end = -1
+        result = self.run_smart_contract(engine, path, 'main', bytes_, bytes_sequence, start, end)
+        self.assertEqual(bytes_.index(bytes_sequence, start, end), result)
+
+        bytes_ = b'unit test'
+        bytes_sequence = b'n'
+        start = 0
+        end = 99
+        result = self.run_smart_contract(engine, path, 'main', bytes_, bytes_sequence, start, end)
+        self.assertEqual(bytes_.index(bytes_sequence, start, end), result)
+
+    def test_bytes_index_end_default(self):
+        path = self.get_contract_path('IndexBytesEndDefault.py')
+        engine = TestEngine()
+
+        bytes_ = b'unit test'
+        bytes_sequence = b't'
+        start = 0
+        result = self.run_smart_contract(engine, path, 'main', bytes_, bytes_sequence, start)
+        self.assertEqual(bytes_.index(bytes_sequence, start), result)
+
+        bytes_ = b'unit test'
+        bytes_sequence = b't'
+        start = 4
+        result = self.run_smart_contract(engine, path, 'main', bytes_, bytes_sequence, start)
+        self.assertEqual(bytes_.index(bytes_sequence, start), result)
+
+        bytes_ = b'unit test'
+        bytes_sequence = b't'
+        start = 6
+        result = self.run_smart_contract(engine, path, 'main', bytes_, bytes_sequence, start)
+        self.assertEqual(bytes_.index(bytes_sequence, start), result)
+
+        with self.assertRaisesRegex(TestExecutionException, f'{self.SUBSEQUENCE_NOT_FOUND_MSG}$'):
+            self.run_smart_contract(engine, path, 'main', 'unit test', 'i', 99)
+
+        with self.assertRaisesRegex(TestExecutionException, f'{self.SUBSEQUENCE_NOT_FOUND_MSG}$'):
+            self.run_smart_contract(engine, path, 'main', 'unit test', 't', -1)
+
+        bytes_ = b'unit test'
+        bytes_sequence = b'i'
+        start = -10
+        result = self.run_smart_contract(engine, path, 'main', bytes_, bytes_sequence, start)
+        self.assertEqual(bytes_.index(bytes_sequence, start), result)
+
+    def test_bytes_index_defaults(self):
+        path = self.get_contract_path('IndexBytesDefaults.py')
+        engine = TestEngine()
+
+        bytes_ = b'unit test'
+        bytes_sequence = b'u'
+        result = self.run_smart_contract(engine, path, 'main', bytes_, bytes_sequence)
+        self.assertEqual(bytes_.index(bytes_sequence), result)
+
+        bytes_ = b'unit test'
+        bytes_sequence = b't'
+        result = self.run_smart_contract(engine, path, 'main', bytes_, bytes_sequence)
+        self.assertEqual(bytes_.index(bytes_sequence), result)
+
+        bytes_ = b'unit test'
+        bytes_sequence = b' '
+        result = self.run_smart_contract(engine, path, 'main', bytes_, bytes_sequence)
+        self.assertEqual(bytes_.index(bytes_sequence), result)
+
+    def test_bytes_index_mismatched_type(self):
+        path = self.get_contract_path('IndexBytesMismatchedType.py')
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)


### PR DESCRIPTION
**Summary or solution description**
Changed IndexStrMethod to accept bytes too.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/7d022080a998d359d213430196680ad631158e99/boa3_test/test_sc/bytes_test/IndexBytes.py#L1-L6

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/7d022080a998d359d213430196680ad631158e99/boa3_test/tests/compiler_tests/test_bytes.py#L1166-L1262

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
