### PR TITLE
Implement interop method `loadScript`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
 
             git clone https://github.com/simplitech/neo-devpack-dotnet.git -b v3.4.0
             cd ./neo-devpack-dotnet
-            git checkout 138176b47accdc09ec5c757ab60080f0f4e2e3b4
+            git checkout 57bedc2a394cb6b94f60561f7bf5b6825d1f1c0e
             cd ..
             dotnet build ./neo-devpack-dotnet/src/Neo.TestEngine/Neo.TestEngine.csproj -o ./Neo.TestEngine
 

--- a/boa3/builtin/interop/runtime/__init__.py
+++ b/boa3/builtin/interop/runtime/__init__.py
@@ -1,8 +1,9 @@
-from typing import Any, List, Union
+from typing import Any, List, Union, Sequence
 
+from boa3.builtin.interop.contract.callflagstype import CallFlags
 from boa3.builtin.interop.runtime.notification import Notification
 from boa3.builtin.interop.runtime.triggertype import TriggerType
-from boa3.builtin.type import ECPoint, UInt160
+from boa3.builtin.type import ECPoint, UInt160, ByteString
 
 
 def check_witness(hash_or_pubkey: Union[UInt160, ECPoint]) -> bool:
@@ -90,6 +91,13 @@ def get_random() -> int:
 
     :return: the next random number
     :rtype: int
