### PR TITLE
Include Opcode enum to the boa.builtin package

### DIFF
--- a/boa3/builtin/vm/__init__.py
+++ b/boa3/builtin/vm/__init__.py
@@ -1,0 +1,3 @@
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+__all__ = ['Opcode']

--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -19,6 +19,7 @@ from boa3.model.type.collection.sequence.uint160type import UInt160Type
 from boa3.model.type.collection.sequence.uint256type import UInt256Type
 from boa3.model.type.itype import IType
 from boa3.model.type.math import Math
+from boa3.model.type.neo.opcodetype import OpcodeType
 from boa3.model.type.primitive.bytestringtype import ByteStringType
 
 
@@ -26,6 +27,7 @@ class BoaPackage(str, Enum):
     Contract = 'contract'
     Interop = 'interop'
     Type = 'type'
+    VM = 'vm'
 
 
 class Builtin:
@@ -175,6 +177,7 @@ class Builtin:
     UInt256 = UInt256Type.build()
     ECPoint = ECPointType.build()
     NeoAccountState = NeoAccountStateType.build()
+    Opcode = OpcodeType.build()
 
     # boa events
     Nep5Transfer = Nep5TransferEvent()
@@ -250,7 +253,9 @@ class Builtin:
                           ECPoint,
                           UInt160,
                           UInt256
-                          ]
+                          ],
+        BoaPackage.VM: [Opcode
+                        ]
     }
 
     _internal_methods = [InnerDeployMethod.instance()

--- a/boa3/model/builtin/classmethod/copydictmethod.py
+++ b/boa3/model/builtin/classmethod/copydictmethod.py
@@ -2,6 +2,7 @@ from typing import List, Optional, Tuple
 
 from boa3.model.builtin.classmethod.copymethod import CopyMethod
 from boa3.model.type.itype import IType
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
@@ -49,10 +50,10 @@ class CopyDictMethod(CopyMethod):
             # jump back to verify_while_condition
         ]
 
-        jmp_back_to_verify = Opcode.get_jump_and_data(Opcode.JMP, -get_bytes_count(while_loop + verify_while_condition))
+        jmp_back_to_verify = OpcodeHelper.get_jump_and_data(Opcode.JMP, -get_bytes_count(while_loop + verify_while_condition))
         while_loop.append(jmp_back_to_verify)
 
-        jmp_while_loop = Opcode.get_jump_and_data(Opcode.JMPLT, get_bytes_count(while_loop))
+        jmp_while_loop = OpcodeHelper.get_jump_and_data(Opcode.JMPLT, get_bytes_count(while_loop))
         verify_while_condition[-1] = jmp_while_loop
 
         clean_stack = [                 # remove all values from stack except the dict_copy

--- a/boa3/model/builtin/classmethod/countsequencegenericmethod.py
+++ b/boa3/model/builtin/classmethod/countsequencegenericmethod.py
@@ -3,6 +3,7 @@ from typing import List, Optional, Tuple
 from boa3.model.builtin.classmethod.countsequencemethod import CountSequenceMethod
 from boa3.model.type.collection.sequence.sequencetype import SequenceType
 from boa3.model.type.itype import IType
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
@@ -98,40 +99,40 @@ class CountSequenceGenericMethod(CountSequenceMethod):
             ]
 
             num_jmp_code = inc_statement_bytes + get_equals_statement_bytes
-            sequence_compare_sequences_end_is_not_equal[-1] = Opcode.get_jump_and_data(Opcode.JMP, num_jmp_code, True)
+            sequence_compare_sequences_end_is_not_equal[-1] = OpcodeHelper.get_jump_and_data(Opcode.JMP, num_jmp_code, True)
 
             num_jmp_code = get_bytes_count(sequence_compare_sequences_end_is_not_equal) + get_equals_statement_bytes
-            sequence_compare_sequences_end_is_equal[-1] = Opcode.get_jump_and_data(Opcode.JMP, num_jmp_code, True)
+            sequence_compare_sequences_end_is_equal[-1] = OpcodeHelper.get_jump_and_data(Opcode.JMP, num_jmp_code, True)
 
             num_jmp_code = -get_bytes_count(sequence_compare_sequences_verify_end + sequence_compare_sequences_start)
-            sequence_compare_sequences_verify_end.append(Opcode.get_jump_and_data(Opcode.JMPGT, num_jmp_code))
+            sequence_compare_sequences_verify_end.append(OpcodeHelper.get_jump_and_data(Opcode.JMPGT, num_jmp_code))
 
             num_jmp_code = get_bytes_count(sequence_compare_sequences_verify_end +
                                            sequence_compare_sequences_end_is_equal)
-            sequence_compare_sequences_start[-1] = Opcode.get_jump_and_data(Opcode.JMPNE, num_jmp_code, True)
+            sequence_compare_sequences_start[-1] = OpcodeHelper.get_jump_and_data(Opcode.JMPNE, num_jmp_code, True)
 
             num_jmp_code = get_bytes_count(
                 sequence_compare_sequences_initialize + sequence_compare_sequences_start +
                 sequence_compare_sequences_verify_end + sequence_compare_sequences_end_is_equal +
                 sequence_compare_sequences_end_is_not_equal) + get_equals_statement_bytes + inc_statement_bytes
-            sequence_remove_aux_and_verify_next[-1] = Opcode.get_jump_and_data(Opcode.JMP, num_jmp_code, True)
+            sequence_remove_aux_and_verify_next[-1] = OpcodeHelper.get_jump_and_data(Opcode.JMP, num_jmp_code, True)
 
             num_jmp_code = get_bytes_count(sequence_remove_aux_and_verify_next)
-            sequence_verify_item_value_is_same_size[-1] = Opcode.get_jump_and_data(Opcode.JMPEQ, num_jmp_code, True)
+            sequence_verify_item_value_is_same_size[-1] = OpcodeHelper.get_jump_and_data(Opcode.JMPEQ, num_jmp_code, True)
 
             num_jmp_code = get_bytes_count(
                 sequence_verify_item_value_is_same_size + sequence_remove_aux_and_verify_next +
                 sequence_compare_sequences_initialize + sequence_compare_sequences_start +
                 sequence_compare_sequences_verify_end + sequence_compare_sequences_end_is_equal +
                 sequence_compare_sequences_end_is_not_equal) + get_equals_statement_bytes + inc_statement_bytes
-            sequence_verify_item_is_sequence[-1] = Opcode.get_jump_and_data(Opcode.JMPIFNOT, num_jmp_code, True)
+            sequence_verify_item_is_sequence[-1] = OpcodeHelper.get_jump_and_data(Opcode.JMPIFNOT, num_jmp_code, True)
 
             num_jmp_code = get_bytes_count(sequence_verify_item_is_sequence + sequence_verify_item_value_is_same_size +
                                            sequence_remove_aux_and_verify_next + sequence_compare_sequences_initialize +
                                            sequence_compare_sequences_start + sequence_compare_sequences_verify_end +
                                            sequence_compare_sequences_end_is_equal +
                                            sequence_compare_sequences_end_is_not_equal)
-            sequence_verify_value_is_sequence[-1] = Opcode.get_jump_and_data(Opcode.JMPIFNOT, num_jmp_code, True)
+            sequence_verify_value_is_sequence[-1] = OpcodeHelper.get_jump_and_data(Opcode.JMPIFNOT, num_jmp_code, True)
 
             self._generic_verification_opcodes = (
                 sequence_verify_value_is_sequence +

--- a/boa3/model/builtin/classmethod/countsequencemethod.py
+++ b/boa3/model/builtin/classmethod/countsequencemethod.py
@@ -5,6 +5,7 @@ from boa3.model.expression import IExpression
 from boa3.model.type.collection.sequence.sequencetype import SequenceType
 from boa3.model.type.itype import IType
 from boa3.model.variable import Variable
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
@@ -92,7 +93,7 @@ class CountSequenceMethod(CountMethod):
         ]
 
         num_jmp_code = get_bytes_count(sequence_count_inc)
