### PR TITLE
Couldn't create an event with the same name as a method

### DIFF
--- a/boa3/analyser/moduleanalyser.py
+++ b/boa3/analyser/moduleanalyser.py
@@ -1166,8 +1166,9 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
         return self.get_type(call.func)
 
     def create_new_event(self, create_call: ast.Call) -> Event:
-        event = Event('')
         event_args = create_call.args
+        args = {}
+        name = ''
 
         if len(event_args) < 0:
             self._log_error(
@@ -1211,7 +1212,7 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
                         arg_type = (self.get_symbol(value.elts[1].id)
                                     if isinstance(value.elts[1], ast.Name)
                                     else self.visit(value.elts[1]))
-                        event.args[arg_name] = Variable(arg_type)
+                        args[arg_name] = Variable(arg_type)
 
             if len(event_args) > 1:
                 if not isinstance(event_args[1], ast.Str):
@@ -1221,8 +1222,10 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
                                                   expected_type_id=Type.str.identifier,
                                                   actual_type_id=name_type.identifier)
                 else:
-                    event.name = event_args[1].s
+                    name = event_args[1].s
 
+        event = Event(name, args)
+        event._origin_node = create_call
         return event
 
     def visit_Attribute(self, attribute: ast.Attribute) -> Union[ISymbol, str]:

--- a/boa3/analyser/moduleanalyser.py
+++ b/boa3/analyser/moduleanalyser.py
@@ -1168,7 +1168,7 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
     def create_new_event(self, create_call: ast.Call) -> Event:
         event_args = create_call.args
         args = {}
-        name = ''
+        name = Builtin.Event.identifier
 
         if len(event_args) < 0:
             self._log_error(

--- a/boa3/model/event.py
+++ b/boa3/model/event.py
@@ -16,7 +16,7 @@ class Event(Callable, IdentifiedSymbol):
         super().__init__(args, vararg, kwargs, defaults, Type.none, True, origin_node)
 
         self.name: str = event_id
-        self._identifier: str = self.name
+        self._identifier: str = None
 
     @property
     def shadowing_name(self) -> str:
@@ -24,7 +24,10 @@ class Event(Callable, IdentifiedSymbol):
 
     @property
     def identifier(self) -> str:
-        return self.name
+        if self._identifier is None:
+            # internal identifier should not be the name to avoid nonexistent duplicated symbol ids
+            self._identifier = f'-{self.name}-{hex(id(self))}'
+        return self._identifier
 
     @property
     def args_to_generate(self) -> Dict[str, Variable]:

--- a/boa3_test/test_sc/event_test/EventWithDuplicatedName.py
+++ b/boa3_test/test_sc/event_test/EventWithDuplicatedName.py
@@ -1,0 +1,13 @@
+from boa3.builtin import CreateNewEvent, public
+
+on_event = CreateNewEvent(
+    [
+        ('a', int)
+    ],
+    'example'
+)
+
+
+@public
+def example(arg: int):
+    on_event(arg)

--- a/boa3_test/tests/compiler_tests/test_event.py
+++ b/boa3_test/tests/compiler_tests/test_event.py
@@ -254,6 +254,20 @@ class TestEvent(BoaTest):
         path = self.get_contract_path('EventWithoutTypes.py')
         self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
 
+    def test_event_with_duplicated_name(self):
+        path = self.get_contract_path('EventWithDuplicatedName.py')
+
+        engine = TestEngine()
+        arg = 10
+        event_id = 'example'
+        result = self.run_smart_contract(engine, path, 'example', arg)
+        self.assertIsVoid(result)
+        self.assertGreater(len(engine.notifications), 0)
+
+        event_notifications = engine.get_events(event_name=event_id)
+        self.assertEqual(1, len(event_notifications))
+        self.assertEqual((arg,), event_notifications[0].arguments)
+
     def test_event_call_mismatched_type(self):
         path = self.get_contract_path('MismatchedTypeCallEvent.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)


### PR DESCRIPTION
**Summary or solution description**
The internal identifier for events was initialized with the event name, which conflicted with other symbols names (i.e. methods with the same name)

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/14a5eaa4fff24e5cad88fa8c8fa92aa76c5f97fa/boa3_test/test_sc/event_test/EventWithDuplicatedName.py#L3-L13

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/14a5eaa4fff24e5cad88fa8c8fa92aa76c5f97fa/boa3_test/tests/compiler_tests/test_event.py#L257-L269

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7+
