### PR TITLE
Fix jagged arrays in neo boa

### DIFF
--- a/boa3_test/tests/compiler_tests/test_list.py
+++ b/boa3_test/tests/compiler_tests/test_list.py
@@ -313,12 +313,15 @@ class TestList(BoaTest):
         self.assertEqual(expected_output, output)
 
         engine = TestEngine()
+
         with self.assertRaisesRegex(TestExecutionException, self.NULL_POINTER_MSG):
-            # TODO: TestEngine fails when running contracts with arrays inside arrays args
+            # TODO: TestEngine error, on TestNet and PrivateNet the vm_state is 'HALT' instead of 'FAULT'
             self.run_smart_contract(engine, path, 'Main', [[1, 2], [3, 4]])
 
-        result = engine.run(nef_path, 'Main', [[1, 2], [3, 4]])
-        self.assertEqual(1, result)
+        engine.run(nef_path, 'Main', [[1, 2], [3, 4]])
+        self.assertIsNotNone(engine.error)
+        from boa3.neo3.vm import VMState
+        self.assertEqual(engine.vm_state, VMState.FAULT)
 
         engine.run(nef_path, 'Main', [])
         self.assertIsNotNone(engine.error)


### PR DESCRIPTION
**Summary or solution description**
It's probably a TestEngine problem, not a Neo3-boa.

**Tests**
I added the smart contract into the TestNet and it worked there.
Smart contract: https://dora.coz.io/contract/neo3/testnet/0x8dcae7549a82fbce77cf4ec0583489e610914ae4

I also sent a transaction with the arg:  [[1,2,3,45], [566,7,8]] and got this back on the tx
![image](https://user-images.githubusercontent.com/49196318/204890154-89b8f424-c358-4c50-b33c-1fd404d6ac22.png)
txId: 0x67d2b60496846e748622038ce0413f3469d0e5a609643883360365cb50010935

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8
