### PR TITLE
CU-3cr16nu - Add a new field on each type-value object on JSON manife…

### DIFF
--- a/boa3/analyser/constructanalyser.py
+++ b/boa3/analyser/constructanalyser.py
@@ -1,6 +1,7 @@
 import ast
 
 from boa3.analyser.astanalyser import IAstAnalyser
+from boa3.model import set_internal_call
 
 
 class ConstructAnalyser(IAstAnalyser, ast.NodeTransformer):
@@ -32,7 +33,7 @@ class ConstructAnalyser(IAstAnalyser, ast.NodeTransformer):
         """
         if isinstance(call.func, ast.Attribute):
             from boa3.model.builtin.builtin import Builtin
-            if call.func.attr == Builtin.ScriptHash.identifier:
+            if call.func.attr == Builtin.ScriptHashMethod_.identifier:
                 from boa3.constants import SYS_VERSION_INFO
                 from boa3.model.type.type import Type
                 types = {
@@ -66,6 +67,6 @@ class ConstructAnalyser(IAstAnalyser, ast.NodeTransformer):
                 elif isinstance(value, str):
                     from boa3.neo.vm.type.String import String
                     value = String(value).to_bytes()
-                return self.parse_to_node(str(to_script_hash(value)), call)
+                return set_internal_call(self.parse_to_node(f"UInt160({str(to_script_hash(value))})", call))
 
         return call

--- a/boa3/builtin/type/__init__.py
+++ b/boa3/builtin/type/__init__.py
@@ -152,3 +152,52 @@ class ByteString:
         Return value*self.
         """
         pass
+
+
+class Address(str):
+    """
+    A class used only to indicate that a parameter or return on the manifest should be treated as an Address.
+    It's a subclass of str and it doesn't implement new properties or methods.
+    """
+    pass
+
+
+class BlockHash(UInt256):
+    """
+    A class used only to indicate that a parameter or return on the manifest should be treated as a BlockHash.
+    It's a subclass of UInt256 and it doesn't implement new properties or methods.
+    """
+    pass
+
+
+class PublicKey(ECPoint):
+    """
+    A class used only to indicate that a parameter or return on the manifest should be treated as a PublicKey.
+    It's a subclass of ECPoint and it doesn't implement new properties or methods.
+    """
+    pass
+
+
+class ScriptHash(UInt160):
+    """
+    A class used only to indicate that a parameter or return on the manifest should be treated as a ScriptHash.
+    It's a subclass of UInt160 and it doesn't implement new properties or methods.
+    """
+    pass
+
+
+class ScriptHashLittleEndian(UInt160):
+    """
+    A class used only to indicate that a parameter or return on the manifest should be treated as a
+    ScriptHashLittleEndian.
+    It's a subclass of UInt160 and it doesn't implement new properties or methods.
+    """
+    pass
+
+
+class TransactionId(UInt256):
+    """
+    A class used only to indicate that a parameter or return on the manifest should be treated as a TransactionId.
+    It's a subclass of UInt256 and it doesn't implement new properties or methods.
+    """
+    pass

--- a/boa3/model/builtin/builtin.py
+++ b/boa3/model/builtin/builtin.py
@@ -19,7 +19,7 @@ from boa3.model.type.collection.sequence.uint160type import UInt160Type
 from boa3.model.type.collection.sequence.uint256type import UInt256Type
 from boa3.model.type.itype import IType
 from boa3.model.type.math import Math
-from boa3.model.type.neo.opcodetype import OpcodeType
+from boa3.model.type.neo import *
 from boa3.model.type.primitive.bytestringtype import ByteStringType
 
 
@@ -55,7 +55,7 @@ class Builtin:
     Max = MaxIntMethod()
     Min = MinIntMethod()
     Print = PrintMethod()
-    ScriptHash = ScriptHashMethod()
+    ScriptHashMethod_ = ScriptHashMethod()
     StrSplit = StrSplitMethod()
     Sum = SumMethod()
 
@@ -145,7 +145,7 @@ class Builtin:
                                                 PropertyDecorator,
                                                 Range,
                                                 Reversed,
-                                                ScriptHash,
+                                                ScriptHashMethod_,
                                                 SequenceAppend,
                                                 SequenceClear,
                                                 SequenceExtend,
@@ -179,6 +179,12 @@ class Builtin:
     ECPoint = ECPointType.build()
     NeoAccountState = NeoAccountStateType.build()
     Opcode = OpcodeType.build()
+    Address = AddressType.build()
+    BlockHash = BlockHashType.build()
+    PublicKey = PublicKeyType.build()
+    ScriptHashType_ = ScriptHashType.build()
+    ScriptHashLittleEndian = ScriptHashLittleEndianType.build()
+    TransactionId = TransactionIdType.build()
 
     # boa events
     Nep5Transfer = Nep5TransferEvent()
@@ -241,14 +247,20 @@ class Builtin:
                               Nep11Transfer,
                               Nep17Transfer,
                               Nep5Transfer,
