### PR TITLE
Don't compile when typechecking doesn't fit Python standard

### DIFF
--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -170,6 +170,7 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
         :param function: the python ast function definition node
         """
         self.visit(function.args)
+
         symbols = self.symbols if self._current_class is None else self._current_class.symbols
         method = symbols[function.name]
 

--- a/boa3_test/test_sc/variable_test/MismatchedTypeInvalidTypeFormat.py
+++ b/boa3_test/test_sc/variable_test/MismatchedTypeInvalidTypeFormat.py
@@ -1,0 +1,8 @@
+# from typing import List
+
+from boa3.builtin import public
+
+
+@public
+def Main(a: [int]) -> [int]:  # should be List[int] instead of [int]
+    return a

--- a/boa3_test/tests/compiler_tests/test_variable.py
+++ b/boa3_test/tests/compiler_tests/test_variable.py
@@ -418,6 +418,10 @@ class TestVariable(BoaTest):
         path = self.get_contract_path('MismatchedTypeAugAssign.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
+    def test_invalid_type_format_mismatched_type(self):
+        path = self.get_contract_path('MismatchedTypeInvalidTypeFormat.py')
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+
     def test_global_declaration_with_assignment(self):
         expected_output = (
             Opcode.LDSFLD0


### PR DESCRIPTION
**Summary or solution description**
Included additional checks so the compiler doesn't accept `[int]` as a type annotation (should be `List[int]` in this case for example)

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/7b19c579948b333a0dedeb8e713b879cf7feb180/boa3_test/test_sc/variable_test/MismatchedTypeInvalidTypeFormat.py#L6-L8

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/7b19c579948b333a0dedeb8e713b879cf7feb180/boa3_test/tests/compiler_tests/test_variable.py#L421-L424

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7+