### PR TITLE
Notifications aren't returned with rollback_on_fault=False

### DIFF
--- a/boa3_test/test_sc/event_test/EventWithAbort.py
+++ b/boa3_test/test_sc/event_test/EventWithAbort.py
@@ -1,0 +1,20 @@
+from boa3.builtin.compile_time import public, CreateNewEvent
+from boa3.builtin.contract import abort
+
+Event = CreateNewEvent(
+    [
+        ('a', int)
+    ],
+    'example'
+)
+
+
+@public
+def send_event():
+    Event(10)
+
+
+@public
+def send_event_with_abort():
+    send_event()
+    abort()


### PR DESCRIPTION
**Summary or solution description**
> I tried to use rollback_on_fault=False to get notifications even when the TestEngine would abort or throw an exception, but it's not returning any value 

Notifications aren't emitted on a fault execution, so the TestEngine not returning them when there's an abort or an exception raise is actually the expected behavior. Setting `roll_back_on_fault` as False can't get any notification because the blockchain doesn't return them to the TestEngine.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/8666dea49f272fb90e5c7c5128f098bf8a94bde7/boa3_test/test_sc/event_test/EventWithAbort.py#L4-L20

**Tests**
Included a test to make sure the expected behavior is executed.
https://github.com/CityOfZion/neo3-boa/blob/8666dea49f272fb90e5c7c5128f098bf8a94bde7/boa3_test/tests/compiler_tests/test_event.py#L276-L298