-                              ScriptHash
+                              ScriptHashMethod_
                               ],
         BoaPackage.Interop: Interop.package_symbols,
         BoaPackage.Type: [ByteString,
                           ECPoint,
                           UInt160,
                           UInt256,
-                          Event
+                          Event,
+                          Address,
+                          BlockHash,
+                          PublicKey,
+                          ScriptHashType_,
+                          ScriptHashLittleEndian,
+                          TransactionId,
                           ],
         BoaPackage.VM: [Opcode
                         ],

--- a/boa3/model/builtin/method/toscripthashmethod.py
+++ b/boa3/model/builtin/method/toscripthashmethod.py
@@ -18,7 +18,8 @@ class ScriptHashMethod(IBuiltinMethod):
 
         identifier = 'to_script_hash'
         args: Dict[str, Variable] = {'self': Variable(data_type)}
-        super().__init__(identifier, args, return_type=Type.bytes)
+        from boa3.model.type.collection.sequence.uint160type import UInt160Type
+        super().__init__(identifier, args, return_type=UInt160Type.build())
 
     @property
     def identifier(self) -> str:

--- a/boa3/model/type/collection/sequence/ecpointtype.py
+++ b/boa3/model/type/collection/sequence/ecpointtype.py
@@ -48,7 +48,7 @@ class ECPointType(BytesType):
 
         from boa3.model.builtin.builtin import Builtin
 
