### PR TITLE
Reset is not resetting contracts on TestEngine

### DIFF
--- a/boa3_test/tests/compiler_tests/test_interop/test_blockchain.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_blockchain.py
@@ -48,7 +48,7 @@ class TestBlockchainInterop(BoaTest):
         nef, manifest = self.get_bytes_output(call_contract_path)
         call_contract_path = call_contract_path.replace('.py', '.nef')
 
-        engine = TestEngine()
+        engine.reset_engine()
         engine.add_contract(call_contract_path)
 
         result = self.run_smart_contract(engine, path, 'main', call_hash)

--- a/boa3_test/tests/compiler_tests/test_interop/test_contract.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_contract.py
@@ -24,7 +24,7 @@ class TestContractInterop(BoaTest):
         expected_output = self.run_smart_contract(engine, call_contract_path, 'add', 1, 2)
         call_hash = engine.executed_script_hash.to_array()
 
-        engine = TestEngine()
+        engine.reset_engine()
         call_contract_path = call_contract_path.replace('.py', '.nef')
         with self.assertRaisesRegex(TestExecutionException, self.CALLED_CONTRACT_DOES_NOT_EXIST_MSG):
             self.run_smart_contract(engine, path, 'Main', call_hash, 'add', [1, 2])
@@ -45,7 +45,7 @@ class TestContractInterop(BoaTest):
         self.run_smart_contract(engine, call_contract_path, 'add', 1, 2)
         call_hash = engine.executed_script_hash.to_array()
 
-        engine = TestEngine()
+        engine.reset_engine()
         call_contract_path = call_contract_path.replace('.py', '.nef')
         with self.assertRaisesRegex(TestExecutionException, self.CALLED_CONTRACT_DOES_NOT_EXIST_MSG):
             self.run_smart_contract(engine, path, 'Main', call_hash, 'add', [1, 2])
@@ -63,7 +63,7 @@ class TestContractInterop(BoaTest):
         expected_output = self.run_smart_contract(engine, call_contract_path, 'Main')
         call_hash = engine.executed_script_hash.to_array()
 
-        engine = TestEngine()
+        engine.reset_engine()
         call_contract_path = call_contract_path.replace('.py', '.nef')
         with self.assertRaisesRegex(TestExecutionException, self.CALLED_CONTRACT_DOES_NOT_EXIST_MSG):
             self.run_smart_contract(engine, path, 'Main', call_hash, 'Main')
@@ -80,7 +80,7 @@ class TestContractInterop(BoaTest):
         self.run_smart_contract(engine, call_contract_path, 'notify_user')
         call_hash = engine.executed_script_hash.to_array()
 
-        engine = TestEngine()
+        engine.reset_engine()
         call_contract_path = call_contract_path.replace('.py', '.nef')
         with self.assertRaisesRegex(TestExecutionException, f'^{self.ARGUMENT_OUT_OF_RANGE_MSG_PREFIX}'):
             self.run_smart_contract(engine, path, 'Main', call_hash, 'Main')
@@ -334,7 +334,7 @@ class TestContractInterop(BoaTest):
         self.run_smart_contract(engine, call_contract_path, 'main')
         call_hash = engine.executed_script_hash.to_array()
 
-        engine = TestEngine()
+        engine.reset_engine()
         call_contract_path = call_contract_path.replace('.py', '.nef')
         with self.assertRaisesRegex(TestExecutionException, f'^{self.ARGUMENT_OUT_OF_RANGE_MSG_PREFIX}'):
             self.run_smart_contract(engine, path, 'Main', call_hash, 'main')
@@ -367,7 +367,7 @@ class TestContractInterop(BoaTest):
         expected_output = self.run_smart_contract(engine, call_contract_path, 'add', 1, 2)
         call_hash = engine.executed_script_hash.to_array()
 
-        engine = TestEngine()
+        engine.reset_engine()
         call_contract_path = call_contract_path.replace('.py', '.nef')
         engine.add_contract(call_contract_path)
 
@@ -386,7 +386,7 @@ class TestContractInterop(BoaTest):
         expected_output = self.run_smart_contract(engine, call_contract_path, 'add', 1, 2)
         call_hash = engine.executed_script_hash.to_array()
 
