### PR TITLE
Don't let compile a smart contract that sets two different methods with the same amount of argument and the same name in the manifest

### DIFF
--- a/boa3/analyser/model/ManifestSymbol.py
+++ b/boa3/analyser/model/ManifestSymbol.py
@@ -1,0 +1,21 @@
+import enum
+
+from boa3.model.callable import Callable
+from boa3.model.event import Event
+
+
+class ManifestSymbol(int, enum.Enum):
+    Method = enum.auto()
+    Event = enum.auto()
+
+    @classmethod
+    def get_manifest_symbol(cls, callable_: Callable):
+        if isinstance(callable_, Event):
+            return cls.Event
+        return cls.Method
+
+    def __str__(self):
+        return self.name
+
+    def __repr__(self):
+        return str(self)

--- a/boa3/analyser/moduleanalyser.py
+++ b/boa3/analyser/moduleanalyser.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 from boa3 import constants
 from boa3.analyser.astanalyser import IAstAnalyser
 from boa3.analyser.importanalyser import ImportAnalyser
+from boa3.analyser.model.ManifestSymbol import ManifestSymbol
 from boa3.analyser.model.functionarguments import FunctionArguments
 from boa3.analyser.model.optimizer import UndefinedType
 from boa3.analyser.model.symbolscope import SymbolScope
@@ -92,7 +93,7 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
 
         self._metadata: NeoMetadata = None
         self._metadata_node: ast.AST = ast.parse('')
-        self._manifest_symbols: Dict[Tuple[str, int], Callable] = {}
+        self._manifest_symbols: Dict[Tuple[ManifestSymbol, str, int], Callable] = {}
         self.imported_nodes: List[ast.AST] = []
 
         if self.filename:
@@ -224,10 +225,10 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
                                                                callable.origin.col_offset,
                                                                callable_id))
 
-        if callable.is_public is not None:
+        if callable.is_public:
             # check if the external name + argument number is unique
             manifest_name = callable.external_name if callable.external_name is not None else callable_id
