### PR TITLE
Add support to str constructor

### DIFF
--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -69,6 +69,9 @@ class Builtin:
     ListSequence = ListSequenceMethod()
     Range = RangeMethod()
     Reversed = ReversedMethod()
+    StrBool = StrBoolMethod()
+    StrByteString = StrByteStringMethod()
+    StrInt = StrIntMethod()
     Super = SuperMethod()
 
     # python class method

--- a/boa3/model/builtin/method/__init__.py
+++ b/boa3/model/builtin/method/__init__.py
@@ -23,6 +23,9 @@ __all__ = ['AbsMethod',
            'RangeMethod',
            'ReversedMethod',
            'ScriptHashMethod',
+           'StrBoolMethod',
+           'StrByteStringMethod',
+           'StrIntMethod',
            'StrSplitMethod',
            'SumMethod',
            'SuperMethod',
@@ -51,6 +54,9 @@ from boa3.model.builtin.method.minintmethod import MinIntMethod
 from boa3.model.builtin.method.printmethod import PrintMethod
 from boa3.model.builtin.method.rangemethod import RangeMethod
 from boa3.model.builtin.method.reversedmethod import ReversedMethod
+from boa3.model.builtin.method.strboolmethod import StrBoolMethod
+from boa3.model.builtin.method.strbytestringmethod import StrByteStringMethod
+from boa3.model.builtin.method.strintmethod import StrIntMethod
 from boa3.model.builtin.method.strsplitmethod import StrSplitMethod
 from boa3.model.builtin.method.summethod import SumMethod
 from boa3.model.builtin.method.supermethod import SuperMethod

--- a/boa3/model/builtin/method/strboolmethod.py
+++ b/boa3/model/builtin/method/strboolmethod.py
@@ -1,0 +1,51 @@
+from typing import Dict, List, Tuple
+
+from boa3.model.builtin.method.strmethod import StrMethod
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+from boa3.neo.vm.type.Integer import Integer
+from boa3.neo.vm.type.String import String
+
+
+class StrBoolMethod(StrMethod):
+
+    def __init__(self):
+        from boa3.model.type.type import Type
+        args: Dict[str, Variable] = {
+            'object': Variable(Type.bool),
+        }
+
+        super().__init__(args)
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        from boa3.compiler.codegenerator import get_bytes_count
+
+        jmp_place_holder = (Opcode.JMP, b'\x01')
+        true = String("True").to_bytes()
+        false = String("False").to_bytes()
+
+        check_is_true = [
+            jmp_place_holder
+        ]
+
+        put_false = [
+            (Opcode.PUSHDATA1, Integer(len(false)).to_byte_array(signed=True, min_length=1) + false),
+            jmp_place_holder
+        ]
+
+        put_true = [
+            (Opcode.PUSHDATA1, Integer(len(true)).to_byte_array(signed=True, min_length=1) + true),
+        ]
+
+        jmp_put_true = Opcode.get_jump_and_data(Opcode.JMP, get_bytes_count(put_true))
+        put_false[-1] = jmp_put_true
+
+        jmp_put_false = Opcode.get_jump_and_data(Opcode.JMPIF, get_bytes_count(put_false))
+        check_is_true[-1] = jmp_put_false
+
+        return (
+            check_is_true +
+            put_false +
+            put_true
+        )

--- a/boa3/model/builtin/method/strbytestringmethod.py
+++ b/boa3/model/builtin/method/strbytestringmethod.py
@@ -9,9 +9,10 @@ from boa3.neo.vm.opcode.Opcode import Opcode
 class StrByteStringMethod(StrMethod):
 
     def __init__(self):
+        from boa3.model.type.primitive.bytestringtype import ByteStringType
         from boa3.model.type.type import Type
         args: Dict[str, Variable] = {
-            'object': Variable(Type.union.build([Type.str, Type.bytes])),
+            'object': Variable(ByteStringType.build()),
         }
         object_default = ast.parse("'{0}'".format(Type.str.default_value)).body[0].value
 

--- a/boa3/model/builtin/method/strbytestringmethod.py
+++ b/boa3/model/builtin/method/strbytestringmethod.py
@@ -1,25 +1,22 @@
 import ast
 from typing import Dict, List, Tuple
 
-from boa3.model.builtin.method.intmethod import IntMethod
+from boa3.model.builtin.method.strmethod import StrMethod
 from boa3.model.variable import Variable
 from boa3.neo.vm.opcode.Opcode import Opcode
 
 
-class IntIntMethod(IntMethod):
+class StrByteStringMethod(StrMethod):
 
     def __init__(self):
         from boa3.model.type.type import Type
         args: Dict[str, Variable] = {
-            'value': Variable(Type.int),
+            'object': Variable(Type.union.build([Type.str, Type.bytes])),
         }
+        object_default = ast.parse("'{0}'".format(Type.str.default_value)).body[0].value
 
-        value_default = ast.parse("{0}".format(Type.int.default_value)
-                                  ).body[0].value
-
-        super().__init__(args, [value_default])
+        super().__init__(args, [object_default])
 
     @property
     def opcode(self) -> List[Tuple[Opcode, bytes]]:
-        # returns the same int
         return []

--- a/boa3/model/builtin/method/strintmethod.py
+++ b/boa3/model/builtin/method/strintmethod.py
@@ -1,0 +1,29 @@
+from typing import Dict, List, Tuple
+
+from boa3.model.builtin.interop.stdlib import ItoaMethod
+from boa3.model.builtin.method.strmethod import StrMethod
+from boa3.model.variable import Variable
+from boa3.neo.vm.opcode.Opcode import Opcode
+
+
+class StrIntMethod(StrMethod):
+
+    def __init__(self):
+        from boa3.model.type.type import Type
+        args: Dict[str, Variable] = {
+            'object': Variable(Type.int),
+        }
+
+        super().__init__(args)
+
+    @property
+    def opcode(self) -> List[Tuple[Opcode, bytes]]:
+        return (
+            [
+                (Opcode.PUSH10, b''),
+                (Opcode.SWAP, b''),
+                (Opcode.PUSH2, b''),
+                (Opcode.PACK, b''),
+            ] +
+            ItoaMethod().opcode
+        )

--- a/boa3/model/builtin/method/strmethod.py
+++ b/boa3/model/builtin/method/strmethod.py
@@ -1,0 +1,52 @@
+import ast
+from typing import Any, Dict, List, Optional
+
+from boa3.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.model.variable import Variable
+
+
+class StrMethod(IBuiltinMethod):
+
+    def __init__(self, args: Dict[str, Variable] = None, defaults: List[ast.AST] = None):
+        from boa3.model.type.type import Type
+        identifier = 'str'
+        super().__init__(identifier, args, defaults=defaults, return_type=Type.str)
+
+    @property
+    def _arg_value(self) -> Variable:
+        return self.args['object']
+
+    @property
+    def identifier(self) -> str:
+        from boa3.model.type.type import Type
+
+        if self._arg_value.type is Type.bool:
+            return '-{0}_{1}'.format(self._identifier, Type.bool.identifier)
+
+        if self._arg_value.type is Type.int:
+            return '-{0}_{1}'.format(self._identifier, Type.int.identifier)
+
+        return self._identifier
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> Optional[str]:
+        return None
+
+    def build(self, value: Any) -> IBuiltinMethod:
+        if not isinstance(value, list):
+            value = [value]
+
+        from boa3.model.type.type import Type
+        from boa3.model.builtin.builtin import Builtin
+        if len(value) == 0 or (Type.str.is_type_of(value[0]) or Type.bytes.is_type_of(value[0])):
+            return Builtin.StrByteString
+
+        if Type.bool.is_type_of(value[0]):
+            return Builtin.StrBool
+
+        if Type.int.is_type_of(value[0]):
+            return Builtin.StrInt

--- a/boa3/model/builtin/method/strmethod.py
+++ b/boa3/model/builtin/method/strmethod.py
@@ -42,11 +42,12 @@ class StrMethod(IBuiltinMethod):
 
         from boa3.model.type.type import Type
         from boa3.model.builtin.builtin import Builtin
-        if len(value) == 0 or (Type.str.is_type_of(value[0]) or Type.bytes.is_type_of(value[0])):
-            return Builtin.StrByteString
+        if len(value) > 0:
 
-        if Type.bool.is_type_of(value[0]):
-            return Builtin.StrBool
+            if Type.bool.is_type_of(value[0]):
+                return Builtin.StrBool
 
-        if Type.int.is_type_of(value[0]):
-            return Builtin.StrInt
+            if Type.int.is_type_of(value[0]):
+                return Builtin.StrInt
+
+        return Builtin.StrByteString

--- a/boa3/model/type/primitive/strtype.py
+++ b/boa3/model/type/primitive/strtype.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from boa3 import constants
 from boa3.model.type.itype import IType
 from boa3.model.type.primitive.ibytestringtype import IByteStringType
 from boa3.neo.vm.type.AbiType import AbiType
@@ -34,6 +35,8 @@ class StrType(IByteStringType):
 
         for instance_method in instance_methods:
             self._instance_methods[instance_method.raw_identifier] = instance_method.build(self)
+
+        self._instance_methods[constants.INIT_METHOD_ID] = Builtin.StrByteString
 
     @classmethod
     def build(cls, value: Any) -> IType:

--- a/boa3_test/test_sc/built_in_methods_test/StrBool.py
+++ b/boa3_test/test_sc/built_in_methods_test/StrBool.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+
+
+@public
+def main(value: bool) -> str:
+    a = str(value)
+    return a

--- a/boa3_test/test_sc/built_in_methods_test/StrByteString.py
+++ b/boa3_test/test_sc/built_in_methods_test/StrByteString.py
@@ -1,0 +1,19 @@
+from boa3.builtin import public
+
+
+@public
+def str_parameter(value: str) -> str:
+    a = str(value)
+    return a
+
+
+@public
+def bytes_parameter(value: bytes) -> str:
+    a = str(value)
+    return a
+
+
+@public
+def empty_parameter() -> str:
+    a = str()
+    return a

--- a/boa3_test/test_sc/built_in_methods_test/StrInt.py
+++ b/boa3_test/test_sc/built_in_methods_test/StrInt.py
@@ -1,0 +1,7 @@
+from boa3.builtin import public
+
+
+@public
+def main(value: int) -> str:
+    a = str(value)
+    return a

--- a/boa3_test/test_sc/built_in_methods_test/StrTooManyParameters.py
+++ b/boa3_test/test_sc/built_in_methods_test/StrTooManyParameters.py
@@ -1,0 +1,2 @@
+def main() -> str:
+    return str('test', 'test')

--- a/boa3_test/tests/compiler_tests/test_builtin_method.py
+++ b/boa3_test/tests/compiler_tests/test_builtin_method.py
@@ -1888,3 +1888,51 @@ class TestBuiltinMethod(BoaTest):
         self.assertEqual(list(val), result)
 
     # endregion
+
+    # region str test
+
+    def test_str_bytes_str(self):
+        path = self.get_contract_path('StrByteString.py')
+        engine = TestEngine()
+
+        value = 'test'
+        result = self.run_smart_contract(engine, path, 'str_parameter', value)
+        self.assertEqual(str(value), result)
+
+        value = b'test'
+        result = self.run_smart_contract(engine, path, 'bytes_parameter', value)
+        # since bytes and string is the same thing internally it will return 'test' instead of the "b'test'"
+        self.assertEqual('test', result)
+
+        result = self.run_smart_contract(engine, path, 'empty_parameter')
+        self.assertEqual(str(), result)
+
+    def test_str_int(self):
+        path = self.get_contract_path('StrInt.py')
+        engine = TestEngine()
+
+        value = 1234567890
+        result = self.run_smart_contract(engine, path, 'main', value)
+        self.assertEqual(str(value), result)
+
+        value = -1234567890
+        result = self.run_smart_contract(engine, path, 'main', value)
+        self.assertEqual(str(value), result)
+
+    def test_str_bool(self):
+        path = self.get_contract_path('StrBool.py')
+        engine = TestEngine()
+
+        value = True
+        result = self.run_smart_contract(engine, path, 'main', value)
+        self.assertEqual(str(value), result)
+
+        value = False
+        result = self.run_smart_contract(engine, path, 'main', value)
+        self.assertEqual(str(value), result)
+
+    def test_str_too_many_parameters(self):
+        path = self.get_contract_path('StrTooManyParameters.py')
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+
+    # endregion


### PR DESCRIPTION
**Summary or solution description**
Added support to `str()`, however it only accepts only one argument (Python can accept up to 3).

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/08d7c99f1b9bd8a691a371415991899d141da18e/boa3_test/test_sc/built_in_methods_test/StrInt.py#L1-L7

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/08d7c99f1b9bd8a691a371415991899d141da18e/boa3_test/tests/compiler_tests/test_builtin_method.py#L1910-L1920

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7

**(Optional) Additional context**
Since bytes and string is the same in Neo, the constructor with a bytes value as a parameter is not returning the same value as the return in Python.