-        engine = TestEngine()
+        engine.reset_engine()
         call_contract_path = call_contract_path.replace('.py', '.nef')
         engine.add_contract(call_contract_path)
 

--- a/boa3_test/tests/compiler_tests/test_interop/test_runtime.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_runtime.py
@@ -482,7 +482,7 @@ class TestRuntimeInterop(BoaTest):
         self.assertEqual('Deploy', event_name)
         script = engine.executed_script_hash.to_array()
 
-        engine = TestEngine()
+        engine.reset_engine()
         result = self.run_smart_contract(engine, path, 'without_param', [1, 2, 3])
         expected_result = [
             [constants.MANAGEMENT_SCRIPT, 'Deploy', script]
@@ -495,11 +495,11 @@ class TestRuntimeInterop(BoaTest):
         # it's the same Deploy error
         self.assertEqual(expected_result[0][:2], result[0][:2])
 
-        engine = TestEngine()
+        engine.reset_engine()
         result = self.run_smart_contract(engine, path, 'with_param', [], script)
         self.assertEqual([], result)
 
-        engine = TestEngine()
+        engine.reset_engine()
         result = self.run_smart_contract(engine, path, 'with_param', [1, 2, 3], script)
         expected_result = []
         for x in [1, 2, 3]:
@@ -508,7 +508,7 @@ class TestRuntimeInterop(BoaTest):
                                     [x]])
         self.assertEqual(expected_result, result)
 
-        engine = TestEngine()
+        engine.reset_engine()
         result = self.run_smart_contract(engine, path, 'with_param', [1, 2, 3], b'\x01' * 20)
         self.assertEqual([], result)
 

--- a/boa3_test/tests/examples_tests/test_amm.py
+++ b/boa3_test/tests/examples_tests/test_amm.py
@@ -30,7 +30,7 @@ class TestTemplate(BoaTest):
         self.run_smart_contract(engine, path_zgas, 'symbol')
         zgas_address = engine.executed_script_hash.to_array()
 
-        engine = TestEngine()
+        engine.reset_engine()
         engine.add_contract(path_zneo.replace('.py', '.nef'))
         engine.add_contract(path_zgas.replace('.py', '.nef'))
 
@@ -106,7 +106,7 @@ class TestTemplate(BoaTest):
         self.run_smart_contract(engine, path_zgas, 'symbol')
         zgas_address = engine.executed_script_hash.to_array()
 
-        engine = TestEngine()
+        engine.reset_engine()
         engine.add_contract(path.replace('.py', '.nef'))
         engine.add_contract(path_zneo.replace('.py', '.nef'))
         engine.add_contract(path_zgas.replace('.py', '.nef'))
@@ -153,7 +153,7 @@ class TestTemplate(BoaTest):
         self.run_smart_contract(engine, path_zgas, 'symbol')
         zgas_address = engine.executed_script_hash.to_array()
 
-        engine = TestEngine()
+        engine.reset_engine()
         engine.add_contract(path.replace('.py', '.nef'))
         engine.add_contract(path_zneo.replace('.py', '.nef'))
         engine.add_contract(path_zgas.replace('.py', '.nef'))
@@ -379,7 +379,7 @@ class TestTemplate(BoaTest):
         self.run_smart_contract(engine, path_zgas, 'symbol')
         zgas_address = engine.executed_script_hash.to_array()
 
-        engine = TestEngine()
+        engine.reset_engine()
         engine.add_contract(path.replace('.py', '.nef'))
         engine.add_contract(path_zneo.replace('.py', '.nef'))
         engine.add_contract(path_zgas.replace('.py', '.nef'))
@@ -519,7 +519,7 @@ class TestTemplate(BoaTest):
         self.run_smart_contract(engine, path_zgas, 'symbol')
         zgas_address = engine.executed_script_hash.to_array()
 
-        engine = TestEngine()
+        engine.reset_engine()
         engine.add_contract(path.replace('.py', '.nef'))
         engine.add_contract(path_zneo.replace('.py', '.nef'))
         engine.add_contract(path_zgas.replace('.py', '.nef'))