-        instance_methods = [Builtin.ScriptHash,
+        instance_methods = [Builtin.ScriptHashMethod_,
                             ]
 
         for instance_method in instance_methods:

--- a/boa3/model/type/neo/__init__.py
+++ b/boa3/model/type/neo/__init__.py
@@ -1,0 +1,17 @@
+__all__ = [
+    'AddressType',
+    'BlockHashType',
+    'OpcodeType',
+    'PublicKeyType',
+    'ScriptHashLittleEndianType',
+    'ScriptHashType',
+    'TransactionIdType',
+]
+
+from boa3.model.type.neo.addresstype import AddressType
+from boa3.model.type.neo.blockhashtype import BlockHashType
+from boa3.model.type.neo.opcodetype import OpcodeType
+from boa3.model.type.neo.publickeytype import PublicKeyType
+from boa3.model.type.neo.scripthashlittleendiantype import ScriptHashLittleEndianType
+from boa3.model.type.neo.scripthashtype import ScriptHashType
+from boa3.model.type.neo.transactionidtype import TransactionIdType

--- a/boa3/model/type/neo/addresstype.py
+++ b/boa3/model/type/neo/addresstype.py
@@ -1,0 +1,21 @@
+from typing import Any
+
+from boa3.model.type.itype import IType
+from boa3.model.type.primitive.strtype import StrType
+
+
+class AddressType(StrType):
+    """
+    A class used to indicate that a parameter or return on the manifest is an Address. It's a subclass of StrType.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._identifier = 'Address'
+
+    @classmethod
+    def build(cls, value: Any = None) -> IType:
+        return _Address
+
+
+_Address = AddressType()

--- a/boa3/model/type/neo/blockhashtype.py
+++ b/boa3/model/type/neo/blockhashtype.py
@@ -1,0 +1,21 @@
+from typing import Any
+
+from boa3.model.type.collection.sequence.uint256type import UInt256Type
+from boa3.model.type.itype import IType
+
+
+class BlockHashType(UInt256Type):
+    """
+    A class used to indicate that a parameter or return on the manifest is a BlockHash. It's a subclass of UInt256Type.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._identifier = 'BlockHash'
+
+    @classmethod
+    def build(cls, value: Any = None) -> IType:
+        return _BlockHash
+
+
+_BlockHash = BlockHashType()

--- a/boa3/model/type/neo/publickeytype.py
+++ b/boa3/model/type/neo/publickeytype.py
@@ -1,0 +1,21 @@
+from typing import Any
+
+from boa3.model.type.collection.sequence.ecpointtype import ECPointType
+from boa3.model.type.itype import IType
+
+
+class PublicKeyType(ECPointType):
+    """
+    A class used to indicate that a parameter or return on the manifest is a PublicKey. It's a subclass of ECPointType.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._identifier = 'PublicKey'
+
+    @classmethod
+    def build(cls, value: Any = None) -> IType:
+        return _PublicKey
+
+
+_PublicKey = PublicKeyType()

--- a/boa3/model/type/neo/scripthashlittleendiantype.py
+++ b/boa3/model/type/neo/scripthashlittleendiantype.py
@@ -1,0 +1,22 @@
+from typing import Any
+
+from boa3.model.type.collection.sequence.uint160type import UInt160Type
+from boa3.model.type.itype import IType
+
+
+class ScriptHashLittleEndianType(UInt160Type):
+    """
+    A class used to indicate that a parameter or return on the manifest is a ScripthashLittleEndian.
+    It's a subclass of UInt160Type.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._identifier = 'ScriptHashLittleEndian'
+
+    @classmethod
+    def build(cls, value: Any = None) -> IType:
+        return _ScriptHashLittleEndian
+
+
+_ScriptHashLittleEndian = ScriptHashLittleEndianType()

--- a/boa3/model/type/neo/scripthashtype.py
+++ b/boa3/model/type/neo/scripthashtype.py
@@ -1,0 +1,22 @@
+from typing import Any
+
+from boa3.model.type.collection.sequence.uint160type import UInt160Type
+from boa3.model.type.itype import IType
+
+
+class ScriptHashType(UInt160Type):
+    """
+    A class used to indicate that a parameter or return on the manifest is a Scripthash.
+    It's a subclass of UInt160Type.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._identifier = 'ScriptHash'
+
+    @classmethod
+    def build(cls, value: Any = None) -> IType:
+        return _ScriptHash
+
+
+_ScriptHash = ScriptHashType()

--- a/boa3/model/type/neo/transactionidtype.py
+++ b/boa3/model/type/neo/transactionidtype.py
@@ -1,0 +1,22 @@
+from typing import Any
+
+from boa3.model.type.collection.sequence.uint256type import UInt256Type
+from boa3.model.type.itype import IType
+
+
+class TransactionIdType(UInt256Type):
+    """
+    A class used to indicate that a parameter or return on the manifest is a TransactionId.
+    It's a subclass of UInt256Type.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._identifier = 'TransactionId'
+
+    @classmethod
+    def build(cls, value: Any = None) -> IType:
+        return _TransactionId
+
+
+_TransactionId = TransactionIdType()

--- a/boa3_test/test_sc/built_in_methods_test/ScriptHashStr.py
+++ b/boa3_test/test_sc/built_in_methods_test/ScriptHashStr.py
@@ -3,4 +3,9 @@ from boa3.builtin.compile_time import public
 
 @public
 def Main() -> bytes:
+    return 'NUnLWXALK2G6gYa7RadPLRiQYunZHnncxg '.to_script_hash()
+
+
+@public
+def Main2() -> bytes:
     return '123'.to_script_hash()

--- a/boa3_test/test_sc/generation_test/ManifestTypeHintAddress.py
+++ b/boa3_test/test_sc/generation_test/ManifestTypeHintAddress.py
@@ -1,0 +1,7 @@
+from boa3.builtin.compile_time import public
+from boa3.builtin.type import Address
+
+
+@public
+def main() -> Address:
+    return Address('NNLi44dJNXtDNSBkofB48aTVYtb1zZrNEs')

--- a/boa3_test/test_sc/generation_test/ManifestTypeHintAny.py
+++ b/boa3_test/test_sc/generation_test/ManifestTypeHintAny.py
@@ -1,0 +1,8 @@
+from typing import Any
+
+from boa3.builtin.compile_time import public
+
+
+@public
+def Main() -> Any:
+    return 'anything'

--- a/boa3_test/test_sc/generation_test/ManifestTypeHintBlockHash.py
+++ b/boa3_test/test_sc/generation_test/ManifestTypeHintBlockHash.py
@@ -1,0 +1,7 @@
+from boa3.builtin.compile_time import public
+from boa3.builtin.type import BlockHash, UInt256
+
+
+@public
+def main() -> BlockHash:
+    return BlockHash(UInt256())

--- a/boa3_test/test_sc/generation_test/ManifestTypeHintFromECPointToPublicKey.py
+++ b/boa3_test/test_sc/generation_test/ManifestTypeHintFromECPointToPublicKey.py
@@ -1,0 +1,7 @@
+from boa3.builtin.compile_time import public
+from boa3.builtin.type import ECPoint, PublicKey
+
+
+@public
+def Main() -> PublicKey:
+    return ECPoint(b'')

--- a/boa3_test/test_sc/generation_test/ManifestTypeHintFromStrToAddress.py
+++ b/boa3_test/test_sc/generation_test/ManifestTypeHintFromStrToAddress.py
@@ -1,0 +1,7 @@
+from boa3.builtin.compile_time import public
+from boa3.builtin.type import Address
+
+
+@public
+def Main() -> Address:
+    return 'NNLi44dJNXtDNSBkofB48aTVYtb1zZrNEs'

--- a/boa3_test/test_sc/generation_test/ManifestTypeHintFromUInt160ToScriptHash.py
+++ b/boa3_test/test_sc/generation_test/ManifestTypeHintFromUInt160ToScriptHash.py
@@ -1,0 +1,7 @@
+from boa3.builtin.compile_time import public
+from boa3.builtin.type import ScriptHash
+
+
+@public
+def Main() -> ScriptHash:
+    return int.to_script_hash(123)

--- a/boa3_test/test_sc/generation_test/ManifestTypeHintFromUInt160ToScriptHashLittleEndian.py
+++ b/boa3_test/test_sc/generation_test/ManifestTypeHintFromUInt160ToScriptHashLittleEndian.py
@@ -1,0 +1,7 @@
+from boa3.builtin.compile_time import public
+from boa3.builtin.type import ScriptHashLittleEndian
+
+
+@public
+def Main() -> ScriptHashLittleEndian:
+    return int.to_script_hash(123)

--- a/boa3_test/test_sc/generation_test/ManifestTypeHintFromUInt256ToBlockHash.py
+++ b/boa3_test/test_sc/generation_test/ManifestTypeHintFromUInt256ToBlockHash.py
@@ -1,0 +1,7 @@
+from boa3.builtin.compile_time import public
+from boa3.builtin.type import BlockHash, UInt256
+
+
+@public
+def Main() -> BlockHash:
+    return UInt256()

--- a/boa3_test/test_sc/generation_test/ManifestTypeHintFromUInt256ToTransactionId.py
+++ b/boa3_test/test_sc/generation_test/ManifestTypeHintFromUInt256ToTransactionId.py
@@ -1,0 +1,7 @@
+from boa3.builtin.compile_time import public
+from boa3.builtin.type import TransactionId, UInt256
+
+
+@public
+def Main() -> TransactionId:
+    return UInt256()

--- a/boa3_test/test_sc/generation_test/ManifestTypeHintListDictNotFromTyping.py
+++ b/boa3_test/test_sc/generation_test/ManifestTypeHintListDictNotFromTyping.py
@@ -1,0 +1,9 @@
+from boa3.builtin.compile_time import public
+
+
+@public
+def Main(var: dict) -> list:
+    if var:
+        return []
+
+    return []

--- a/boa3_test/test_sc/generation_test/ManifestTypeHintMapsArraysUnionHint.py
+++ b/boa3_test/test_sc/generation_test/ManifestTypeHintMapsArraysUnionHint.py
@@ -1,0 +1,10 @@
+from typing import List, Dict, Union
+
+from boa3.builtin.compile_time import public
+
+
+@public
+def Main(var: Dict[str, List[bool]]) -> List[Union[Dict[str, int], str, bool]]:
+    if var:
+        return []
+    return []

--- a/boa3_test/test_sc/generation_test/ManifestTypeHintOptional.py
+++ b/boa3_test/test_sc/generation_test/ManifestTypeHintOptional.py
@@ -1,0 +1,11 @@
+from typing import Optional
+
+from boa3.builtin.compile_time import public
+
+
+@public
+def main(var: Optional[int, str]) -> Optional[int]:
+    if isinstance(var, int):
+        return 123
+    else:
+        return None

--- a/boa3_test/test_sc/generation_test/ManifestTypeHintPublicKey.py
+++ b/boa3_test/test_sc/generation_test/ManifestTypeHintPublicKey.py
@@ -1,0 +1,7 @@
+from boa3.builtin.compile_time import public
+from boa3.builtin.type import PublicKey, ECPoint
+
+
+@public
+def main(arg: bytes) -> PublicKey:
+    return PublicKey(ECPoint(arg))

--- a/boa3_test/test_sc/generation_test/ManifestTypeHintScriptHash.py
+++ b/boa3_test/test_sc/generation_test/ManifestTypeHintScriptHash.py
@@ -1,0 +1,7 @@
+from boa3.builtin.compile_time import public
+from boa3.builtin.type import ScriptHash, UInt160
+
+
+@public
+def main() -> ScriptHash:
+    return ScriptHash(UInt160())

--- a/boa3_test/test_sc/generation_test/ManifestTypeHintScriptHashLittleEndian.py
+++ b/boa3_test/test_sc/generation_test/ManifestTypeHintScriptHashLittleEndian.py
@@ -1,0 +1,7 @@
+from boa3.builtin.compile_time import public
+from boa3.builtin.type import ScriptHashLittleEndian, UInt160
+
+
+@public
+def main() -> ScriptHashLittleEndian:
+    return ScriptHashLittleEndian(UInt160())

--- a/boa3_test/test_sc/generation_test/ManifestTypeHintTransactionId.py
+++ b/boa3_test/test_sc/generation_test/ManifestTypeHintTransactionId.py
@@ -1,0 +1,7 @@
+from boa3.builtin.compile_time import public
+from boa3.builtin.type import TransactionId, UInt256
+
+
+@public
+def main() -> TransactionId:
+    return TransactionId(UInt256())

--- a/boa3_test/tests/compiler_tests/test_builtin_method.py
+++ b/boa3_test/tests/compiler_tests/test_builtin_method.py
@@ -413,7 +413,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_script_hash_str(self):
         from boa3.neo import to_script_hash
-        script_hash = to_script_hash(String('123').to_bytes())
+        script_hash = to_script_hash(String('NUnLWXALK2G6gYa7RadPLRiQYunZHnncxg').to_bytes())
 
         path = self.get_contract_path('ScriptHashStr.py')
 
@@ -422,16 +422,17 @@ class TestBuiltinMethod(BoaTest):
                                          expected_result_type=bytes)
         self.assertEqual(script_hash, result)
 
