### PR TITLE
Isolate position-opcode map logic from the code generator

### DIFF
--- a/boa3/compiler/codegenerator/vmcodemap.py
+++ b/boa3/compiler/codegenerator/vmcodemap.py
@@ -12,11 +12,11 @@ class VMCodeMap:
         self._vm_code_with_target: List[VMCode] = []
 
     def __len__(self) -> int:
-        return min(len(self._vm_code_list), len(self._vm_code_addresses))
+        return self._vm_code_list.__len__()
 
     def clear(self):
         self._vm_code_addresses.clear()
-        return self._vm_code_list.clear()
+        self._vm_code_list.clear()
 
     def get_code_map(self) -> Dict[int, VMCode]:
         size = len(self)

--- a/boa3/compiler/codegenerator/vmcodemap.py
+++ b/boa3/compiler/codegenerator/vmcodemap.py
@@ -1,0 +1,179 @@
+from typing import List, Dict, Optional
+
+from boa3.neo.vm.VMCode import VMCode
+
+
+class VMCodeMap:
+    def __init__(self):
+        self._vm_code_list: List[VMCode] = []
+        self._vm_code_addresses: List[int] = []
+
+    def __len__(self) -> int:
+        return min(len(self._vm_code_list), len(self._vm_code_addresses))
+
+    def clear(self):
+        self._vm_code_addresses.clear()
+        return self._vm_code_list.clear()
+
+    def get_code_map(self) -> Dict[int, VMCode]:
+        size = len(self)
+        return {self._vm_code_addresses[index]: self._vm_code_list[index] for index in range(size)}
+
+    def get_code_list(self) -> List[VMCode]:
+        return self._vm_code_list
+
+    def get_bytecode_size(self) -> int:
+        if len(self) < 1:
+            return 0
+
+        return self._vm_code_addresses[-1] + self._vm_code_list[-1].size
+
+    def insert_code(self, vm_code: VMCode):
+        if vm_code not in self._vm_code_list:
+            self._vm_code_addresses.append(self.get_bytecode_size())
+            self._vm_code_list.append(vm_code)
+
+    def get_code(self, address: int) -> Optional[VMCode]:
+        try:
+            index = self._vm_code_addresses.index(address)
+        except ValueError:
+            # the address is not int the list
+            if address >= self.get_bytecode_size():
+                # the address is not in the bytecode
+                return None
+
+            # if the address is not the start of a instruction, gets the last instruction before given address
+            code_address = 0
+            for addr in self._vm_code_addresses:
+                if addr > address:
+                    break
+                code_address = addr
+
+            index = self._vm_code_addresses.index(code_address)
+
+        return self._vm_code_list[index]
+
+    def get_start_address(self, vm_code: VMCode) -> int:
+        try:
+            index = self._vm_code_list.index(vm_code)
+            return self._vm_code_addresses[index]
+        except ValueError:
+            return 0
+
+    def get_end_address(self, vm_code: VMCode) -> int:
+        try:
+            index = self._vm_code_list.index(vm_code) + 1
+            if index == len(self._vm_code_list):
+                return self.get_bytecode_size()
+            else:
+                return self._vm_code_addresses[index] - 1
+        except ValueError:
+            return 0
+
+    def get_addresses(self, start_address: int, end_address: int) -> List[int]:
+        if start_address > end_address:
+            start_address, end_address = end_address, start_address
+
+        addresses = []
+        for address in range(start_address, end_address + 1):
+            if address in self._vm_code_addresses:
+                addresses.append(address)
+        return addresses
+
+    def get_addresses_from_codes(self, codes: List[VMCode]) -> List[int]:
+        if len(codes) < 1:
+            return []
+
+        addresses = []
+        for vm_code in codes:
+            try:
+                index = self._vm_code_list.index(vm_code)
+                addresses.append(self._vm_code_addresses[index])
+            except ValueError:
+                continue
+
+        return addresses
+
+    def get_opcodes(self, addresses: List[int]) -> List[VMCode]:
+        codes = []
+
+        for address in sorted(addresses):
+            try:
+                index = self._vm_code_addresses.index(address)
+                codes.append(self._vm_code_list[index])
+            except ValueError:
+                # address not in list
+                continue
+
+        return codes
+
+    def update_addresses(self, start_address: int = 0):
+        next_address = -1
+        final_size = len(self._vm_code_list)
+
+        if len(self._vm_code_addresses) > final_size:
+            self._vm_code_addresses = self._vm_code_addresses[:final_size]
+
+        for index in range(final_size):
+            address = self._vm_code_addresses[index]
+
+            if address >= start_address:
+                if next_address < 0:
+                    if index > 0:
+                        new_address = self._vm_code_addresses[index - 1]
+                        next_address = new_address + self._vm_code_list[index - 1].size
+                    else:
+                        next_address = 0
+
+                if next_address != address:
+                    if index < len(self._vm_code_addresses):
+                        self._vm_code_addresses[index] = next_address
+                    else:
+                        self._vm_code_addresses.append(next_address)
+
+                next_address += self._vm_code_list[index].size
+
+    def move_to_end(self, first_code_address: int, last_code_address: int) -> int:
+        if last_code_address < first_code_address:
+            return
+
+        if (len(self._vm_code_addresses) > 0 and
+                last_code_address == self._vm_code_addresses[-1]):
+            # there's nothing to change if it's moving the all the codes
+            return self.get_bytecode_size()
+
+        first_index = -1
+        last_index = 0
+        for index, address in enumerate(self._vm_code_addresses):
+            if first_code_address <= address and first_index < 0:
+                first_index = index
+            elif address > last_code_address:
+                last_index = index
+                break
+
+        if first_index >= 0:
+            # if the first index was not set, there's nothing to move
+            if last_index < first_index:
+                last_index = len(self._vm_code_addresses)
+
+            self._vm_code_list[first_index:] = (self._vm_code_list[last_index:] +
+                                                self._vm_code_list[first_index:last_index])
+            self.update_addresses(first_code_address)
+
+        index = self.get_bytecode_size()
+        return index
+
+    def remove_opcodes_by_addresses(self, addresses: List[int]):
+        was_changed = False
+        # reversed so we only need to update addresses once after all are removed
+        for code_address in sorted(addresses, reverse=True):
+            try:
+                index = self._vm_code_addresses.index(code_address)
+                self._vm_code_list.pop(index)
+                was_changed = True
+            except ValueError:
+                # don't stop the loop if an address is not found
+                continue
+
+        if was_changed:
+            self.update_addresses(min(addresses))

