### PR TITLE
Detect standards from implemented methods and events | #2kq0v7d

### DIFF
--- a/boa3/analyser/supportedstandard/standardanalyser.py
+++ b/boa3/analyser/supportedstandard/standardanalyser.py
@@ -155,30 +155,36 @@ class StandardAnalyser(IAstAnalyser):
 
             # verify the methods
             methods_implemented = True
-            for standard_method in other_standards[standard].methods:
+            standard_methods = other_standards[standard].methods
+            index = 0
+
+            while methods_implemented and index < len(standard_methods):
+                standard_method = standard_methods[index]
                 method_id = standard_method.external_name
                 found_methods = self.get_methods_by_display_name(method_id)
 
                 methods_implemented = any(
                      other_standards[standard].match_definition(standard_method, method) for method in found_methods
                 )
+                index += 1
 
-                if not methods_implemented:
-                    break
             if not methods_implemented:
-                continue    # if at least one of the methods were not implemented, then check the next standard
+                continue    # if even one of the methods was not implemented, then check the next standard
 
             # verify the events
             events_implemented = True
-            for standard_event in other_standards[standard].events:
+            standard_events = other_standards[standard].events
+            index = 0
+
+            while events_implemented and index < len(standard_events):
+                standard_event = standard_events[index]
                 events_implemented = any(
                     (event.name == standard_event.name and
                      other_standards[standard].match_definition(standard_event, event)) for event in events
                 )
-                if not events_implemented:
-                    break
+                index += 1
 
             if not events_implemented:
-                continue    # if at least one of the events were not implemented, then check the next standard
+                continue    # if even one of the events was not implemented, then check the next standard
 
             self.standards.append(standard)

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsNotExplicit.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsNotExplicit.py
@@ -1,0 +1,37 @@
+from typing import Any
+
+from boa3.builtin import public
+from boa3.builtin.contract import Nep17TransferEvent
+from boa3.builtin.type import UInt160
+
+on_transfer = Nep17TransferEvent
+
+
+@public
+def main() -> int:
+    return 5
+
+
+@public(safe=True)
+def symbol() -> str:
+    pass
+
+
+@public(safe=True)
+def decimals() -> int:
+    pass
+
+
+@public(name='totalSupply', safe=True)
+def total_supply() -> int:
+    pass
+
+
+@public(name='balanceOf', safe=True)
+def balance_of(account: UInt160) -> int:
+    pass
+
+
+@public
+def transfer(from_address: UInt160, to_address: UInt160, amount: int, data: Any) -> bool:
+    pass

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsNotExplicitIncompleteEvents.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsNotExplicitIncompleteEvents.py
@@ -1,0 +1,34 @@
+from typing import Any
+
+from boa3.builtin import public
+from boa3.builtin.type import UInt160
+
+
+@public
+def main() -> int:
+    return 5
+
+
+@public(safe=True)
+def symbol() -> str:
+    pass
+
+
+@public(safe=True)
+def decimals() -> int:
+    pass
+
+
+@public(name='totalSupply', safe=True)
+def total_supply() -> int:
+    pass
+
+
+@public(name='balanceOf', safe=True)
+def balance_of(account: UInt160) -> int:
+    pass
+
+
+@public
+def transfer(from_address: UInt160, to_address: UInt160, amount: int, data: Any) -> bool:
+    pass

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsNotExplicitIncompleteMethods.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsNotExplicitIncompleteMethods.py
@@ -1,0 +1,32 @@
+from typing import Any
+
+from boa3.builtin import public
+from boa3.builtin.contract import Nep17TransferEvent
+from boa3.builtin.type import UInt160
+
+on_transfer = Nep17TransferEvent
+
+
+@public
+def main() -> int:
+    return 5
+
+
+@public(safe=True)
+def symbol() -> str:
+    pass
+
+
+@public(safe=True)
+def decimals() -> int:
+    pass
+
+
+@public(name='balanceOf', safe=True)
+def balance_of(account: UInt160) -> int:
+    pass
+
+
+@public
+def transfer(from_address: UInt160, to_address: UInt160, amount: int, data: Any) -> bool:
+    pass

--- a/boa3_test/tests/compiler_tests/test_metadata.py
+++ b/boa3_test/tests/compiler_tests/test_metadata.py
@@ -219,6 +219,31 @@ class TestMetadata(BoaTest):
         # Standards that doesn't begin with NEP will not the filtered
         self.assertIn('not neo standard 1', manifest['supportedstandards'])
 
+    def test_metadata_info_supported_standards_not_explicit(self):
+        path = self.get_contract_path('MetadataInfoSupportedStandardsNotExplicit.py')
+        output, manifest = self.compile_and_save(path)
+
+        self.assertIn('supportedstandards', manifest)
+        self.assertIsInstance(manifest['supportedstandards'], list)
+        self.assertGreater(len(manifest['supportedstandards']), 0)
+        self.assertIn('NEP-17', manifest['supportedstandards'])
+
+    def test_metadata_info_supported_standards_not_explicit_incomplete_methods(self):
+        path = self.get_contract_path('MetadataInfoSupportedStandardsNotExplicitIncompleteMethods.py')
+        output, manifest = self.compile_and_save(path)
+
+        self.assertIn('supportedstandards', manifest)
+        self.assertIsInstance(manifest['supportedstandards'], list)
+        self.assertEqual(len(manifest['supportedstandards']), 0)
+
+    def test_metadata_info_supported_standards_not_explicit_incomplete_events(self):
+        path = self.get_contract_path('MetadataInfoSupportedStandardsNotExplicitIncompleteEvents.py')
+        output, manifest = self.compile_and_save(path)
+
+        self.assertIn('supportedstandards', manifest)
+        self.assertIsInstance(manifest['supportedstandards'], list)
+        self.assertEqual(len(manifest['supportedstandards']), 0)
+
     def test_metadata_info_supported_standards_missing_implementations_nep17(self):
         path = self.get_contract_path('MetadataInfoSupportedStandardsMissingImplementationNEP17.py')
         self.assertCompilerLogs(CompilerError.MissingStandardDefinition, path)


### PR DESCRIPTION
**Summary or solution description**
Standards will now be added to the `supportedstandards` field on the manifest event if it wasn't explicitly added on the MetadataInfo.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/5543e88cc9add8937000c50d9c28430b74495c40/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsNotExplicit.py#L1-L37

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/5543e88cc9add8937000c50d9c28430b74495c40/boa3_test/tests/compiler_tests/test_metadata.py#L222-L230

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
