### PR TITLE
Detect which native methods are called in the contract and set the permissions in the manifest

### DIFF
--- a/boa3/analyser/analyser.py
+++ b/boa3/analyser/analyser.py
@@ -11,6 +11,7 @@ from boa3.analyser.moduleanalyser import ModuleAnalyser
 from boa3.analyser.supportedstandard.standardanalyser import StandardAnalyser
 from boa3.analyser.typeanalyser import TypeAnalyser
 from boa3.builtin.compile_time import NeoMetadata
+from boa3.compiler.compiledmetadata import CompiledMetadata
 from boa3.exception.CompilerError import CompilerError
 from boa3.exception.CompilerWarning import CompilerWarning
 from boa3.model.symbol import ISymbol
@@ -75,6 +76,7 @@ class Analyser:
             ast_tree = ast.parse(source.read())
 
         analyser = Analyser(ast_tree, path, root if isinstance(root, str) else path, log)
+        CompiledMetadata.set_current_metadata(analyser.metadata)
         analyser.__pre_execute()
 
         # fill symbol table
@@ -136,6 +138,7 @@ class Analyser:
 
         :return: a boolean value that represents if the analysis was successful
         """
+        current_metadata = self.metadata
         module_analyser = ModuleAnalyser(self, self.symbol_table,
                                          log=self._log,
                                          filename=self.filename,
@@ -146,6 +149,10 @@ class Analyser:
         self.ast_tree.body.extend(module_analyser.imported_nodes)
         self.__update_logs(module_analyser)
         self._imported_files = module_analyser.analysed_files.copy()
+
+        if self.metadata != current_metadata:
+            CompiledMetadata.set_current_metadata(self.metadata)
+
         return not module_analyser.has_errors
 
     def __check_standards(self) -> bool:

--- a/boa3/compiler/compiledmetadata.py
+++ b/boa3/compiler/compiledmetadata.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from typing import Union
+
+from boa3 import constants
+from boa3.builtin.compile_time import NeoMetadata
+from boa3.neo3.core.types import UInt160
+
+
+class CompiledMetadata:
+    _instance = None
+
+    @classmethod
+    def instance(cls) -> CompiledMetadata:
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    def __init__(self):
+        self._metadata = NeoMetadata()
+
+    @classmethod
+    def reset(cls):
+        cls.instance()._metadata = NeoMetadata()
+
+    @classmethod
+    def set_current_metadata(cls, metadata: NeoMetadata):
+        cls.instance()._metadata = metadata
+
+    def add_contract_permission(self, contract: Union[bytes, str], method: str = None):
+        if isinstance(contract, bytes):
+            contract = UInt160(contract)
+        else:
+            contract = UInt160.from_string(contract)
+        contract_hex_script = str(contract)
+        method_string = method if isinstance(method, str) and len(method) > 0 else constants.IMPORT_WILDCARD
+
+        # look for permissions for the given contract
+        existing_permission = next((permission for permission in self._metadata.permissions
+                                    if ('contract' in permission
+                                        and permission['contract'] == contract_hex_script)
+                                    ), None)
+
+        if existing_permission is not None:
+            # if there's already a permission, include the method name
+            permitted_methods = existing_permission['methods'] if 'methods' in existing_permission else []
+
+            # if it's using the wildcard, all methods in this contract can already be called
+            if permitted_methods != constants.IMPORT_WILDCARD:
+                if method_string == constants.IMPORT_WILDCARD:
+                    existing_permission['methods'] = constants.IMPORT_WILDCARD
+                else:
+                    if method_string not in permitted_methods:
+                        permitted_methods.append(method_string)
+
+                    if 'methods' not in existing_permission:
+                        existing_permission['methods'] = permitted_methods
+
+            return
+
+        # look for generic permissions for the given method
+        existing_permission = next((permission for permission in self._metadata.permissions
+                                    if ('contract' in permission
+                                        and permission['contract'] == constants.IMPORT_WILDCARD
+                                        and 'method' in permission
+                                        and (permission['methods'] == constants.IMPORT_WILDCARD
+                                             or method_string in permission['methods']))
+                                    ), None)
+
+        if existing_permission is None:
+            # if no permission is found, include it
+            self._metadata.add_permission(contract=contract_hex_script,
+                                          methods=([method_string] if method_string != constants.IMPORT_WILDCARD
+                                                   else method_string))
+

--- a/boa3/compiler/compiler.py
+++ b/boa3/compiler/compiler.py
@@ -40,8 +40,10 @@ class Compiler:
         logging.info(f'Started compiling\t{filename}')
         self._entry_smart_contract = os.path.splitext(filename)[0]
 
+        from boa3.compiler.compiledmetadata import CompiledMetadata
         from boa3.model.imports.builtin import CompilerBuiltin
         CompilerBuiltin.reset()
+        CompiledMetadata.reset()
 
         self._analyse(fullpath, root_folder, log)
         return self._compile()

--- a/boa3/model/builtin/interop/nativecontract/nativecontractmethod.py
+++ b/boa3/model/builtin/interop/nativecontract/nativecontractmethod.py
@@ -1,6 +1,7 @@
 import ast
 from typing import Dict, List, Tuple, Optional
 
+from boa3.compiler.compiledmetadata import CompiledMetadata
 from boa3.model.builtin.interop.contractgethashmethod import ContractGetHashMethod
 from boa3.model.builtin.interop.interopmethod import InteropMethod
 from boa3.model.type.itype import IType
@@ -51,6 +52,7 @@ class NativeContractMethod(InteropMethod):
         if self._pack_arguments is None:
             self._pack_arguments = False
 
+        CompiledMetadata.instance().add_contract_permission(self.contract_script_hash, self._sys_call)
         self_method_token_id = self._get_method_token_id(call_flag)
 
         if isinstance(self_method_token_id, int) and self_method_token_id >= 0:

--- a/boa3_test/examples/auxiliary_contracts/update_contract.py
+++ b/boa3_test/examples/auxiliary_contracts/update_contract.py
@@ -33,10 +33,6 @@ def manifest_metadata() -> NeoMetadata:
     meta.description = "Update Contract Example. This contract represents the updated smart contract to be deployed " \
                        "on the blockchain, with the method now working properly"
     meta.email = "contact@coz.io"
-
-    # requires access to ContractManagement methods
-    meta.add_permission(contract='0xfffdc93764dbaddd97c48f252a53ea4643faa3fd',
-                        methods=['update'])
     return meta
 
 

--- a/boa3_test/examples/htlc.py
+++ b/boa3_test/examples/htlc.py
@@ -19,6 +19,7 @@ def manifest_metadata() -> NeoMetadata:
     Defines this smart contract's metadata information
     """
     meta = NeoMetadata()