--- a/boa3/compiler/codegenerator/vmcodemapping.py
+++ b/boa3/compiler/codegenerator/vmcodemapping.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Dict, List, Optional, Union
 
 from boa3.compiler.codegenerator.methodtokencollection import MethodTokenCollection
+from boa3.compiler.codegenerator.vmcodemap import VMCodeMap
 from boa3.compiler.compileroutput import CompilerOutput
 from boa3.model.builtin.method import IBuiltinMethod
 from boa3.neo.vm.VMCode import VMCode
@@ -27,7 +28,8 @@ class VMCodeMapping:
         return cls._instance
 
     def __init__(self):
-        self._codes: Dict[int, VMCode] = {}
+        # self._codes: Dict[int, VMCode] = {}
+        self._code_map: VMCodeMap = VMCodeMap()
         self._method_tokens: MethodTokenCollection = MethodTokenCollection()
 
     @classmethod
@@ -36,7 +38,8 @@ class VMCodeMapping:
         Resets the map to the first state
         """
         if cls._instance is not None:
-            cls._instance._codes.clear()
+            # cls._instance._codes.clear()
+            cls._instance._code_map.clear()
             cls._instance._method_tokens.clear()
 
     def add_method_token(self, method: IBuiltinMethod, call_flag: CallFlags) -> Optional[int]:
@@ -55,7 +58,7 @@ class VMCodeMapping:
 
         :return: a list of vm codes ordered by its address in the bytecode
         """
-        return list(self.code_map.values())
+        return self._code_map.get_code_list()
 
     @property
     def code_map(self) -> Dict[int, VMCode]:
@@ -64,7 +67,7 @@ class VMCodeMapping:
 
         :return: a dictionary that maps each instruction with its address. The keys are ordered by the address.
         """
-        return {key: self._codes[key] for key in sorted(self._codes)}
+        return self._code_map.get_code_map()
 
     def targeted_address(self) -> Dict[int, List[int]]:
         """