-            manifest_id = (manifest_name, len(callable.args))
+            manifest_id = (ManifestSymbol.get_manifest_symbol(callable), manifest_name, len(callable.args))
 
             if manifest_id in self._manifest_symbols:
                 self._log_error(CompilerError.DuplicatedManifestIdentifier(callable.origin.lineno,

--- a/boa3/analyser/moduleanalyser.py
+++ b/boa3/analyser/moduleanalyser.py
@@ -92,6 +92,7 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
 
         self._metadata: NeoMetadata = None
         self._metadata_node: ast.AST = ast.parse('')
+        self._manifest_symbols: Dict[Tuple[str, int], Callable] = {}
         self.imported_nodes: List[ast.AST] = []
 
         if self.filename:
@@ -222,6 +223,19 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
             self._log_error(CompilerError.DuplicatedIdentifier(callable.origin.lineno,
                                                                callable.origin.col_offset,
                                                                callable_id))
+
+        if callable.is_public is not None:
+            # check if the external name + argument number is unique
+            manifest_name = callable.external_name if callable.external_name is not None else callable_id
+            manifest_id = (manifest_name, len(callable.args))
+
+            if manifest_id in self._manifest_symbols:
+                self._log_error(CompilerError.DuplicatedManifestIdentifier(callable.origin.lineno,
+                                                                           callable.origin.col_offset,
+                                                                           manifest_name, len(callable.args)
+                                                                           ))
+            else:
+                self._manifest_symbols[manifest_id] = callable
 
     def __include_class_variable(self, cl_var_id: str, cl_var: Variable):
         """

--- a/boa3/compiler/codegenerator/codegenerator.py
+++ b/boa3/compiler/codegenerator/codegenerator.py
@@ -2029,7 +2029,7 @@ class CodeGenerator:
 
         if None in self._missing_target:
             for code in self._missing_target[None]:
-                if code.info.opcode.is_jump and code.target is None:
+                if OpcodeHelper.is_jump(code.info.opcode) and code.target is None:
                     target = Integer.from_bytes(code.raw_data) + VMCodeMapping.instance().get_start_address(code) + 1
                     if target >= current_bytecode_size:
                         return True

--- a/boa3/exception/CompilerError.py
+++ b/boa3/exception/CompilerError.py
@@ -67,6 +67,21 @@ class DuplicatedIdentifier(CompilerError):
         return f"Duplicate identifier: '{self._duplicated_id}'"
 
 
+class DuplicatedManifestIdentifier(CompilerError):
+    """
+    An error raised when more than one symbol uses the same identifier in the manifest.
+    """
+
+    def __init__(self, line: int, col: int, duplicated_id: str = None, duplicated_arg_count: int = None):
+        self._duplicated_id = duplicated_id
+        self._arg_count = duplicated_arg_count
+        super().__init__(line, col)
+
+    @property
+    def _error_message(self) -> Optional[str]:
+        return f"Duplicate manifest identifier: '{self._duplicated_id}' with {self._arg_count} argument(s)"
+
+
 class IncorrectNumberOfOperands(CompilerError):
     """
     An error raised when an operation is used with the wrong number of operands

--- a/boa3_test/test_sc/generation_test/MetadataMethodDuplicatedNameAndArgs.py
+++ b/boa3_test/test_sc/generation_test/MetadataMethodDuplicatedNameAndArgs.py
@@ -1,0 +1,16 @@
+from boa3.builtin import public
+
+
+@public(name='Add')
+def Main(a: int, b: int) -> int:
+    return Add(a, b)
+
+
+@public(name='Add')
+def Add(a: int, b: int) -> int:
+    return a + b
+
+
+@public
+def Sub(a: int, b: int) -> int:
+    return a - b

--- a/boa3_test/test_sc/generation_test/MetadataMethodDuplicatedNameDifferentArgs.py
+++ b/boa3_test/test_sc/generation_test/MetadataMethodDuplicatedNameDifferentArgs.py
@@ -1,0 +1,16 @@
+from boa3.builtin import public
+
+
+@public(name='Add')
+def Inc(a: int) -> int:
+    return Add(a, 1)
+
+
+@public(name='Add')
+def Add(a: int, b: int) -> int:
+    return a + b
+
+
+@public
+def Sub(a: int, b: int) -> int:
+    return a - b

--- a/boa3_test/tests/compiler_tests/test_file_generation.py
+++ b/boa3_test/tests/compiler_tests/test_file_generation.py
@@ -276,6 +276,36 @@ class TestFileGeneration(BoaTest):
         path = self.get_contract_path('MetadataMethodNameMismatchedType.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
+    def test_metadata_abi_method_with_duplicated_name_but_different_args(self):
+        path = self.get_contract_path('MetadataMethodDuplicatedNameDifferentArgs.py')
+        expected_manifest_output = path.replace('.py', '.manifest.json')
+        output, manifest = self.compile_and_save(path)
+
+        self.assertTrue(os.path.exists(expected_manifest_output))
+        self.assertIn('abi', manifest)
+        abi = manifest['abi']
+
+        self.assertIn('methods', abi)
+        self.assertEqual(3, len(abi['methods']))
+
+        # method Inc named as Add
+        method0 = abi['methods'][0]
+        self.assertIn('name', method0)
+        self.assertEqual('Add', method0['name'])
+        self.assertIn('parameters', method0)
+        self.assertEqual(1, len(method0['parameters']))
+
+        # method Add also named as Add, but with different arg count
+        method1 = abi['methods'][1]
+        self.assertIn('name', method1)
+        self.assertEqual('Add', method1['name'])
+        self.assertIn('parameters', method1)
+        self.assertEqual(2, len(method1['parameters']))
+
+    def test_metadata_abi_method_with_duplicated_name_and_args(self):
+        path = self.get_contract_path('MetadataMethodDuplicatedNameAndArgs.py')
+        self.assertCompilerLogs(CompilerError.DuplicatedManifestIdentifier, path)
+
     def test_generate_manifest_file_with_public_safe_decorator_kwarg(self):
         path = self.get_contract_path('MetadataMethodSafe.py')
         expected_manifest_output = path.replace('.py', '.manifest.json')


### PR DESCRIPTION
**Summary or solution description**
We cannot have different methods in the manifest with the same name and the same number of arguments.
Methods with the same name but a different number of arguments are allowed.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/5e900756697401b46c0b0003d12ff2ee578c432c/boa3_test/test_sc/generation_test/MetadataMethodDuplicatedNameAndArgs.py#L4-L11

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/5e900756697401b46c0b0003d12ff2ee578c432c/boa3_test/tests/compiler_tests/test_file_generation.py#L279-L307

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