+    meta.add_permission(methods=['transfer'])
     return meta
 
 

--- a/boa3_test/examples/wrapped_gas.py
+++ b/boa3_test/examples/wrapped_gas.py
@@ -22,8 +22,6 @@ def manifest_metadata() -> NeoMetadata:
     meta = NeoMetadata()
     meta.supported_standards = ['NEP-17']
     meta.add_permission(methods=['onNEP17Payment'])
-    # this contract needs to call GAS methods
-    meta.add_permission(contract='0xd2a4cff31913016155e38e474a2c06d08be276cf')
 
     meta.author = "Mirella Medeiros, Ricardo Prado and Lucas Uezu. COZ in partnership with Simpli"
     meta.description = "Wrapped GAS Example"

--- a/boa3_test/examples/wrapped_neo.py
+++ b/boa3_test/examples/wrapped_neo.py
@@ -21,8 +21,6 @@ def manifest_metadata() -> NeoMetadata:
     meta = NeoMetadata()
     meta.supported_standards = ['NEP-17']
     meta.add_permission(methods=['onNEP17Payment'])
-    # this contract needs to call NEO methods
-    meta.add_permission(contract='0xef4073a0f2b305a38ec4050e4d3d28bc40ea63f5')
 
     meta.author = "Mirella Medeiros, Ricardo Prado and Lucas Uezu. COZ in partnership with Simpli"
     meta.description = "Wrapped NEO Example"