-        jmp_to_dec_statement = Opcode.get_jump_and_data(Opcode.JMPIFNOT, num_jmp_code, True)
+        jmp_to_dec_statement = OpcodeHelper.get_jump_and_data(Opcode.JMPIFNOT, num_jmp_code, True)
         sequence_equals[-1] = jmp_to_dec_statement
 
         list_tuple_count_index_dec = [  # decreases the index
@@ -105,12 +106,12 @@ class CountSequenceMethod(CountMethod):
 
         num_jmp_code = -get_bytes_count(list_tuple_count_index_dec + sequence_count_inc + sequence_equals +
                                         sequence_get_element + sequence_verify_while + in_depth_verification)
-        jmp_back_to_while_verify_statement = Opcode.get_jump_and_data(Opcode.JMP, num_jmp_code)
+        jmp_back_to_while_verify_statement = OpcodeHelper.get_jump_and_data(Opcode.JMP, num_jmp_code)
         list_tuple_count_index_dec.append(jmp_back_to_while_verify_statement)
 
         num_jmp_code = get_bytes_count(sequence_get_element + sequence_equals +
                                        sequence_count_inc + list_tuple_count_index_dec + in_depth_verification)
-        jmp_to_clean_statement = Opcode.get_jump_and_data(Opcode.JMPLT, num_jmp_code, True)
+        jmp_to_clean_statement = OpcodeHelper.get_jump_and_data(Opcode.JMPLT, num_jmp_code, True)
         sequence_verify_while[-1] = jmp_to_clean_statement
 
         sequence_clean_stack = [

--- a/boa3/model/builtin/classmethod/countstrmethod.py
+++ b/boa3/model/builtin/classmethod/countstrmethod.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Tuple
 from boa3.model import set_internal_call
 from boa3.model.builtin.classmethod.countmethod import CountMethod
 from boa3.model.variable import Variable
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
@@ -50,7 +51,7 @@ class CountStrMethod(CountMethod):
         ]
 
         num_jmp_code = get_bytes_count(end_null)
-        jmp_str_end_null_statement = Opcode.get_jump_and_data(Opcode.JMPIFNOT, num_jmp_code, True)
+        jmp_str_end_null_statement = OpcodeHelper.get_jump_and_data(Opcode.JMPIFNOT, num_jmp_code, True)
         verify_end_null[-1] = jmp_str_end_null_statement
 
         verify_end_neg = [      # verifies if end is < 0
@@ -75,7 +76,7 @@ class CountStrMethod(CountMethod):
         ]
 
         num_jmp_code = get_bytes_count(end_still_neg)
-        jmp_end_still_neg_statement = Opcode.get_jump_and_data(Opcode.JMPGE, num_jmp_code, True)
+        jmp_end_still_neg_statement = OpcodeHelper.get_jump_and_data(Opcode.JMPGE, num_jmp_code, True)
         end_neg[-1] = jmp_end_still_neg_statement
 
         skip_end_gt_size = [
@@ -83,7 +84,7 @@ class CountStrMethod(CountMethod):
         ]
 
         num_jmp_code = get_bytes_count(end_still_neg + end_neg + skip_end_gt_size)
-        jmp_end_neg_statement = Opcode.get_jump_and_data(Opcode.JMPGE, num_jmp_code, True)
+        jmp_end_neg_statement = OpcodeHelper.get_jump_and_data(Opcode.JMPGE, num_jmp_code, True)
         verify_end_neg[-1] = jmp_end_neg_statement
 
         verify_end_gt_size = [  # verifies if end >= len(self)
@@ -102,17 +103,17 @@ class CountStrMethod(CountMethod):
         ]
 
         num_jmp_code = get_bytes_count(end_gt_size)
-        jmp_end_gt_size_statement = Opcode.get_jump_and_data(Opcode.JMPLE, num_jmp_code, True)
+        jmp_end_gt_size_statement = OpcodeHelper.get_jump_and_data(Opcode.JMPLE, num_jmp_code, True)
         verify_end_gt_size[-1] = jmp_end_gt_size_statement
 
         num_jmp_code = get_bytes_count(end_gt_size + verify_end_gt_size)
-        jmp_whole_end_gt_size_statement = Opcode.get_jump_and_data(Opcode.JMP, num_jmp_code, True)
+        jmp_whole_end_gt_size_statement = OpcodeHelper.get_jump_and_data(Opcode.JMP, num_jmp_code, True)
         skip_end_gt_size[-1] = jmp_whole_end_gt_size_statement
 
         num_jmp_code = get_bytes_count(
             end_gt_size + verify_end_gt_size + skip_end_gt_size + end_still_neg + end_neg + verify_end_neg
         )
-        jmp_whole_end_gt_size_statement = Opcode.get_jump_and_data(Opcode.JMP, num_jmp_code, True)
+        jmp_whole_end_gt_size_statement = OpcodeHelper.get_jump_and_data(Opcode.JMP, num_jmp_code, True)
         end_null[-1] = jmp_whole_end_gt_size_statement
 
         verify_end = (
@@ -153,7 +154,7 @@ class CountStrMethod(CountMethod):
         ]
 
         num_jmp_code = get_bytes_count(start_still_neg)
-        jmp_str_start_still_neg_statement = Opcode.get_jump_and_data(Opcode.JMPGE, num_jmp_code, True)
+        jmp_str_start_still_neg_statement = OpcodeHelper.get_jump_and_data(Opcode.JMPGE, num_jmp_code, True)
         start_neg[-1] = jmp_str_start_still_neg_statement
 
         correct_start_position = [  # put start on the correct position
@@ -161,7 +162,7 @@ class CountStrMethod(CountMethod):
         ]
 
         num_jmp_code = get_bytes_count(correct_start_position + start_still_neg + start_neg)
-        jmp_str_start_neg_statement = Opcode.get_jump_and_data(Opcode.JMPGE, num_jmp_code, True)
+        jmp_str_start_neg_statement = OpcodeHelper.get_jump_and_data(Opcode.JMPGE, num_jmp_code, True)
         verify_start_neg[-1] = jmp_str_start_neg_statement
 
         verify_start = (
@@ -213,7 +214,7 @@ class CountStrMethod(CountMethod):
         ]
 
         num_jmp_code = get_bytes_count(count_plusplus)
-        jmp_count_plusplus_statement = Opcode.get_jump_and_data(Opcode.JMPIFNOT, num_jmp_code, True)
+        jmp_count_plusplus_statement = OpcodeHelper.get_jump_and_data(Opcode.JMPIFNOT, num_jmp_code, True)
         count_substring[-1] = jmp_count_plusplus_statement
 
         go_back_to_while = [    # go back to while verification
@@ -224,11 +225,11 @@ class CountStrMethod(CountMethod):
         ]
 
         num_jmp_code = -get_bytes_count(go_back_to_while + count_plusplus + count_substring + verify_while)
-        jmp_back_to_while_statement = Opcode.get_jump_and_data(Opcode.JMP, num_jmp_code)
+        jmp_back_to_while_statement = OpcodeHelper.get_jump_and_data(Opcode.JMP, num_jmp_code)
         go_back_to_while.append(jmp_back_to_while_statement)
 
         num_jmp_code = get_bytes_count(go_back_to_while + count_plusplus + count_substring)
-        jmp_to_clean_stack_statement = Opcode.get_jump_and_data(Opcode.JMPGT, num_jmp_code, True)
+        jmp_to_clean_stack_statement = OpcodeHelper.get_jump_and_data(Opcode.JMPGT, num_jmp_code, True)
         verify_while[-1] = jmp_to_clean_stack_statement
 
         clean_stack = [         # remove auxiliary values

--- a/boa3/model/builtin/classmethod/indexbytesstringmethod.py
+++ b/boa3/model/builtin/classmethod/indexbytesstringmethod.py
@@ -6,6 +6,7 @@ from boa3.model.expression import IExpression
 from boa3.model.type.primitive.bytestype import BytesType
 from boa3.model.type.primitive.strtype import StrType
 from boa3.model.variable import Variable
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.String import String
@@ -84,7 +85,7 @@ class IndexBytesStringMethod(IndexMethod):
             (Opcode.PUSH0, b''),            # end = 0
         ]
 
-        jmp_fix_negative_index = Opcode.get_jump_and_data(Opcode.JMPGT, get_bytes_count(fix_negative_end +
+        jmp_fix_negative_index = OpcodeHelper.get_jump_and_data(Opcode.JMPGT, get_bytes_count(fix_negative_end +
                                                                                         fix_still_negative_index), True)
         verify_negative_index[-1] = jmp_fix_negative_index
 
@@ -103,12 +104,12 @@ class IndexBytesStringMethod(IndexMethod):
             (Opcode.SIZE, b''),             # end = len(str)
         ]
 
-        jmp_other_verifies = Opcode.get_jump_and_data(Opcode.JMPGT, get_bytes_count(fix_still_negative_index +
+        jmp_other_verifies = OpcodeHelper.get_jump_and_data(Opcode.JMPGT, get_bytes_count(fix_still_negative_index +
                                                                                     verify_big_end +
                                                                                     fix_big_end), True)
         fix_negative_end[-1] = jmp_other_verifies
 
-        jmp_fix_big_index = Opcode.get_jump_and_data(Opcode.JMPLE, get_bytes_count(fix_big_end), True)
+        jmp_fix_big_index = OpcodeHelper.get_jump_and_data(Opcode.JMPLE, get_bytes_count(fix_big_end), True)
         verify_big_end[-1] = jmp_fix_big_index
 
         verify_and_fix_end = [              # collection of Opcodes regarding verifying and fixing end index
@@ -165,12 +166,12 @@ class IndexBytesStringMethod(IndexMethod):
             # jump to verify_while
         ]
 
-        jmp_back_to_verify = Opcode.get_jump_and_data(Opcode.JMP, -get_bytes_count(verify_while +
+        jmp_back_to_verify = OpcodeHelper.get_jump_and_data(Opcode.JMP, -get_bytes_count(verify_while +
                                                                                    compare_item +
                                                                                    not_found), True)
         not_found.append(jmp_back_to_verify)
 
-        jmp_to_error = Opcode.get_jump_and_data(Opcode.JMPLT, get_bytes_count(compare_item +
+        jmp_to_error = OpcodeHelper.get_jump_and_data(Opcode.JMPLT, get_bytes_count(compare_item +
                                                                               not_found), True)
         verify_while[-1] = jmp_to_error
 
@@ -179,7 +180,7 @@ class IndexBytesStringMethod(IndexMethod):
             (Opcode.THROW, b''),
         ]
 
-        jmp_to_return_index = Opcode.get_jump_and_data(Opcode.JMPIF, get_bytes_count(not_found +
+        jmp_to_return_index = OpcodeHelper.get_jump_and_data(Opcode.JMPIF, get_bytes_count(not_found +
                                                                                      not_inside_sequence), True)
         compare_item[-1] = jmp_to_return_index
 

--- a/boa3/model/builtin/classmethod/indexsequencemethod.py
+++ b/boa3/model/builtin/classmethod/indexsequencemethod.py
@@ -6,6 +6,7 @@ from boa3.model.expression import IExpression
 from boa3.model.type.collection.sequence.sequencetype import SequenceType
 from boa3.model.type.itype import IType
 from boa3.model.variable import Variable
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.String import String
@@ -86,7 +87,7 @@ class IndexSequenceMethod(IndexMethod):
             (Opcode.PUSH0, b''),            # end = 0
         ]
 
-        jmp_fix_negative_index = Opcode.get_jump_and_data(Opcode.JMPGT, get_bytes_count(fix_negative_end +
+        jmp_fix_negative_index = OpcodeHelper.get_jump_and_data(Opcode.JMPGT, get_bytes_count(fix_negative_end +
                                                                                         fix_still_negative_index), True)
         verify_negative_index[-1] = jmp_fix_negative_index
 
@@ -105,12 +106,12 @@ class IndexSequenceMethod(IndexMethod):
             (Opcode.SIZE, b''),             # end = len(sequence)
         ]
 
-        jmp_other_verifies = Opcode.get_jump_and_data(Opcode.JMPGT, get_bytes_count(fix_still_negative_index +
+        jmp_other_verifies = OpcodeHelper.get_jump_and_data(Opcode.JMPGT, get_bytes_count(fix_still_negative_index +
                                                                                     verify_big_end +
                                                                                     fix_big_end), True)
         fix_negative_end[-1] = jmp_other_verifies
 
-        jmp_fix_big_index = Opcode.get_jump_and_data(Opcode.JMPLE, get_bytes_count(fix_big_end), True)
+        jmp_fix_big_index = OpcodeHelper.get_jump_and_data(Opcode.JMPLE, get_bytes_count(fix_big_end), True)
         verify_big_end[-1] = jmp_fix_big_index
 
         verify_and_fix_end = [              # collection of Opcodes regarding verifying and fixing end index
@@ -153,12 +154,12 @@ class IndexSequenceMethod(IndexMethod):
             # jump to verify_while
         ]
 
-        jmp_back_to_verify = Opcode.get_jump_and_data(Opcode.JMP, -get_bytes_count(verify_while +
+        jmp_back_to_verify = OpcodeHelper.get_jump_and_data(Opcode.JMP, -get_bytes_count(verify_while +
                                                                                    compare_item +
                                                                                    not_found), True)
         not_found.append(jmp_back_to_verify)
 
-        jmp_to_error = Opcode.get_jump_and_data(Opcode.JMPLE, get_bytes_count(compare_item +
+        jmp_to_error = OpcodeHelper.get_jump_and_data(Opcode.JMPLE, get_bytes_count(compare_item +
                                                                               not_found), True)
         verify_while[-1] = jmp_to_error
 
@@ -167,7 +168,7 @@ class IndexSequenceMethod(IndexMethod):
             (Opcode.THROW, b''),
         ]
 
-        jmp_to_return_index = Opcode.get_jump_and_data(Opcode.JMPIF, get_bytes_count(not_found +
+        jmp_to_return_index = OpcodeHelper.get_jump_and_data(Opcode.JMPIF, get_bytes_count(not_found +
                                                                                      not_inside_sequence), True)
         compare_item[-1] = jmp_to_return_index
 

--- a/boa3/model/builtin/classmethod/isdigitmethod.py
+++ b/boa3/model/builtin/classmethod/isdigitmethod.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.type.primitive.ibytestringtype import IByteStringType
 from boa3.model.variable import Variable
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
@@ -56,7 +57,7 @@ class IsDigitMethod(IBuiltinMethod):
             jmp_place_holder,               # jump to return_bool if index >= len(string)
         ]
 
-        jmp_verify_while = Opcode.get_jump_and_data(Opcode.JMP, get_bytes_count(verify_while), True)
+        jmp_verify_while = OpcodeHelper.get_jump_and_data(Opcode.JMP, get_bytes_count(verify_while), True)
         skip_first_verify_while[-1] = jmp_verify_while
 
         while_verify_lt_0 = [               # verifies if ord(string[index]) is < ord('0')
@@ -84,13 +85,13 @@ class IsDigitMethod(IBuiltinMethod):
             # jump back to verify_while
         ]
 
-        jmp_back_to_verify = Opcode.get_jump_and_data(Opcode.JMP, -get_bytes_count(verify_while +
+        jmp_back_to_verify = OpcodeHelper.get_jump_and_data(Opcode.JMP, -get_bytes_count(verify_while +
                                                                                    while_verify_lt_0 +
                                                                                    while_verify_gt_9 +
                                                                                    while_go_to_verify))
         while_go_to_verify.append(jmp_back_to_verify)
 
-        jmp_out_of_while = Opcode.get_jump_and_data(Opcode.JMPLT, get_bytes_count(while_verify_gt_9 +
+        jmp_out_of_while = OpcodeHelper.get_jump_and_data(Opcode.JMPLT, get_bytes_count(while_verify_gt_9 +
                                                                                   while_go_to_verify), True)
         while_verify_lt_0[-1] = jmp_out_of_while
 
@@ -98,7 +99,7 @@ class IsDigitMethod(IBuiltinMethod):
             (Opcode.DROP, b'')
         ]
 
-        jmp_to_change_to_false = Opcode.get_jump_and_data(Opcode.JMPGT, get_bytes_count(while_go_to_verify +
+        jmp_to_change_to_false = OpcodeHelper.get_jump_and_data(Opcode.JMPGT, get_bytes_count(while_go_to_verify +
                                                                                         drop_char), True)
         while_verify_gt_9[-1] = jmp_to_change_to_false
 
@@ -107,7 +108,7 @@ class IsDigitMethod(IBuiltinMethod):
             (Opcode.PUSH0, b''),
         ]
 
-        jmp_to_return = Opcode.get_jump_and_data(Opcode.JMPEQ, get_bytes_count(skip_first_verify_while +
+        jmp_to_return = OpcodeHelper.get_jump_and_data(Opcode.JMPEQ, get_bytes_count(skip_first_verify_while +
                                                                                verify_while +
                                                                                while_verify_lt_0 +
                                                                                while_verify_gt_9 +
@@ -115,7 +116,7 @@ class IsDigitMethod(IBuiltinMethod):
                                                                                drop_char), True)
         verify_empty_string[-1] = jmp_to_return
 
-        jmp_to_return = Opcode.get_jump_and_data(Opcode.JMPLT, get_bytes_count(while_verify_lt_0 +
+        jmp_to_return = OpcodeHelper.get_jump_and_data(Opcode.JMPLT, get_bytes_count(while_verify_lt_0 +
                                                                                while_verify_gt_9 +
                                                                                while_go_to_verify +
                                                                                drop_char +

--- a/boa3/model/builtin/classmethod/joinmethod.py
+++ b/boa3/model/builtin/classmethod/joinmethod.py
@@ -5,6 +5,7 @@ from boa3.model.type.collection.mapping.mutable.dicttype import DictType
 from boa3.model.type.collection.sequence.sequencetype import SequenceType
 from boa3.model.type.primitive.ibytestringtype import IByteStringType
 from boa3.model.variable import Variable
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
@@ -102,11 +103,11 @@ class JoinMethod(IBuiltinMethod):
             # jump back to verify_index
         ]
 
-        jmp_back_to_verify = Opcode.get_jump_and_data(Opcode.JMP, -get_bytes_count(verify_index +
+        jmp_back_to_verify = OpcodeHelper.get_jump_and_data(Opcode.JMP, -get_bytes_count(verify_index +
                                                                                    concat_strings))
         concat_strings.append(jmp_back_to_verify)
 
-        jmp_concatenation = Opcode.get_jump_and_data(Opcode.JMPLE, get_bytes_count(initialize_string +
+        jmp_concatenation = OpcodeHelper.get_jump_and_data(Opcode.JMPLE, get_bytes_count(initialize_string +
                                                                                    verify_index +
                                                                                    concat_strings), True)
         verify_empty_string[-1] = jmp_concatenation
@@ -115,7 +116,7 @@ class JoinMethod(IBuiltinMethod):
             (Opcode.PUSHDATA1, b'\x00')
         ]
 
-        jmp_concatenation = Opcode.get_jump_and_data(Opcode.JMPGE, get_bytes_count(concat_strings +
+        jmp_concatenation = OpcodeHelper.get_jump_and_data(Opcode.JMPGE, get_bytes_count(concat_strings +
                                                                                    add_empty_string), True)
         verify_index[-1] = jmp_concatenation
 

--- a/boa3/model/builtin/classmethod/lowermethod.py
+++ b/boa3/model/builtin/classmethod/lowermethod.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.type.primitive.ibytestringtype import IByteStringType
 from boa3.model.variable import Variable
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
@@ -79,11 +80,11 @@ class LowerMethod(IBuiltinMethod):
             (Opcode.CONVERT, StackItemType.ByteString),
         ]
 
-        jmp_to_join_substring = Opcode.get_jump_and_data(Opcode.JMPLT, get_bytes_count(verify_greater_than_z +
+        jmp_to_join_substring = OpcodeHelper.get_jump_and_data(Opcode.JMPLT, get_bytes_count(verify_greater_than_z +
                                                                                        swap_upper_to_lower_case), True)
         get_substring_middle[-1] = jmp_to_join_substring
 
-        jmp_to_join_substring = Opcode.get_jump_and_data(Opcode.JMPGT, get_bytes_count(swap_upper_to_lower_case), True)
+        jmp_to_join_substring = OpcodeHelper.get_jump_and_data(Opcode.JMPGT, get_bytes_count(swap_upper_to_lower_case), True)
         verify_greater_than_z[-1] = jmp_to_join_substring
 
         get_substring_middle.extend(verify_greater_than_z)
@@ -110,7 +111,7 @@ class LowerMethod(IBuiltinMethod):
             # jump back to verify,
         ]
 
-        jmp_to_verify_while = Opcode.get_jump_and_data(Opcode.JMP, -get_bytes_count(verify_while +
+        jmp_to_verify_while = OpcodeHelper.get_jump_and_data(Opcode.JMP, -get_bytes_count(verify_while +
                                                                                     get_substring_left +
                                                                                     get_substring_middle +
                                                                                     get_substring_right +
@@ -129,7 +130,7 @@ class LowerMethod(IBuiltinMethod):
             join_substrings
         )
 
-        jmp_to_clean_stack = Opcode.get_jump_and_data(Opcode.JMPLE, get_bytes_count(while_body), True)
+        jmp_to_clean_stack = OpcodeHelper.get_jump_and_data(Opcode.JMPLE, get_bytes_count(while_body), True)
         verify_while[-1] = jmp_to_clean_stack
 
         return (

--- a/boa3/model/builtin/classmethod/popdictdefaultmethod.py
+++ b/boa3/model/builtin/classmethod/popdictdefaultmethod.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Optional, Tuple
 from boa3.model.builtin.classmethod.popmethod import PopMethod
 from boa3.model.type.itype import IType
 from boa3.model.variable import Variable
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
@@ -72,10 +73,10 @@ class PopDictDefaultMethod(PopMethod):
         ]
 
         num_jmp_code = get_bytes_count(return_default)
-        pop_from_dict[-1] = Opcode.get_jump_and_data(Opcode.JMP, num_jmp_code, True)
+        pop_from_dict[-1] = OpcodeHelper.get_jump_and_data(Opcode.JMP, num_jmp_code, True)
 
         num_jmp_code = get_bytes_count(pick_from_dict + pop_from_dict)
-        verify_has_key[-1] = Opcode.get_jump_and_data(Opcode.JMPIFNOT, num_jmp_code, True)
+        verify_has_key[-1] = OpcodeHelper.get_jump_and_data(Opcode.JMPIFNOT, num_jmp_code, True)
 
         return (
             put_default_at_bottom +

--- a/boa3/model/builtin/classmethod/startswithmethod.py
+++ b/boa3/model/builtin/classmethod/startswithmethod.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.type.primitive.ibytestringtype import IByteStringType
 from boa3.model.variable import Variable
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
@@ -64,7 +65,7 @@ class StartsWithMethod(IBuiltinMethod):
             (Opcode.PUSH0, b''),            # end = 0
         ]
 
-        jmp_fix_negative_index = Opcode.get_jump_and_data(Opcode.JMPGT, get_bytes_count(fix_negative_end +
+        jmp_fix_negative_index = OpcodeHelper.get_jump_and_data(Opcode.JMPGT, get_bytes_count(fix_negative_end +
                                                                                         fix_still_negative_index), True)
         verify_negative_index[-1] = jmp_fix_negative_index
 
@@ -83,12 +84,12 @@ class StartsWithMethod(IBuiltinMethod):
             (Opcode.SIZE, b''),             # end = len(string)
         ]
 
-        jmp_other_verifies = Opcode.get_jump_and_data(Opcode.JMPGT, get_bytes_count(fix_still_negative_index +
+        jmp_other_verifies = OpcodeHelper.get_jump_and_data(Opcode.JMPGT, get_bytes_count(fix_still_negative_index +
                                                                                     verify_big_end +
                                                                                     fix_big_end), True)
         fix_negative_end[-1] = jmp_other_verifies
 
-        jmp_fix_big_index = Opcode.get_jump_and_data(Opcode.JMPLE, get_bytes_count(fix_big_end), True)
+        jmp_fix_big_index = OpcodeHelper.get_jump_and_data(Opcode.JMPLE, get_bytes_count(fix_big_end), True)
         verify_big_end[-1] = jmp_fix_big_index
 
         verify_and_fix_end = [              # verify and fix end index
@@ -114,7 +115,7 @@ class StartsWithMethod(IBuiltinMethod):
             jmp_place_holder                # if start >= len(string), return False
         ]
 
-        jmp_other_verifies = Opcode.get_jump_and_data(Opcode.JMPGT, get_bytes_count(fix_still_negative_index +
+        jmp_other_verifies = OpcodeHelper.get_jump_and_data(Opcode.JMPGT, get_bytes_count(fix_still_negative_index +
                                                                                     verify_big_start), True)
         fix_negative_end[-1] = jmp_other_verifies
 
@@ -144,10 +145,10 @@ class StartsWithMethod(IBuiltinMethod):
             jmp_place_holder                # jumps other opcodes
         ]
 
-        jmp_compare_starts = Opcode.get_jump_and_data(Opcode.JMPGT, get_bytes_count(compare_starts), True)
+        jmp_compare_starts = OpcodeHelper.get_jump_and_data(Opcode.JMPGT, get_bytes_count(compare_starts), True)
         verify_size[-1] = jmp_compare_starts
 
-        jmp_to_false = Opcode.get_jump_and_data(Opcode.JMPGE, get_bytes_count(verify_size +
+        jmp_to_false = OpcodeHelper.get_jump_and_data(Opcode.JMPGE, get_bytes_count(verify_size +
                                                                               compare_starts), True)
         verify_big_start[-1] = jmp_to_false
 
@@ -164,7 +165,7 @@ class StartsWithMethod(IBuiltinMethod):
             (Opcode.PUSH0, b''),            # return False
         ]
 
-        jmp_bigger_substr = Opcode.get_jump_and_data(Opcode.JMP, get_bytes_count(return_false), True)
+        jmp_bigger_substr = OpcodeHelper.get_jump_and_data(Opcode.JMP, get_bytes_count(return_false), True)
         compare_starts[-1] = jmp_bigger_substr
 
         return (

--- a/boa3/model/builtin/classmethod/stripmethod.py
+++ b/boa3/model/builtin/classmethod/stripmethod.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.type.primitive.ibytestringtype import IByteStringType
 from boa3.model.variable import Variable
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
@@ -96,7 +97,7 @@ class StripMethod(IBuiltinMethod):
             # jump back to verify_if_index_gt_len_chars if not equal
         ]
 
-        jmp_back_to_verify_index = Opcode.get_jump_and_data(Opcode.JMPIFNOT,
+        jmp_back_to_verify_index = OpcodeHelper.get_jump_and_data(Opcode.JMPIFNOT,
                                                             -get_bytes_count(verify_if_char_in_chars +
                                                                              verify_if_index_gt_len_chars))
         verify_if_char_in_chars.append(jmp_back_to_verify_index)
@@ -108,7 +109,7 @@ class StripMethod(IBuiltinMethod):
             # jump back to verify_leading_chars
         ]
 
-        jmp_back_to_verify_leading_chars = Opcode.get_jump_and_data(Opcode.JMP,
+        jmp_back_to_verify_leading_chars = OpcodeHelper.get_jump_and_data(Opcode.JMP,
                                                                     -get_bytes_count(verify_leading_chars +
                                                                                      get_leading_char_at_index +
                                                                                      verify_if_index_gt_len_chars +
@@ -117,7 +118,7 @@ class StripMethod(IBuiltinMethod):
 
         leading_char_found.append(jmp_back_to_verify_leading_chars)
 
-        jmp_to_leading_chars = Opcode.get_jump_and_data(Opcode.JMPGE, get_bytes_count(verify_if_char_in_chars +
+        jmp_to_leading_chars = OpcodeHelper.get_jump_and_data(Opcode.JMPGE, get_bytes_count(verify_if_char_in_chars +
                                                                                       leading_char_found), True)
         verify_if_index_gt_len_chars[-1] = jmp_to_leading_chars
 
@@ -126,7 +127,7 @@ class StripMethod(IBuiltinMethod):
             (Opcode.DROP, b''),
         ]
 
-        jmp_to_leading_chars = Opcode.get_jump_and_data(Opcode.JMPGE, get_bytes_count(get_leading_char_at_index +
+        jmp_to_leading_chars = OpcodeHelper.get_jump_and_data(Opcode.JMPGE, get_bytes_count(get_leading_char_at_index +
                                                                                       verify_if_index_gt_len_chars +
                                                                                       verify_if_char_in_chars +
                                                                                       leading_char_found +
@@ -175,7 +176,7 @@ class StripMethod(IBuiltinMethod):
             # jump back to get_trailing_char_at_index
         ]
 
-        jmp_back_to_verify_trailing_chars = Opcode.get_jump_and_data(Opcode.JMP,
+        jmp_back_to_verify_trailing_chars = OpcodeHelper.get_jump_and_data(Opcode.JMP,
                                                                      -get_bytes_count(get_trailing_char_at_index +
                                                                                       trailing_char_found))
 
@@ -186,7 +187,7 @@ class StripMethod(IBuiltinMethod):
             (Opcode.DROP, b''),
         ]
 
-        jmp_to_strip_string = Opcode.get_jump_and_data(Opcode.JMPLE, get_bytes_count(get_trailing_char_at_index +
+        jmp_to_strip_string = OpcodeHelper.get_jump_and_data(Opcode.JMPLE, get_bytes_count(get_trailing_char_at_index +
                                                                                      trailing_char_found +
                                                                                      remove_extras), True)
         verify_trailing_chars[-1] = jmp_to_strip_string

--- a/boa3/model/builtin/classmethod/tobytesmethod.py
+++ b/boa3/model/builtin/classmethod/tobytesmethod.py
@@ -10,6 +10,7 @@ from boa3.model.type.primitive.bytestype import BytesType
 from boa3.model.type.primitive.inttype import IntType
 from boa3.model.type.primitive.strtype import StrType
 from boa3.model.variable import Variable
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
@@ -105,9 +106,9 @@ class IntToBytesMethod(ToBytesMethod):
             (Opcode.PUSHDATA1, Integer(len(number_zero_to_bytes)).to_byte_array() + number_zero_to_bytes),
         ]
 
-        number_is_not_zero[-1] = Opcode.get_jump_and_data(Opcode.JMP, get_bytes_count(number_is_zero))
+        number_is_not_zero[-1] = OpcodeHelper.get_jump_and_data(Opcode.JMP, get_bytes_count(number_is_zero))
 
-        verify_number_is_zero[-1] = Opcode.get_jump_and_data(Opcode.JMPIFNOT, get_bytes_count(number_is_not_zero))
+        verify_number_is_zero[-1] = OpcodeHelper.get_jump_and_data(Opcode.JMPIFNOT, get_bytes_count(number_is_not_zero))
 
         return (
             verify_number_is_zero +

--- a/boa3/model/builtin/classmethod/uppermethod.py
+++ b/boa3/model/builtin/classmethod/uppermethod.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.type.primitive.ibytestringtype import IByteStringType
 from boa3.model.variable import Variable
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
@@ -80,11 +81,11 @@ class UpperMethod(IBuiltinMethod):
             (Opcode.CONVERT, StackItemType.ByteString),
         ]
 
-        jmp_to_join_substring = Opcode.get_jump_and_data(Opcode.JMPLT, get_bytes_count(verify_greater_than_z +
+        jmp_to_join_substring = OpcodeHelper.get_jump_and_data(Opcode.JMPLT, get_bytes_count(verify_greater_than_z +
                                                                                        swap_lower_to_upper_case), True)
         get_substring_middle[-1] = jmp_to_join_substring
 
-        jmp_to_join_substring = Opcode.get_jump_and_data(Opcode.JMPGT, get_bytes_count(swap_lower_to_upper_case), True)
+        jmp_to_join_substring = OpcodeHelper.get_jump_and_data(Opcode.JMPGT, get_bytes_count(swap_lower_to_upper_case), True)
         verify_greater_than_z[-1] = jmp_to_join_substring
 
         get_substring_middle.extend(verify_greater_than_z)
@@ -111,7 +112,7 @@ class UpperMethod(IBuiltinMethod):
             # jump back to verify,
         ]
 
-        jmp_to_verify_while = Opcode.get_jump_and_data(Opcode.JMP, -get_bytes_count(verify_while +
+        jmp_to_verify_while = OpcodeHelper.get_jump_and_data(Opcode.JMP, -get_bytes_count(verify_while +
                                                                                     get_substring_left +
                                                                                     get_substring_middle +
                                                                                     get_substring_right +
@@ -130,7 +131,7 @@ class UpperMethod(IBuiltinMethod):
             join_substrings
         )
 
-        jmp_to_clean_stack = Opcode.get_jump_and_data(Opcode.JMPLE, get_bytes_count(while_body), True)
+        jmp_to_clean_stack = OpcodeHelper.get_jump_and_data(Opcode.JMPLE, get_bytes_count(while_body), True)
         verify_while[-1] = jmp_to_clean_stack
 
         return (

--- a/boa3/model/builtin/contract/neoaccountstatetype.py
+++ b/boa3/model/builtin/contract/neoaccountstatetype.py
@@ -8,6 +8,7 @@ from boa3.model.method import Method
 from boa3.model.property import Property
 from boa3.model.type.classes.classarraytype import ClassArrayType
 from boa3.model.variable import Variable
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
@@ -85,7 +86,7 @@ class NeoAccountStateMethod(IBuiltinMethod):
     def opcode(self) -> List[Tuple[Opcode, bytes]]:
         from boa3.model.type.collection.sequence.ecpointtype import ECPointType
         return [
-            Opcode.get_pushdata_and_data(ECPointType.build().default_value),  # vote_to
+            OpcodeHelper.get_pushdata_and_data(ECPointType.build().default_value),  # vote_to
             (Opcode.PUSH0, b''),  # height
             (Opcode.PUSH0, b''),  # balance
             (Opcode.PUSH3, b''),

--- a/boa3/model/builtin/interop/blockchain/witnessconditiontype.py
+++ b/boa3/model/builtin/interop/blockchain/witnessconditiontype.py
@@ -8,6 +8,7 @@ from boa3.model.method import Method
 from boa3.model.property import Property
 from boa3.model.type.classes.classarraytype import ClassArrayType
 from boa3.model.variable import Variable
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
@@ -83,7 +84,7 @@ class WitnessConditionMethod(IBuiltinMethod):
         from boa3.model.builtin.interop.blockchain.witnessconditionenumtype import WitnessConditionType as WitnessConditionEnum
 
         return [
-            Opcode.get_push_and_data(WitnessConditionEnum.build().default_value),  # type
+            OpcodeHelper.get_push_and_data(WitnessConditionEnum.build().default_value),  # type
             (Opcode.PUSH1, b''),
             (Opcode.PACK, b'')
         ]

--- a/boa3/model/builtin/interop/nativecontract/Neo/getneoscripthashmethod.py
+++ b/boa3/model/builtin/interop/nativecontract/Neo/getneoscripthashmethod.py
@@ -4,6 +4,7 @@ from boa3.constants import NEO_SCRIPT
 from boa3.model.builtin.builtinproperty import IBuiltinProperty
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.variable import Variable
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
@@ -26,7 +27,7 @@ class GetNeoScriptHashMethod(IBuiltinMethod):
     def opcode(self) -> List[Tuple[Opcode, bytes]]:
         value = NEO_SCRIPT
         return [
-            Opcode.get_pushdata_and_data(value)
+            OpcodeHelper.get_pushdata_and_data(value)
         ]
 
 

--- a/boa3/model/builtin/interop/runtime/getnotificationsmethod.py
+++ b/boa3/model/builtin/interop/runtime/getnotificationsmethod.py
@@ -5,6 +5,7 @@ from boa3.model import set_internal_call
 from boa3.model.builtin.interop.interopmethod import InteropMethod
 from boa3.model.builtin.interop.runtime.notificationtype import NotificationType
 from boa3.model.variable import Variable
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
@@ -47,7 +48,7 @@ class GetNotificationsMethod(InteropMethod):
         ]
 
         from boa3.compiler.codegenerator import get_bytes_count
-        jmp_to_convert = Opcode.get_jump_and_data(Opcode.JMPIFNOT, get_bytes_count(arg_is_not_null), True)
+        jmp_to_convert = OpcodeHelper.get_jump_and_data(Opcode.JMPIFNOT, get_bytes_count(arg_is_not_null), True)
         verify_arg_is_null[-1] = jmp_to_convert
 
         return (

--- a/boa3/model/builtin/math/decimalceil.py
+++ b/boa3/model/builtin/math/decimalceil.py
@@ -2,6 +2,7 @@ from typing import Dict, List, Optional, Tuple
 
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.variable import Variable
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
@@ -34,11 +35,11 @@ class DecimalCeilingMethod(IBuiltinMethod):
         decimals_unit = [
             (Opcode.OVER, b''),
             (Opcode.PUSH0, b''),
-            Opcode.get_jump_and_data(Opcode.JMPGE, get_bytes_count(if_negative_decimal), True),
+            OpcodeHelper.get_jump_and_data(Opcode.JMPGE, get_bytes_count(if_negative_decimal), True),
         ] + if_negative_decimal + [
             (Opcode.DUP, b''),
             (Opcode.REVERSE3, b''),
-            Opcode.get_push_and_data(10),
+            OpcodeHelper.get_push_and_data(10),
             (Opcode.SWAP, b''),
             (Opcode.POW, b''),
             (Opcode.SWAP, b''),
@@ -55,13 +56,13 @@ class DecimalCeilingMethod(IBuiltinMethod):
             (Opcode.NIP, b'')
         ]
         num_jmp_code = get_bytes_count(else_negative_mod)
-        if_negative_mod[-1] = Opcode.get_jump_and_data(Opcode.JMP, num_jmp_code, True)
+        if_negative_mod[-1] = OpcodeHelper.get_jump_and_data(Opcode.JMP, num_jmp_code, True)
 
         num_jmp_code = get_bytes_count(if_negative_mod)
         floor_computation = [
             (Opcode.DUP, b''),
             (Opcode.PUSH0, b''),
-            Opcode.get_jump_and_data(Opcode.JMPGE, num_jmp_code, True),
+            OpcodeHelper.get_jump_and_data(Opcode.JMPGE, num_jmp_code, True),
         ] + if_negative_mod + else_negative_mod + [
             (Opcode.ADD, b'')
         ]

--- a/boa3/model/builtin/math/decimalfloor.py
+++ b/boa3/model/builtin/math/decimalfloor.py
@@ -2,6 +2,7 @@ from typing import Dict, List, Optional, Tuple
 
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.variable import Variable
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
@@ -34,11 +35,11 @@ class DecimalFloorMethod(IBuiltinMethod):
         decimals_unit = [
             (Opcode.OVER, b''),
             (Opcode.PUSH0, b''),
-            Opcode.get_jump_and_data(Opcode.JMPGE, get_bytes_count(if_negative_decimal), True),
+            OpcodeHelper.get_jump_and_data(Opcode.JMPGE, get_bytes_count(if_negative_decimal), True),
         ] + if_negative_decimal + [
             (Opcode.DUP, b''),
             (Opcode.REVERSE3, b''),
-            Opcode.get_push_and_data(10),
+            OpcodeHelper.get_push_and_data(10),
             (Opcode.SWAP, b''),
             (Opcode.POW, b''),
             (Opcode.SWAP, b''),
@@ -54,13 +55,13 @@ class DecimalFloorMethod(IBuiltinMethod):
             (Opcode.NIP, b'')
         ]
         num_jmp_code = get_bytes_count(else_negative_mod)
-        if_negative_mod[-1] = Opcode.get_jump_and_data(Opcode.JMP, num_jmp_code, True)
+        if_negative_mod[-1] = OpcodeHelper.get_jump_and_data(Opcode.JMP, num_jmp_code, True)
 
         num_jmp_code = get_bytes_count(if_negative_mod)
         floor_computation = [
             (Opcode.DUP, b''),
             (Opcode.PUSH0, b''),
-            Opcode.get_jump_and_data(Opcode.JMPGE, num_jmp_code, True),
+            OpcodeHelper.get_jump_and_data(Opcode.JMPGE, num_jmp_code, True),
         ] + if_negative_mod + else_negative_mod + [
             (Opcode.SUB, b'')
         ]

--- a/boa3/model/builtin/method/boolmethod.py
+++ b/boa3/model/builtin/method/boolmethod.py
@@ -2,6 +2,7 @@ from typing import Dict, List, Optional, Tuple
 
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.variable import Variable
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
@@ -79,19 +80,19 @@ class BoolMethod(IBuiltinMethod):
         # region jump logic
 
         jump_instructions = collection_non_zero + non_zero
-        put_true[-1] = Opcode.get_jump_and_data(Opcode.JMP, get_bytes_count(jump_instructions), True)
+        put_true[-1] = OpcodeHelper.get_jump_and_data(Opcode.JMP, get_bytes_count(jump_instructions), True)
 
         jump_instructions = collection_non_zero + put_true
-        verify_is_bytestring[-1] = Opcode.get_jump_and_data(Opcode.JMPIF, get_bytes_count(jump_instructions), True)
+        verify_is_bytestring[-1] = OpcodeHelper.get_jump_and_data(Opcode.JMPIF, get_bytes_count(jump_instructions), True)
 
         jump_instructions = collection_non_zero + put_true + verify_is_bytestring
-        verify_is_int[-1] = Opcode.get_jump_and_data(Opcode.JMPIF, get_bytes_count(jump_instructions), True)
+        verify_is_int[-1] = OpcodeHelper.get_jump_and_data(Opcode.JMPIF, get_bytes_count(jump_instructions), True)
 
         jump_instructions = put_true + verify_is_int + verify_is_bytestring
-        verify_is_map[-1] = Opcode.get_jump_and_data(Opcode.JMPIF, get_bytes_count(jump_instructions), True)
+        verify_is_map[-1] = OpcodeHelper.get_jump_and_data(Opcode.JMPIF, get_bytes_count(jump_instructions), True)
 
         jump_instructions = verify_is_map + verify_is_int + verify_is_bytestring + put_true
-        verify_is_array[-1] = Opcode.get_jump_and_data(Opcode.JMPIF, get_bytes_count(jump_instructions), True)
+        verify_is_array[-1] = OpcodeHelper.get_jump_and_data(Opcode.JMPIF, get_bytes_count(jump_instructions), True)
 
         jump_instructions = (
             verify_is_array +
@@ -102,10 +103,10 @@ class BoolMethod(IBuiltinMethod):
             collection_non_zero +
             non_zero
         )
-        value_is_none[-1] = Opcode.get_jump_and_data(Opcode.JMP, get_bytes_count(jump_instructions), True)
+        value_is_none[-1] = OpcodeHelper.get_jump_and_data(Opcode.JMP, get_bytes_count(jump_instructions), True)
 
         jump_instructions = value_is_none
-        verify_is_none[-1] = Opcode.get_jump_and_data(Opcode.JMPIFNOT, get_bytes_count(jump_instructions), True)
+        verify_is_none[-1] = OpcodeHelper.get_jump_and_data(Opcode.JMPIFNOT, get_bytes_count(jump_instructions), True)
 
         # endregion
 

--- a/boa3/model/builtin/method/ecpointmethod.py
+++ b/boa3/model/builtin/method/ecpointmethod.py
@@ -6,6 +6,7 @@ from boa3.model.expression import IExpression
 from boa3.model.type.collection.sequence.ecpointtype import ECPointType
 from boa3.model.type.itype import IType
 from boa3.model.variable import Variable
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
@@ -60,14 +61,14 @@ class ECPointMethod(IBuiltinMethod):
             (Opcode.DUP, b''),
             (Opcode.SIZE, b''),
             (Opcode.PUSHINT8, Integer(ECPOINT_SIZE).to_byte_array(signed=True)),
-            Opcode.get_jump_and_data(Opcode.JMPEQ, get_bytes_count(throw_if_invalid), jump_through=True),
+            OpcodeHelper.get_jump_and_data(Opcode.JMPEQ, get_bytes_count(throw_if_invalid), jump_through=True),
         ]
 
         return [
             (Opcode.CONVERT, StackItemType.ByteString),  # convert to ECPoint
             (Opcode.DUP, b''),
             (Opcode.ISNULL, b''),
-            Opcode.get_jump_and_data(Opcode.JMPIF, get_bytes_count(check_bytestr_size), jump_through=True),
+            OpcodeHelper.get_jump_and_data(Opcode.JMPIF, get_bytes_count(check_bytestr_size), jump_through=True),
         ] + check_bytestr_size + throw_if_invalid
 
     @property

--- a/boa3/model/builtin/method/ecpointtoscripthashmethod.py
+++ b/boa3/model/builtin/method/ecpointtoscripthashmethod.py
@@ -3,6 +3,7 @@ from typing import List, Tuple
 from boa3.model.builtin.method import ScriptHashMethod
 from boa3.model.type.collection.sequence.ecpointtype import ECPointType
 from boa3.model.type.type import IType
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
@@ -24,28 +25,28 @@ class ECPointToScriptHashMethod(ScriptHashMethod):
         from boa3.model.type.type import Type
 
         # build CheckSig script
-        pushdata, pushbytes = Opcode.get_pushdata_and_data_from_size(constants.SIZE_OF_ECPOINT)
+        pushdata, pushbytes = OpcodeHelper.get_pushdata_and_data_from_size(constants.SIZE_OF_ECPOINT)
         opcodes = [
-            Opcode.get_pushdata_and_data(pushdata + pushbytes),
+            OpcodeHelper.get_pushdata_and_data(pushdata + pushbytes),
             (Opcode.SWAP, b''),
-            Opcode.get_pushdata_and_data(CheckSigMethod.get_raw_bytes()),
+            OpcodeHelper.get_pushdata_and_data(CheckSigMethod.get_raw_bytes()),
             (Opcode.CAT, b''),
             (Opcode.CAT, b''),
         ]
 
-        opcodes.extend([Opcode.get_push_and_data(1),  # pack argument to call syscall
+        opcodes.extend([OpcodeHelper.get_push_and_data(1),  # pack argument to call syscall
                         (Opcode.PACK, b'')
                         ] + Sha256Method().opcode
                        )
-        opcodes.extend([Opcode.get_push_and_data(1),  # pack argument to call syscall
+        opcodes.extend([OpcodeHelper.get_push_and_data(1),  # pack argument to call syscall
                         (Opcode.PACK, b'')
                         ] + Ripemd160Method().opcode
                        )
 
         opcodes.extend([
             # limit result to UInt160 length
-            Opcode.get_push_and_data(0),
-            Opcode.get_push_and_data(constants.SIZE_OF_INT160),
+            OpcodeHelper.get_push_and_data(0),
+            OpcodeHelper.get_push_and_data(constants.SIZE_OF_INT160),
             (Opcode.SUBSTR, b''),
             (Opcode.CONVERT, Type.bytes.stack_item)
         ])

--- a/boa3/model/builtin/method/intbytestringmethod.py
+++ b/boa3/model/builtin/method/intbytestringmethod.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Tuple
 
 from boa3.model.builtin.method.intmethod import IntMethod
 from boa3.model.variable import Variable
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
@@ -40,7 +41,7 @@ class IntByteStringMethod(IntMethod):
 
         verify_base_ge37 = [    # verifies if base >= 37, base greater than 36 shouldn't be accepted
             (Opcode.OVER, b''),
-            Opcode.get_push_and_data(37),
+            OpcodeHelper.get_push_and_data(37),
             jmp_place_holder,   # jumps to an assertion error
         ]
 
@@ -68,16 +69,16 @@ class IntByteStringMethod(IntMethod):
         # region verify_base jump logic
 
         jump_instructions = verify_base_error
-        verify_base_jump_error[-1] = Opcode.get_jump_and_data(Opcode.JMP, get_bytes_count(jump_instructions), True)
+        verify_base_jump_error[-1] = OpcodeHelper.get_jump_and_data(Opcode.JMP, get_bytes_count(jump_instructions), True)
 
         jump_instructions = verify_base_jump_error
-        verify_base_le_minus1[-1] = Opcode.get_jump_and_data(Opcode.JMPLE, get_bytes_count(jump_instructions), True)
+        verify_base_le_minus1[-1] = OpcodeHelper.get_jump_and_data(Opcode.JMPLE, get_bytes_count(jump_instructions), True)
 
         jump_instructions = verify_base_jump_error + verify_base_le_minus1
-        verify_base_equal1[-1] = Opcode.get_jump_and_data(Opcode.JMPEQ, get_bytes_count(jump_instructions), True)
+        verify_base_equal1[-1] = OpcodeHelper.get_jump_and_data(Opcode.JMPEQ, get_bytes_count(jump_instructions), True)
 
         jump_instructions = verify_base_jump_error + verify_base_le_minus1 + verify_base_equal1
-        verify_base_ge37[-1] = Opcode.get_jump_and_data(Opcode.JMPGE, get_bytes_count(jump_instructions), True)
+        verify_base_ge37[-1] = OpcodeHelper.get_jump_and_data(Opcode.JMPGE, get_bytes_count(jump_instructions), True)
 
         # endregion
 
@@ -99,7 +100,7 @@ class IntByteStringMethod(IntMethod):
             (Opcode.PUSH1, b''),
             (Opcode.SUBSTR, b''),
             (Opcode.CONVERT, StackItemType.ByteString),
-            Opcode.get_pushdata_and_data('0'),
+            OpcodeHelper.get_pushdata_and_data('0'),
             jmp_place_holder,                       # if first char is not 0, skip all verify_code_literal methods
         ]
 
@@ -148,7 +149,7 @@ class IntByteStringMethod(IntMethod):
             verify_code_literal_drop_aux
         )
 
-        verify_code_literal_first_char_is_0[-1] = Opcode.get_jump_and_data(Opcode.JMPNE_L,
+        verify_code_literal_first_char_is_0[-1] = OpcodeHelper.get_jump_and_data(Opcode.JMPNE_L,
                                                                            get_bytes_count(jump_instructions), True)
 
         # endregion
@@ -190,7 +191,7 @@ class IntByteStringMethod(IntMethod):
 
         ascii_to_int_verify_az_lower_lt = [     # verifies ord(char) is less than ord('a')
             (Opcode.DUP, b''),                  # if ord(char) is indeed less, go to verify with ord('A')
-            Opcode.get_push_and_data(a_lower),
+            OpcodeHelper.get_push_and_data(a_lower),
             jmp_place_holder                    # jump to ascii_to_int_verify_az_upper_lt
         ]
 
@@ -198,14 +199,14 @@ class IntByteStringMethod(IntMethod):
             (Opcode.DUP, b''),                  # the minimum base that accepts letters is base 11, that's why it's
             (Opcode.PUSH6, b''),                # adding 86
             (Opcode.PICK, b''),                 # if ord(char) is greater than base + 86, the char is invalid
-            Opcode.get_push_and_data(86),
+            OpcodeHelper.get_push_and_data(86),
             (Opcode.ADD, b''),
             (Opcode.LE, b''),
             (Opcode.ASSERT, b''),               # if assert is False, then the char was indeed invalid
         ]
 
         ascii_to_int_verify_az_lower = [        # the char was in between 'a' and 'z',
-            Opcode.get_push_and_data(87),       # so it will be converted to the respective base 10 number
+            OpcodeHelper.get_push_and_data(87),       # so it will be converted to the respective base 10 number
             (Opcode.SUB, b''),
             (Opcode.OVER, b''),
             (Opcode.MUL, b''),
@@ -219,7 +220,7 @@ class IntByteStringMethod(IntMethod):
 
         ascii_to_int_verify_az_upper_lt = [     # verifies ord(char) is less than ord('A')
             (Opcode.DUP, b''),                  # if ord(char) is indeed less, go to verify with ord('0')
-            Opcode.get_push_and_data(a_upper),
+            OpcodeHelper.get_push_and_data(a_upper),
             jmp_place_holder                    # jump to ascii_to_int_verify_09_lt
         ]
 
@@ -227,14 +228,14 @@ class IntByteStringMethod(IntMethod):
             (Opcode.DUP, b''),                  # the minimum base that accepts letters is base 11, that's why it's
             (Opcode.PUSH6, b''),                # adding 54
             (Opcode.PICK, b''),                 # if ord(char) is greater than base + 54, the char is invalid
-            Opcode.get_push_and_data(54),
+            OpcodeHelper.get_push_and_data(54),
             (Opcode.ADD, b''),
             (Opcode.LE, b''),
             (Opcode.ASSERT, b''),               # if assert is False, then the char was indeed invalid
         ]
 
         ascii_to_int_verify_az_upper = [        # the char was in between 'A' and 'Z',
-            Opcode.get_push_and_data(55),       # so it will be converted to the respective base 10 number
+            OpcodeHelper.get_push_and_data(55),       # so it will be converted to the respective base 10 number
             (Opcode.SUB, b''),
             (Opcode.OVER, b''),
             (Opcode.MUL, b''),
@@ -248,7 +249,7 @@ class IntByteStringMethod(IntMethod):
 
         ascii_to_int_verify_09_lt = [           # verifies ord(char) is less than ord('0')
             (Opcode.DUP, b''),                  # if ord(char) is indeed less, the char is invalid
-            Opcode.get_push_and_data(zero),
+            OpcodeHelper.get_push_and_data(zero),
             (Opcode.GE, b''),
             (Opcode.ASSERT, b''),               # if assert is False, then the char was indeed invalid
         ]
@@ -257,14 +258,14 @@ class IntByteStringMethod(IntMethod):
             (Opcode.DUP, b''),                  # if ord(char) is greater than base + ord('0'), the char is invalid
             (Opcode.PUSH6, b''),
             (Opcode.PICK, b''),
-            Opcode.get_push_and_data(zero),
+            OpcodeHelper.get_push_and_data(zero),
             (Opcode.ADD, b''),
             (Opcode.LE, b''),
             (Opcode.ASSERT, b''),               # if assert is False, then the char was indeed invalid
         ]
 
         ascii_to_int_verify_09 = [              # the char was in between '0' and '9',
-            Opcode.get_push_and_data(zero),     # so it will be converted to the respective base 10 number
+            OpcodeHelper.get_push_and_data(zero),     # so it will be converted to the respective base 10 number
             (Opcode.SUB, b''),
             (Opcode.OVER, b''),
             (Opcode.MUL, b''),
@@ -296,7 +297,7 @@ class IntByteStringMethod(IntMethod):
             ascii_to_int_verify_09
         )
 
-        ascii_to_int_verify_az_upper[-1] = Opcode.get_jump_and_data(Opcode.JMP,
+        ascii_to_int_verify_az_upper[-1] = OpcodeHelper.get_jump_and_data(Opcode.JMP,
                                                                     get_bytes_count(jump_instructions), True)
 
         jump_instructions = (
@@ -304,7 +305,7 @@ class IntByteStringMethod(IntMethod):
             ascii_to_int_verify_az_upper
         )
 
-        ascii_to_int_verify_az_upper_lt[-1] = Opcode.get_jump_and_data(Opcode.JMPLT,
+        ascii_to_int_verify_az_upper_lt[-1] = OpcodeHelper.get_jump_and_data(Opcode.JMPLT,
                                                                        get_bytes_count(jump_instructions), True)
 
         jump_instructions = (
@@ -316,7 +317,7 @@ class IntByteStringMethod(IntMethod):
             ascii_to_int_verify_09
         )
 
-        ascii_to_int_verify_az_lower[-1] = Opcode.get_jump_and_data(Opcode.JMP,
+        ascii_to_int_verify_az_lower[-1] = OpcodeHelper.get_jump_and_data(Opcode.JMP,
                                                                     get_bytes_count(jump_instructions), True)
 
         jump_instructions = (
@@ -324,7 +325,7 @@ class IntByteStringMethod(IntMethod):
             ascii_to_int_verify_az_lower
         )
 
-        ascii_to_int_verify_az_lower_lt[-1] = Opcode.get_jump_and_data(Opcode.JMPLT,
+        ascii_to_int_verify_az_lower_lt[-1] = OpcodeHelper.get_jump_and_data(Opcode.JMPLT,
                                                                        get_bytes_count(jump_instructions), True)
 
         jump_instructions = (
@@ -341,7 +342,7 @@ class IntByteStringMethod(IntMethod):
             ascii_to_int_verify_while
         )
 
-        ascii_to_int_verify_while.append(Opcode.get_jump_and_data(Opcode.JMPGE,
+        ascii_to_int_verify_while.append(OpcodeHelper.get_jump_and_data(Opcode.JMPGE,
                                                                   -get_bytes_count(jump_instructions), True))
 
         # endregion
@@ -397,7 +398,7 @@ class IntByteStringMethod(IntMethod):
 
         compare_char = [            # compares the char with b, B, o, O, x, or X
             (Opcode.DUP, b''),
-            Opcode.get_pushdata_and_data(char),
+            OpcodeHelper.get_pushdata_and_data(char),
             jmp_place_holder
         ]
 
@@ -410,7 +411,7 @@ class IntByteStringMethod(IntMethod):
         verify_base_is_the_same = [     # verify if the equivalent base is the same as current base
             (Opcode.PUSH2, b''),
             (Opcode.PICK, b''),
-            Opcode.get_push_and_data(base),
+            OpcodeHelper.get_push_and_data(base),
             jmp_place_holder            # jump to remove_base_char if equivalent base is the same as current base
         ]
 
@@ -424,7 +425,7 @@ class IntByteStringMethod(IntMethod):
         change_base = [                 # if base was 0, then change it to the equivalent base
             (Opcode.REVERSE3, b''),
             (Opcode.DROP, b''),
-            Opcode.get_push_and_data(base),
+            OpcodeHelper.get_push_and_data(base),
             (Opcode.REVERSE3, b''),
         ]
 
@@ -446,16 +447,16 @@ class IntByteStringMethod(IntMethod):
         # region jmp logic
 
         jump_instructions = change_base + remove_base_char
-        verify_base_is_0[-1] = Opcode.get_jump_and_data(Opcode.JMPNE, get_bytes_count(jump_instructions), True)
+        verify_base_is_0[-1] = OpcodeHelper.get_jump_and_data(Opcode.JMPNE, get_bytes_count(jump_instructions), True)
 
         jump_instructions = change_base + verify_base_is_0
-        verify_base_is_the_same[-1] = Opcode.get_jump_and_data(Opcode.JMPEQ, get_bytes_count(jump_instructions), True)
+        verify_base_is_the_same[-1] = OpcodeHelper.get_jump_and_data(Opcode.JMPEQ, get_bytes_count(jump_instructions), True)
 
         jump_instructions = change_base + remove_base_char + put_true_in_stack + verify_base_is_0 + verify_base_is_the_same
-        char_not_equal[-1] = Opcode.get_jump_and_data(Opcode.JMP, get_bytes_count(jump_instructions), True)
+        char_not_equal[-1] = OpcodeHelper.get_jump_and_data(Opcode.JMP, get_bytes_count(jump_instructions), True)
 
         jump_instructions = char_not_equal
-        compare_char[-1] = Opcode.get_jump_and_data(Opcode.JMPEQ, get_bytes_count(jump_instructions), True)
+        compare_char[-1] = OpcodeHelper.get_jump_and_data(Opcode.JMPEQ, get_bytes_count(jump_instructions), True)
 
         jump_instructions = (
             compare_char +
@@ -466,10 +467,10 @@ class IntByteStringMethod(IntMethod):
             verify_base_is_0 +
             remove_base_char
         )
-        top_stack_is_true[-1] = Opcode.get_jump_and_data(Opcode.JMP, get_bytes_count(jump_instructions), True)
+        top_stack_is_true[-1] = OpcodeHelper.get_jump_and_data(Opcode.JMP, get_bytes_count(jump_instructions), True)
 
         jump_instructions = top_stack_is_true
-        verify_top_stack[-1] = Opcode.get_jump_and_data(Opcode.JMPIFNOT, get_bytes_count(jump_instructions), True)
+        verify_top_stack[-1] = OpcodeHelper.get_jump_and_data(Opcode.JMPIFNOT, get_bytes_count(jump_instructions), True)
 
         # endregion
 

--- a/boa3/model/builtin/method/listbytesstringmethod.py
+++ b/boa3/model/builtin/method/listbytesstringmethod.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Tuple
 from boa3.model.builtin.method.listmethod import ListMethod
 from boa3.model.type.itype import IType
 from boa3.model.variable import Variable
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
@@ -62,7 +63,7 @@ class ListBytesStringMethod(ListMethod):
             ]
 
             num_jmp_code = -get_bytes_count(verify_loop_end + loop_for_char_or_byte)
-            jmp_to_dec_statement = Opcode.get_jump_and_data(Opcode.JMPGE, num_jmp_code)
+            jmp_to_dec_statement = OpcodeHelper.get_jump_and_data(Opcode.JMPGE, num_jmp_code)
             verify_loop_end.append(jmp_to_dec_statement)
 
             self._prepare_for_packing = (

--- a/boa3/model/builtin/method/listgenericmethod.py
+++ b/boa3/model/builtin/method/listgenericmethod.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Tuple
 from boa3.model.builtin.method.listmethod import ListMethod
 from boa3.model.type.itype import IType
 from boa3.model.variable import Variable
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
@@ -93,28 +94,28 @@ class ListGenericMethod(ListMethod):
             ]
 
             num_jmp_code = get_bytes_count(invalid_value)
-            jmp_to_end_from_mapping = Opcode.get_jump_and_data(Opcode.JMP, num_jmp_code, True)
+            jmp_to_end_from_mapping = OpcodeHelper.get_jump_and_data(Opcode.JMP, num_jmp_code, True)
             pre_packing_mapping.append(jmp_to_end_from_mapping)
 
             num_jmp_code = get_bytes_count(pre_packing_mapping)
-            jmp_prepare_mapping = Opcode.get_jump_and_data(Opcode.JMPIFNOT, num_jmp_code, True)
+            jmp_prepare_mapping = OpcodeHelper.get_jump_and_data(Opcode.JMPIFNOT, num_jmp_code, True)
             verify_is_mapping.append(jmp_prepare_mapping)
 
             num_jmp_code = get_bytes_count(invalid_value + pre_packing_mapping + verify_is_mapping)
-            jmp_to_end_from_sequence = Opcode.get_jump_and_data(Opcode.JMP, num_jmp_code, True)
+            jmp_to_end_from_sequence = OpcodeHelper.get_jump_and_data(Opcode.JMP, num_jmp_code, True)
             pre_packing_sequence.append(jmp_to_end_from_sequence)
 
             num_jmp_code = get_bytes_count(pre_packing_sequence)
-            jmp_prepare_sequence = Opcode.get_jump_and_data(Opcode.JMPIFNOT, num_jmp_code, True)
+            jmp_prepare_sequence = OpcodeHelper.get_jump_and_data(Opcode.JMPIFNOT, num_jmp_code, True)
             verify_is_sequence.append(jmp_prepare_sequence)
 
             num_jmp_code = get_bytes_count(invalid_value + pre_packing_mapping + verify_is_mapping +
                                            pre_packing_sequence + verify_is_sequence)
-            jmp_to_end_from_bytes_string = Opcode.get_jump_and_data(Opcode.JMP, num_jmp_code, True)
+            jmp_to_end_from_bytes_string = OpcodeHelper.get_jump_and_data(Opcode.JMP, num_jmp_code, True)
             pre_packing_bytes_string.append(jmp_to_end_from_bytes_string)
 
             num_jmp_code = get_bytes_count(pre_packing_bytes_string)
-            jmp_prepare_bytes_string = Opcode.get_jump_and_data(Opcode.JMPIFNOT, num_jmp_code, True)
+            jmp_prepare_bytes_string = OpcodeHelper.get_jump_and_data(Opcode.JMPIFNOT, num_jmp_code, True)
             verify_is_bytes_string.append(jmp_prepare_bytes_string)
 
             self._prepare_for_packing = (

--- a/boa3/model/builtin/method/maxmethod.py
+++ b/boa3/model/builtin/method/maxmethod.py
@@ -6,6 +6,7 @@ from boa3.model.type.collection.sequence.sequencetype import SequenceType
 from boa3.model.type.collection.sequence.tupletype import TupleType
 from boa3.model.type.itype import IType
 from boa3.model.variable import Variable
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
@@ -75,10 +76,10 @@ class MaxMethod(IBuiltinMethod):
             (Opcode.PUSH2, b'')
         ]
 
-        jmp_n_parameters_eq_2 = Opcode.get_jump_and_data(Opcode.JMP, get_bytes_count(if_n_parameters_eq_2), True)
+        jmp_n_parameters_eq_2 = OpcodeHelper.get_jump_and_data(Opcode.JMP, get_bytes_count(if_n_parameters_eq_2), True)
         if_n_parameters_gt_2[-1] = jmp_n_parameters_eq_2
 
-        jmp_n_parameters_gt_2 = Opcode.get_jump_and_data(Opcode.JMPEQ, get_bytes_count(if_n_parameters_gt_2))
+        jmp_n_parameters_gt_2 = OpcodeHelper.get_jump_and_data(Opcode.JMPEQ, get_bytes_count(if_n_parameters_gt_2))
         verify_number_of_parameters[-1] = jmp_n_parameters_gt_2
 
         repack_array = [        # pack all the arguments in the array

--- a/boa3/model/builtin/method/minbytestringmethod.py
+++ b/boa3/model/builtin/method/minbytestringmethod.py
@@ -3,6 +3,7 @@ from typing import List, Optional, Tuple
 from boa3.compiler.codegenerator import get_bytes_count
 from boa3.model.builtin.method.minmethod import MinMethod
 from boa3.model.type.itype import IType
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
@@ -22,7 +23,7 @@ class MinByteStringMethod(MinMethod):
             (Opcode.OVER, b''),
             (Opcode.OVER, b''),
             (Opcode.EQUAL, b''),  # if str1 == str2:
-            Opcode.get_jump_and_data(Opcode.JMPIFNOT, 4),
+            OpcodeHelper.get_jump_and_data(Opcode.JMPIFNOT, 4),
             (Opcode.PUSH1, b''),
             jmp_place_holder,     # go to final test
         ]
@@ -38,12 +39,12 @@ class MinByteStringMethod(MinMethod):
 
         while_body_before_compare = [
             (Opcode.PUSH3, b''),  # value1 = str1[index]
-            (Opcode.get_dup(3), b''),
+            (OpcodeHelper.get_dup(3), b''),
             (Opcode.OVER, b''),
             (Opcode.PICKITEM, b''),
             (Opcode.OVER, b''),
             (Opcode.PUSH4, b''),  # value2 = str2[index]
-            (Opcode.get_dup(4), b''),
+            (OpcodeHelper.get_dup(4), b''),
             (Opcode.SWAP, b''),
             (Opcode.PICKITEM, b''),
         ]
@@ -65,7 +66,7 @@ class MinByteStringMethod(MinMethod):
         while_full_body = while_body_before_compare + while_body_compare + while_body_after_compare
         while_bytes_size = get_bytes_count(while_full_body)
         get_limit_index.append(
-            Opcode.get_jump_and_data(Opcode.JMP, while_bytes_size, True)
+            OpcodeHelper.get_jump_and_data(Opcode.JMP, while_bytes_size, True)
         )
 
         while_condition = [
@@ -73,7 +74,7 @@ class MinByteStringMethod(MinMethod):
             (Opcode.OVER, b'')
         ]
         while_condition_bytes_size = get_bytes_count(while_condition)
-        while_condition.append(Opcode.get_jump_and_data(Opcode.JMPGT, -while_bytes_size - while_condition_bytes_size))
+        while_condition.append(OpcodeHelper.get_jump_and_data(Opcode.JMPGT, -while_bytes_size - while_condition_bytes_size))
 
         while_else_body = [
             (Opcode.DROP, b''),
@@ -86,14 +87,14 @@ class MinByteStringMethod(MinMethod):
         ]
 
         everything_after_while_check = while_body_after_compare + while_condition + while_else_body
-        jmp_while_check = Opcode.get_jump_and_data(Opcode.JMP, get_bytes_count(everything_after_while_check), True)
+        jmp_while_check = OpcodeHelper.get_jump_and_data(Opcode.JMP, get_bytes_count(everything_after_while_check), True)
         while_body_compare[-1] = jmp_while_check
 
         everything_after_equal_check = (get_limit_index +
                                         while_body_before_compare +
                                         while_body_compare +
                                         everything_after_while_check)
-        jmp_test_equal = Opcode.get_jump_and_data(Opcode.JMP, get_bytes_count(everything_after_equal_check), True)
+        jmp_test_equal = OpcodeHelper.get_jump_and_data(Opcode.JMP, get_bytes_count(everything_after_equal_check), True)
         test_if_are_equal[-1] = jmp_test_equal
 
         final_test = [

--- a/boa3/model/builtin/method/minmethod.py
+++ b/boa3/model/builtin/method/minmethod.py
@@ -6,6 +6,7 @@ from boa3.model.type.collection.sequence.sequencetype import SequenceType
 from boa3.model.type.collection.sequence.tupletype import TupleType
 from boa3.model.type.itype import IType
 from boa3.model.variable import Variable
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
@@ -76,10 +77,10 @@ class MinMethod(IBuiltinMethod):
             (Opcode.PUSH2, b'')
         ]
 
-        jmp_n_parameters_eq_2 = Opcode.get_jump_and_data(Opcode.JMP, get_bytes_count(if_n_parameters_eq_2), True)
+        jmp_n_parameters_eq_2 = OpcodeHelper.get_jump_and_data(Opcode.JMP, get_bytes_count(if_n_parameters_eq_2), True)
         if_n_parameters_gt_2[-1] = jmp_n_parameters_eq_2
 
-        jmp_n_parameters_gt_2 = Opcode.get_jump_and_data(Opcode.JMPEQ, get_bytes_count(if_n_parameters_gt_2))
+        jmp_n_parameters_gt_2 = OpcodeHelper.get_jump_and_data(Opcode.JMPEQ, get_bytes_count(if_n_parameters_gt_2))
         verify_number_of_parameters[-1] = jmp_n_parameters_gt_2
 
         repack_array = [  # pack all the arguments in the array

--- a/boa3/model/builtin/method/printboolmethod.py
+++ b/boa3/model/builtin/method/printboolmethod.py
@@ -1,6 +1,7 @@
 from typing import List, Tuple
 
 from boa3.model.builtin.method.printmethod import PrintMethod
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
@@ -17,17 +18,17 @@ class PrintBoolMethod(PrintMethod):
         if self._print_value_opcodes is None:
             from boa3.compiler.codegenerator import get_bytes_count
             if_value_is_true = [
-                Opcode.get_pushdata_and_data('True')
+                OpcodeHelper.get_pushdata_and_data('True')
             ]
             if_value_is_false = [
-                Opcode.get_pushdata_and_data('False'),
-                Opcode.get_jump_and_data(Opcode.JMP, get_bytes_count(if_value_is_true), jump_through=True)
+                OpcodeHelper.get_pushdata_and_data('False'),
+                OpcodeHelper.get_jump_and_data(Opcode.JMP, get_bytes_count(if_value_is_true), jump_through=True)
             ]
 
             self._print_value_opcodes = (
                 [
                     (Opcode.NZ, b''),
-                    Opcode.get_jump_and_data(Opcode.JMPIF, get_bytes_count(if_value_is_false), jump_through=True),
+                    OpcodeHelper.get_jump_and_data(Opcode.JMPIF, get_bytes_count(if_value_is_false), jump_through=True),
                 ] + if_value_is_false
                 + if_value_is_true
             )

--- a/boa3/model/builtin/method/printintmethod.py
+++ b/boa3/model/builtin/method/printintmethod.py
@@ -1,6 +1,7 @@
 from typing import List, Tuple
 
 from boa3.model.builtin.method.printmethod import PrintMethod
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
@@ -19,7 +20,7 @@ class PrintIntMethod(PrintMethod):
             itoa_method = Interop.Itoa
             self._print_value_opcodes = (
                 [
-                    Opcode.get_push_and_data(1),
+                    OpcodeHelper.get_push_and_data(1),
                     (Opcode.PACK, b'')
                 ] +
                 itoa_method.opcode.copy()

--- a/boa3/model/builtin/method/reversedmethod.py
+++ b/boa3/model/builtin/method/reversedmethod.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple
 from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.model.type.collection.sequence.sequencetype import SequenceType
 from boa3.model.variable import Variable
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
@@ -89,10 +90,10 @@ class ReversedMethod(IBuiltinMethod):
             # returns to beginning of the while to verify if it index < limit
         ]
 
-        jmp_back_to_while_statement = Opcode.get_jump_and_data(Opcode.JMP, -get_bytes_count(while_body + while_statement))
+        jmp_back_to_while_statement = OpcodeHelper.get_jump_and_data(Opcode.JMP, -get_bytes_count(while_body + while_statement))
         while_body.append(jmp_back_to_while_statement)
 
-        jmp_to_break_body = Opcode.get_jump_and_data(Opcode.JMPIFNOT, get_bytes_count(while_body), True)
+        jmp_to_break_body = OpcodeHelper.get_jump_and_data(Opcode.JMPIFNOT, get_bytes_count(while_body), True)
         while_statement[-1] = jmp_to_break_body
 
         break_opcode = [        # remove auxiliary values from stack after leaving `while`
@@ -107,12 +108,12 @@ class ReversedMethod(IBuiltinMethod):
             (Opcode.PACK, b''),
         ]
 
-        jmp_else_body = Opcode.get_jump_and_data(Opcode.JMP, get_bytes_count(else_body), True)
+        jmp_else_body = OpcodeHelper.get_jump_and_data(Opcode.JMP, get_bytes_count(else_body), True)
         break_opcode.append(jmp_else_body)
 
         if_true_body = if_true_body + while_statement + while_body + break_opcode
 
-        jmp_if_true_body = Opcode.get_jump_and_data(Opcode.JMPIFNOT, get_bytes_count(if_true_body))
+        jmp_if_true_body = OpcodeHelper.get_jump_and_data(Opcode.JMPIFNOT, get_bytes_count(if_true_body))
         if_statement.append(jmp_if_true_body)
 
         reverse_array = [   # reverse the array

--- a/boa3/model/builtin/method/strboolmethod.py
+++ b/boa3/model/builtin/method/strboolmethod.py
@@ -2,6 +2,7 @@ from typing import Dict, List, Tuple
 
 from boa3.model.builtin.method.strmethod import StrMethod
 from boa3.model.variable import Variable
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.String import String
@@ -38,10 +39,10 @@ class StrBoolMethod(StrMethod):
             (Opcode.PUSHDATA1, Integer(len(true)).to_byte_array(signed=True, min_length=1) + true),
         ]
 
-        jmp_put_true = Opcode.get_jump_and_data(Opcode.JMP, get_bytes_count(put_true))
+        jmp_put_true = OpcodeHelper.get_jump_and_data(Opcode.JMP, get_bytes_count(put_true))
         put_false[-1] = jmp_put_true
 
-        jmp_put_false = Opcode.get_jump_and_data(Opcode.JMPIF, get_bytes_count(put_false))
+        jmp_put_false = OpcodeHelper.get_jump_and_data(Opcode.JMPIF, get_bytes_count(put_false))
         check_is_true[-1] = jmp_put_false
 
         return (

--- a/boa3/model/builtin/method/strsplitmethod.py
+++ b/boa3/model/builtin/method/strsplitmethod.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Tuple
 
 from boa3.model.builtin.interop.nativecontract import StdLibMethod
 from boa3.model.variable import Variable
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
@@ -76,15 +77,15 @@ class StrSplitMethod(StdLibMethod):
         ]
 
         num_jmp_code = -get_bytes_count(while_verify + concatenate_array)
-        jmp_back_to_while = Opcode.get_jump_and_data(Opcode.JMP, num_jmp_code)
+        jmp_back_to_while = OpcodeHelper.get_jump_and_data(Opcode.JMP, num_jmp_code)
         concatenate_array.append(jmp_back_to_while)
 
         num_jmp_code = get_bytes_count(while_verify + concatenate_array)
-        jmp_to_clean_from_verify_maxsplit = Opcode.get_jump_and_data(Opcode.JMPLE, num_jmp_code, True)
+        jmp_to_clean_from_verify_maxsplit = OpcodeHelper.get_jump_and_data(Opcode.JMPLE, num_jmp_code, True)
         verify_maxsplit[-1] = jmp_to_clean_from_verify_maxsplit
 
         num_jmp_code = get_bytes_count(concatenate_array)
-        jmp_to_clean_from_while_verify = Opcode.get_jump_and_data(Opcode.JMPLE, num_jmp_code, True)
+        jmp_to_clean_from_while_verify = OpcodeHelper.get_jump_and_data(Opcode.JMPLE, num_jmp_code, True)
         while_verify[-1] = jmp_to_clean_from_while_verify
 
         clean_stack = [

--- a/boa3/model/imports/builtin.py
+++ b/boa3/model/imports/builtin.py
@@ -49,6 +49,7 @@ class CompilerBuiltin:
         self._set_events(Interop.interop_events())
         self._generate_builtin_package('boa3.builtin.nativecontract', NativeContract.package_symbols)
         self._generate_builtin_package('boa3.builtin.type', Builtin.package_symbols('type'))
+        self._generate_builtin_package('boa3.builtin.vm', Builtin.package_symbols('vm'))
 
     @classmethod
     def reset(cls):

--- a/boa3/model/operation/binary/arithmetic/modulo.py
+++ b/boa3/model/operation/binary/arithmetic/modulo.py
@@ -3,6 +3,7 @@ from typing import List, Tuple
 from boa3.model.operation.binary.binaryoperation import BinaryOperation
 from boa3.model.operation.operator import Operator
 from boa3.model.type.type import IType, Type
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
@@ -63,12 +64,12 @@ class Modulo(BinaryOperation):
             jmp_place_holder
         ]
         num_jmp_code = get_bytes_count(if_negative)
-        mod[-1] = Opcode.get_jump_and_data(Opcode.JMPIF, num_jmp_code, True)
+        mod[-1] = OpcodeHelper.get_jump_and_data(Opcode.JMPIF, num_jmp_code, True)
 
         else_negative = [
             (Opcode.NIP, b'')
         ]
         num_jmp_code = get_bytes_count(else_negative)
-        if_negative[-1] = Opcode.get_jump_and_data(Opcode.JMP, num_jmp_code, True)
+        if_negative[-1] = OpcodeHelper.get_jump_and_data(Opcode.JMP, num_jmp_code, True)
 
         return mod + if_negative + else_negative

--- a/boa3/model/type/classes/classtype.py
+++ b/boa3/model/type/classes/classtype.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Tuple
 from boa3.compiler.codegenerator import get_bytes_count
 from boa3.model.symbol import ISymbol
 from boa3.model.type.itype import IType
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.AbiType import AbiType
 from boa3.neo.vm.type.Integer import Integer
@@ -191,7 +192,7 @@ class ClassType(IType, ABC):
             final_instructions += (validate_type + final_jmp)
 
             bytes_size = get_bytes_count(final_instructions)
-            jmp_opcode, jmp_arg = Opcode.get_jump_and_data(Opcode.JMPIFNOT, bytes_size + 1)
+            jmp_opcode, jmp_arg = OpcodeHelper.get_jump_and_data(Opcode.JMPIFNOT, bytes_size + 1)
 
             final_instructions = (is_type_opcodes +
                                   [(jmp_opcode, jmp_arg)] +
@@ -210,7 +211,7 @@ class ClassType(IType, ABC):
         variables_count_is_equal = [
             (Opcode.DUP, b''),
             (Opcode.SIZE, b''),
-            Opcode.get_push_and_data(len(self._all_variables)),
+            OpcodeHelper.get_push_and_data(len(self._all_variables)),
             (Opcode.NUMEQUAL, b''),
         ]
 
@@ -223,9 +224,9 @@ class ClassType(IType, ABC):
 
                 # validate primitive types only to avoid recursive code
                 if self.stack_item == StackItemType.Map:
-                    get = Opcode.get_pushdata_and_data(var_id)
+                    get = OpcodeHelper.get_pushdata_and_data(var_id)
                 else:
-                    get = Opcode.get_push_and_data(var_index)
+                    get = OpcodeHelper.get_push_and_data(var_index)
 
                 new_opcodes = [
                     (Opcode.DUP, b''),
@@ -236,14 +237,14 @@ class ClassType(IType, ABC):
                 if len(variables_type_validations) == 0:
                     new_opcodes.append((Opcode.NIP, b''))
                 elif total_size > 0:
-                    new_opcodes.append((Opcode.get_jump_and_data(Opcode.JMPIFNOT, total_size + 1)))
+                    new_opcodes.append((OpcodeHelper.get_jump_and_data(Opcode.JMPIFNOT, total_size + 1)))
 
                 variables_type_validations = new_opcodes + variables_type_validations
                 total_size += get_bytes_count(new_opcodes)
 
         if total_size > 0:
             if len(variables_type_validations) > 0:
-                final_opcode = (Opcode.get_jump_and_data(Opcode.JMPIFNOT, total_size + 1))
+                final_opcode = (OpcodeHelper.get_jump_and_data(Opcode.JMPIFNOT, total_size + 1))
             else:
                 final_opcode = (Opcode.NIP, b'')
             variables_count_is_equal.append(final_opcode)

--- a/boa3/model/type/collection/sequence/ecpointtype.py
+++ b/boa3/model/type/collection/sequence/ecpointtype.py
@@ -4,6 +4,7 @@ from boa3 import constants
 from boa3.model.method import Method
 from boa3.model.type.itype import IType
 from boa3.model.type.primitive.bytestype import BytesType
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.AbiType import AbiType
 
@@ -59,7 +60,7 @@ class ECPointType(BytesType):
 
     def _is_instance_inner_opcodes(self, jmp_to_if_false: int = 0) -> List[Tuple[Opcode, bytes]]:
         from boa3 import constants
-        push_int_opcode, size_data = Opcode.get_push_and_data(constants.SIZE_OF_ECPOINT)
+        push_int_opcode, size_data = OpcodeHelper.get_push_and_data(constants.SIZE_OF_ECPOINT)
 
         return [
             (Opcode.SIZE, b''),  # return len(value) == 33

--- a/boa3/model/type/collection/sequence/uint160type.py
+++ b/boa3/model/type/collection/sequence/uint160type.py
@@ -4,6 +4,7 @@ from boa3 import constants
 from boa3.model.method import Method
 from boa3.model.type.itype import IType
 from boa3.model.type.primitive.bytestype import BytesType
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.AbiType import AbiType
 
@@ -47,7 +48,7 @@ class UInt160Type(BytesType):
         return super(PythonClass, self).is_instance_opcodes()
 
     def _is_instance_inner_opcodes(self, jmp_to_if_false: int = 0) -> List[Tuple[Opcode, bytes]]:
-        push_int_opcode, size_data = Opcode.get_push_and_data(constants.SIZE_OF_INT160)
+        push_int_opcode, size_data = OpcodeHelper.get_push_and_data(constants.SIZE_OF_INT160)
 
         return [
             (Opcode.SIZE, b''),  # return len(value) == 20

--- a/boa3/model/type/collection/sequence/uint256type.py
+++ b/boa3/model/type/collection/sequence/uint256type.py
@@ -5,6 +5,7 @@ from boa3.model.method import Method
 from boa3.model.type.classes.classtype import ClassType
 from boa3.model.type.itype import IType
 from boa3.model.type.primitive.bytestype import BytesType
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.AbiType import AbiType
 
@@ -48,7 +49,7 @@ class UInt256Type(BytesType, ClassType):
         return super(PythonClass, self).is_instance_opcodes()
 
     def _is_instance_inner_opcodes(self, jmp_to_if_false: int = 0) -> List[Tuple[Opcode, bytes]]:
-        push_int_opcode, size_data = Opcode.get_push_and_data(constants.SIZE_OF_INT256)
+        push_int_opcode, size_data = OpcodeHelper.get_push_and_data(constants.SIZE_OF_INT256)
 
         return [
             (Opcode.SIZE, b''),  # return len(value) == 32

--- a/boa3/model/type/neo/opcodetype.py
+++ b/boa3/model/type/neo/opcodetype.py
@@ -1,0 +1,60 @@
+from typing import Any, Dict
+
+from boa3.model.symbol import ISymbol
+from boa3.model.type.itype import IType
+from boa3.model.type.primitive.bytestype import BytesType
+
+
+class OpcodeType(BytesType):
+    """
+    A class used to represent Neo interop Opcode type
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._identifier = 'Opcode'
+
+    @property
+    def default_value(self) -> Any:
+        from boa3.neo.vm.opcode.Opcode import Opcode
+        return Opcode.NOP
+
+    @classmethod
+    def build(cls, value: Any = None) -> IType:
+        if value is None or cls._is_type_of(value):
+            return _Opcode
+
+    @classmethod
+    def _is_type_of(cls, value: Any):
+        from boa3.neo.vm.opcode.Opcode import Opcode
+        return isinstance(value, (Opcode, OpcodeType))
+
+    @property
+    def symbols(self) -> Dict[str, ISymbol]:
+        """
+        Gets the class symbols of this type
+
+        :return: a dictionary that maps each symbol in the module with its name
+        """
+        from boa3.neo.vm.opcode.Opcode import Opcode
+        from boa3.model.variable import Variable
+
+        _symbols = super().symbols
+        _symbols.update({name: Variable(self) for name in Opcode.__members__.keys()})
+
+        return _symbols
+
+    def get_value(self, symbol_id) -> Any:
+        """
+        Gets the literal value of a symbol
+
+        :return: the value if this type has this symbol. None otherwise.
+        """
+        if symbol_id in self.symbols:
+            from boa3.neo.vm.opcode.Opcode import Opcode
+            return Opcode.__members__[symbol_id]
+
+        return None
+
+
+_Opcode = OpcodeType()

--- a/boa3/neo/vm/VMCode.py
+++ b/boa3/neo/vm/VMCode.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Optional
 
+from boa3.neo.vm.opcode import OpcodeHelper
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.opcode.OpcodeInformation import OpcodeInformation
 from boa3.neo.vm.type.Integer import Integer
@@ -93,7 +94,7 @@ class VMCode:
         :return: the target code if this is a control code. None otherwise
         :rtype: VMCode
         """
-        return self._target if self.opcode.has_target() else None
+        return self._target if OpcodeHelper.has_target(self.opcode) else None
 
     def set_target(self, target_code):
         """
@@ -102,7 +103,7 @@ class VMCode:
         :param target_code: the target code of this instruction
         :type target_code: VMCode
         """
-        if self.opcode.has_target():
+        if OpcodeHelper.has_target(self.opcode):
             self._target = target_code
 
     def __str__(self) -> str:

--- a/boa3/neo/vm/opcode/OpcodeHelper.py
+++ b/boa3/neo/vm/opcode/OpcodeHelper.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+from typing import Dict, Optional, Tuple, Union
+
+from boa3.constants import FOUR_BYTES_MAX_VALUE
+from boa3.neo.vm.opcode.Opcode import Opcode
+from boa3.neo.vm.type.Integer import Integer
+from boa3.neo.vm.type.String import String
+
+
+def get_pushdata_and_data(bytestring: Union[str, bytes]) -> Tuple[Opcode, bytes]:
+    """
+    Gets the push opcode and data to the respective str ot bytes value
+
+    :param bytestring: value that will be pushed
+    :return: the respective opcode and its required data
+    :rtype: Tuple[Opcode, bytes]
+    """
+    if isinstance(bytestring, str):
+        bytestring = String(bytestring).to_bytes()
+
+    bytes_size = Integer(len(bytestring)).to_byte_array(min_length=1)
+    if len(bytes_size) == 1:
+        opcode = Opcode.PUSHDATA1
+    elif len(bytes_size) == 2:
+        opcode = Opcode.PUSHDATA2
+    else:
+        if len(bytes_size) > 4:
+            bytestring = bytestring[:FOUR_BYTES_MAX_VALUE]
+        bytes_size = Integer(len(bytestring)).to_byte_array(min_length=4)
+        opcode = Opcode.PUSHDATA4
+
+    data = bytes_size + bytestring
+    return opcode, data
+
+
+def get_pushdata_and_data_from_size(data_size: int) -> Tuple[Opcode, bytes]:
+    bytes_size = Integer(data_size).to_byte_array(min_length=1)
+    if len(bytes_size) == 1:
+        opcode = Opcode.PUSHDATA1
+    elif len(bytes_size) == 2:
+        opcode = Opcode.PUSHDATA2
+    else:
+        bytes_size = FOUR_BYTES_MAX_VALUE
+        opcode = Opcode.PUSHDATA4
+
+    return opcode, bytes_size
+
+
+def get_literal_push(integer: int) -> Optional[Opcode]:
+    """
+    Gets the push opcode to the respective integer
+
+    :param integer: value that will be pushed
+    :return: the respective opcode
+    :rtype: Opcode or None
+    """
+    if -1 <= integer <= 16:
+        opcode_value: int = Integer.from_bytes(Opcode.PUSH0) + integer
+        return Opcode(Integer(opcode_value).to_byte_array())
+    else:
+        return None
+
+
+def get_push_and_data(integer: int) -> Tuple[Opcode, bytes]:
+    """
+    Gets the push opcode and data to the respective integer
+
+    :param integer: value that will be pushed
+    :return: the respective opcode and its required data
+    :rtype: Tuple[Opcode, bytes]
+    """
+    opcode = get_literal_push(integer)
+    if isinstance(opcode, Opcode):
+        return opcode, b''
+    else:
+        data = Integer(integer).to_byte_array(signed=True, min_length=1)
+        if len(data) == 1:
+            opcode = Opcode.PUSHINT8
+        elif len(data) == 2:
+            opcode = Opcode.PUSHINT16
+        elif len(data) <= 4:
+            data = Integer(integer).to_byte_array(signed=True, min_length=4)
+            opcode = Opcode.PUSHINT32
+        elif len(data) <= 8:
+            data = Integer(integer).to_byte_array(signed=True, min_length=8)
+            opcode = Opcode.PUSHINT64
+        elif len(data) <= 16:
+            data = Integer(integer).to_byte_array(signed=True, min_length=16)
+            opcode = Opcode.PUSHINT128
+        else:
+            data = data[:32]
+            opcode = Opcode.PUSHINT256
+
+        return opcode, data
+
+
+def has_larger_opcode(opcode: Opcode) -> bool:
+    return opcode in _larger_opcode
+
+
+def get_larger_opcode(opcode: Opcode):
+    """
+    Gets the large opcode to the standard opcode
+
+    :return: the respective opcode
+    :rtype: Opcode or None
+    """
+    if opcode in _larger_opcode:
+        return _larger_opcode[opcode]
+    elif opcode in _larger_opcode.values():
+        return opcode
+    else:
+        return None
+
+
+_larger_opcode: Dict[Opcode, Opcode] = {
+    Opcode.JMP: Opcode.JMP_L,
+    Opcode.JMPIF: Opcode.JMPIF_L,
+    Opcode.JMPIFNOT: Opcode.JMPIFNOT_L,
+    Opcode.JMPEQ: Opcode.JMPEQ_L,
+    Opcode.JMPNE: Opcode.JMPNE_L,
+    Opcode.JMPGT: Opcode.JMPGT_L,
+    Opcode.JMPGE: Opcode.JMPGE_L,
+    Opcode.JMPLT: Opcode.JMPLT_L,
+    Opcode.JMPLE: Opcode.JMPLE_L,
+    Opcode.CALL: Opcode.CALL_L,
+    Opcode.TRY: Opcode.TRY_L,
+    Opcode.ENDTRY: Opcode.ENDTRY_L
+}
+
+
+def is_jump(opcode: Opcode) -> bool:
+    return Opcode.JMP <= opcode <= Opcode.JMPLE_L
+
+
+def get_jump_and_data(opcode: Opcode, integer: int, jump_through: bool = False) -> Tuple[Opcode, bytes]:
+    """
+    Gets the jump opcode and data to the respective integer
+
+    :param opcode: which jump will be used
+    :param integer: number of bytes that'll be jumped
+    :param jump_through: whether it should go over the instructions or not
+    :return: the respective opcode and its required data
+    :rtype: Tuple[Opcode, bytes]
+    """
+    if not is_jump(opcode):
+        opcode = Opcode.JMP
+
+    from boa3.neo.vm.opcode.OpcodeInfo import OpcodeInfo
+    opcode_info = OpcodeInfo.get_info(opcode)
+    arg_size = opcode_info.data_len
+    jmp_arg = Integer(arg_size + integer + jump_through).to_byte_array(min_length=arg_size) if integer > 0 \
+        else Integer(integer).to_byte_array(min_length=arg_size)
+
+    if len(jmp_arg) > opcode_info.max_data_len and has_larger_opcode(opcode):
+        opcode = opcode.get_larger_opcode()
+        opcode_info = OpcodeInfo.get_info(opcode)
+        arg_size = opcode_info.data_len
+        jmp_arg = Integer(arg_size + integer + jump_through).to_byte_array(min_length=arg_size) if integer > 0 \
+            else Integer(integer).to_byte_array(min_length=arg_size)
+        jmp_opcode = opcode
+    else:
+        jmp_opcode = opcode
+
+    jmp_arg = jmp_arg[-arg_size:]
+
+    return jmp_opcode, jmp_arg
+
+
+def has_target(opcode: Opcode) -> bool:
+    return Opcode.JMP <= opcode <= Opcode.CALL_L or Opcode.TRY <= opcode < Opcode.ENDFINALLY
+
+
+def get_drop(position: int) -> Optional[Opcode]:
+    """
+    Gets the opcode to remove the item n back in the stack
+
+    :param position: index of the variable
+    :return: the respective opcode
+    :rtype: Opcode
+    """
+    duplicate_item = {
+        1: Opcode.DROP,
+        2: Opcode.NIP
+    }
+
+    if position > 0:
+        if position in duplicate_item:
+            return duplicate_item[position]
+        else:
+            return Opcode.XDROP
+
+
+def get_dup(position: int) -> Optional[Opcode]:
+    """
+    Gets the opcode to duplicate the item n back in the stack
+
+    :param position: index of the variable
+    :return: the respective opcode
+    :rtype: Opcode
+    """
+    duplicate_item = {
+        1: Opcode.DUP,
+        2: Opcode.OVER
+    }
+
+    if position >= 0:
+        if position in duplicate_item:
+            return duplicate_item[position]
+        else:
+            return Opcode.PICK
+
+
+def get_reverse(no_stack_items: int) -> Optional[Opcode]:
+    """
+    Gets the opcode to reverse n items on the stack
+
+    :param no_stack_items: index of the variable
+    :return: the respective opcode
+    :rtype: Opcode
+    """
+    reverse_stack = {
+        2: Opcode.SWAP,
+        3: Opcode.REVERSE3,
+        4: Opcode.REVERSE4
+    }
+
+    if no_stack_items >= 0:
+        if no_stack_items in reverse_stack:
+            return reverse_stack[no_stack_items]
+        else:
+            return Opcode.REVERSEN
+
+
+def get_store(index: int, local: bool, is_arg: bool = False) -> Opcode:
+    """
+    Gets the opcode to store the variable
+
+    :param index: index of the variable
+    :param local: identifies if the variable is local or global
+    :param is_arg: identifies if the variable is an argument of a function. False if local is False.
+    :return: the respective opcode
+    :rtype: Opcode
+    """
+    if not local:
+        is_arg = False
+
+    if 0 <= index <= 6:
+        if is_arg:
+            opcode_value: int = Integer.from_bytes(Opcode.STARG0) + index
+        elif local:
+            opcode_value: int = Integer.from_bytes(Opcode.STLOC0) + index
+        else:
+            opcode_value: int = Integer.from_bytes(Opcode.STSFLD0) + index
+        return Opcode(Integer(opcode_value).to_byte_array())
+    else:
+        if is_arg:
+            return Opcode.STARG
+        elif local:
+            return Opcode.STLOC
+        else:
+            return Opcode.STSFLD
+
+
+def get_load(index: int, local: bool, is_arg: bool = False) -> Opcode:
+    """
+    Gets the opcode to load the variable
+
+    :param index: index of the variable
+    :param local: identifies if the variable is local or global
+    :param is_arg: identifies if the variable is an argument of a function. False if local is False.
+    :return: the respective opcode
+    :rtype: Opcode
+    """
+    if not local:
+        is_arg = False
+
+    if 0 <= index <= 6:
+        if is_arg:
+            opcode_value: int = Integer.from_bytes(Opcode.LDARG0) + index
+        elif local:
+            opcode_value: int = Integer.from_bytes(Opcode.LDLOC0) + index
+        else:
+            opcode_value: int = Integer.from_bytes(Opcode.LDSFLD0) + index
+        return Opcode(Integer(opcode_value).to_byte_array())
+    else:
+        if is_arg:
+            return Opcode.LDARG
+        elif local:
+            return Opcode.LDLOC
+        else:
+            return Opcode.LDSFLD
+
+
+def is_load_slot(opcode: Opcode) -> bool:
+    return (Opcode.LDSFLD0 <= opcode <= Opcode.LDSFLD
+            or Opcode.LDLOC0 <= opcode <= Opcode.LDLOC
+            or Opcode.LDARG0 <= opcode <= Opcode.LDARG)
+
+
+def get_store_from_load(load_opcode) -> Optional[Opcode]:
+    """
+    Gets the store slot opcode equivalent to the given load slot opcode.
+
+    :param load_opcode: load opcode
+    :type load_opcode: Opcode
+    :return: equivalent store opcode if the given opcode is a load slot. Otherwise, returns None
+    :rtype: Opcode or None
+    """
+    if is_load_slot(load_opcode):
+        opcode_value: int = Integer.from_bytes(load_opcode) + 8
+        return Opcode(Integer(opcode_value).to_byte_array())

--- a/boa3_test/test_sc/neo_type_test/opcode/ConcatMismatchedType.py
+++ b/boa3_test/test_sc/neo_type_test/opcode/ConcatMismatchedType.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.vm import Opcode
+
+
+@public
+def concat(arg: Opcode) -> str:
+    return '12345' + arg

--- a/boa3_test/test_sc/neo_type_test/opcode/ConcatWithBytes.py
+++ b/boa3_test/test_sc/neo_type_test/opcode/ConcatWithBytes.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.vm import Opcode
+
+
+@public
+def concat(arg: Opcode) -> bytes:
+    return b'12345' + arg

--- a/boa3_test/test_sc/neo_type_test/opcode/ConcatWithOpcode.py
+++ b/boa3_test/test_sc/neo_type_test/opcode/ConcatWithOpcode.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.vm import Opcode
+
+
+@public
+def concat() -> Opcode:
+    return Opcode.LDARG0 + Opcode.LDARG1 + Opcode.ADD

--- a/boa3_test/test_sc/neo_type_test/opcode/OpcodeMultiplication.py
+++ b/boa3_test/test_sc/neo_type_test/opcode/OpcodeMultiplication.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+from boa3.builtin.vm import Opcode
+
+
+@public
+def opcode_mult(multiplier: int) -> Opcode:
+    return Opcode.NOP * multiplier

--- a/boa3_test/tests/compiler_tests/test_neo_types.py
+++ b/boa3_test/tests/compiler_tests/test_neo_types.py
@@ -476,6 +476,82 @@ class TestNeoTypes(BoaTest):
 
     # endregion
 
+    # region Opcode
+
+    def test_opcode_manifest_generation(self):
+        path = self.get_contract_path('opcode', 'ConcatWithBytes.py')
+        expected_manifest_output = path.replace('.py', '.manifest.json')
+        output, manifest = self.get_output(path)
+
+        import os
+        from boa3.neo.vm.type.AbiType import AbiType
+
+        self.assertTrue(os.path.exists(expected_manifest_output))
+        self.assertIn('abi', manifest)
+        abi = manifest['abi']
+
+        self.assertIn('methods', abi)
+        self.assertEqual(1, len(abi['methods']))
+
+        method = abi['methods'][0]
+
+        self.assertIn('parameters', method)
+        self.assertEqual(1, len(method['parameters']))
+        self.assertIn('type', method['parameters'][0])
+        self.assertEqual(AbiType.ByteArray, method['parameters'][0]['type'])
+
+    def test_opcode_concat(self):
+        from boa3.neo.vm.opcode.Opcode import Opcode
+        path = self.get_contract_path('opcode', 'ConcatWithOpcode.py')
+
+        engine = TestEngine()
+        expected_result = Opcode.LDARG0 + Opcode.LDARG1 + Opcode.ADD
+        result = self.run_smart_contract(engine, path, 'concat')
+        self.assertEqual(expected_result, result)
+
+    def test_opcode_concat_with_bytes(self):
+        from boa3.neo.vm.opcode.Opcode import Opcode
+        path = self.get_contract_path('opcode', 'ConcatWithBytes.py')
+
+        engine = TestEngine()
+        concat_bytes = b'12345'
+        arg = Opcode.LDARG0
+        result = self.run_smart_contract(engine, path, 'concat', arg,
+                                         expected_result_type=bytes)
+        self.assertEqual(concat_bytes + arg, result)
+
+        arg = Opcode.LDLOC1
+        result = self.run_smart_contract(engine, path, 'concat', arg,
+                                         expected_result_type=bytes)
+        self.assertEqual(concat_bytes + arg, result)
+
+        arg = Opcode.NOP
+        result = self.run_smart_contract(engine, path, 'concat', arg,
+                                         expected_result_type=bytes)
+        self.assertEqual(concat_bytes + arg, result)
+
+    def test_opcode_concat_mismatched_type(self):
+        path = self.get_contract_path('opcode', 'ConcatMismatchedType.py')
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+
+    def test_opcode_multiplication(self):
+        from boa3.neo.vm.opcode.Opcode import Opcode
+        path = self.get_contract_path('opcode', 'OpcodeMultiplication.py')
+
+        engine = TestEngine()
+
+        multiplier = 4
+        result = self.run_smart_contract(engine, path, 'opcode_mult', multiplier,
+                                         expected_result_type=bytes)
+        self.assertEqual(Opcode.NOP * multiplier, result)
+
+        multiplier = 50
+        result = self.run_smart_contract(engine, path, 'opcode_mult', multiplier,
+                                         expected_result_type=bytes)
+        self.assertEqual(Opcode.NOP * multiplier, result)
+
+    # endregion
+
     # region IsInstance Neo Types
 
     def test_isinstance_contract(self):


### PR DESCRIPTION
**Related issue**
#937

**Summary or solution description**
Included the `Opcode` enum class in the supported classes to be imported in a smart contract. 
It can be accessed by importing the package `boa3.builtin.vm`.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/1a3b27cc7aadde01e472eea1ec5d50dff47a5564/boa3_test/test_sc/neo_type_test/opcode/ConcatWithOpcode.py#L2-L7

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/1a3b27cc7aadde01e472eea1ec5d50dff47a5564/boa3_test/tests/compiler_tests/test_neo_types.py#L503-L551

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7+