+    """
+    pass
+
+
+def load_script(script: ByteString, args: Sequence = (), flags: CallFlags = CallFlags.NONE) -> Any:
+    """
+    Loads a script at runtime.
     """
     pass
 

--- a/boa3/model/builtin/interop/interop.py
+++ b/boa3/model/builtin/interop/interop.py
@@ -18,6 +18,10 @@ from boa3.model.event import Event
 from boa3.model.identifiedsymbol import IdentifiedSymbol
 from boa3.model.imports.package import Package
 
+__all__ = ['Interop',
+           'InteropPackage'
+           ]
+
 
 class InteropPackage(str, Enum):
     Blockchain = 'blockchain'
@@ -149,6 +153,7 @@ class Interop:
     GetRandom = GetRandomMethod()
     GetTrigger = GetTriggerMethod(TriggerType)
     InvocationCounter = InvocationCounterProperty()
+    LoadScript = LoadScriptMethod()
     Log = LogMethod()
     Notify = NotifyMethod()
     Platform = PlatformProperty()
@@ -350,6 +355,7 @@ class Interop:
                                       GetNotifications,
                                       GetRandom,
                                       GetTrigger,
+                                      LoadScript,
                                       Log,
                                       Notify
                                       ],

--- a/boa3/model/builtin/interop/runtime/__init__.py
+++ b/boa3/model/builtin/interop/runtime/__init__.py
@@ -10,6 +10,7 @@ __all__ = ['AddressVersionProperty',
            'GetNotificationsMethod',
            'GetRandomMethod',
            'InvocationCounterProperty',
+           'LoadScriptMethod',
            'LogMethod',
            'NotificationType',
            'NotifyMethod',
@@ -33,6 +34,7 @@ from boa3.model.builtin.interop.runtime.getnotificationsmethod import GetNotific
 from boa3.model.builtin.interop.runtime.getplatformmethod import PlatformProperty
 from boa3.model.builtin.interop.runtime.getrandommethod import GetRandomMethod
 from boa3.model.builtin.interop.runtime.gettriggermethod import GetTriggerMethod
+from boa3.model.builtin.interop.runtime.loadscriptmethod import LoadScriptMethod
 from boa3.model.builtin.interop.runtime.logmethod import LogMethod
 from boa3.model.builtin.interop.runtime.notificationtype import NotificationType
 from boa3.model.builtin.interop.runtime.notifymethod import NotifyMethod

--- a/boa3/model/builtin/interop/runtime/loadscriptmethod.py
+++ b/boa3/model/builtin/interop/runtime/loadscriptmethod.py
@@ -12,6 +12,7 @@ class LoadScriptMethod(InteropMethod):
         from boa3.model.builtin.interop.contract.callflagstype import CallFlagsType
         from boa3.model.type.type import Type
         from boa3.model.type.primitive.bytestringtype import ByteStringType
+        from boa3.neo3.contracts import CallFlags
 
         identifier = 'load_script'
         syscall = 'System.Runtime.LoadScript'
@@ -26,7 +27,7 @@ class LoadScriptMethod(InteropMethod):
         args_default = ast.parse("{0}".format(Type.sequence.default_value)
                                  ).body[0].value
         call_flags_default = set_internal_call(ast.parse("{0}.{1}".format(call_flags.identifier,
-                                                                          call_flags.get_value("NONE").name)
+                                                                          CallFlags.NONE.name)
                                                          ).body[0].value)
 
         super().__init__(identifier, syscall, args, defaults=[args_default, call_flags_default], return_type=Type.any)

--- a/boa3/model/builtin/interop/runtime/loadscriptmethod.py
+++ b/boa3/model/builtin/interop/runtime/loadscriptmethod.py
@@ -1,0 +1,44 @@
+import ast
+from typing import Dict, List
+
+from boa3.model import set_internal_call
+from boa3.model.builtin.interop.interopmethod import InteropMethod
+from boa3.model.variable import Variable
+
+
+class LoadScriptMethod(InteropMethod):
+
+    def __init__(self):
+        from boa3.model.builtin.interop.contract.callflagstype import CallFlagsType
+        from boa3.model.type.type import Type
+        from boa3.model.type.primitive.bytestringtype import ByteStringType
+
+        identifier = 'load_script'
+        syscall = 'System.Runtime.LoadScript'
+        call_flags: CallFlagsType = CallFlagsType.build()
+
+        args: Dict[str, Variable] = {
+            'script': Variable(ByteStringType.build()),
+            'args': Variable(Type.sequence),
+            'call_flags': Variable(call_flags)
+        }
+
+        args_default = ast.parse("{0}".format(Type.sequence.default_value)
+                                 ).body[0].value
+        call_flags_default = set_internal_call(ast.parse("{0}.{1}".format(call_flags.identifier,
+                                                                          call_flags.get_value("NONE").name)
+                                                         ).body[0].value)
+
+        super().__init__(identifier, syscall, args, defaults=[args_default, call_flags_default], return_type=Type.any)
+
+    @property
+    def generation_order(self) -> List[int]:
+        indexes = super().generation_order
+        context_index = list(self.args).index('args')
+
+        if indexes[-1] != context_index:
+            # args must be the first generated argument
+            indexes.remove(context_index)
+            indexes.insert(0, context_index)
+
+        return indexes

--- a/boa3_test/test_sc/interop_test/runtime/LoadScriptDynamicCall.py
+++ b/boa3_test/test_sc/interop_test/runtime/LoadScriptDynamicCall.py
@@ -1,0 +1,19 @@
+from typing import cast
+
+from boa3.builtin.compile_time import public
+from boa3.builtin.interop.contract import CallFlags
+from boa3.builtin.interop.runtime import load_script
+from boa3.builtin.type import ByteString
+from boa3.builtin.vm import Opcode
+
+
+@public
+def dynamic_sum_with_flags(a: int, b: int, flags: CallFlags) -> int:
+    script: ByteString = Opcode.ADD
+    return cast(int, load_script(script, [a, b], flags))
+
+
+@public
+def dynamic_sum(a: int, b: int) -> int:
+    script: ByteString = Opcode.ADD
+    return cast(int, load_script(script, [a, b]))

--- a/boa3_test/tests/compiler_tests/test_interop/test_runtime.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_runtime.py
@@ -708,3 +708,20 @@ class TestRuntimeInterop(BoaTest):
     def test_address_version_cant_assign(self):
         path = self.get_contract_path('AddressVersionCantAssign.py')
         self.assertCompilerLogs(CompilerWarning.NameShadowing, path)
+
+    def test_load_script(self):
+        path = self.get_contract_path('LoadScriptDynamicCall.py')
+        self.compile_and_save(path)
+        engine = TestEngine()
+
+        operand_1 = 1
+        operand_2 = 2
+        expected_result = operand_1 + operand_2
+        result = self.run_smart_contract(engine, path, 'dynamic_sum',
+                                         operand_1, operand_2)
+        self.assertEqual(expected_result, result)
+
+        from boa3.neo3.contracts import CallFlags
+        result = self.run_smart_contract(engine, path, 'dynamic_sum_with_flags',
+                                         operand_1, operand_2, CallFlags.READ_ONLY)
+        self.assertEqual(expected_result, result)


### PR DESCRIPTION
**Summary or solution description**
Added the interop method `runtime.loadScript`
https://github.com/CityOfZion/neo3-boa/blob/02b7f332e62800a89540d1a18d30a88300847d47/boa3/builtin/interop/runtime/__init__.py#L98-L102

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/02b7f332e62800a89540d1a18d30a88300847d47/boa3_test/test_sc/interop_test/runtime/LoadScriptDynamicCall.py#L5-L19

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/02b7f332e62800a89540d1a18d30a88300847d47/boa3_test/tests/compiler_tests/test_interop/test_runtime.py#L712-L727

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7+