### PR TITLE
Bug fix - False shadow naming warning

### DIFF
--- a/boa3/analyser/moduleanalyser.py
+++ b/boa3/analyser/moduleanalyser.py
@@ -171,7 +171,8 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
                         outer_symbol.set_is_reassigned()
                     self.__set_source_origin(source_node, is_module_scope)
             else:
-                if not isinstance(source_node, ast.Global):
+                if (not isinstance(source_node, ast.Global) and
+                        (not hasattr(source_node, 'targets') or not isinstance(source_node.targets[x], ast.Subscript))):
                     if outer_symbol is not None:
                         self._log_warning(
                             CompilerWarning.NameShadowing(source_node.lineno, source_node.col_offset, outer_symbol, var_id)

--- a/boa3_test/tests/compiler_tests/test_dict.py
+++ b/boa3_test/tests/compiler_tests/test_dict.py
@@ -277,7 +277,7 @@ class TestDict(BoaTest):
         )
 
         path = self.get_contract_path('SetValue.py')
-        output = Boa3.compile(path)
+        output = self.assertCompilerNotLogs(CompilerWarning.NameShadowing, path)
         self.assertEqual(expected_output, output)
 
         engine = TestEngine()

--- a/boa3_test/tests/compiler_tests/test_list.py
+++ b/boa3_test/tests/compiler_tests/test_list.py
@@ -207,6 +207,7 @@ class TestList(BoaTest):
 
     def test_list_set_value(self):
         path = self.get_contract_path('SetValue.py')
+        self.assertCompilerNotLogs(CompilerWarning.NameShadowing, path)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', [1, 2, 3, 4])
@@ -219,6 +220,7 @@ class TestList(BoaTest):
 
     def test_list_set_value_with_negative_index(self):
         path = self.get_contract_path('SetValueNegativeIndex.py')
+        self.assertCompilerNotLogs(CompilerWarning.NameShadowing, path)
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main', [1, 2, 3, 4])

--- a/boa3_test/tests/compiler_tests/test_variable.py
+++ b/boa3_test/tests/compiler_tests/test_variable.py
@@ -643,7 +643,7 @@ class TestVariable(BoaTest):
             + Opcode.RET
         )
         path = self.get_contract_path('AssignLocalWithArgumentShadowingGlobal.py')
-        output = Boa3.compile(path)
+        output = self.assertCompilerLogs(CompilerWarning.NameShadowing, path)
         self.assertEqual(expected_output, output)
 
         engine = TestEngine()


### PR DESCRIPTION
**Summary or solution description**
Shadow naming warning was raised when setting values in variable sequences from outer scopes.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/db29cb6cb09dd2e3560fc93131a9a0cb374894e1/boa3_test/test_sc/list_test/SetValue.py#L6-L9

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/db29cb6cb09dd2e3560fc93131a9a0cb374894e1/boa3_test/tests/compiler_tests/test_list.py#L208-L232
https://github.com/CityOfZion/neo3-boa/blob/db29cb6cb09dd2e3560fc93131a9a0cb374894e1/boa3_test/tests/compiler_tests/test_dict.py#L279-L285

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7+