### PR TITLE
Cast to shadowed variable still fails compilation

### DIFF
--- a/boa3/analyser/model/symbolscope.py
+++ b/boa3/analyser/model/symbolscope.py
@@ -16,15 +16,24 @@ class SymbolScope:
     def copy(self) -> SymbolScope:
         return SymbolScope(self._symbols)
 
-    def include_symbol(self, symbol_id: str, symbol: ISymbol):
+    def include_symbol(self, symbol_id: str, symbol: ISymbol, reassign_original: bool = True):
         """
         Includes a symbols into the scope
 
         :param symbol_id: symbol identifier
         :param symbol: symbol to be included
         """
-        if symbol_id in self._symbols and hasattr(symbol, 'set_is_reassigned'):
-            symbol.set_is_reassigned()
+
+        if symbol_id in self._symbols:
+            if not reassign_original:
+                if hasattr(symbol, 'copy'):
+                    symbol = symbol.copy()
+                else:
+                    return
+
+            if hasattr(symbol, 'set_is_reassigned'):
+                symbol.set_is_reassigned()
+
         self._symbols[symbol_id] = symbol
 
     def remove_symbol(self, symbol_id: str):

--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -407,15 +407,19 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
 
                 else:
                     if self._current_method is not None and node.id in self._current_method.symbols:
-                        can_change_target_type = self._current_method.symbols[node.id].type is UndefinedType
+                        can_change_target_type = (self._current_method.symbols[node.id].type is UndefinedType
+                                                  or node.id in self._current_method.args)
+                        can_change_original = node.id not in self._current_method.args
                     else:
                         can_change_target_type = True
+                        can_change_original = True
 
                     if can_change_target_type:
                         if (not target_type.is_type_of(value_type) and
                                 value != target_type.default_value):
                             target_type = value_type
-                        self._current_scope.include_symbol(node.id, Variable(value_type))
+                        self._current_scope.include_symbol(node.id, Variable(value_type),
+                                                           reassign_original=can_change_original)
 
         if not target_type.is_type_of(value_type) and value != target_type.default_value:
             if not implicit_cast:

--- a/boa3_test/test_sc/typing_test/CastPersistedInScope.py
+++ b/boa3_test/test_sc/typing_test/CastPersistedInScope.py
@@ -1,0 +1,29 @@
+from typing import Any, cast, Union
+
+from boa3.builtin import public
+from boa3.builtin.interop import runtime
+from boa3.builtin.type import UInt160
+
+
+TEST_AMOUNT_1 = 10
+TEST_AMOUNT_2 = 2
+
+
+@public
+def main(from_address: Union[UInt160, None], amount: int, data: Any):
+    if from_address is None:
+        return
+    from_address = cast(UInt160, from_address)
+
+    if runtime.calling_script_hash == runtime.executing_script_hash:
+        corresponding_amount = amount * TEST_AMOUNT_1
+        mint(from_address, corresponding_amount)   # typing failed here
+    else:
+        corresponding_amount = amount * TEST_AMOUNT_2
+        mint(from_address, corresponding_amount)   # typing failed here
+
+
+def mint(account: UInt160, amount: int):
+    assert amount >= 0
+    if amount != 0:
+        runtime.log(account.to_str())

--- a/boa3_test/tests/compiler_tests/test_typing.py
+++ b/boa3_test/tests/compiler_tests/test_typing.py
@@ -149,3 +149,11 @@ class TestTyping(BoaTest):
 
         result = self.run_smart_contract(engine, path, 'main')
         self.assertEqual('body', result)
+
+    def test_cast_persisted_in_scope(self):
+        path = self.get_contract_path('CastPersistedInScope.py')
+        engine = TestEngine()
+
+        test_address = bytes(20)
+        result = self.run_smart_contract(engine, path, 'main', test_address, 10, None)
+        self.assertIsVoid(result)


### PR DESCRIPTION
**Summary or solution description**
Type casting of variables which ids shadowed the function argument variables was not persisted after the casting, causing compiler error.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/c9002b30b392553501925654fbf4722fc4e74e68/boa3_test/test_sc/typing_test/CastPersistedInScope.py#L12-L27

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/c9002b30b392553501925654fbf4722fc4e74e68/boa3_test/tests/compiler_tests/test_typing.py#L153-L159

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7+