### PR TITLE
Include source to nef generation

### DIFF
--- a/boa3/builtin/__init__.py
+++ b/boa3/builtin/__init__.py
@@ -106,6 +106,7 @@ class NeoMetadata:
 
     def __init__(self):
         self.name: str = ''
+        self.source: str = None
         self.supported_standards: List[str] = []
         self._trusts: List[str] = []
         self._permissions: List[dict] = []
@@ -120,6 +121,7 @@ class NeoMetadata:
         """
         # list the variables names that are part of the manifest
         specific_field_names = ['name',
+                                'source',
                                 'supported_standards',
                                 ]
         extra = {}

--- a/boa3/compiler/filegenerator.py
+++ b/boa3/compiler/filegenerator.py
@@ -28,7 +28,7 @@ class FileGenerator:
         self._entry_file_full_path = analyser.path.replace(os.sep, constants.PATH_SEPARATOR)
 
         self._files: List[str] = [self._entry_file_full_path]
-        self._nef: NefFile = NefFile(bytecode)
+        self._nef: NefFile = NefFile(bytecode, source=self._metadata.source)
 
         self.__all_imports: List[Import] = None
         self._all_methods: Dict[str, Method] = None

--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -207,6 +207,7 @@ class Builtin:
 
     metadata_fields: Dict[str, Union[type, Tuple[type]]] = {
         'name': str,
+        'source': (str, type(None)),
         'supported_standards': list,
         'trusts': list,
         'author': (str, type(None)),

--- a/boa3/neo/contracts/neffile.py
+++ b/boa3/neo/contracts/neffile.py
@@ -16,14 +16,16 @@ class NefFile:
     """
 
     def __init__(self, script_bytes: bytes,
-                 method_tokens: List[MethodToken] = None):
+                 method_tokens: List[MethodToken] = None,
+                 source: str = None):
         """
         :param script_bytes: the script of the smart contract
         """
         compiler: str = f"neo3-boa by COZ-{Version.from_string(boa3.__version__)}"
         self._nef = NEF(compiler_name=compiler,
                         script=script_bytes,
-                        tokens=[] if method_tokens is None else method_tokens)
+                        tokens=[] if method_tokens is None else method_tokens,
+                        source=source)
 
     @property
     def script(self) -> bytes:
@@ -33,6 +35,10 @@ class NefFile:
     def script_hash(self) -> bytes:
         from boa3.neo.cryptography import hash160
         return hash160(self.script)
+
+    @property
+    def source(self) -> str:
+        return self._nef.source
 
     def serialize(self) -> bytes:
         """

--- a/boa3_test/examples/nep11_non_divisible.py
+++ b/boa3_test/examples/nep11_non_divisible.py
@@ -31,7 +31,7 @@ def gm_manifest() -> NeoMetadata:
     meta.description = "Some Description"  # TODO_TEMPLATE
     meta.email = "hello@example.com"  # TODO_TEMPLATE
     meta.supported_standards = ["NEP-11"]
-    meta.source = ["https://github.com/"]  # TODO_TEMPLATE
+    meta.source = "https://github.com/"  # TODO_TEMPLATE
     # meta.add_permission(contract='*', methods=['*'])
     return meta
 

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSource.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSource.py
@@ -1,0 +1,13 @@
+from boa3.builtin import NeoMetadata, metadata, public
+
+
+@public
+def Main() -> int:
+    return 5
+
+
+@metadata
+def email_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+    meta.source = 'https://github.com/CityOfZion/neo3-boa'
+    return meta

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSourceDefault.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSourceDefault.py
@@ -1,0 +1,13 @@
+from boa3.builtin import NeoMetadata, metadata, public
+
+
+@public
+def Main() -> int:
+    return 5
+
+
+@metadata
+def name_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+
+    return meta

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSourceMismatchedType.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSourceMismatchedType.py
@@ -1,0 +1,14 @@
+from boa3.builtin import NeoMetadata, metadata
+
+
+def Main() -> int:
+    return 5
+
+
+@metadata
+def name_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+
+    meta.source = 1234567
+
+    return meta

--- a/boa3_test/tests/compiler_tests/test_metadata.py
+++ b/boa3_test/tests/compiler_tests/test_metadata.py
@@ -449,3 +449,30 @@ class TestMetadata(BoaTest):
         self.assertIn('groups', manifest)
         self.assertIsInstance(manifest['groups'], list)
         self.assertEqual(len(manifest['groups']), 0)
+
+    def test_metadata_info_source(self):
+        path = self.get_contract_path('MetadataInfoSource.py')
+        self.compile_and_save(path)
+
+        nef_path = path.replace('.py', '.nef')
+        with open(nef_path, mode='rb') as nef:
+            from boa3.neo.contracts.neffile import NefFile
+            generated_source = NefFile.deserialize(nef.read()).source
+
+        self.assertEqual(generated_source, 'https://github.com/CityOfZion/neo3-boa')
+
+    def test_metadata_info_source_default(self):
+        path = self.get_contract_path('MetadataInfoSourceDefault.py')
+        self.compile_and_save(path)
+
+        nef_path = path.replace('.py', '.nef')
+        with open(nef_path, mode='rb') as nef:
+            from boa3.neo.contracts.neffile import NefFile
+            generated_source = NefFile.deserialize(nef.read()).source
+
+        self.assertEqual(generated_source, '')
+
+    def test_metadata_info_source_mismatched_type(self):
+        path = self.get_contract_path('MetadataInfoSourceMismatchedType.py')
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+


### PR DESCRIPTION
**Related issue**
#771

**Summary or solution description**
Included `source` field to NeoMetadata.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/e5137e4be022e9021025ba162172122cd4766b29/boa3_test/test_sc/metadata_test/MetadataInfoSource.py#L9-L13

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/e5137e4be022e9021025ba162172122cd4766b29/boa3_test/tests/compiler_tests/test_metadata.py#L453-L462

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7+