@@ -655,7 +655,7 @@ class TestTemplate(BoaTest):
         self.run_smart_contract(engine, path_zgas, 'symbol')
         zgas_address = engine.executed_script_hash.to_array()
 
-        engine = TestEngine()
+        engine.reset_engine()
         engine.add_contract(path.replace('.py', '.nef'))
         engine.add_contract(path_zneo.replace('.py', '.nef'))
         engine.add_contract(path_zgas.replace('.py', '.nef'))

--- a/boa3_test/tests/examples_tests/test_htlc.py
+++ b/boa3_test/tests/examples_tests/test_htlc.py
@@ -43,7 +43,7 @@ class TestHTLCTemplate(BoaTest):
         self.run_smart_contract(engine, path, 'refund')
         htlc_address = engine.executed_script_hash.to_array()
 
-        engine = TestEngine()
+        engine.reset_engine()
         engine.add_neo(self.OTHER_ACCOUNT_1, transferred_amount_neo)
         engine.add_gas(self.OTHER_ACCOUNT_2, transferred_amount_gas)
 
@@ -154,7 +154,7 @@ class TestHTLCTemplate(BoaTest):
         self.run_smart_contract(engine, path, 'refund')
         htlc_address = engine.executed_script_hash.to_array()
 
-        engine = TestEngine()
+        engine.reset_engine()
         engine.add_neo(self.OTHER_ACCOUNT_1, transferred_amount_neo)
         engine.add_gas(self.OTHER_ACCOUNT_2, transferred_amount_gas)
 
@@ -267,7 +267,7 @@ class TestHTLCTemplate(BoaTest):
         self.run_smart_contract(engine, path, 'refund')
         htlc_address = engine.executed_script_hash.to_array()
 
-        engine = TestEngine()
+        engine.reset_engine()
         engine.add_neo(self.OTHER_ACCOUNT_1, transferred_amount_neo)
         engine.add_gas(self.OTHER_ACCOUNT_2, transferred_amount_gas)
 

--- a/boa3_test/tests/examples_tests/test_nep17.py
+++ b/boa3_test/tests/examples_tests/test_nep17.py
@@ -145,7 +145,7 @@ class TestNEP17Template(BoaTest):
         self.run_smart_contract(engine, path, 'symbol')
         nep17_address = engine.executed_script_hash.to_array()
 
-        engine = TestEngine()
+        engine.reset_engine()
         engine.add_contract(path.replace('.py', '.nef'))
 
         engine.add_neo(self.OTHER_ACCOUNT_1, transferred_amount)

--- a/boa3_test/tests/examples_tests/test_wrapped_neo.py
+++ b/boa3_test/tests/examples_tests/test_wrapped_neo.py
@@ -159,7 +159,7 @@ class TestTemplate(BoaTest):
         self.run_smart_contract(engine, path, 'symbol')
         wrapped_neo_address = engine.executed_script_hash.to_array()
 
-        engine = TestEngine()
+        engine.reset_engine()
         engine.add_neo(wrapped_neo_address, 10_000_000 * 10 ** 8)
         burned_amount = 100 * 10 ** 8
 
@@ -224,7 +224,7 @@ class TestTemplate(BoaTest):
         self.run_smart_contract(engine, path, 'symbol')
         wrapped_neo_address = engine.executed_script_hash.to_array()
 
-        engine = TestEngine()
+        engine.reset_engine()
         engine.add_contract(path.replace('.py', '.nef'))
         allowed_amount = 10 * 10 ** 8
 
@@ -267,7 +267,7 @@ class TestTemplate(BoaTest):
         self.run_smart_contract(engine, path, 'symbol')
         wrapped_neo_address = engine.executed_script_hash.to_array()
 
-        engine = TestEngine()
+        engine.reset_engine()
         engine.add_contract(path.replace('.py', '.nef'))
         allowed_amount = 10 * 10 ** 8
 
@@ -301,7 +301,7 @@ class TestTemplate(BoaTest):
         self.run_smart_contract(engine, path, 'symbol')
         wrapped_neo_address = engine.executed_script_hash.to_array()
 
