### PR TITLE
Could not use class variable inside instance method

### DIFF
--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -1616,7 +1616,7 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
                 ))
             return Attribute(attribute.value, None, attr_symbol, attribute)
 
-        if not is_from_class_name and is_class_variable_from_class and isinstance(attribute.ctx, ast.Store):
+        if is_class_variable_from_class and isinstance(attribute.ctx, ast.Store):
             # reassign class variables in objects is not supported yet
             self._log_error(
                 CompilerError.NotSupportedOperation(

--- a/boa3/compiler/codegenerator/generatordata.py
+++ b/boa3/compiler/codegenerator/generatordata.py
@@ -16,6 +16,7 @@ class GeneratorData:
                  symbol: Optional[ISymbol] = None,
                  result_type: Optional[IType] = None,
                  index: Optional[int] = None,
+                 origin_object_type: Optional[IType] = None,
                  already_generated: bool = False):
 
         if symbol_id is None and isinstance(symbol, IdentifiedSymbol):
@@ -28,6 +29,7 @@ class GeneratorData:
         self.symbol_id: Optional[str] = symbol_id
         self.type: Optional[IType] = result_type
         self.index: Optional[int] = index
+        self.origin_object_type: Optional[ISymbol] = origin_object_type
         self.already_generated: bool = already_generated
 
     def copy(self, new_origin: Optional[ast.AST] = None) -> GeneratorData:

--- a/boa3/compiler/codegenerator/vmcodemapping.py
+++ b/boa3/compiler/codegenerator/vmcodemapping.py
@@ -243,7 +243,9 @@ class VMCodeMapping:
         self._update_targets()
         return result
 
-    def remove_opcodes(self, first_code_address: int, last_code_address: int):
+    def remove_opcodes(self, first_code_address: int, last_code_address: int = None):
+        if not isinstance(last_code_address, int):
+            last_code_address = self.bytecode_size
         addresses_to_remove = self._code_map.get_addresses(first_code_address, last_code_address)
         for address in addresses_to_remove:
             self._validate_targets(address)

--- a/boa3_test/test_sc/class_test/UserClassUpdateClassVariableOnInit.py
+++ b/boa3_test/test_sc/class_test/UserClassUpdateClassVariableOnInit.py
@@ -1,0 +1,31 @@
+from boa3.builtin.compile_time import public
+
+
+class Example:
+    class_val = 0
+
+    def __init__(self):
+        self.val1 = 1
+        self.val2 = 2
+
+        Example.class_val += 1
+
+
+@public
+def test_1(arg: int) -> Example:
+    obj = Example()
+
+    for _ in range(arg):
+        Example()
+
+    return obj
+
+
+@public
+def test_2(arg: int) -> Example:
+    for _ in range(arg):
+        Example()
+
+    obj = Example()
+
+    return obj

--- a/boa3_test/tests/compiler_tests/test_class.py
+++ b/boa3_test/tests/compiler_tests/test_class.py
@@ -237,6 +237,10 @@ class TestClass(BoaTest):
         path = self.get_contract_path('UserClassUpdateClassVariable.py')
         self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
 
+    def test_user_class_update_instance_variable_on_init(self):
+        path = self.get_contract_path('UserClassUpdateClassVariableOnInit.py')
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+
     def test_user_class_with_class_variable_and_class_method(self):
         path = self.get_contract_path('UserClassWithClassVariableAndClassMethod.py')
         engine = TestEngine()


### PR DESCRIPTION
**Summary or solution description**
Reassigning class variables is not implemented yet in boa and so the following shouldn't be compiled:
https://github.com/CityOfZion/neo3-boa/blob/c9ce0aaa7ab92a3b5c6b9f1f241ba3b17964688c/boa3_test/test_sc/class_test/UserClassUpdateClassVariableOnInit.py#L4-L11
But it was being compiled and executing it caused an exception in runtime.

Investigating this, the same exception reported was raised when trying to update instance variables.
Fixed the bug when using instance variables and change the compiler to not accept reassigning class variables in augmented assignments

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/c9ce0aaa7ab92a3b5c6b9f1f241ba3b17964688c/boa3_test/tests/compiler_tests/test_class.py#L236-L242

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7+