@@ -107,15 +110,10 @@ class VMCodeMapping:
 
     @property
     def bytecode_size(self) -> int:
-        if len(self._codes) < 1:
-            return 0
-
-        last_key = list(self.code_map)[-1]
-        return last_key + self._codes[last_key].size
+        return self._code_map.get_bytecode_size()
 
     def insert_code(self, vm_code: VMCode):
-        if vm_code not in self._codes.values():
-            self._codes[self.bytecode_size] = vm_code
+        return self._code_map.insert_code(vm_code)
 
     def get_code(self, address: int) -> Optional[VMCode]:
         """
@@ -125,29 +123,10 @@ class VMCodeMapping:
         :return: the opcode if it exists. None otherwise
         :rtype: VMCode or None
         """
-        if address in self._codes:
-            return self._codes[address]
-        elif address >= self.bytecode_size:
-            # the address is not in the bytecode
-            return None
-        else:
-            # if the address is not the start of a instruction, gets the last instruction before given address
-            code_address = 0
-            for addr in self._codes:
-                if addr > address:
-                    break
-                code_address = addr
-            return self._codes[code_address]
+        return self._code_map.get_code(address)
 
     def get_addresses(self, start_address: int, end_address: int) -> List[int]:
-        if start_address > end_address:
-            start_address, end_address = end_address, start_address
-
-        addresses = []
-        for address in range(start_address, end_address + 1):
-            if address in self._codes:
-                addresses.append(address)
-        return addresses
+        return self._code_map.get_addresses(start_address, end_address)
 
     def get_start_address(self, vm_code: VMCode) -> int:
         """
@@ -156,9 +135,7 @@ class VMCodeMapping:
         :param vm_code: the instruction to get the address
         :return: the vm code's address if it's in the map. Otherwise, return's zero.
         """
-        if vm_code not in self._codes.values():
-            return 0
-        return next(key for key, value in self._codes.items() if value == vm_code)
+        return self._code_map.get_start_address(vm_code)
 
     def get_end_address(self, vm_code: VMCode) -> int:
         """
@@ -167,17 +144,10 @@ class VMCodeMapping:
         :param vm_code: the instruction to get the address
         :return: the vm code's last address if it's in the map. Otherwise, return's zero.
         """
-        if vm_code not in self._codes.values():
-            return 0
-        return self.get_start_address(vm_code) + vm_code.size - 1  # start + size returns next opcode address
+        return self._code_map.get_end_address(vm_code)
 
     def get_opcodes(self, addresses: List[int]) -> List[VMCode]:
-        codes = []
-        for index in sorted(addresses):
-            if index in self._codes:
-                codes.append(self._codes[index])
-
-        return codes
+        return self._code_map.get_opcodes(addresses)
 
     def update_vm_code(self, vm_code: VMCode, opcode: OpcodeInformation, data: bytes = bytes()):
         """
@@ -199,20 +169,7 @@ class VMCodeMapping:
 
         :param start_address: the address from the changed opcode
         """
-        new_address = -1
-        last_code: VMCode = None
-        updated_codes: Dict[int, VMCode] = {}
-
-        for address, code in list(self.code_map.items()):
-            if address >= start_address:
-                if new_address < 0:
-                    new_address = self.get_start_address(last_code) if last_code is not None else 0
-
-                new_address += last_code.size if last_code is not None else 0
-                if new_address != address:
-                    updated_codes[new_address] = self._codes.pop(address)
-            last_code = code
-        self._codes.update(updated_codes)
+        return self._code_map.update_addresses(start_address)
 
     def _update_targets(self):
         from boa3.neo.vm.type.Integer import Integer
