### PR TITLE
cannot update the update_contract.py example

### DIFF
--- a/boa3_test/examples/auxiliary_contracts/update_contract.py
+++ b/boa3_test/examples/auxiliary_contracts/update_contract.py
@@ -33,6 +33,10 @@ def manifest_metadata() -> NeoMetadata:
     meta.description = "Update Contract Example. This contract represents the updated smart contract to be deployed " \
                        "on the blockchain, with the method now working properly"
     meta.email = "contact@coz.io"
+
+    # requires access to ContractManagement methods
+    meta.add_permission(contract='0xfffdc93764dbaddd97c48f252a53ea4643faa3fd',
+                        methods=['update'])
     return meta
 
 
@@ -55,7 +59,7 @@ on_transfer = CreateNewEvent(
 # Methods
 # -------------------------------------------
 
-@public(safe=True)
+@public
 def update_sc(nef_file: bytes, manifest: bytes, data: Any = None):
     """
     Updates the smart contract. In this example there is a bugged method, so, the smart contract will be updated to fix

--- a/boa3_test/examples/update_contract.py
+++ b/boa3_test/examples/update_contract.py
@@ -34,6 +34,10 @@ def manifest_metadata() -> NeoMetadata:
     meta.description = "Update Contract Example. This contract represents the first smart contract deployed on the" \
                        "blockchain, with a buggy method."
     meta.email = "contact@coz.io"
+
+    # requires access to ContractManagement methods
+    meta.add_permission(contract='0xfffdc93764dbaddd97c48f252a53ea4643faa3fd',
+                        methods=['update'])
     return meta
 
 
@@ -57,7 +61,7 @@ on_transfer = CreateNewEvent(
 # -------------------------------------------
 
 
-@public(safe=True)
+@public
 def update_sc(nef_file: bytes, manifest: bytes, data: Any = None):
     """
     Updates the smart contract. In this example there is a bugged method, so, the smart contract will be updated to fix


### PR DESCRIPTION
**Summary or solution description**
Changed the example that set the update method as `safe`. Cannot update a contract from a read-only method, so calling this method would fail.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/865b5d3ae38c50a30ff9a9fe8f07bd30c4993530/boa3_test/examples/update_contract.py#L63-L72