-        engine = TestEngine()
+        engine.reset_engine()
         engine.add_contract(path.replace('.py', '.nef'))
         allowed_amount = 10 * 10 ** 8
 
@@ -417,7 +417,7 @@ class TestTemplate(BoaTest):
         self.run_smart_contract(engine, path, 'symbol')
         wrapped_neo_address = engine.executed_script_hash.to_array()
 
-        engine = TestEngine()
+        engine.reset_engine()
         engine.add_contract(path.replace('.py', '.nef'))
         minted_amount = 10 * 10 ** 8
         engine.add_neo(self.OTHER_ACCOUNT_1, minted_amount)

--- a/boa3_test/tests/test_classes/storage.py
+++ b/boa3_test/tests/test_classes/storage.py
@@ -18,11 +18,14 @@ class Storage:
         storage_key = StorageKey(key)
         return self._dict.pop(storage_key)
 
-    def clear(self):
+    def clear(self, delete_deploy_data: bool = True):
         prefix, native_id = get_native_contract_data(constants.MANAGEMENT_SCRIPT)
         for key in list(self._dict.keys()):
             should_delete = (key._ID > 0  # it's a deployd contract
-                             or key._ID == native_id and key._key.startswith(prefix)  # it's a deployed contract register
+                             or (delete_deploy_data
+                                 and key._ID == native_id
+                                 and key._key.startswith(prefix)  # it's a deployed contract register
+                                 )
                              )
             if should_delete:
                 # keep native contracts storage

--- a/boa3_test/tests/test_classes/storage.py
+++ b/boa3_test/tests/test_classes/storage.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Union
 
+from boa3 import constants
 from boa3.neo.utils import contract_parameter_to_json, stack_item_from_json
 from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.String import String
@@ -18,8 +19,12 @@ class Storage:
         return self._dict.pop(storage_key)
 
     def clear(self):
+        prefix, native_id = get_native_contract_data(constants.MANAGEMENT_SCRIPT)
         for key in list(self._dict.keys()):
-            if key._ID > 0:
+            should_delete = (key._ID > 0  # it's a deployd contract
+                             or key._ID == native_id and key._key.startswith(prefix)  # it's a deployed contract register
+                             )
+            if should_delete:
                 # keep native contracts storage
                 self._dict.pop(key)
 
@@ -73,7 +78,6 @@ class Storage:
         return True
 
     def has_contract(self, script_hash: bytes) -> bool:
-        from boa3 import constants
         prefix, native_id = get_native_contract_data(constants.MANAGEMENT_SCRIPT)
         if prefix is None or native_id is None:
             return False
@@ -82,7 +86,6 @@ class Storage:
         return storage_key in self
 
     def get_contract_id(self, script_hash: bytes) -> int:
-        from boa3 import constants
         prefix, native_id = get_native_contract_data(constants.MANAGEMENT_SCRIPT)
         if prefix is None or native_id is None:
             return False

--- a/boa3_test/tests/test_classes/testengine.py
+++ b/boa3_test/tests/test_classes/testengine.py
@@ -398,6 +398,7 @@ class TestEngine:
         self.reset_state()
         self._notifications.clear()
         self._storage.clear()
+        self._contract_paths.clear()
 
     def _filter_result(self, value: Any, called_method: str, contract_id=None):
         if contract_id is None:

--- a/boa3_test/tests/test_classes/testengine.py
+++ b/boa3_test/tests/test_classes/testengine.py
@@ -121,7 +121,7 @@ class TestEngine:
             self._storage[storage_key] = value
 
     def set_storage(self, storage: Dict[Tuple[Union[str, bytes], str], Any]):
-        self._storage.clear()
+        self._storage.clear(delete_deploy_data=False)
         for (key, contract_path), value in storage.items():
             self.storage_put(key, value, contract_path)
 


### PR DESCRIPTION
**Summary or solution description**
`reset_engine` weren't clearing the contract list nor removing the deployed contract data from the mocked storage.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/514bac7964f91b7a656ecc4f14df9038da01fafa/boa3_test/tests/compiler_tests/test_interop/test_contract.py#L20-L34

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7+
