### PR TITLE
Update CircleCI to use TestEngine v3.3.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,10 +41,7 @@ jobs:
             sudo apt update && \
               sudo apt-get install -y dotnet-sdk-6.0
 
-            git clone https://github.com/simplitech/neo-devpack-dotnet.git -b v3.2.1
-            cd ./neo-devpack-dotnet
-            git checkout 7445246ad5fa806929a136db9d8ae4e6c38a8c1d
-            cd ..
+            git clone https://github.com/simplitech/neo-devpack-dotnet.git -b v3.3.1
             dotnet build ./neo-devpack-dotnet/src/Neo.TestEngine/Neo.TestEngine.csproj -o ./Neo.TestEngine
             python -m unittest discover boa3_test
 

--- a/boa3/model/builtin/interop/blockchain/signertype.py
+++ b/boa3/model/builtin/interop/blockchain/signertype.py
@@ -28,7 +28,6 @@ class SignerType(ClassArrayType):
         list_uint160 = Type.list.build([uint160])
 
         self._variables: Dict[str, Variable] = {
-            '-internal_signer': Variable(Type.bytes),
             'account': Variable(uint160),
             'scopes': Variable(WitnessScopeType.build()),
             'allowed_contracts': Variable(list_uint160),

--- a/boa3_test/tests/compiler_tests/test_interop/test_blockchain.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_blockchain.py
@@ -395,7 +395,7 @@ class TestBlockchainInterop(BoaTest):
         self.assertEqual(len(result), 2)
         self.assertIsInstance(result[0], list)
         self.assertEqual(len(result[0]), len(Interop.SignerType.variables))
-        self.assertEqual(result[0][1], String.from_bytes(example_account))
+        self.assertEqual(result[0][0], String.from_bytes(example_account))
 
     def test_get_transaction_signers_mismatched_type(self):
         path = self.get_contract_path('GetTransactionSignersMismatchedType.py')

--- a/boa3_test/tests/compiler_tests/test_list.py
+++ b/boa3_test/tests/compiler_tests/test_list.py
@@ -311,7 +311,7 @@ class TestList(BoaTest):
         self.assertEqual(expected_output, output)
 
         engine = TestEngine()
-        with self.assertRaisesRegex(TestExecutionException, self.GIVEN_KEY_NOT_PRESENT_IN_DICT_MSG_REGEX):
+        with self.assertRaisesRegex(TestExecutionException, self.NULL_POINTER_MSG):
             # TODO: TestEngine fails when running contracts with arrays inside arrays args
             self.run_smart_contract(engine, path, 'Main', [[1, 2], [3, 4]])
 

--- a/boa3_test/tests/compiler_tests/test_native/test_ledger.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_ledger.py
@@ -328,7 +328,7 @@ class TestLedgerContract(BoaTest):
         self.assertEqual(len(result), 2)
         self.assertIsInstance(result[0], list)
         self.assertEqual(len(result[0]), len(Interop.SignerType.variables))
-        self.assertEqual(result[0][1], String.from_bytes(example_account))
+        self.assertEqual(result[0][0], String.from_bytes(example_account))
 
     def test_get_transaction_signers_mismatched_type(self):
         path = self.get_contract_path('GetTransactionSignersMismatchedType.py')

--- a/boa3_test/tests/compiler_tests/test_tuple.py
+++ b/boa3_test/tests/compiler_tests/test_tuple.py
@@ -200,7 +200,7 @@ class TestTuple(BoaTest):
         self.assertEqual(expected_output, output)
 
         engine = TestEngine()
-        with self.assertRaisesRegex(TestExecutionException, self.GIVEN_KEY_NOT_PRESENT_IN_DICT_MSG_REGEX):
+        with self.assertRaisesRegex(TestExecutionException, self.NULL_POINTER_MSG):
             # TODO: TestEngine fails when running contracts with arrays inside arrays args
             self.run_smart_contract(engine, path, 'Main', ((1, 2), (3, 4)))
 


### PR DESCRIPTION
**Summary or solution description**
Updating CircleCI workflow to run the tests using the updated version of the TestEngine