### PR TITLE
Bug fix - Method `to_script_hash` may not work with some values

### DIFF
--- a/boa3/neo/__init__.py
+++ b/boa3/neo/__init__.py
@@ -17,6 +17,8 @@ def to_script_hash(data_bytes: bytes) -> bytes:
         base58_decoded = b58decode(data_bytes)[1:]  # first byte is the address version
 
         from boa3.constants import SIZE_OF_INT160
+        if len(base58_decoded) < SIZE_OF_INT160:
+            raise ValueError
         return bytes(base58_decoded[:SIZE_OF_INT160])
     except BaseException:
         return cryptography.hash160(data_bytes)

--- a/boa3_test/tests/compiler_tests/test_builtin_method.py
+++ b/boa3_test/tests/compiler_tests/test_builtin_method.py
@@ -413,26 +413,30 @@ class TestBuiltinMethod(BoaTest):
 
     def test_script_hash_str(self):
         from boa3.neo import to_script_hash
-        script_hash = to_script_hash(String('NUnLWXALK2G6gYa7RadPLRiQYunZHnncxg').to_bytes())
 
         path = self.get_contract_path('ScriptHashStr.py')
+        engine = TestEngine()
+
+        expected_result = to_script_hash(String('NUnLWXALK2G6gYa7RadPLRiQYunZHnncxg').to_bytes())
+        result = self.run_smart_contract(engine, path, 'Main',
+                                         expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+        expected_result = to_script_hash(String('123').to_bytes())
+        result = self.run_smart_contract(engine, path, 'Main2',
+                                         expected_result_type=bytes)
+        self.assertEqual(expected_result, result)
+
+    def test_script_hash_str_with_builtin(self):
+        from boa3.neo import to_script_hash
+        script_hash = to_script_hash(String('123').to_bytes())
+
+        path = self.get_contract_path('ScriptHashStrBuiltinCall.py')
 
         engine = TestEngine()
         result = self.run_smart_contract(engine, path, 'Main',
                                          expected_result_type=bytes)
         self.assertEqual(script_hash, result)
-
-        # TODO: to_script_hash is returning a bytes value that has length 1
-        with self.assertRaises(TestExecutionException):
-            self.run_smart_contract(engine, path, 'Main2')
-
-    def test_script_hash_str_with_builtin(self):
-        path = self.get_contract_path('ScriptHashStrBuiltinCall.py')
-
-        engine = TestEngine()
-        # TODO: to_script_hash is returning a bytes value that has length 1
-        with self.assertRaises(TestExecutionException):
-            self.run_smart_contract(engine, path, 'Main')
 
     def test_script_hash_variable(self):
         path = self.get_contract_path('ScriptHashVariable.py')
@@ -458,7 +462,7 @@ class TestBuiltinMethod(BoaTest):
         from base58 import b58encode
         engine = TestEngine()
 
-        script_hash = to_script_hash('123')
+        script_hash = to_script_hash(String('123').to_bytes())
         result = self.run_smart_contract(engine, path, 'Main', '123',
                                          expected_result_type=bytes)
         self.assertEqual(script_hash, result)

--- a/boa3_test/tests/compiler_tests/test_constant.py
+++ b/boa3_test/tests/compiler_tests/test_constant.py
@@ -426,8 +426,8 @@ class TestConstant(BoaTest):
         import base58
         from boa3.neo import to_script_hash
 
-        input = String('123').to_bytes()
-        expected_output = base58.b58decode(input)[1:]
+        input = String('NUnLWXALK2G6gYa7RadPLRiQYunZHnncxg').to_bytes()
+        expected_output = base58.b58decode(input)[1:21]
         output = to_script_hash(input)
 
         self.assertEqual(expected_output, output)


### PR DESCRIPTION
**Summary or solution description**
We had inconsistent behavior with the method `to_script_hash`. There were cases where the results didn't have the length a script hash should have (20 bytes).

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/705c163b9d3180eac66fd9aafb08f33d76a24a29/boa3_test/test_sc/built_in_methods_test/ScriptHashVariable.py#L4-L6

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/705c163b9d3180eac66fd9aafb08f33d76a24a29/boa3_test/tests/compiler_tests/test_builtin_method.py#L414-L477

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7+