### PR TITLE
Include `hash` property to classes with @contract decorator

### DIFF
--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -1600,8 +1600,8 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
         is_from_class_name = isinstance(origin, ast.Name) and isinstance(self.get_symbol(origin.id), UserClass)
         is_instance_variable_from_class = (isinstance(symbol, UserClass)
                                            and attribute.attr in symbol.instance_variables)
-        is_class_variable_from_class = isinstance(symbol, UserClass) and attribute.attr in symbol.class_variables
-        is_property_from_class = isinstance(symbol, UserClass) and attribute.attr in symbol.properties
+        is_class_variable_from_class = isinstance(symbol, UserClass) and attribute.attr in symbol.class_variables and not symbol.is_interface
+        is_property_from_class = isinstance(symbol, UserClass) and attribute.attr in symbol.properties and not symbol.is_interface
 
         if ((attr_symbol is None and hasattr(symbol, 'symbols'))
                 or is_invalid_method

--- a/boa3/builtin/__init__.py
+++ b/boa3/builtin/__init__.py
@@ -56,7 +56,10 @@ def contract(script_hash: type.ByteString):
     :param script_hash: Script hash of the interfaced contract
     :type script_hash: str or bytes
     """
-    pass
+    def decorator_wrapper(cls, *args, **kwargs):
+        cls.hash = script_hash
+        return cls
+    return decorator_wrapper
 
 
 def display_name(name: str):

--- a/boa3/model/type/classes/contractinterfaceclass.py
+++ b/boa3/model/type/classes/contractinterfaceclass.py
@@ -2,6 +2,7 @@ from typing import List
 
 from boa3.model.callable import Callable
 from boa3.model.type.classes.classtype import ClassType
+from boa3.model.type.classes.contractinterfacehash import ContractHashProperty
 from boa3.model.type.classes.userclass import UserClass
 from boa3.neo3.core.types import UInt160
 
@@ -18,6 +19,9 @@ class ContractInterfaceClass(UserClass):
 
         super().__init__(identifier, decorators, bases)
         self.contract_hash = contract_hash
+
+        contract_hash_property = ContractHashProperty(f'-{identifier}_hash', contract_hash.to_array())
+        self.include_property('hash', contract_hash_property)
 
     @property
     def is_interface(self) -> bool:

--- a/boa3/model/type/classes/contractinterfacehash.py
+++ b/boa3/model/type/classes/contractinterfacehash.py
@@ -1,0 +1,27 @@
+from typing import Dict, Optional
+
+from boa3.model.builtin.builtinproperty import IBuiltinProperty
+from boa3.model.builtin.interop.contractgethashmethod import ContractGetHashMethod
+from boa3.model.type.collection.sequence.uint160type import UInt160Type
+from boa3.model.variable import Variable
+
+
+class ContractInterfaceGetScriptHashMethod(ContractGetHashMethod):
+    def __init__(self, identifier: str, contract_script: bytes):
+        identifier = f'-get_{identifier}'
+        args: Dict[str, Variable] = {}
+        super().__init__(contract_script, identifier, args, return_type=UInt160Type.build())
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> Optional[str]:
+        return None
+
+
+class ContractHashProperty(IBuiltinProperty):
+    def __init__(self, identifier: str, contract_script: bytes):
+        getter = ContractInterfaceGetScriptHashMethod(identifier, contract_script)
+        super().__init__(identifier, getter)

--- a/boa3_test/test_sc/contract_interface_test/ContractInterfaceGetHash.py
+++ b/boa3_test/test_sc/contract_interface_test/ContractInterfaceGetHash.py
@@ -1,0 +1,15 @@
+from boa3.builtin import contract, public
+from boa3.builtin.type import UInt160
+
+
+@contract('0x000102030405060708090A0B0C0D0E0F10111213')
+class ContractInterface:
+
+    @staticmethod
+    def foo():
+        pass
+
+
+@public
+def main() -> UInt160:
+    return ContractInterface.hash

--- a/boa3_test/tests/compiler_tests/test_contract_interface.py
+++ b/boa3_test/tests/compiler_tests/test_contract_interface.py
@@ -181,3 +181,12 @@ class TestContractInterface(BoaTest):
         nep17_result = self.run_smart_contract(engine, nep17_path, 'symbol')
         result = self.run_smart_contract(engine, path, 'nep17_symbol')
         self.assertEqual(nep17_result, result)
+
+    def test_get_hash(self):
+        path = self.get_contract_path('ContractInterfaceGetHash.py')
+        engine = TestEngine()
+
+        contract_script_bytes = bytes(reversed(range(20)))
+        result = self.run_smart_contract(engine, path, 'main',
+                                         expected_result_type=bytes)
+        self.assertEqual(contract_script_bytes, result)


### PR DESCRIPTION
**Summary or solution description**
Implemented a property in contract interface classes to access their script hash

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/7143df2be36308c546597227ad18f2deef5178d0/boa3_test/test_sc/contract_interface_test/ContractInterfaceGetHash.py#L5-L15

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/7143df2be36308c546597227ad18f2deef5178d0/boa3_test/tests/compiler_tests/test_contract_interface.py#L185-L192

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7+