@@ -228,7 +185,7 @@ class VMCodeMapping:
         Checks if each instruction data fits in its opcode maximum size and updates the opcode from those that don't
         """
         # gets a list with all instructions which its opcode has a larger equivalent, ordered by its address
-        instr_with_small_codes = [code for code in self._codes.values() if OpcodeHelper.has_larger_opcode(code.opcode)]
+        instr_with_small_codes = [code for code in self._code_map.get_code_list() if OpcodeHelper.has_larger_opcode(code.opcode)]
         instr_with_small_codes.sort(key=lambda code: self.get_start_address(code), reverse=True)
 
         from boa3.neo.vm.opcode.OpcodeInfo import OpcodeInfo
@@ -269,74 +226,43 @@ class VMCodeMapping:
         if address in targeted_addresses:
             next_address = self.get_end_address(code) + 1
             if next_address < self.bytecode_size:
-                next_code = self._codes[next_address]
+                next_code = self._code_map.get_code(next_address)
                 for source in targeted_addresses[address]:
-                    self._codes[source].set_target(next_code)
+                    self._code_map.get_code(source).set_target(next_code)
 
-    def move_to_end(self, first_code_address: int, last_code_address: int):
+    def move_to_end(self, first_code_address: int, last_code_address: int) -> int:
         """
         Moves a set of instructions to the end of the current bytecode
 
         :param first_code_address: first instruction start address
         :param last_code_address: last instruction end address
         """
-        if last_code_address < first_code_address:
-            return
-
-        moved_codes: List[VMCode] = []
-        for address in list(self.code_map):
-            if first_code_address <= address <= last_code_address:
-                moved_codes.append(self._codes.pop(address))
-            elif address > last_code_address:
-                break
-
-        self._update_addresses(first_code_address)
-        index = self.bytecode_size
-
-        for code in moved_codes:
-            self.insert_code(code)
+        result = self._code_map.move_to_end(first_code_address, last_code_address)
         self._update_targets()
-        return index
+        return result
 
     def remove_opcodes(self, first_code_address: int, last_code_address: int):
-        if last_code_address < first_code_address:
-            first_code_address, last_code_address = last_code_address, first_code_address
-
-        map_codes = self._codes.copy()
-        for index in sorted(map_codes):
-            if first_code_address <= index <= last_code_address:
-                self._validate_targets(index)
-                self._codes.pop(index)
-
-        self._update_addresses()
-
-    def remove_opcodes_by_addresses(self, addresses: List[int]):
-        for index in sorted(self._codes).copy():
-            if index in addresses:
-                self._validate_targets(index)
-                self._codes.pop(index)
-
-        self._update_addresses()
+        addresses_to_remove = self._code_map.get_addresses(first_code_address, last_code_address)
+        for address in addresses_to_remove:
+            self._validate_targets(address)
+        return self._code_map.remove_opcodes_by_addresses(addresses_to_remove)
 
     def remove_opcodes_by_code(self, codes: List[VMCode]):
-        code_map = self.code_map
-        addresses = list(code_map.keys()).copy()
-        code_list = list(code_map.values()).copy()
-
-        for code in codes:
-            if code in code_list:
-                self._validate_targets(code)
-                self._codes.pop(addresses[code_list.index(code)])
-
-        self._update_addresses()
+        addresses_to_remove = self._code_map.get_addresses_from_codes(codes)
+        for address in addresses_to_remove:
+            self._validate_targets(address)
+        return self._code_map.remove_opcodes_by_addresses(addresses_to_remove)
 
     def _remove_empty_targets(self):
         """
         Checks if each instruction that requires a target has one set and remove those that don't
         """
-        for code in list(self._codes.values()).copy():
+        addresses_to_remove = []
+        for code in self._code_map.get_code_list():
             if OpcodeHelper.has_target(code.opcode) and (code.target is None or code.target is code):
-                self._validate_targets(code)
-                index = self.get_start_address(code)
-                self._codes.pop(index)
-                self._update_addresses(index)
+                address = self.get_start_address(code)
+                self._validate_targets(address)
+                addresses_to_remove.append(address)
+
+        if len(addresses_to_remove) > 0:
+            self._code_map.remove_opcodes_by_addresses(addresses_to_remove)

--- a/boa3/neo/vm/VMCode.py
+++ b/boa3/neo/vm/VMCode.py
@@ -108,6 +108,3 @@ class VMCode:
 
     def __str__(self) -> str:
         return self.opcode.name + ' ' + self.data.hex()
-
-    def __repr__(self) -> str:
-        return str(self)


### PR DESCRIPTION
**Summary or solution description**
The logic to ensure the position and address of each opcode in the generated bytecode was taking too much time with longer smart contracts. 
The logic in mapping each opcode to its address was isolated from the class responsible for changing the bytecode so we can test options to optimize it without a big refactoring. In addition to this isolation, the map iteration was changed to avoid unnecessary iterations and to decrease the compilation time