--- a/boa3_test/test_sc/metadata_test/MetadataInfoPermissionsNativeContract.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoPermissionsNativeContract.py
@@ -1,0 +1,19 @@
+from boa3.builtin.compile_time import metadata, public, NeoMetadata
+from boa3.builtin.nativecontract.contractmanagement import ContractManagement
+
+
+@metadata
+def permissions_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+    # permission to call 'update' and 'destroy' from ContractManagement should be included by the compiler
+    return meta
+
+
+@public
+def update(nef_file: bytes, manifest: bytes):
+    ContractManagement.update(nef_file, manifest)
+
+
+@public
+def destroy():
+    ContractManagement.destroy()

--- a/boa3_test/tests/compiler_tests/test_metadata.py
+++ b/boa3_test/tests/compiler_tests/test_metadata.py
@@ -1,6 +1,8 @@
+from boa3 import constants
 from boa3.constants import IMPORT_WILDCARD
 from boa3.exception import CompilerError, CompilerWarning
 from boa3.neo.vm.opcode.Opcode import Opcode
+from boa3.neo3.core.types import UInt160
 from boa3_test.tests.boa_test import BoaTest
 from boa3_test.tests.test_classes.contract.neomanifeststruct import NeoManifestStruct
 from boa3_test.tests.test_classes.testengine import TestEngine
@@ -404,7 +406,7 @@ class TestMetadata(BoaTest):
         self.assertEqual(len(manifest['permissions']), 1)
         self.assertIn({"contract": "*", "methods": "*"}, manifest['permissions'])
 
-    def test_metadata_info_permissions_Wildcard(self):
+    def test_metadata_info_permissions_wildcard(self):
         path = self.get_contract_path('MetadataInfoPermissionsWildcard.py')
         output, manifest = self.compile_and_save(path)
 
@@ -412,6 +414,19 @@ class TestMetadata(BoaTest):
         self.assertIsInstance(manifest['permissions'], list)
         self.assertEqual(len(manifest['permissions']), 1)
         self.assertIn({"contract": "*", "methods": "*"}, manifest['permissions'])
+
+    def test_metadata_info_permissions_native_contract(self):
+        path = self.get_contract_path('MetadataInfoPermissionsNativeContract.py')
+        output, manifest = self.compile_and_save(path)
+
+        expected_permission = {
+            'contract': str(UInt160(constants.MANAGEMENT_SCRIPT)),
+            'methods': ['update', 'destroy']
+        }
+        self.assertIn('permissions', manifest)
+        self.assertIsInstance(manifest['permissions'], list)
+        self.assertEqual(len(manifest['permissions']), 1)
+        self.assertIn(expected_permission, manifest['permissions'])
 
     def test_metadata_info_name(self):
         path = self.get_contract_path('MetadataInfoName.py')


### PR DESCRIPTION
**Summary or solution description**
When the smart contract called the non-safe methods from native contracts using their boa interfaces, a runtime error would be thrown if those methods weren't explicitly included in the manifest permissions.
This PR changes it so the compiler can detect the native contract methods that the smart contract calls and include then in the manifest

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/e3b2588f72573cb389d1612914a0bf4a3e3dac91/boa3_test/test_sc/metadata_test/MetadataInfoPermissionsNativeContract.py#L2-L19

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/e3b2588f72573cb389d1612914a0bf4a3e3dac91/boa3_test/tests/compiler_tests/test_metadata.py#L418-L430

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7+