### PR TITLE
Problem with jagged arrays as parameter on TestEngine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
 
             git clone https://github.com/simplitech/neo-devpack-dotnet.git -b v3.4.0
             cd ./neo-devpack-dotnet
-            git checkout 6768e3424bcd8a1eae10b9f112fc262ce0f9d348
+            git checkout f0296dfe03ff67f2bb03ca84caf817255c7465f0
             cd ..
             dotnet build ./neo-devpack-dotnet/src/Neo.TestEngine/Neo.TestEngine.csproj -o ./Neo.TestEngine
 

--- a/boa3_test/tests/compiler_tests/test_list.py
+++ b/boa3_test/tests/compiler_tests/test_list.py
@@ -308,26 +308,18 @@ class TestList(BoaTest):
         )
 
         path = self.get_contract_path('ListOfList.py')
-        nef_path = path.replace('.py', '.nef')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
         engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'Main', [[1, 2], [3, 4]])
+        self.assertEqual(result, 1)
 
-        with self.assertRaisesRegex(TestExecutionException, self.NULL_POINTER_MSG):
-            # TODO: TestEngine error, on TestNet and PrivateNet the vm_state is 'HALT' instead of 'FAULT'
-            self.run_smart_contract(engine, path, 'Main', [[1, 2], [3, 4]])
+        with self.assertRaisesRegex(TestExecutionException, self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX):
+            self.run_smart_contract(engine, path, 'Main', [])
 
-        engine.run(nef_path, 'Main', [[1, 2], [3, 4]])
-        self.assertIsNotNone(engine.error)
-        from boa3.neo3.vm import VMState
-        self.assertEqual(engine.vm_state, VMState.FAULT)
-
-        engine.run(nef_path, 'Main', [])
-        self.assertIsNotNone(engine.error)
-
-        engine.run(nef_path, 'Main', [[], [1, 2], [3, 4]])
-        self.assertIsNotNone(engine.error)
+        with self.assertRaisesRegex(TestExecutionException, self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX):
+            self.run_smart_contract(engine, path, 'Main', [[], [1, 2], [3, 4]])
 
     def test_nep5_main(self):
         expected_output = (

--- a/boa3_test/tests/compiler_tests/test_tuple.py
+++ b/boa3_test/tests/compiler_tests/test_tuple.py
@@ -195,23 +195,18 @@ class TestTuple(BoaTest):
         )
 
         path = self.get_contract_path('TupleOfTuple.py')
-        nef_path = path.replace('.py', '.nef')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
         engine = TestEngine()
-        with self.assertRaisesRegex(TestExecutionException, self.NULL_POINTER_MSG):
-            # TODO: TestEngine fails when running contracts with arrays inside arrays args
-            self.run_smart_contract(engine, path, 'Main', ((1, 2), (3, 4)))
+        result = self.run_smart_contract(engine, path, 'Main', ((1, 2), (3, 4)))
+        self.assertEqual(result, 1)
 
-        result = engine.run(nef_path, 'Main', ((1, 2), (3, 4)))
-        self.assertEqual(1, result)
+        with self.assertRaisesRegex(TestExecutionException, self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX):
+            self.run_smart_contract(engine, path, 'Main', ())
 
-        engine.run(nef_path, 'Main', ())
-        self.assertIsNotNone(engine.error)
-
-        engine.run(nef_path, 'Main', ((), (1, 2), (3, 4)))
-        self.assertIsNotNone(engine.error)
+        with self.assertRaisesRegex(TestExecutionException, self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX):
+            self.run_smart_contract(engine, path, 'Main', ((), (1, 2), (3, 4)))
 
     def test_nep5_main(self):
         expected_output = (


### PR DESCRIPTION
**Summary or solution description**
Updated the unit tests that expected failures when passing arrays as arguments

https://github.com/CityOfZion/neo3-boa/blob/d43476809c443a958b3bdda27b2295fd864c3a25/boa3_test/tests/compiler_tests/test_list.py#L314-L322