### PR TITLE
CU-3ccgt1y - Boolean expression is having an odd behavior

### DIFF
--- a/boa3/compiler/codegenerator/codegenerator.py
+++ b/boa3/compiler/codegenerator/codegenerator.py
@@ -2138,7 +2138,8 @@ class CodeGenerator:
 
     def clear_stack(self, clear_if_in_loop: bool = False):
         if not clear_if_in_loop or len(self._current_for) > 0:
-            self.__insert1(OpcodeInfo.CLEAR)
+            for _ in range(self.stack_size):
+                self.__insert1(OpcodeInfo.DROP)
 
     def remove_stack_top_item(self):
         self.remove_stack_item(1)

--- a/boa3_test/test_sc/logical_test/LogicOperationWithReturnAndStackFilled.py
+++ b/boa3_test/test_sc/logical_test/LogicOperationWithReturnAndStackFilled.py
@@ -1,0 +1,17 @@
+from boa3.builtin.compile_time import public
+
+
+@public
+def main() -> bool:
+    test_var = True and return_inside_for()
+
+    return test_var
+
+
+def return_inside_for() -> bool:
+    for number in [1, 10, 3]:
+        if number == 10:
+            return True
+        elif number > 2:
+            return True
+    return False

--- a/boa3_test/tests/compiler_tests/test_function.py
+++ b/boa3_test/tests/compiler_tests/test_function.py
@@ -580,7 +580,7 @@ class TestFunction(BoaTest):
             + Opcode.LDARG0  # for_sequence = arg0
             + Opcode.PUSH0  # for_index = 0
             + Opcode.JMP  # begin for
-            + Integer(18).to_byte_array(min_length=1, signed=True)
+            + Integer(19).to_byte_array(min_length=1, signed=True)
             + Opcode.OVER  # value = for_sequence[for_index]
             + Opcode.OVER
             + Opcode.DUP
@@ -593,7 +593,8 @@ class TestFunction(BoaTest):
             + Opcode.ADD
             + Opcode.PICKITEM
             + Opcode.STLOC0
-            + Opcode.CLEAR
+            + Opcode.DROP
+            + Opcode.DROP
             + Opcode.LDLOC0  # return value
             + Opcode.RET
             + Opcode.INC  # for_index = for_index + 1
@@ -603,7 +604,7 @@ class TestFunction(BoaTest):
             + Opcode.SIZE
             + Opcode.LT
             + Opcode.JMPIF
-            + Integer(-21).to_byte_array(min_length=1, signed=True)
+            + Integer(-22).to_byte_array(min_length=1, signed=True)
             + Opcode.DROP
             + Opcode.DROP
             + Opcode.PUSH5  # else

--- a/boa3_test/tests/compiler_tests/test_logical.py
+++ b/boa3_test/tests/compiler_tests/test_logical.py
@@ -534,6 +534,13 @@ class TestLogical(BoaTest):
         result = self.run_smart_contract(engine, path, 'Main', True, True, True)
         self.assertEqual(False, result)
 
+    def test_logic_operation_with_return_and_stack_filled(self):
+        path = self.get_contract_path('LogicOperationWithReturnAndStackFilled.py')
+        engine = TestEngine()
+
+        result = self.run_smart_contract(engine, path, 'main')
+        self.assertEqual(True, result)
+
     # endregion
 
     # region RightShift


### PR DESCRIPTION
**Summary or solution description**
There were some instances where the stack was not empty, but it was considered empty, some values were added and then a Opcode.CLEAN followed next. So CLEAN was removed and a number of DROPs were added.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/d7a2ff0de70ae3291d6e5623182cca1aaf40555c/boa3_test/test_sc/logical_test/LogicOperationWithReturnAndStackFilled.py#L1-L17

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/d7a2ff0de70ae3291d6e5623182cca1aaf40555c/boa3_test/tests/compiler_tests/test_logical.py#L537-L542

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8