-    def test_script_hash_str_with_builtin(self):
-        from boa3.neo import to_script_hash
-        script_hash = to_script_hash(String('123').to_bytes())
+        # TODO: to_script_hash is returning a bytes value that has length 1
+        with self.assertRaises(TestExecutionException):
+            self.run_smart_contract(engine, path, 'Main2')
 
+    def test_script_hash_str_with_builtin(self):
         path = self.get_contract_path('ScriptHashStrBuiltinCall.py')
 
         engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main',
-                                         expected_result_type=bytes)
-        self.assertEqual(script_hash, result)
+        # TODO: to_script_hash is returning a bytes value that has length 1
+        with self.assertRaises(TestExecutionException):
+            self.run_smart_contract(engine, path, 'Main')
 
     def test_script_hash_variable(self):
         path = self.get_contract_path('ScriptHashVariable.py')

--- a/boa3_test/tests/compiler_tests/test_file_generation.py
+++ b/boa3_test/tests/compiler_tests/test_file_generation.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict
+from typing import Dict, Tuple
 
 from boa3 import constants
 from boa3.boa3 import Boa3
@@ -776,3 +776,321 @@ class TestFileGeneration(BoaTest):
         if f <= 1:
             return 1
         return f * self.fact(f - 1)
+
+    def test_generate_manifest_file_with_type_hint_list(self):
+        path = self.get_contract_path('test_sc/list_test', 'CopyBool.py')
+        _, abi_methods = self.verify_parameters_and_return_manifest(path)     # type: dict, list
+
+        abi_method_main = abi_methods[0]
+        self.assertEqual('Array', abi_method_main['returntype'])
+        self.assertIn('returngeneric', abi_method_main)
+        self.assertIn('type', abi_method_main['returngeneric'])
+        self.assertEqual('Array', abi_method_main['returngeneric']['type'])
+        self.assertIn('generic', abi_method_main['returngeneric'])
+        self.assertIn('type', abi_method_main['returngeneric']['generic'])
+
+        abi_method_main_parameters = abi_method_main['parameters']
+        self.assertIn('generic', abi_method_main_parameters[0])
+        self.assertIn('type', abi_method_main_parameters[0]['generic'])
+
+    def test_generate_manifest_file_with_type_hint_dict(self):
+        path = self.get_contract_path('test_sc/dict_test', 'SetValue.py')
+        _, abi_methods = self.verify_parameters_and_return_manifest(path)     # type: dict, list
+
+        abi_method_main = abi_methods[0]
+        self.assertEqual('Map', abi_method_main['returntype'])
+        self.assertIn('returngenerickey', abi_method_main)
+        self.assertIn('type', abi_method_main['returngenerickey'])
+        self.assertIn('returngenericitem', abi_method_main)
+        self.assertIn('type', abi_method_main['returngenericitem'])
+
+        abi_method_main_parameters = abi_method_main['parameters']
+        self.assertIn('generickey', abi_method_main_parameters[0])
+        self.assertIn('type', abi_method_main_parameters[0]['generickey'])
+        self.assertIn('genericitem', abi_method_main_parameters[0])
+        self.assertIn('type', abi_method_main_parameters[0]['genericitem'])
+
+    def test_generate_manifest_file_with_type_hint_union_return(self):
+        path = self.get_contract_path('test_sc/union_test', 'UnionReturn.py')
+        _, abi_methods = self.verify_parameters_and_return_manifest(path)     # type: dict, list
+
+        abi_method_main = abi_methods[0]
+        self.assertEqual('Any', abi_method_main['returntype'])
+        self.assertIn('returnunion', abi_method_main)
+        self.assertIsInstance(abi_method_main['returnunion'], list)
+        for union_type in abi_method_main['returnunion']:
+            self.assertIn('type', union_type)
+
+    def test_generate_manifest_file_with_type_hint_union_args(self):
+        path = self.get_contract_path('test_sc/union_test', 'UnionIsInstanceValidation.py')
+        _, abi_methods = self.verify_parameters_and_return_manifest(path)     # type: dict, list
+
+        abi_method_main = abi_methods[0]
+        abi_method_main_parameters = abi_method_main['parameters']
+        self.assertIn('union', abi_method_main_parameters[0])
+        self.assertIsInstance(abi_method_main_parameters[0]['union'], list)
+        for union_type in abi_method_main_parameters[0]['union']:
+            self.assertIn('type', union_type)
+
+    def test_generate_manifest_file_with_type_hint_optional(self):
+        path = self.get_contract_path('test_sc/generation_test', 'ManifestTypeHintOptional.py')
+        _, abi_methods = self.verify_parameters_and_return_manifest(path)     # type: dict, list
+
+        abi_method_main = abi_methods[0]
+        self.assertEqual('Integer', abi_method_main['returntype'])
+        self.assertIn('returnnullable', abi_method_main)
+
+        abi_method_main_parameters = abi_method_main['parameters']
+        self.assertIn('nullable', abi_method_main_parameters[0])
+        self.assertIn('union', abi_method_main_parameters[0])
+        self.assertIsInstance(abi_method_main_parameters[0]['union'], list)
+        for union_type in abi_method_main_parameters[0]['union']:
+            self.assertIn('type', union_type)
+
+    def test_generate_manifest_file_with_type_hint_storage_context(self):
+        path = self.get_contract_path('test_sc/interop_test/storage', 'StorageGetContext.py')
+        _, abi_methods = self.verify_parameters_and_return_manifest(path)     # type: dict, list
+
+        abi_method_main = abi_methods[0]
+        self.assertEqual('InteropInterface', abi_method_main['returntype'])
+        self.assertIn('returnhint', abi_method_main)
+        self.assertEqual(abi_method_main['returnhint'], 'StorageContext')
+
+    def test_generate_manifest_file_with_type_hint_iterator(self):
+        path = self.get_contract_path('test_sc/interop_test/iterator', 'ImportIterator.py')
+        _, abi_methods = self.verify_parameters_and_return_manifest(path)     # type: dict, list
+
+        abi_method_main = abi_methods[0]
+        self.assertEqual('InteropInterface', abi_method_main['returntype'])
+        self.assertIn('returnhint', abi_method_main)
+        self.assertEqual(abi_method_main['returnhint'], 'Iterator')
+
+    def test_generate_manifest_file_with_type_hint_address(self):
+        path = self.get_contract_path('test_sc/generation_test', 'ManifestTypeHintAddress.py')
+        methods, abi_methods = self.verify_parameters_and_return_manifest(path)     # type: dict, list
+
+        method_main: Method = methods[abi_methods[0]['name']]
+
+        from boa3.model.type.neo import AddressType
+        self.assertIsInstance(method_main.return_type, AddressType)
+
+        abi_method_main = abi_methods[0]
+        self.assertEqual(abi_method_main['returntype'], 'String')
+        self.assertIn('returnhint', abi_method_main)
+        self.assertEqual(abi_method_main['returnhint'], 'Address')
+
+    def test_generate_manifest_file_with_type_hint_str_to_address(self):
+        path = self.get_contract_path('test_sc/generation_test', 'ManifestTypeHintFromStrToAddress.py')
+        methods, abi_methods = self.verify_parameters_and_return_manifest(path)     # type: dict, list
+
+        method_main: Method = methods[abi_methods[0]['name']]
+
+        from boa3.model.type.neo import AddressType
+        self.assertIsInstance(method_main.return_type, AddressType)
+
+    def test_generate_manifest_file_with_type_hint_blockhash(self):
+        path = self.get_contract_path('test_sc/generation_test', 'ManifestTypeHintBlockHash.py')
+        methods, abi_methods = self.verify_parameters_and_return_manifest(path)     # type: dict, list
+
+        method_main: Method = methods[abi_methods[0]['name']]
+
+        from boa3.model.type.neo import BlockHashType
+        self.assertIsInstance(method_main.return_type, BlockHashType)
+
+        abi_method_main = abi_methods[0]
+        self.assertEqual(abi_method_main['returntype'], 'Hash256')
+        self.assertIn('returnhint', abi_method_main)
+        self.assertEqual(abi_method_main['returnhint'], 'BlockHash')
+
+    def test_generate_manifest_file_with_type_hint_uint256_to_blockhash(self):
+        path = self.get_contract_path('test_sc/generation_test', 'ManifestTypeHintFromUInt256ToBlockHash.py')
+        methods, abi_methods = self.verify_parameters_and_return_manifest(path)     # type: dict, list
+
+        method_main: Method = methods[abi_methods[0]['name']]
+
+        from boa3.model.type.neo import BlockHashType
+        self.assertIsInstance(method_main.return_type, BlockHashType)
+
+    def test_generate_manifest_file_with_type_hint_publickey(self):
+        path = self.get_contract_path('test_sc/generation_test', 'ManifestTypeHintPublicKey.py')
+        methods, abi_methods = self.verify_parameters_and_return_manifest(path)     # type: dict, list
+
+        method_main: Method = methods[abi_methods[0]['name']]
+
+        from boa3.model.type.neo import PublicKeyType
+        self.assertIsInstance(method_main.return_type, PublicKeyType)
+
+        abi_method_main = abi_methods[0]
+        self.assertEqual(abi_method_main['returntype'], 'PublicKey')
+        # 'PublicKey' already is a abi type, so there is no need to use a 'returnhint'
+        self.assertNotIn('returnhint', abi_method_main)
+
+    def test_generate_manifest_file_with_type_hint_ecpoint_to_publickey(self):
+        path = self.get_contract_path('test_sc/generation_test', 'ManifestTypeHintFromECPointToPublicKey.py')
+        methods, abi_methods = self.verify_parameters_and_return_manifest(path)  # type: dict, list
+
+        method_main: Method = methods[abi_methods[0]['name']]
+
+        from boa3.model.type.neo import PublicKeyType
+        self.assertIsInstance(method_main.return_type, PublicKeyType)
+
+    def test_generate_manifest_file_with_type_hint_scripthash(self):
+        path = self.get_contract_path('test_sc/generation_test', 'ManifestTypeHintScriptHash.py')
+        methods, abi_methods = self.verify_parameters_and_return_manifest(path)     # type: dict, list
+
+        method_main: Method = methods[abi_methods[0]['name']]
+
+        from boa3.model.type.neo import ScriptHashType
+        self.assertIsInstance(method_main.return_type, ScriptHashType)
+
+        abi_method_main = abi_methods[0]
+        self.assertEqual(abi_method_main['returntype'], 'Hash160')
+        self.assertIn('returnhint', abi_method_main)
+        self.assertEqual(abi_method_main['returnhint'], 'ScriptHash')
+
+    def test_generate_manifest_file_with_type_hint_uint160_to_scripthash(self):
+        path = self.get_contract_path('test_sc/generation_test', 'ManifestTypeHintFromUInt160ToScriptHash.py')
+        methods, abi_methods = self.verify_parameters_and_return_manifest(path)     # type: dict, list
+
+        method_main: Method = methods[abi_methods[0]['name']]
+
+        from boa3.model.type.neo import ScriptHashType
+        self.assertIsInstance(method_main.return_type, ScriptHashType)
+
+    def test_generate_manifest_file_with_type_hint_scripthashlittleendian(self):
+        path = self.get_contract_path('test_sc/generation_test', 'ManifestTypeHintScriptHashLittleEndian.py')
+        methods, abi_methods = self.verify_parameters_and_return_manifest(path)     # type: dict, list
+
+        method_main: Method = methods[abi_methods[0]['name']]
+
+        from boa3.model.type.neo import ScriptHashLittleEndianType
+        self.assertIsInstance(method_main.return_type, ScriptHashLittleEndianType)
+
+        abi_method_main = abi_methods[0]
+        self.assertEqual(abi_method_main['returntype'], 'Hash160')
+        self.assertIn('returnhint', abi_method_main)
+        self.assertEqual(abi_method_main['returnhint'], 'ScriptHashLittleEndian')
+
+    def test_generate_manifest_file_with_type_hint_uint160_to_scripthashlittleendian(self):
+        path = self.get_contract_path('test_sc/generation_test', 'ManifestTypeHintFromUInt160ToScriptHashLittleEndian.py')
+        methods, abi_methods = self.verify_parameters_and_return_manifest(path)     # type: dict, list
+
+        method_main: Method = methods[abi_methods[0]['name']]
+
+        from boa3.model.type.neo import ScriptHashLittleEndianType
+        self.assertIsInstance(method_main.return_type, ScriptHashLittleEndianType)
+
+    def test_generate_manifest_file_with_type_hint_transactionid(self):
+        path = self.get_contract_path('test_sc/generation_test', 'ManifestTypeHintTransactionId.py')
+        methods, abi_methods = self.verify_parameters_and_return_manifest(path)     # type: dict, list
+
+        method_main: Method = methods[abi_methods[0]['name']]
+
+        from boa3.model.type.neo import TransactionIdType
+        self.assertIsInstance(method_main.return_type, TransactionIdType)
+
+        abi_method_main = abi_methods[0]
+        self.assertEqual(abi_method_main['returntype'], 'Hash256')
+        self.assertIn('returnhint', abi_method_main)
+        self.assertEqual(abi_method_main['returnhint'], 'TransactionId')
+
+    def test_generate_manifest_file_with_type_hint_uint256_to_transactionid(self):
+        path = self.get_contract_path('test_sc/generation_test', 'ManifestTypeHintFromUInt256ToTransactionId.py')
+        methods, abi_methods = self.verify_parameters_and_return_manifest(path)     # type: dict, list
+
+        method_main: Method = methods[abi_methods[0]['name']]
+
+        from boa3.model.type.neo import TransactionIdType
+        self.assertIsInstance(method_main.return_type, TransactionIdType)
+
+    def test_generate_manifest_file_with_type_hint_any(self):
+        path = self.get_contract_path('test_sc/generation_test', 'ManifestTypeHintAny.py')
+        _, abi_methods = self.verify_parameters_and_return_manifest(path)  # type: dict, list
+
+        abi_method_main = abi_methods[0]
+        self.assertEqual(abi_method_main['returntype'], 'Any')
+        # verifying if 'returnunion' was not wrongfully added to the manifest
+        self.assertNotIn('returnunion', abi_method_main)
+
+    def test_generate_manifest_file_with_type_hint_maps_array_union_hint(self):
+        path = self.get_contract_path('test_sc/generation_test', 'ManifestTypeHintMapsArraysUnionHint.py')
+        _, abi_methods = self.verify_parameters_and_return_manifest(path)  # type: dict, list
+
+        abi_method_main = abi_methods[0]
+        abi_method_main_parameter = abi_method_main['parameters'][0]
+
+        # verifying arg type
+        self.assertEqual('Map', abi_method_main_parameter['type'])
+        self.assertIn('generickey', abi_method_main_parameter)
+        self.assertIn('type', abi_method_main_parameter['generickey'])
+        self.assertEqual('String', abi_method_main_parameter['generickey']['type'])
+        self.assertIn('genericitem', abi_method_main_parameter)
+        self.assertIn('type', abi_method_main_parameter['genericitem'])
+        self.assertEqual('Array', abi_method_main_parameter['genericitem']['type'])
+        self.assertIn('generic', abi_method_main_parameter['genericitem'])
+        self.assertIn('type', abi_method_main_parameter['genericitem']['generic'])
+
+        # verifying return type
+        self.assertEqual('Array', abi_method_main['returntype'])
+        self.assertIn('returngeneric', abi_method_main)
+        self.assertIn('type', abi_method_main['returngeneric'])
+        self.assertEqual('Any', abi_method_main['returngeneric']['type'])
+        self.assertIn('union', abi_method_main['returngeneric'])
+        self.assertEqual(3, len(abi_method_main['returngeneric']['union']))
+        self.assertTrue(any(
+            union_type['type'] == 'Map' and 'generickey' in union_type and 'genericitem' in union_type
+            for union_type in abi_method_main['returngeneric']['union']
+        ))
+
+    def test_generate_manifest_file_with_type_hint_list_and_dict_not_from_typing(self):
+        path = self.get_contract_path('test_sc/generation_test', 'ManifestTypeHintListDictNotFromTyping.py')
+        _, abi_methods = self.verify_parameters_and_return_manifest(path)  # type: dict, list
+
+        abi_method_main = abi_methods[0]
+        abi_method_main_parameter = abi_method_main['parameters'][0]
+
+        # verifying arg type
+        self.assertEqual('Map', abi_method_main_parameter['type'])
+        self.assertIn('generickey', abi_method_main_parameter)
+        self.assertIn('type', abi_method_main_parameter['generickey'])
+        self.assertEqual('Any', abi_method_main_parameter['generickey']['type'])
+        self.assertIn('genericitem', abi_method_main_parameter)
+        self.assertIn('type', abi_method_main_parameter['genericitem'])
+        self.assertEqual('Any', abi_method_main_parameter['genericitem']['type'])
+
+        # verifying return type
+        self.assertEqual('Array', abi_method_main['returntype'])
+        self.assertIn('returngeneric', abi_method_main)
+        self.assertIn('type', abi_method_main['returngeneric'])
+        self.assertEqual('Any', abi_method_main['returngeneric']['type'])
+
+    def verify_parameters_and_return_manifest(self, path: str) -> Tuple[dict, list]:
+        expected_manifest_output = path.replace('.py', '.manifest.json')
+        compiler = Compiler()
+        compiler.compile_and_save(path, path.replace('.py', '.nef'))
+        methods: Dict[str, Event] = {
+            name: method
+            for name, method in self.get_compiler_analyser(compiler).symbol_table.items()
+            if isinstance(method, Method)
+        }
+
+        output, manifest = self.get_output(path)
+        self.assertTrue(os.path.exists(expected_manifest_output))
+        self.assertIn('abi', manifest)
+        abi = manifest['abi']
+
+        self.assertIn('methods', abi)
+
+        for abi_method in abi['methods']:
+            self.assertIn('name', abi_method)
+            self.assertIn(abi_method['name'], abi_method['name'])
+            self.assertIn('parameters', abi_method)
+
+            method_args = methods[abi_method['name']].args
+            for abi_method_param in abi_method['parameters']:
+                self.assertIn('name', abi_method_param)
+                self.assertIn(abi_method_param['name'], method_args)
+
+            self.assertIn('returntype', abi_method)
+
+        return methods, abi['methods']


### PR DESCRIPTION
…st file generation to better describe the specific type/format of that field.

**Summary or solution description**
Added more types to better indicate what sort of parameters the smart contract has.
Now, when compiling a smart contract, if the user wants to they can use one of the added types to hint the type on the manifest. 
`List`s, `Dict`s and `Union` also have a hint indicating the items types.
Using `Optional` now adds a `nullable` on the parameter or return on the manifest.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/d43c0a3cdb1db11e80093d8da8b30441384ba213/boa3_test/test_sc/generation_test/ManifestTypeHintFromStrToAddress.py#L1-L7

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/d43c0a3cdb1db11e80093d8da8b30441384ba213/boa3_test/tests/compiler_tests/test_file_generation.py#L780-L1096

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7

**(Optional) Additional context**
Tring to use the method `to_script_hash()` on strings that when turned into bytes doesn't have length 20 or is not an Address, will end up in a runtime error. An issue will be created to verify this behaviour and fix this if needed.
