### PR TITLE
Update TestEngine to Neo 3.5.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,10 +36,7 @@ jobs:
             sudo apt update && \
               sudo apt-get install -y dotnet-sdk-6.0
 
-            git clone https://github.com/simplitech/neo-devpack-dotnet.git -b v3.4.0
-            cd ./neo-devpack-dotnet
-            git checkout 57bedc2a394cb6b94f60561f7bf5b6825d1f1c0e
-            cd ..
+            git clone https://github.com/simplitech/neo-devpack-dotnet.git -b v3.5.0
             dotnet build ./neo-devpack-dotnet/src/Neo.TestEngine/Neo.TestEngine.csproj -o ./Neo.TestEngine
 
       - python/save-cache


### PR DESCRIPTION
**Summary or solution description**
Updated the TestEngine version used in CI/CD