### PR TITLE
Change missing standard definition error message for clarity

### DIFF
--- a/boa3/exception/CompilerError.py
+++ b/boa3/exception/CompilerError.py
@@ -278,10 +278,9 @@ class MissingStandardDefinition(CompilerError):
 
     @property
     def _error_message(self) -> Optional[str]:
-        return "'{0}': Missing '{1}' {2} definition '{3}'".format(self.standard,
-                                                                  self.symbol_id,
-                                                                  self.symbol.shadowing_name,
-                                                                  self.symbol)
+        safe_symbol_prefix = 'safe ' if self.symbol.is_safe else ''
+        return f"'{self.standard}': Missing '{self.symbol_id}' {self.symbol.shadowing_name} definition " \
+               f"'{safe_symbol_prefix}{self.symbol}'"
 
     @property
     def message(self) -> str:


### PR DESCRIPTION
**Summary or solution description**
Changed the message error to show which methods should also be marked as `safe` to fulfill the standard, to avoid confusions like the following when the methods are implemented correctly
```
ERROR: 'NEP-11': Missing 'symbol' method definition 'public () -> str'
ERROR: 'NEP-11': Missing 'decimals' method definition 'public () -> int'
ERROR: 'NEP-11': Missing 'totalSupply' method definition 'public () -> int'
ERROR: 'NEP-11': Missing 'balanceOf' method definition 'public (UInt160) -> int'
ERROR: 'NEP-11': Missing 'tokensOf' method definition 'public (UInt160) -> Iterator[any, any]'
ERROR: 'NEP-11': Missing 'transfer' method definition 'public (UInt160, ByteString, any) -> bool'
ERROR: 'NEP-11': Missing 'ownerOf' method definition 'public (ByteString) -> UInt160'
ERROR: 'NEP-11': Missing 'Transfer' event definition 'public (Union[none, UInt160], Union[none, UInt160], int, ByteString)'
ERROR: 'NEP-11': Missing 'tokens' method definition 'public () -> Iterator[any, any]'
ERROR: 'NEP-11': Missing 'properties' method definition 'public (ByteString) -> dict[any, any]'
ERROR: Could not compile
```

