### PR TITLE
Internal compiler error raised on `for` statement

### DIFF
--- a/boa3/compiler/codegenerator/codegenerator.py
+++ b/boa3/compiler/codegenerator/codegenerator.py
@@ -1812,10 +1812,10 @@ class CodeGenerator:
             self.__insert_code(call_code)
             self._update_codes_with_target(call_code)
 
-        for arg in range(num_args):
-            self._stack_pop()
-        if function.is_init:
-            self._stack_pop()  # pop duplicated result if it's init
+            for arg in range(num_args):
+                self._stack_pop()
+            if function.is_init:
+                self._stack_pop()  # pop duplicated result if it's init
 
         if function.return_type is not Type.none:
             self._stack_append(function.return_type)

--- a/boa3_test/test_sc/for_test/ForWithContractInterface.py
+++ b/boa3_test/test_sc/for_test/ForWithContractInterface.py
@@ -1,0 +1,20 @@
+from typing import List
+
+from boa3.builtin import public, contract
+
+
+@public
+def main(number: int) -> List[int]:
+    result_list: List[int] = []
+    for x in range(number):
+        idx: int = AnotherContract.return_zero()
+        result_list.append(idx)
+    return result_list
+
+
+@contract('0xdd6eea9717f5467b7a9cb49dabce80d8b3700270')
+class AnotherContract:
+
+    @staticmethod
+    def return_zero() -> int:
+        pass

--- a/boa3_test/test_sc/for_test/ForWithContractInterfaceCalled.py
+++ b/boa3_test/test_sc/for_test/ForWithContractInterfaceCalled.py
@@ -1,0 +1,6 @@
+from boa3.builtin import public
+
+
+@public
+def return_zero() -> int:
+    return 0

--- a/boa3_test/tests/compiler_tests/test_for.py
+++ b/boa3_test/tests/compiler_tests/test_for.py
@@ -314,3 +314,12 @@ class TestFor(BoaTest):
 
         result = self.run_smart_contract(engine, path, 'main')
         self.assertIsVoid(result)
+
+    def test_for_range(self):
+        path = self.get_contract_path('ForWithContractInterface.py')
+        path_contract_called = self.get_contract_path('ForWithContractInterfaceCalled.py')
+        engine = TestEngine()
+        self.run_smart_contract(engine, path_contract_called, 'return_zero')
+
+        result = self.run_smart_contract(engine, path, 'main', 3)
+        self.assertEqual([0, 0, 0], result)


### PR DESCRIPTION
**Summary or solution description**
Using a ContractInterface inside a `for` loop was making it end on the first iteration (this was also probably happening in other instances too).
There was a piece of code on the `codegenerator` that shouldn't be a part of the `ContractInterface` condition.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/f2e2ce4a655e56ae5f491b5ee6322f19de4b3c8c/boa3_test/test_sc/for_test/ForWithContractInterface.py#L1-L20

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/f2e2ce4a655e56ae5f491b5ee6322f19de4b3c8c/boa3_test/tests/compiler_tests/test_for.py#L318-L325

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
