### PR TITLE
Refactor unit tests to use TestRunner instead of TestEngine

### DIFF
--- a/boa3_test/test_drive/model/invoker/neoinvokecollection.py
+++ b/boa3_test/test_drive/model/invoker/neoinvokecollection.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Type
 
 from boa3_test.test_drive.model.invoker.neoinvoke import NeoInvoke
 from boa3_test.test_drive.model.invoker.neoinvokeresult import NeoInvokeResult
@@ -12,10 +12,11 @@ class NeoInvokeCollection:
         self._invoke_results: List[NeoInvokeResult] = []
         self._pending_results: List[NeoInvokeResult] = []
 
-    def append_contract_invoke(self, contract: TestContract, operation: str, *args: Any) -> NeoInvokeResult:
+    def append_contract_invoke(self, contract: TestContract, operation: str, *args: Any,
+                               expected_result_type: Type = None) -> NeoInvokeResult:
         invoker = NeoInvoke(contract.name, operation, *args)
         invoker._contract = contract
-        invoke_result = NeoInvokeResult(invoker)
+        invoke_result = NeoInvokeResult(invoker, expected_result_type=expected_result_type)
         self._internal_list.append(invoker)
         self._invoke_results.append(invoke_result)
         self._pending_results.append(invoke_result)

--- a/boa3_test/test_drive/model/invoker/neoinvokeresult.py
+++ b/boa3_test/test_drive/model/invoker/neoinvokeresult.py
@@ -1,10 +1,16 @@
+from typing import Type
+
 from boa3_test.test_drive.model.invoker.neoinvoke import NeoInvoke
 
 
 class NeoInvokeResult:
-    def __init__(self, invoke: NeoInvoke):
+    def __init__(self, invoke: NeoInvoke, expected_result_type: Type = None):
         self._invoke: NeoInvoke = invoke
         self._result = NOT_EXECUTED
+
+        if not isinstance(expected_result_type, type):
+            expected_result_type = None
+        self._expected_result_type = expected_result_type
 
     @property
     def invoke(self) -> NeoInvoke:
@@ -13,8 +19,26 @@ class NeoInvokeResult:
     @property
     def result(self):
         if hasattr(self._result, 'copy'):
-            return self._result.copy()
-        return self._result
+            result = self._result.copy()
+        else:
+            result = self._result
+
+        if self._expected_result_type is not None:
+            if self._expected_result_type is not str and isinstance(result, str):
+                from boa3.neo.vm.type.String import String
+                result = String(result).to_bytes()
+
+            if self._expected_result_type is bool:
+                if isinstance(result, bytes):
+                    from boa3.neo.vm.type.Integer import Integer
+                    result = Integer.from_bytes(result, signed=True)
+                if isinstance(result, int) and result in (False, True):
+                    result = bool(result)
+
+            if self._expected_result_type is bytearray and isinstance(result, bytes):
+                result = bytearray(result)
+
+        return result
 
     def __repr__(self):
         return f'{self._invoke.__repr__()} -> {self._result.__repr__()}'

--- a/boa3_test/test_drive/neoxp/__init__.py
+++ b/boa3_test/test_drive/neoxp/__init__.py
@@ -1,0 +1,1 @@
+from boa3_test.test_drive.neoxp import utils

--- a/boa3_test/test_drive/neoxp/utils.py
+++ b/boa3_test/test_drive/neoxp/utils.py
@@ -27,6 +27,10 @@ def get_account_by_identifier(account_identifier: str) -> Account:
                 None)
 
 
+def get_address_version() -> int:
+    return _NEOXP_CONFIG.version
+
+
 def get_account_identifier_from_script_hash_or_name(script_hash_or_address: Union[bytes, str]) -> str:
     if isinstance(script_hash_or_address, bytes):
         address = wallet_utils.address_from_script_hash(script_hash_or_address, _NEOXP_CONFIG.version)

--- a/boa3_test/test_drive/testrunner/neo_test_runner.py
+++ b/boa3_test/test_drive/testrunner/neo_test_runner.py
@@ -1,7 +1,7 @@
 import json
 import os.path
 import subprocess
-from typing import Any, List, Tuple, Dict, Optional, Union
+from typing import Any, List, Tuple, Dict, Optional, Union, Type
 
 from boa3 import env, constants
 from boa3.neo import utils as neo_utils
@@ -131,13 +131,15 @@ class NeoTestRunner:
             contract = self._contracts[nef_path]
         return contract
 
-    def call_contract(self, nef_path: str, method: str, *arguments: Any) -> NeoInvokeResult:
+    def call_contract(self, nef_path: str, method: str, *arguments: Any,
+                      expected_result_type: Type = None) -> NeoInvokeResult:
         if nef_path not in self._contracts:
             contract = self.deploy_contract(nef_path)
         else:
             contract = self._contracts[nef_path]
 
-        return self._invokes.append_contract_invoke(contract, method, *arguments)
+        return self._invokes.append_contract_invoke(contract, method, *arguments,
+                                                    expected_result_type=expected_result_type)
 
     def get_contract(self, contract_id: Union[str, bytes]) -> TestContract:
         return self._contracts[contract_id]
@@ -297,3 +299,6 @@ class NeoTestRunner:
                                    stderr=subprocess.STDOUT,
                                    text=True)
         return process.communicate()
+
+    def increase_block(self, new_height: int = None):
+        self._batch.mint_block(new_height)

--- a/boa3_test/test_sc/arithmetic_test/ConcatBytesVariablesAndConstants.py
+++ b/boa3_test/test_sc/arithmetic_test/ConcatBytesVariablesAndConstants.py
@@ -1,5 +1,5 @@
 from boa3.builtin.compile_time import public
-from boa3.builtin.interop.runtime import time
+from boa3.builtin.interop.runtime import address_version
 
 
 VALUE1 = b'value1'
@@ -9,17 +9,17 @@ VALUE3 = b'value3'
 
 @public
 def concat1() -> bytes:
-    current_time = time.to_bytes() + b'some_bytes_after'
+    current_time = address_version.to_bytes() + b'some_bytes_after'
     return VALUE1 + b'  ' + VALUE2 + b'  ' + VALUE3 + b'  ' + current_time
 
 
 @public
 def concat2() -> bytes:
-    current_time = time.to_bytes() + b'some_bytes_after'
+    current_time = address_version.to_bytes() + b'some_bytes_after'
     return VALUE1 + VALUE2 + VALUE3 + current_time
 
 
 @public
 def concat3() -> bytes:
-    current_time = time.to_bytes() + b'some_bytes_after'
+    current_time = address_version.to_bytes() + b'some_bytes_after'
     return VALUE1 + b'__' + VALUE2 + b'__' + VALUE3 + b'__' + current_time

--- a/boa3_test/tests/boa_test.py
+++ b/boa3_test/tests/boa_test.py
@@ -139,6 +139,8 @@ class BoaTest(TestCase):
             raise TypeError(type_error_message.format(2, num_args + 1))
         if num_args > 3:
             raise TypeError(type_error_message.format(4, num_args + 1))
+        if os.path.isabs(args[0]):
+            return args[0]
 
         values = [None, self.default_test_folder, env.PROJECT_ROOT_DIRECTORY]
         for index, value in enumerate(reversed(args)):
@@ -173,7 +175,11 @@ class BoaTest(TestCase):
         contract_path = self.get_contract_path(*args)
         if isinstance(contract_path, str):
             file_path_without_ext, _ = os.path.splitext(contract_path)
-            return f'{file_path_without_ext}.nef', f'{file_path_without_ext}.manifest.json'
+            nef_path, manifest_path = f'{file_path_without_ext}.nef', f'{file_path_without_ext}.manifest.json'
+            if not (os.path.isfile(nef_path) and os.path.isfile(manifest_path)):
+                # both .nef and .manifest.json are required to execute the smart contract
+                self.compile_and_save(contract_path, log=False)
+            return nef_path, manifest_path
 
         return contract_path, contract_path
 

--- a/boa3_test/tests/compiler_tests/test_arithmetic.py
+++ b/boa3_test/tests/compiler_tests/test_arithmetic.py
@@ -5,9 +5,10 @@ from boa3.model.type.type import Type
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3.neo3.contracts import FindOptions
+from boa3.neo3.vm import VMState
+from boa3_test.test_drive import neoxp
+from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.boa_test import BoaTest
-from boa3_test.tests.test_classes.TestExecutionException import TestExecutionException
-from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestArithmetic(BoaTest):
@@ -16,55 +17,115 @@ class TestArithmetic(BoaTest):
     # region Addition
 
     def test_boa2_add_test(self):
-        path = self.get_contract_path('AddBoa2Test.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', 2)
-        self.assertEqual(4, result)
+        path, _ = self.get_deploy_file_paths('AddBoa2Test.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', 23234)
-        self.assertEqual(23236, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', 0)
-        self.assertEqual(2, result)
+        invokes.append(runner.call_contract(path, 'main', 2))
+        expected_results.append(4)
 
-        result = self.run_smart_contract(engine, path, 'main', -112)
-        self.assertEqual(-110, result)
+        invokes.append(runner.call_contract(path, 'main', 23234))
+        expected_results.append(23236)
+
+        invokes.append(runner.call_contract(path, 'main', 0))
+        expected_results.append(2)
+
+        invokes.append(runner.call_contract(path, 'main', -112))
+        expected_results.append(-110)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_boa2_add_test1(self):
-        path = self.get_contract_path('AddBoa2Test1.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', 1, 2, 3, 4)
-        self.assertEqual(9, result)
+        path, _ = self.get_deploy_file_paths('AddBoa2Test1.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', 0, 0, 0, 2)
-        self.assertEqual(2, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', -2, 3, -6, 2)
-        self.assertEqual(-2, result)
+        invokes.append(runner.call_contract(path, 'main', 1, 2, 3, 4))
+        expected_results.append(9)
+
+        invokes.append(runner.call_contract(path, 'main', 0, 0, 0, 2))
+        expected_results.append(2)
+
+        invokes.append(runner.call_contract(path, 'main', -2, 3, -6, 2))
+        expected_results.append(-2)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_boa2_add_test2(self):
-        path = self.get_contract_path('AddBoa2Test2.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(3, result)
+        path, _ = self.get_deploy_file_paths('AddBoa2Test2.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(3)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_boa2_add_test3(self):
-        path = self.get_contract_path('AddBoa2Test3.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(-9, result)
+        path, _ = self.get_deploy_file_paths('AddBoa2Test3.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(-9)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_boa2_add_test4(self):
-        path = self.get_contract_path('AddBoa2Test4.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', 1, 2, 3, 4)
-        self.assertEqual(-9, result)
+        path, _ = self.get_deploy_file_paths('AddBoa2Test4.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', 1, 2, 3, 4))
+        expected_results.append(-9)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_boa2_add_test_void(self):
-        path = self.get_contract_path('AddBoa2TestVoid.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', 3)
-        self.assertIsVoid(result)
+        path, _ = self.get_deploy_file_paths('AddBoa2TestVoid.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', 3))
+        expected_results.append(None)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_addition_operation(self):
         expected_output = (
@@ -81,13 +142,24 @@ class TestArithmetic(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'add', 1, 2)
-        self.assertEqual(3, result)
-        result = self.run_smart_contract(engine, path, 'add', -42, -24)
-        self.assertEqual(-66, result)
-        result = self.run_smart_contract(engine, path, 'add', -42, 24)
-        self.assertEqual(-18, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'add', 1, 2))
+        expected_results.append(3)
+        invokes.append(runner.call_contract(path, 'add', -42, -24))
+        expected_results.append(-66)
+        invokes.append(runner.call_contract(path, 'add', -42, 24))
+        expected_results.append(-18)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_addition_augmented_assignment(self):
         expected_output = (
@@ -103,15 +175,23 @@ class TestArithmetic(BoaTest):
 
         path = self.get_contract_path('AdditionAugmentedAssignment.py')
         output = Boa3.compile(path)
-
         self.assertEqual(expected_output, output)
 
     def test_addition_builtin_type(self):
-        path = self.get_contract_path('AdditionBuiltinType.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('AdditionBuiltinType.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', FindOptions.VALUES_ONLY, FindOptions.DESERIALIZE_VALUES)
-        self.assertEqual(FindOptions.VALUES_ONLY + FindOptions.DESERIALIZE_VALUES, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', FindOptions.VALUES_ONLY, FindOptions.DESERIALIZE_VALUES))
+        expected_results.append(FindOptions.VALUES_ONLY + FindOptions.DESERIALIZE_VALUES)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_addition_literal_operation(self):
         expected_output = (
@@ -123,9 +203,20 @@ class TestArithmetic(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'add_one_two')
-        self.assertEqual(3, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'add_one_two'))
+        expected_results.append(3)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_addition_literal_and_variable(self):
         expected_output = (
@@ -142,13 +233,24 @@ class TestArithmetic(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'add_one', 1)
-        self.assertEqual(2, result)
-        result = self.run_smart_contract(engine, path, 'add_one', -10)
-        self.assertEqual(-9, result)
-        result = self.run_smart_contract(engine, path, 'add_one', -1)
-        self.assertEqual(0, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'add_one', 1))
+        expected_results.append(2)
+        invokes.append(runner.call_contract(path, 'add_one', -10))
+        expected_results.append(-9)
+        invokes.append(runner.call_contract(path, 'add_one', -1))
+        expected_results.append(0)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_sequence_addition(self):
         expected_output = (
@@ -167,13 +269,24 @@ class TestArithmetic(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'add_four', 1, 2)
-        self.assertEqual(7, result)
-        result = self.run_smart_contract(engine, path, 'add_four', -42, -24)
-        self.assertEqual(-62, result)
-        result = self.run_smart_contract(engine, path, 'add_four', -42, 24)
-        self.assertEqual(-14, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'add_four', 1, 2))
+        expected_results.append(7)
+        invokes.append(runner.call_contract(path, 'add_four', -42, -24))
+        expected_results.append(-62)
+        invokes.append(runner.call_contract(path, 'add_four', -42, 24))
+        expected_results.append(-14)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_sequence_addition_different_orders(self):
         expected_output = (
@@ -196,20 +309,33 @@ class TestArithmetic(BoaTest):
         output_3 = Boa3.compile(path_3)
         self.assertEqual(expected_output, output_3)
 
-        engine = TestEngine()
-        result_1 = self.run_smart_contract(engine, path_1, 'add_six', 5)
-        result_2 = self.run_smart_contract(engine, path_2, 'add_six', 5)
-        result_3 = self.run_smart_contract(engine, path_2, 'add_six', 5)
-        self.assertEqual(11, result_1)
-        self.assertEqual(11, result_2)
-        self.assertEqual(11, result_3)
+        path_1, _ = self.get_deploy_file_paths(path_1)
+        path_2, _ = self.get_deploy_file_paths(path_2)
+        path_3, _ = self.get_deploy_file_paths(path_3)
+        runner = NeoTestRunner()
 
-        result_1 = self.run_smart_contract(engine, path_1, 'add_six', -42)
-        result_2 = self.run_smart_contract(engine, path_2, 'add_six', -42)
-        result_3 = self.run_smart_contract(engine, path_2, 'add_six', -42)
-        self.assertEqual(-36, result_1)
-        self.assertEqual(-36, result_2)
-        self.assertEqual(-36, result_3)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path_1, 'add_six', 5))
+        expected_results.append(11)
+        invokes.append(runner.call_contract(path_2, 'add_six', 5))
+        expected_results.append(11)
+        invokes.append(runner.call_contract(path_3, 'add_six', 5))
+        expected_results.append(11)
+
+        invokes.append(runner.call_contract(path_1, 'add_six', -42))
+        expected_results.append(-36)
+        invokes.append(runner.call_contract(path_2, 'add_six', -42))
+        expected_results.append(-36)
+        invokes.append(runner.call_contract(path_3, 'add_six', -42))
+        expected_results.append(-36)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_addition_variable_and_literal(self):
         expected_output = (
@@ -226,37 +352,54 @@ class TestArithmetic(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'add_one', 1)
-        self.assertEqual(2, result)
-        result = self.run_smart_contract(engine, path, 'add_one', -10)
-        self.assertEqual(-9, result)
-        result = self.run_smart_contract(engine, path, 'add_one', -1)
-        self.assertEqual(0, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'add_one', 1))
+        expected_results.append(2)
+        invokes.append(runner.call_contract(path, 'add_one', -10))
+        expected_results.append(-9)
+        invokes.append(runner.call_contract(path, 'add_one', -1))
+        expected_results.append(0)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     # endregion
 
     # region Concatenation
 
     def test_concat_bytes_variables_and_constants(self):
-        path = self.get_contract_path('ConcatBytesVariablesAndConstants.py')
+        path, _ = self.get_deploy_file_paths('ConcatBytesVariablesAndConstants.py')
+        address_version = Integer(neoxp.utils.get_address_version()).to_byte_array()
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        engine.increase_block()  # increase to get consistent block_time between execution and engine
-        result = self.run_smart_contract(engine, path, 'concat1',
-                                         expected_result_type=bytes)
-        current_time = Integer(engine.current_block.timestamp).to_byte_array()
-        self.assertEqual(b'value1  value2  value3  ' + current_time + b'some_bytes_after', result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'concat2',
-                                         expected_result_type=bytes)
-        current_time = Integer(engine.current_block.timestamp).to_byte_array()
-        self.assertEqual(b'value1value2value3' + current_time + b'some_bytes_after', result)
+        invokes.append(runner.call_contract(path, 'concat1',
+                                            expected_result_type=bytes))
+        expected_results.append(b'value1  value2  value3  ' + address_version + b'some_bytes_after')
 
-        result = self.run_smart_contract(engine, path, 'concat3',
-                                         expected_result_type=bytes)
-        current_time = Integer(engine.current_block.timestamp).to_byte_array()
-        self.assertEqual(b'value1__value2__value3__' + current_time + b'some_bytes_after', result)
+        invokes.append(runner.call_contract(path, 'concat2',
+                                            expected_result_type=bytes))
+        expected_results.append(b'value1value2value3' + address_version + b'some_bytes_after')
+
+        invokes.append(runner.call_contract(path, 'concat3',
+                                            expected_result_type=bytes))
+        expected_results.append(b'value1__value2__value3__' + address_version + b'some_bytes_after')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_concatenation_operation(self):
         expected_output = (
@@ -275,11 +418,22 @@ class TestArithmetic(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'concat', 'a', 'b')
-        self.assertEqual('ab', result)
-        result = self.run_smart_contract(engine, path, 'concat', 'unit', 'test')
-        self.assertEqual('unittest', result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'concat', 'a', 'b'))
+        expected_results.append('ab')
+        invokes.append(runner.call_contract(path, 'concat', 'unit', 'test'))
+        expected_results.append('unittest')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_concatenation_augmented_assignment(self):
         expected_output = (
@@ -297,15 +451,24 @@ class TestArithmetic(BoaTest):
 
         path = self.get_contract_path('ConcatenationAugmentedAssignment.py')
         output = Boa3.compile(path)
-
         self.assertEqual(expected_output, output)
 
     def test_concat_string_variables_and_constants(self):
-        path = self.get_contract_path('ConcatStringVariablesAndConstants.py')
+        path, _ = self.get_deploy_file_paths('ConcatStringVariablesAndConstants.py')
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'concat')
-        self.assertEqual('[1,2]', result)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'concat'))
+        expected_results.append('[1,2]')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     # endregion
 
@@ -320,11 +483,20 @@ class TestArithmetic(BoaTest):
         self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
 
     def test_division_builtin_type(self):
-        path = self.get_contract_path('DivisionBuiltinType.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('DivisionBuiltinType.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', FindOptions.DESERIALIZE_VALUES, FindOptions.VALUES_ONLY)
-        self.assertEqual(FindOptions.DESERIALIZE_VALUES // FindOptions.VALUES_ONLY, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', FindOptions.DESERIALIZE_VALUES, FindOptions.VALUES_ONLY))
+        expected_results.append(FindOptions.DESERIALIZE_VALUES // FindOptions.VALUES_ONLY)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_integer_division_operation(self):
         expected_output = (
@@ -341,13 +513,24 @@ class TestArithmetic(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'floor_div', 10, 3)
-        self.assertEqual(3, result)
-        result = self.run_smart_contract(engine, path, 'floor_div', -42, -9)
-        self.assertEqual(4, result)
-        result = self.run_smart_contract(engine, path, 'floor_div', -100, 3)
-        self.assertEqual(-33, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'floor_div', 10, 3))
+        expected_results.append(3)
+        invokes.append(runner.call_contract(path, 'floor_div', -42, -9))
+        expected_results.append(4)
+        invokes.append(runner.call_contract(path, 'floor_div', -100, 3))
+        expected_results.append(-33)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_integer_division_augmented_assignment(self):
         expected_output = (
@@ -363,7 +546,6 @@ class TestArithmetic(BoaTest):
 
         path = self.get_contract_path('IntegerDivisionAugmentedAssignment.py')
         output = Boa3.compile(path)
-
         self.assertEqual(expected_output, output)
 
     # endregion
@@ -371,17 +553,26 @@ class TestArithmetic(BoaTest):
     # region ListAddition
 
     def test_list_addition(self):
-        path = self.get_contract_path('ListAddition.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ListAddition.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'add_any', [1, 'str', '123'], [2, True, False])
-        self.assertEqual([1, 'str', '123'] + [2, True, False], result)
-        result = self.run_smart_contract(engine, path, 'add_int', [1, 3], [2, 5])
-        self.assertEqual([1, 3] + [2, 5], result)
-        result = self.run_smart_contract(engine, path, 'add_bool', [True], [False, True])
-        self.assertEqual([True] + [False, True], result)
-        result = self.run_smart_contract(engine, path, 'add_str', ['unit', ' '], ['test', '.'])
-        self.assertEqual(['unit', ' '] + ['test', '.'], result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'add_any', [1, 'str', '123'], [2, True, False]))
+        expected_results.append([1, 'str', '123'] + [2, True, False])
+        invokes.append(runner.call_contract(path, 'add_int', [1, 3], [2, 5]))
+        expected_results.append([1, 3] + [2, 5])
+        invokes.append(runner.call_contract(path, 'add_bool', [True], [False, True]))
+        expected_results.append([True] + [False, True])
+        invokes.append(runner.call_contract(path, 'add_str', ['unit', ' '], ['test', '.']))
+        expected_results.append(['unit', ' '] + ['test', '.'])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     # endregion
 
@@ -407,13 +598,13 @@ class TestArithmetic(BoaTest):
             + Opcode.LDARG0
             + Opcode.LDARG2
             + Opcode.LDARG4
-            + Opcode.MUL        # multiplicative operations
-            + Opcode.ADD        # additive operations
+            + Opcode.MUL  # multiplicative operations
+            + Opcode.ADD  # additive operations
             + Opcode.LDARG3
-            + Opcode.NEGATE     # parentheses
+            + Opcode.NEGATE  # parentheses
             + Opcode.LDARG1
-            + Opcode.DIV        # multiplicative
-            + Opcode.SUB        # additive
+            + Opcode.DIV  # multiplicative
+            + Opcode.SUB  # additive
             + Opcode.RET
         )
 
@@ -421,9 +612,20 @@ class TestArithmetic(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'mixed', 10, 20, 30, 40, 50)
-        self.assertEqual(10 + 30 * 50 + 40 // 20, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'mixed', 10, 20, 30, 40, 50))
+        expected_results.append(10 + 30 * 50 + 40 // 20)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_mixed_operations_with_parentheses(self):
         expected_output = (
@@ -434,12 +636,12 @@ class TestArithmetic(BoaTest):
             + Opcode.LDARG2
             + Opcode.LDARG4
             + Opcode.LDARG3
-            + Opcode.NEGATE     # inside parentheses
-            + Opcode.SUB        # parentheses
-            + Opcode.MUL        # multiplicative operations
+            + Opcode.NEGATE  # inside parentheses
+            + Opcode.SUB  # parentheses
+            + Opcode.MUL  # multiplicative operations
             + Opcode.LDARG1
-            + Opcode.DIV        # multiplicative
-            + Opcode.ADD        # additive operations
+            + Opcode.DIV  # multiplicative
+            + Opcode.ADD  # additive operations
             + Opcode.RET
         )
 
@@ -447,76 +649,114 @@ class TestArithmetic(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'mixed', 10, 20, 30, 40, 50)
-        self.assertEqual(10 + 30 * (50 + 40) // 20, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'mixed', 10, 20, 30, 40, 50))
+        expected_results.append(10 + 30 * (50 + 40) // 20)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     # endregion
 
     # region Modulo
 
     def test_modulo_operation(self):
-        path = self.get_contract_path('Modulo.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Modulo.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         op1 = 10
         op2 = 3
         expected_output = op1 % op2
-        result = self.run_smart_contract(engine, path, 'mod', op1, op2)
-        self.assertEqual(expected_output, result)
+        invokes.append(runner.call_contract(path, 'mod', op1, op2))
+        expected_results.append(expected_output)
 
         op1 = -42
         op2 = -9
         expected_output = op1 % op2
-        result = self.run_smart_contract(engine, path, 'mod', op1, op2)
-        self.assertEqual(expected_output, result)
+        invokes.append(runner.call_contract(path, 'mod', op1, op2))
+        expected_results.append(expected_output)
 
         op1 = -100
         op2 = 3
         expected_output = op1 % op2
-        result = self.run_smart_contract(engine, path, 'mod', op1, op2)
-        self.assertEqual(expected_output, result)
+        invokes.append(runner.call_contract(path, 'mod', op1, op2))
+        expected_results.append(expected_output)
 
         op1 = 100
         op2 = -3
         expected_output = op1 % op2
-        result = self.run_smart_contract(engine, path, 'mod', op1, op2)
-        self.assertEqual(expected_output, result)
+        invokes.append(runner.call_contract(path, 'mod', op1, op2))
+        expected_results.append(expected_output)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_modulo_augmented_assignment(self):
-        path = self.get_contract_path('ModuloAugmentedAssignment.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ModuloAugmentedAssignment.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         op1 = 10
         op2 = 3
         expected_output = op1 % op2
-        result = self.run_smart_contract(engine, path, 'mod', op1, op2)
-        self.assertEqual(expected_output, result)
+        invokes.append(runner.call_contract(path, 'mod', op1, op2))
+        expected_results.append(expected_output)
 
         op1 = -42
         op2 = -9
         expected_output = op1 % op2
-        result = self.run_smart_contract(engine, path, 'mod', op1, op2)
-        self.assertEqual(expected_output, result)
+        invokes.append(runner.call_contract(path, 'mod', op1, op2))
+        expected_results.append(expected_output)
 
         op1 = -100
         op2 = 3
         expected_output = op1 % op2
-        result = self.run_smart_contract(engine, path, 'mod', op1, op2)
-        self.assertEqual(expected_output, result)
+        invokes.append(runner.call_contract(path, 'mod', op1, op2))
+        expected_results.append(expected_output)
 
         op1 = 100
         op2 = -3
         expected_output = op1 % op2
-        result = self.run_smart_contract(engine, path, 'mod', op1, op2)
-        self.assertEqual(expected_output, result)
+        invokes.append(runner.call_contract(path, 'mod', op1, op2))
+        expected_results.append(expected_output)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_modulo_builtin_type(self):
-        path = self.get_contract_path('ModuloBuiltinType.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ModuloBuiltinType.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', FindOptions.DESERIALIZE_VALUES, FindOptions.VALUES_ONLY)
-        self.assertEqual(FindOptions.DESERIALIZE_VALUES % FindOptions.VALUES_ONLY, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', FindOptions.DESERIALIZE_VALUES, FindOptions.VALUES_ONLY))
+        expected_results.append(FindOptions.DESERIALIZE_VALUES % FindOptions.VALUES_ONLY)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     # endregion
 
@@ -537,15 +777,26 @@ class TestArithmetic(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'mult', 10, 3)
-        self.assertEqual(30, result)
-        result = self.run_smart_contract(engine, path, 'mult', -42, -2)
-        self.assertEqual(84, result)
-        result = self.run_smart_contract(engine, path, 'mult', -4, 20)
-        self.assertEqual(-80, result)
-        result = self.run_smart_contract(engine, path, 'mult', 0, 20)
-        self.assertEqual(0, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'mult', 10, 3))
+        expected_results.append(30)
+        invokes.append(runner.call_contract(path, 'mult', -42, -2))
+        expected_results.append(84)
+        invokes.append(runner.call_contract(path, 'mult', -4, 20))
+        expected_results.append(-80)
+        invokes.append(runner.call_contract(path, 'mult', 0, 20))
+        expected_results.append(0)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_multiplication_augmented_assignment(self):
         expected_output = (
@@ -561,15 +812,23 @@ class TestArithmetic(BoaTest):
 
         path = self.get_contract_path('MultiplicationAugmentedAssignment.py')
         output = Boa3.compile(path)
-
         self.assertEqual(expected_output, output)
 
     def test_multiplication_builtin_type(self):
-        path = self.get_contract_path('MultiplicationBuiltinType.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('MultiplicationBuiltinType.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', FindOptions.DESERIALIZE_VALUES, FindOptions.VALUES_ONLY)
-        self.assertEqual(FindOptions.DESERIALIZE_VALUES * FindOptions.VALUES_ONLY, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', FindOptions.DESERIALIZE_VALUES, FindOptions.VALUES_ONLY))
+        expected_results.append(FindOptions.DESERIALIZE_VALUES * FindOptions.VALUES_ONLY)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     # endregion
 
@@ -589,17 +848,31 @@ class TestArithmetic(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'pow', 10, 3)
-        self.assertEqual(1000, result)
-        result = self.run_smart_contract(engine, path, 'pow', 1, 15)
-        self.assertEqual(1, result)
-        result = self.run_smart_contract(engine, path, 'pow', -2, 2)
-        self.assertEqual(4, result)
-        result = self.run_smart_contract(engine, path, 'pow', 0, 20)
-        self.assertEqual(0, result)
-        with self.assertRaisesRegex(TestExecutionException, '^Invalid shift value'):
-            self.run_smart_contract(engine, path, 'pow', 1, -2)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'pow', 10, 3))
+        expected_results.append(1000)
+        invokes.append(runner.call_contract(path, 'pow', 1, 15))
+        expected_results.append(1)
+        invokes.append(runner.call_contract(path, 'pow', -2, 2))
+        expected_results.append(4)
+        invokes.append(runner.call_contract(path, 'pow', 0, 20))
+        expected_results.append(0)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        runner.call_contract(path, 'pow', 1, -2)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, '^Invalid shift value')
 
     def test_power_augmented_assignment(self):
         expected_output = (
@@ -614,15 +887,23 @@ class TestArithmetic(BoaTest):
         )
         path = self.get_contract_path('PowerAugmentedAssignment.py')
         output = Boa3.compile(path)
-
         self.assertEqual(expected_output, output)
 
     def test_power_builtin_type(self):
-        path = self.get_contract_path('PowerBuiltinType.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('PowerBuiltinType.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', FindOptions.DESERIALIZE_VALUES, FindOptions.VALUES_ONLY)
-        self.assertEqual(FindOptions.DESERIALIZE_VALUES ** FindOptions.VALUES_ONLY, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', FindOptions.DESERIALIZE_VALUES, FindOptions.VALUES_ONLY))
+        expected_results.append(FindOptions.DESERIALIZE_VALUES ** FindOptions.VALUES_ONLY)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     # endregion
 
@@ -642,20 +923,40 @@ class TestArithmetic(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'minus', 10)
-        self.assertEqual(-10, result)
-        result = self.run_smart_contract(engine, path, 'minus', -1)
-        self.assertEqual(1, result)
-        result = self.run_smart_contract(engine, path, 'minus', 0)
-        self.assertEqual(0, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'minus', 10))
+        expected_results.append(-10)
+        invokes.append(runner.call_contract(path, 'minus', -1))
+        expected_results.append(1)
+        invokes.append(runner.call_contract(path, 'minus', 0))
+        expected_results.append(0)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_negative_builtin_type(self):
-        path = self.get_contract_path('NegativeBuiltinType.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('NegativeBuiltinType.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'minus', FindOptions.DESERIALIZE_VALUES)
-        self.assertEqual(-FindOptions.DESERIALIZE_VALUES, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'minus', FindOptions.DESERIALIZE_VALUES))
+        expected_results.append(-FindOptions.DESERIALIZE_VALUES)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_positive_operation(self):
         expected_output = (
@@ -670,20 +971,40 @@ class TestArithmetic(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'plus', 10)
-        self.assertEqual(10, result)
-        result = self.run_smart_contract(engine, path, 'plus', -1)
-        self.assertEqual(-1, result)
-        result = self.run_smart_contract(engine, path, 'plus', 0)
-        self.assertEqual(0, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'plus', 10))
+        expected_results.append(10)
+        invokes.append(runner.call_contract(path, 'plus', -1))
+        expected_results.append(-1)
+        invokes.append(runner.call_contract(path, 'plus', 0))
+        expected_results.append(0)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_positive_builtin_type(self):
-        path = self.get_contract_path('PositiveBuiltinType.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('PositiveBuiltinType.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'plus', FindOptions.DESERIALIZE_VALUES)
-        self.assertEqual(+FindOptions.DESERIALIZE_VALUES, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'plus', FindOptions.DESERIALIZE_VALUES))
+        expected_results.append(+FindOptions.DESERIALIZE_VALUES)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     # endregion
 
@@ -704,13 +1025,24 @@ class TestArithmetic(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'bytes_mult', b'a', 4,
-                                         expected_result_type=bytes)
-        self.assertEqual(b'aaaa', result)
-        result = self.run_smart_contract(engine, path, 'bytes_mult', b'unit', 50,
-                                         expected_result_type=bytes)
-        self.assertEqual(b'unit' * 50, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'bytes_mult', b'a', 4,
+                                            expected_result_type=bytes))
+        expected_results.append(b'aaaa')
+        invokes.append(runner.call_contract(path, 'bytes_mult', b'unit', 50,
+                                            expected_result_type=bytes))
+        expected_results.append(b'unit' * 50)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_bytes_multiplication_operation_augmented_assignment(self):
         expected_output = (
@@ -729,18 +1061,38 @@ class TestArithmetic(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', b'unit', 50,
-                                         expected_result_type=bytes)
-        self.assertEqual(b'unit' * 50, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', b'unit', 50,
+                                            expected_result_type=bytes))
+        expected_results.append(b'unit' * 50)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_bytes_multiplication_builtin_type(self):
-        path = self.get_contract_path('BytesMultiplicationBuiltinType.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('BytesMultiplicationBuiltinType.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'bytes_mult', b'unit test', FindOptions.VALUES_ONLY,
-                                         expected_result_type=bytes)
-        self.assertEqual(b'unit test' * FindOptions.VALUES_ONLY, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'bytes_mult', b'unit test', FindOptions.VALUES_ONLY,
+                                            expected_result_type=bytes))
+        expected_results.append(b'unit test' * FindOptions.VALUES_ONLY)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_str_multiplication_operation(self):
         expected_output = (
@@ -757,11 +1109,22 @@ class TestArithmetic(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'str_mult', 'a', 4)
-        self.assertEqual('aaaa', result)
-        result = self.run_smart_contract(engine, path, 'str_mult', 'unit', 50)
-        self.assertEqual('unit' * 50, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'str_mult', 'a', 4))
+        expected_results.append('aaaa')
+        invokes.append(runner.call_contract(path, 'str_mult', 'unit', 50))
+        expected_results.append('unit' * 50)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_str_multiplication_operation_augmented_assignment(self):
         expected_output = (
@@ -780,16 +1143,36 @@ class TestArithmetic(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', 'unit', 50)
-        self.assertEqual('unit' * 50, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', 'unit', 50))
+        expected_results.append('unit' * 50)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_str_multiplication_builtin_type(self):
-        path = self.get_contract_path('StringMultiplicationBuiltinType.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('StringMultiplicationBuiltinType.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'str_mult', 'unit test', FindOptions.VALUES_ONLY)
-        self.assertEqual('unit test' * FindOptions.VALUES_ONLY, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'str_mult', 'unit test', FindOptions.VALUES_ONLY))
+        expected_results.append('unit test' * FindOptions.VALUES_ONLY)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     # endregion
 
@@ -810,13 +1193,24 @@ class TestArithmetic(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'sub', 10, 3)
-        self.assertEqual(7, result)
-        result = self.run_smart_contract(engine, path, 'sub', -42, -24)
-        self.assertEqual(-18, result)
-        result = self.run_smart_contract(engine, path, 'sub', -42, 24)
-        self.assertEqual(-66, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'sub', 10, 3))
+        expected_results.append(7)
+        invokes.append(runner.call_contract(path, 'sub', -42, -24))
+        expected_results.append(-18)
+        invokes.append(runner.call_contract(path, 'sub', -42, 24))
+        expected_results.append(-66)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_subtraction_augmented_assignment(self):
         expected_output = (
@@ -832,14 +1226,22 @@ class TestArithmetic(BoaTest):
 
         path = self.get_contract_path('SubtractionAugmentedAssignment.py')
         output = Boa3.compile(path)
-
         self.assertEqual(expected_output, output)
 
     def test_subtraction_builtin_type(self):
-        path = self.get_contract_path('SubtractionBuiltinType.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('SubtractionBuiltinType.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', FindOptions.DESERIALIZE_VALUES, FindOptions.VALUES_ONLY)
-        self.assertEqual(FindOptions.DESERIALIZE_VALUES - FindOptions.VALUES_ONLY, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', FindOptions.DESERIALIZE_VALUES, FindOptions.VALUES_ONLY))
+        expected_results.append(FindOptions.DESERIALIZE_VALUES - FindOptions.VALUES_ONLY)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     # endregion

--- a/boa3_test/tests/compiler_tests/test_logical.py
+++ b/boa3_test/tests/compiler_tests/test_logical.py
@@ -2,8 +2,9 @@ from boa3.boa3 import Boa3
 from boa3.exception import CompilerError
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo3.contracts import FindOptions
+from boa3.neo3.vm import VMState
+from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.boa_test import BoaTest
-from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestLogical(BoaTest):
@@ -26,15 +27,26 @@ class TestLogical(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', True, True)
-        self.assertEqual(True, result)
-        result = self.run_smart_contract(engine, path, 'Main', True, False)
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'Main', False, True)
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'Main', False, False)
-        self.assertEqual(False, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', True, True))
+        expected_results.append(True)
+        invokes.append(runner.call_contract(path, 'Main', True, False))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'Main', False, True))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'Main', False, False))
+        expected_results.append(False)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_mismatched_type_binary_operation(self):
         path = self.get_contract_path('MismatchedOperandAnd.py')
@@ -58,11 +70,22 @@ class TestLogical(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', True)
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'Main', False)
-        self.assertEqual(True, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', True))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'Main', False))
+        expected_results.append(True)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_mismatched_type_unary_operation(self):
         path = self.get_contract_path('MismatchedOperandNot.py')
@@ -87,15 +110,26 @@ class TestLogical(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', True, True)
-        self.assertEqual(True, result)
-        result = self.run_smart_contract(engine, path, 'Main', True, False)
-        self.assertEqual(True, result)
-        result = self.run_smart_contract(engine, path, 'Main', False, True)
-        self.assertEqual(True, result)
-        result = self.run_smart_contract(engine, path, 'Main', False, False)
-        self.assertEqual(False, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', True, True))
+        expected_results.append(True)
+        invokes.append(runner.call_contract(path, 'Main', True, False))
+        expected_results.append(True)
+        invokes.append(runner.call_contract(path, 'Main', False, True))
+        expected_results.append(True)
+        invokes.append(runner.call_contract(path, 'Main', False, False))
+        expected_results.append(False)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_sequence_boolean_or(self):
         expected_output = (
@@ -114,15 +148,26 @@ class TestLogical(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', True, False, False)
-        self.assertEqual(True, result)
-        result = self.run_smart_contract(engine, path, 'Main', False, True, False)
-        self.assertEqual(True, result)
-        result = self.run_smart_contract(engine, path, 'Main', False, False, False)
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'Main', True, True, True)
-        self.assertEqual(True, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', True, False, False))
+        expected_results.append(True)
+        invokes.append(runner.call_contract(path, 'Main', False, True, False))
+        expected_results.append(True)
+        invokes.append(runner.call_contract(path, 'Main', False, False, False))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'Main', True, True, True))
+        expected_results.append(True)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     # endregion
 
@@ -143,20 +188,40 @@ class TestLogical(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', int('100', 2), 2)
-        self.assertEqual(int('10000', 2), result)
-        result = self.run_smart_contract(engine, path, 'Main', int('11', 2), 1)
-        self.assertEqual(int('110', 2), result)
-        result = self.run_smart_contract(engine, path, 'Main', int('101010', 2), 4)
-        self.assertEqual(int('1010100000', 2), result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', int('100', 2), 2))
+        expected_results.append(int('10000', 2))
+        invokes.append(runner.call_contract(path, 'Main', int('11', 2), 1))
+        expected_results.append(int('110', 2))
+        invokes.append(runner.call_contract(path, 'Main', int('101010', 2), 4))
+        expected_results.append(int('1010100000', 2))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_logic_left_shift_builtin_type(self):
-        path = self.get_contract_path('LogicLeftShiftBuiltinType.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('LogicLeftShiftBuiltinType.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', FindOptions.NONE, FindOptions.DESERIALIZE_VALUES)
-        self.assertEqual(FindOptions.NONE << FindOptions.DESERIALIZE_VALUES, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', FindOptions.NONE, FindOptions.DESERIALIZE_VALUES))
+        expected_results.append(FindOptions.NONE << FindOptions.DESERIALIZE_VALUES)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_mismatched_type_logic_left_shift(self):
         path = self.get_contract_path('MismatchedOperandLogicLeftShift.py')
@@ -181,13 +246,24 @@ class TestLogical(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', True, True)
-        self.assertEqual(True, result)
-        result = self.run_smart_contract(engine, path, 'Main', True, False)
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'Main', False, False)
-        self.assertEqual(False, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', True, True))
+        expected_results.append(True)
+        invokes.append(runner.call_contract(path, 'Main', True, False))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'Main', False, False))
+        expected_results.append(False)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_logic_and_with_int_operand(self):
         expected_output = (
@@ -204,20 +280,40 @@ class TestLogical(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', 4, 6)
-        self.assertEqual(4 & 6, result)
-        result = self.run_smart_contract(engine, path, 'Main', 40, 6)
-        self.assertEqual(40 & 6, result)
-        result = self.run_smart_contract(engine, path, 'Main', -4, 32)
-        self.assertEqual(-4 & 32, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', 4, 6))
+        expected_results.append(4 & 6)
+        invokes.append(runner.call_contract(path, 'Main', 40, 6))
+        expected_results.append(40 & 6)
+        invokes.append(runner.call_contract(path, 'Main', -4, 32))
+        expected_results.append(-4 & 32)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_logic_and_builtin_type(self):
-        path = self.get_contract_path('LogicAndBuiltinType.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('LogicAndBuiltinType.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', FindOptions.NONE, FindOptions.DESERIALIZE_VALUES)
-        self.assertEqual(FindOptions.NONE & FindOptions.DESERIALIZE_VALUES, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', FindOptions.NONE, FindOptions.DESERIALIZE_VALUES))
+        expected_results.append(FindOptions.NONE & FindOptions.DESERIALIZE_VALUES)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_mismatched_type_logic_and(self):
         path = self.get_contract_path('MismatchedOperandLogicAnd.py')
@@ -241,18 +337,38 @@ class TestLogical(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', True)
-        self.assertEqual(-2, result)
-        result = self.run_smart_contract(engine, path, 'Main', False)
-        self.assertEqual(-1, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', True))
+        expected_results.append(-2)
+        invokes.append(runner.call_contract(path, 'Main', False))
+        expected_results.append(-1)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_logic_not_builtin_type(self):
-        path = self.get_contract_path('LogicNotBuiltinType.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('LogicNotBuiltinType.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', FindOptions.VALUES_ONLY)
-        self.assertEqual(~FindOptions.VALUES_ONLY, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', FindOptions.VALUES_ONLY))
+        expected_results.append(~FindOptions.VALUES_ONLY)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_logic_not_with_int_operand(self):
         expected_output = (
@@ -268,13 +384,24 @@ class TestLogical(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', 4)
-        self.assertEqual(-5, result)
-        result = self.run_smart_contract(engine, path, 'Main', 40)
-        self.assertEqual(-41, result)
-        result = self.run_smart_contract(engine, path, 'Main', -4)
-        self.assertEqual(3, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', 4))
+        expected_results.append(-5)
+        invokes.append(runner.call_contract(path, 'Main', 40))
+        expected_results.append(-41)
+        invokes.append(runner.call_contract(path, 'Main', -4))
+        expected_results.append(3)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_mismatched_type_logic_not(self):
         path = self.get_contract_path('MismatchedOperandLogicNot.py')
@@ -299,13 +426,24 @@ class TestLogical(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', True, True)
-        self.assertEqual(True, result)
-        result = self.run_smart_contract(engine, path, 'Main', True, False)
-        self.assertEqual(True, result)
-        result = self.run_smart_contract(engine, path, 'Main', False, False)
-        self.assertEqual(False, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', True, True))
+        expected_results.append(True)
+        invokes.append(runner.call_contract(path, 'Main', True, False))
+        expected_results.append(True)
+        invokes.append(runner.call_contract(path, 'Main', False, False))
+        expected_results.append(False)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_logic_or_with_int_operand(self):
         expected_output = (
@@ -322,39 +460,57 @@ class TestLogical(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', 4, 6)
-        self.assertEqual(4 | 6, result)
-        result = self.run_smart_contract(engine, path, 'Main', 40, 6)
-        self.assertEqual(40 | 6, result)
-        result = self.run_smart_contract(engine, path, 'Main', -4, 32)
-        self.assertEqual(-4 | 32, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', 4, 6))
+        expected_results.append(4 | 6)
+        invokes.append(runner.call_contract(path, 'Main', 40, 6))
+        expected_results.append(40 | 6)
+        invokes.append(runner.call_contract(path, 'Main', -4, 32))
+        expected_results.append(-4 | 32)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_logic_or_builtin_type(self):
-        path = self.get_contract_path('LogicOrBuiltinType.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('LogicOrBuiltinType.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', FindOptions.REMOVE_PREFIX, FindOptions.KEYS_ONLY,
-                                         expected_result_type=int)
-        int_value_to_check = int(FindOptions.REMOVE_PREFIX | FindOptions.KEYS_ONLY)
-        self.assertEqual(int_value_to_check, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', FindOptions.REMOVE_PREFIX, FindOptions.KEYS_ONLY,
-                                         expected_result_type=FindOptions)
-        self.assertEqual(FindOptions.REMOVE_PREFIX | FindOptions.KEYS_ONLY, result)
+        invokes.append(runner.call_contract(path, 'main', FindOptions.REMOVE_PREFIX, FindOptions.KEYS_ONLY,
+                                            expected_result_type=int))
+        expected_results.append(int(FindOptions.REMOVE_PREFIX | FindOptions.KEYS_ONLY))
 
-        result = self.run_smart_contract(engine, path, 'main', 2, 4,
-                                         expected_result_type=int)
-        int_value_to_check = int(2 | 4)
-        self.assertEqual(int_value_to_check, result)
+        invokes.append(runner.call_contract(path, 'main', FindOptions.REMOVE_PREFIX, FindOptions.KEYS_ONLY,
+                                            expected_result_type=FindOptions))
+        expected_results.append(FindOptions.REMOVE_PREFIX | FindOptions.KEYS_ONLY)
 
-        result = self.run_smart_contract(engine, path, 'main', 0, 123456789,
-                                         expected_result_type=int)
-        self.assertEqual(123456789, result)
+        invokes.append(runner.call_contract(path, 'main', 2, 4,
+                                            expected_result_type=int))
+        expected_results.append(int(2 | 4))
 
-        result = self.run_smart_contract(engine, path, 'main', 123456789, 0,
-                                         expected_result_type=int)
-        self.assertEqual(123456789, result)
+        invokes.append(runner.call_contract(path, 'main', 0, 123456789,
+                                            expected_result_type=int))
+        expected_results.append(123456789)
+
+        invokes.append(runner.call_contract(path, 'main', 123456789, 0,
+                                            expected_result_type=int))
+        expected_results.append(123456789)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_mismatched_type_logic_or(self):
         path = self.get_contract_path('MismatchedOperandLogicOr.py')
@@ -379,13 +535,24 @@ class TestLogical(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', True, True)
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'Main', True, False)
-        self.assertEqual(True, result)
-        result = self.run_smart_contract(engine, path, 'Main', False, False)
-        self.assertEqual(False, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', True, True))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'Main', True, False))
+        expected_results.append(True)
+        invokes.append(runner.call_contract(path, 'Main', False, False))
+        expected_results.append(False)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_logic_xor_with_int_operand(self):
         expected_output = (
@@ -402,20 +569,40 @@ class TestLogical(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', 4, 6)
-        self.assertEqual(4 ^ 6, result)
-        result = self.run_smart_contract(engine, path, 'Main', 40, 6)
-        self.assertEqual(40 ^ 6, result)
-        result = self.run_smart_contract(engine, path, 'Main', -4, 32)
-        self.assertEqual(-4 ^ 32, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', 4, 6))
+        expected_results.append(4 ^ 6)
+        invokes.append(runner.call_contract(path, 'Main', 40, 6))
+        expected_results.append(40 ^ 6)
+        invokes.append(runner.call_contract(path, 'Main', -4, 32))
+        expected_results.append(-4 ^ 32)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_logic_xor_builtin_type(self):
-        path = self.get_contract_path('LogicXorBuiltinType.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('LogicXorBuiltinType.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', FindOptions.NONE, FindOptions.DESERIALIZE_VALUES)
-        self.assertEqual(FindOptions.NONE ^ FindOptions.DESERIALIZE_VALUES, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', FindOptions.NONE, FindOptions.DESERIALIZE_VALUES))
+        expected_results.append(FindOptions.NONE ^ FindOptions.DESERIALIZE_VALUES)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_mismatched_type_logic_xor(self):
         path = self.get_contract_path('MismatchedOperandLogicXor.py')
@@ -426,85 +613,94 @@ class TestLogical(BoaTest):
     # region Mixed
 
     def test_logic_augmented_assignment(self):
-        path = self.get_contract_path('AugmentedAssignmentOperators.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('AugmentedAssignmentOperators.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         a = 1
         b = 4
-        result = self.run_smart_contract(engine, path, 'right_shift', a, b)
-        a >>= b
-        expected_result = a
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'right_shift', a, b))
+        expected_results.append(a >> b)
 
         a = 4
         b = 1
-        result = self.run_smart_contract(engine, path, 'left_shift', a, b)
-        a <<= b
-        expected_result = a
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'left_shift', a, b))
+        expected_results.append(a << b)
 
         a = 255
         b = 123
-        result = self.run_smart_contract(engine, path, 'l_and', a, b)
-        a &= b
-        expected_result = a
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'l_and', a, b))
+        expected_results.append(a & b)
 
         a = 255
         b = 123
-        result = self.run_smart_contract(engine, path, 'l_or', a, b)
-        a |= b
-        expected_result = a
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'l_or', a, b))
+        expected_results.append(a | b)
 
         a = 255
         b = 123
-        result = self.run_smart_contract(engine, path, 'xor', a, b)
-        a ^= b
-        expected_result = a
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'xor', a, b))
+        expected_results.append(a ^ b)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_boa2_logic_test(self):
-        path = self.get_contract_path('BinOpBoa2Test.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', '&', 4, 4)
-        self.assertEqual(4, result)
+        path, _ = self.get_deploy_file_paths('BinOpBoa2Test.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', '|', 4, 3)
-        self.assertEqual(7, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', '|', 4, 8)
-        self.assertEqual(12, result)
+        invokes.append(runner.call_contract(path, 'main', '&', 4, 4))
+        expected_results.append(4)
 
-        result = self.run_smart_contract(engine, path, 'main', '^', 4, 4)
-        self.assertEqual(0, result)
+        invokes.append(runner.call_contract(path, 'main', '|', 4, 3))
+        expected_results.append(7)
 
-        result = self.run_smart_contract(engine, path, 'main', '^', 4, 2)
-        self.assertEqual(6, result)
+        invokes.append(runner.call_contract(path, 'main', '|', 4, 8))
+        expected_results.append(12)
 
-        result = self.run_smart_contract(engine, path, 'main', '>>', 16, 2)
-        self.assertEqual(4, result)
+        invokes.append(runner.call_contract(path, 'main', '^', 4, 4))
+        expected_results.append(0)
 
-        result = self.run_smart_contract(engine, path, 'main', '>>', 16, 0)
-        self.assertEqual(16, result)
+        invokes.append(runner.call_contract(path, 'main', '^', 4, 2))
+        expected_results.append(6)
 
-        result = self.run_smart_contract(engine, path, 'main', '%', 16, 2)
-        self.assertEqual(0, result)
+        invokes.append(runner.call_contract(path, 'main', '>>', 16, 2))
+        expected_results.append(4)
 
-        result = self.run_smart_contract(engine, path, 'main', '%', 16, 11)
-        self.assertEqual(5, result)
+        invokes.append(runner.call_contract(path, 'main', '>>', 16, 0))
+        expected_results.append(16)
 
-        result = self.run_smart_contract(engine, path, 'main', '//', 16, 2)
-        self.assertEqual(8, result)
+        invokes.append(runner.call_contract(path, 'main', '%', 16, 2))
+        expected_results.append(0)
 
-        result = self.run_smart_contract(engine, path, 'main', '//', 16, 7)
-        self.assertEqual(2, result)
+        invokes.append(runner.call_contract(path, 'main', '%', 16, 11))
+        expected_results.append(5)
 
-        result = self.run_smart_contract(engine, path, 'main', '~', 16, 0)
-        self.assertEqual(-17, result)
+        invokes.append(runner.call_contract(path, 'main', '//', 16, 2))
+        expected_results.append(8)
 
-        result = self.run_smart_contract(engine, path, 'main', '~', -3, 0)
-        self.assertEqual(2, result)
+        invokes.append(runner.call_contract(path, 'main', '//', 16, 7))
+        expected_results.append(2)
+
+        invokes.append(runner.call_contract(path, 'main', '~', 16, 0))
+        expected_results.append(-17)
+
+        invokes.append(runner.call_contract(path, 'main', '~', -3, 0))
+        expected_results.append(2)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_mixed_operations(self):
         expected_output = (
@@ -524,22 +720,42 @@ class TestLogical(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', True, False, False)
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'Main', False, True, False)
-        self.assertEqual(True, result)
-        result = self.run_smart_contract(engine, path, 'Main', False, False, False)
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'Main', True, True, True)
-        self.assertEqual(False, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', True, False, False))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'Main', False, True, False))
+        expected_results.append(True)
+        invokes.append(runner.call_contract(path, 'Main', False, False, False))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'Main', True, True, True))
+        expected_results.append(False)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_logic_operation_with_return_and_stack_filled(self):
-        path = self.get_contract_path('LogicOperationWithReturnAndStackFilled.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('LogicOperationWithReturnAndStackFilled.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(True, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(True)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     # endregion
 
@@ -560,20 +776,40 @@ class TestLogical(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', int('10000', 2), 2)
-        self.assertEqual(int('100', 2), result)
-        result = self.run_smart_contract(engine, path, 'Main', int('110', 2), 1)
-        self.assertEqual(int('11', 2), result)
-        result = self.run_smart_contract(engine, path, 'Main', int('1010100000', 2), 4)
-        self.assertEqual(int('101010', 2), result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', int('10000', 2), 2))
+        expected_results.append(int('100', 2))
+        invokes.append(runner.call_contract(path, 'Main', int('110', 2), 1))
+        expected_results.append(int('11', 2))
+        invokes.append(runner.call_contract(path, 'Main', int('1010100000', 2), 4))
+        expected_results.append(int('101010', 2))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_logic_right_shift_builtin_type(self):
-        path = self.get_contract_path('LogicRightShiftBuiltinType.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('LogicRightShiftBuiltinType.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', FindOptions.NONE, FindOptions.DESERIALIZE_VALUES)
-        self.assertEqual(FindOptions.NONE >> FindOptions.DESERIALIZE_VALUES, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', FindOptions.NONE, FindOptions.DESERIALIZE_VALUES))
+        expected_results.append(FindOptions.NONE >> FindOptions.DESERIALIZE_VALUES)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_mismatched_type_logic_right_shift(self):
         path = self.get_contract_path('MismatchedOperandLogicRightShift.py')

--- a/boa3_test/tests/compiler_tests/test_multiple_expressions.py
+++ b/boa3_test/tests/compiler_tests/test_multiple_expressions.py
@@ -2,8 +2,9 @@ from boa3.boa3 import Boa3
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.String import String
+from boa3.neo3.vm import VMState
+from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.boa_test import BoaTest
-from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestMultipleExpressions(BoaTest):
@@ -30,11 +31,22 @@ class TestMultipleExpressions(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', 1, 2)
-        self.assertEqual(3, result)
-        result = self.run_smart_contract(engine, path, 'Main', 5, -7)
-        self.assertEqual(-2, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', 1, 2))
+        expected_results.append(3)
+        invokes.append(runner.call_contract(path, 'Main', 5, -7))
+        expected_results.append(-2)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_multiple_relational_expressions(self):
         expected_output = (
@@ -62,13 +74,24 @@ class TestMultipleExpressions(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', 1, 2)
-        self.assertEqual(True, result)
-        result = self.run_smart_contract(engine, path, 'Main', 5, -7)
-        self.assertEqual(True, result)
-        result = self.run_smart_contract(engine, path, 'Main', -4, -4)
-        self.assertEqual(False, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', 1, 2))
+        expected_results.append(True)
+        invokes.append(runner.call_contract(path, 'Main', 5, -7))
+        expected_results.append(True)
+        invokes.append(runner.call_contract(path, 'Main', -4, -4))
+        expected_results.append(False)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_multiple_logic_expressions(self):
         expected_output = (
@@ -100,15 +123,26 @@ class TestMultipleExpressions(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', True, False, False)
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'Main', False, True, False)
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'Main', False, False, False)
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'Main', True, True, False)
-        self.assertEqual(True, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', True, False, False))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'Main', False, True, False))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'Main', False, False, False))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'Main', True, True, False))
+        expected_results.append(True)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_multiple_tuple_expressions(self):
         a = String('a').to_bytes()
@@ -156,11 +190,22 @@ class TestMultipleExpressions(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', [1, 2])
-        self.assertEqual(5, result)
-        result = self.run_smart_contract(engine, path, 'Main', [-5, -7])
-        self.assertEqual(-1, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', [1, 2]))
+        expected_results.append(5)
+        invokes.append(runner.call_contract(path, 'Main', [-5, -7]))
+        expected_results.append(-1)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_multiple_list_expressions(self):
         one = String('1').to_bytes()
@@ -205,8 +250,19 @@ class TestMultipleExpressions(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', [2, 1])
-        self.assertEqual(7, result)
-        result = self.run_smart_contract(engine, path, 'Main', [-7, 5])
-        self.assertEqual(-2, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', [2, 1]))
+        expected_results.append(7)
+        invokes.append(runner.call_contract(path, 'Main', [-7, 5]))
+        expected_results.append(-2)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)

--- a/boa3_test/tests/compiler_tests/test_python_operation.py
+++ b/boa3_test/tests/compiler_tests/test_python_operation.py
@@ -1,7 +1,8 @@
 from boa3.exception import CompilerError
 from boa3.neo3.contracts import FindOptions
+from boa3.neo3.vm import VMState
+from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.boa_test import BoaTest
-from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestPythonOperation(BoaTest):
@@ -10,295 +11,515 @@ class TestPythonOperation(BoaTest):
     # region Membership
 
     def test_in_bytes(self):
-        path = self.get_contract_path('BytesIn.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('BytesIn.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', b'123', b'1234')
-        self.assertEqual(b'123' in b'1234', result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', b'42', b'1234')
-        self.assertEqual(b'42' in b'1234', result)
+        invokes.append(runner.call_contract(path, 'main', b'123', b'1234'))
+        expected_results.append(b'123' in b'1234')
 
-        result = self.run_smart_contract(engine, path, 'main', b'34', b'1234')
-        self.assertEqual(b'34' in b'1234', result)
+        invokes.append(runner.call_contract(path, 'main', b'42', b'1234'))
+        expected_results.append(b'42' in b'1234')
+
+        invokes.append(runner.call_contract(path, 'main', b'34', b'1234'))
+        expected_results.append(b'34' in b'1234')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_bytes_membership_mismatched_type(self):
         path = self.get_contract_path('BytesMembershipMismatchedType.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_int_in_bytes(self):
-        path = self.get_contract_path('BytesMembershipWithInt.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', 1, b'1234')
-        self.assertEqual(1 in b'1234', result)
+        path, _ = self.get_deploy_file_paths('BytesMembershipWithInt.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', 50, b'1234')
-        self.assertEqual(50 in b'1234', result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', 1, b'1234'))
+        expected_results.append(1 in b'1234')
+
+        invokes.append(runner.call_contract(path, 'main', 50, b'1234'))
+        expected_results.append(50 in b'1234')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_in_dict(self):
-        path = self.get_contract_path('DictIn.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', 1, {1: '2', '4': 8})
-        self.assertEqual(1 in {1: '2', '4': 8}, result)
+        path, _ = self.get_deploy_file_paths('DictIn.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', '1', {1: '2', '4': 8})
-        self.assertEqual('1' in {1: '2', '4': 8}, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', 8, {1: '2', '4': 8})
-        self.assertEqual(8 in {1: '2', '4': 8}, result)
+        invokes.append(runner.call_contract(path, 'main', 1, {1: '2', '4': 8}))
+        expected_results.append(1 in {1: '2', '4': 8})
 
-        result = self.run_smart_contract(engine, path, 'main', '4', {1: '2', '4': 8})
-        self.assertEqual('4' in {1: '2', '4': 8}, result)
+        invokes.append(runner.call_contract(path, 'main', '1', {1: '2', '4': 8}))
+        expected_results.append('1' in {1: '2', '4': 8})
+
+        invokes.append(runner.call_contract(path, 'main', 8, {1: '2', '4': 8}))
+        expected_results.append(8 in {1: '2', '4': 8})
+
+        invokes.append(runner.call_contract(path, 'main', '4', {1: '2', '4': 8}))
+        expected_results.append('4' in {1: '2', '4': 8})
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_dict_membership_mismatched_type(self):
         path = self.get_contract_path('DictMembershipMismatchedType.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_in_list(self):
-        path = self.get_contract_path('ListIn.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', 1, [1, 2, '3', '4'])
-        self.assertEqual(1 in [1, 2, '3', '4'], result)
+        path, _ = self.get_deploy_file_paths('ListIn.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', 3, [1, 2, '3', '4'])
-        self.assertEqual(3 in [1, 2, '3', '4'], result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', '4', [1, 2, '3', '4'])
-        self.assertEqual('4' in [1, 2, '3', '4'], result)
+        invokes.append(runner.call_contract(path, 'main', 1, [1, 2, '3', '4']))
+        expected_results.append(1 in [1, 2, '3', '4'])
+
+        invokes.append(runner.call_contract(path, 'main', 3, [1, 2, '3', '4']))
+        expected_results.append(3 in [1, 2, '3', '4'])
+
+        invokes.append(runner.call_contract(path, 'main', '4', [1, 2, '3', '4']))
+        expected_results.append('4' in [1, 2, '3', '4'])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_list_membership_mismatched_type(self):
         path = self.get_contract_path('ListMembershipMismatchedType.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_in_str(self):
-        path = self.get_contract_path('StringIn.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('StringIn.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', '123', '1234')
-        self.assertEqual('123' in '1234', result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', '42', '1234')
-        self.assertEqual('42' in '1234', result)
+        invokes.append(runner.call_contract(path, 'main', '123', '1234'))
+        expected_results.append('123' in '1234')
+
+        invokes.append(runner.call_contract(path, 'main', '42', '1234'))
+        expected_results.append('42' in '1234')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_str_membership_mismatched_type(self):
         path = self.get_contract_path('StringMembershipMismatchedType.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_in_tuple(self):
-        path = self.get_contract_path('TupleIn.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', 1, (1, 2, '3', '4'))
-        self.assertEqual(1 in (1, 2, '3', '4'), result)
+        path, _ = self.get_deploy_file_paths('TupleIn.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', 3, (1, 2, '3', '4'))
-        self.assertEqual(3 in (1, 2, '3', '4'), result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', '4', (1, 2, '3', '4'))
-        self.assertEqual('4' in (1, 2, '3', '4'), result)
+        invokes.append(runner.call_contract(path, 'main', 1, (1, 2, '3', '4')))
+        expected_results.append(1 in (1, 2, '3', '4'))
+
+        invokes.append(runner.call_contract(path, 'main', 3, (1, 2, '3', '4')))
+        expected_results.append(3 in (1, 2, '3', '4'))
+
+        invokes.append(runner.call_contract(path, 'main', '4', (1, 2, '3', '4')))
+        expected_results.append('4' in (1, 2, '3', '4'))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_tuple_membership_mismatched_type(self):
         path = self.get_contract_path('TupleMembershipMismatchedType.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_in_typed_dict_builtin_type(self):
-        path = self.get_contract_path('TypedDictBuiltinTypeIn.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('TypedDictBuiltinTypeIn.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         element = FindOptions.VALUES_ONLY
         dict_ = {FindOptions.NONE: 'FindOptions.NONE', FindOptions.DESERIALIZE_VALUES: 'FindOptions.DESERIALIZE_VALUES'}
-        result = self.run_smart_contract(engine, path, 'main', element, dict_)
-        self.assertEqual(element in dict_, result)
+        invokes.append(runner.call_contract(path, 'main', element, dict_))
+        expected_results.append(element in dict_)
 
         element = FindOptions.PICK_FIELD_0
         dict_ = {FindOptions.NONE: 'FindOptions.NONE', FindOptions.DESERIALIZE_VALUES: 'FindOptions.DESERIALIZE_VALUES'}
-        result = self.run_smart_contract(engine, path, 'main', element, dict_)
-        self.assertEqual(element in dict_, result)
+        invokes.append(runner.call_contract(path, 'main', element, dict_))
+        expected_results.append(element in dict_)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_in_typed_dict(self):
-        path = self.get_contract_path('TypedDictIn.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', 1, {1: '2', 4: '8'})
-        self.assertEqual(1 in {1: '2', 4: '8'}, result)
+        path, _ = self.get_deploy_file_paths('TypedDictIn.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', 3, {1: '2', 4: '8'})
-        self.assertEqual(3 in {1: '2', 4: '8'}, result)
+        invokes = []
+        expected_results = []
+        
+        invokes.append(runner.call_contract(path, 'main', 1, {1: '2', 4: '8'}))
+        expected_results.append(1 in {1: '2', 4: '8'})
+
+        invokes.append(runner.call_contract(path, 'main', 3, {1: '2', 4: '8'}))
+        expected_results.append(3 in {1: '2', 4: '8'})
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_in_typed_list_builtin_type(self):
-        path = self.get_contract_path('TypedListBuiltinTypeIn.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('TypedListBuiltinTypeIn.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         element = FindOptions.VALUES_ONLY
         list_ = [FindOptions.NONE, FindOptions.VALUES_ONLY, FindOptions.DESERIALIZE_VALUES, FindOptions.KEYS_ONLY]
-        result = self.run_smart_contract(engine, path, 'main', element, list_)
-        self.assertEqual(element in list_, result)
+        invokes.append(runner.call_contract(path, 'main', element, list_))
+        expected_results.append(element in list_)
 
         element = FindOptions.PICK_FIELD_0
         list_ = [FindOptions.NONE, FindOptions.VALUES_ONLY, FindOptions.DESERIALIZE_VALUES, FindOptions.KEYS_ONLY]
-        result = self.run_smart_contract(engine, path, 'main', element, list_)
-        self.assertEqual(element in list_, result)
+        invokes.append(runner.call_contract(path, 'main', element, list_))
+        expected_results.append(element in list_)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_in_typed_list(self):
-        path = self.get_contract_path('TypedListIn.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', 1, [1, 2, 3, 4])
-        self.assertEqual(1 in [1, 2, 3, 4], result)
+        path, _ = self.get_deploy_file_paths('TypedListIn.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', 6, [1, 2, 3, 4])
-        self.assertEqual(6 in [1, 2, 3, 4], result)
+        invokes = []
+        expected_results = []
+        
+        invokes.append(runner.call_contract(path, 'main', 1, [1, 2, 3, 4]))
+        expected_results.append(1 in [1, 2, 3, 4])
+
+        invokes.append(runner.call_contract(path, 'main', 6, [1, 2, 3, 4]))
+        expected_results.append(6 in [1, 2, 3, 4])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_in_typed_tuple_builtin_type(self):
-        path = self.get_contract_path('TypedTupleBuiltinTypeIn.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('TypedTupleBuiltinTypeIn.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         element = FindOptions.VALUES_ONLY
         tuple_ = (FindOptions.NONE, FindOptions.VALUES_ONLY, FindOptions.DESERIALIZE_VALUES, FindOptions.KEYS_ONLY)
-        result = self.run_smart_contract(engine, path, 'main', element, tuple_)
-        self.assertEqual(element in tuple_, result)
+        invokes.append(runner.call_contract(path, 'main', element, tuple_))
+        expected_results.append(element in tuple_)
 
         element = FindOptions.PICK_FIELD_0
         tuple_ = (FindOptions.NONE, FindOptions.VALUES_ONLY, FindOptions.DESERIALIZE_VALUES, FindOptions.KEYS_ONLY)
-        result = self.run_smart_contract(engine, path, 'main', element, tuple_)
-        self.assertEqual(element in tuple_, result)
+        invokes.append(runner.call_contract(path, 'main', element, tuple_))
+        expected_results.append(element in tuple_)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_in_typed_tuple(self):
-        path = self.get_contract_path('TypedTupleIn.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', 1, (1, 2, 3, 4))
-        self.assertEqual(1 in (1, 2, 3, 4), result)
+        path, _ = self.get_deploy_file_paths('TypedTupleIn.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', 6, (1, 2, 3, 4))
-        self.assertEqual(6 in (1, 2, 3, 4), result)
+        invokes = []
+        expected_results = []
+        
+        invokes.append(runner.call_contract(path, 'main', 1, (1, 2, 3, 4)))
+        expected_results.append(1 in (1, 2, 3, 4))
+
+        invokes.append(runner.call_contract(path, 'main', 6, (1, 2, 3, 4)))
+        expected_results.append(6 in (1, 2, 3, 4))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     # endregion
 
     # region NotMembership
 
     def test_not_in_bytes(self):
-        path = self.get_contract_path('BytesNotIn.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('BytesNotIn.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', b'123', b'1234')
-        self.assertEqual(b'123' not in b'1234', result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', b'42', b'1234')
-        self.assertEqual(b'42' not in b'1234', result)
+        invokes.append(runner.call_contract(path, 'main', b'123', b'1234'))
+        expected_results.append(b'123' not in b'1234')
+
+        invokes.append(runner.call_contract(path, 'main', b'42', b'1234'))
+        expected_results.append(b'42' not in b'1234')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_not_in_dict(self):
-        path = self.get_contract_path('DictNotIn.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', 1, {1: '2', '4': 8})
-        self.assertEqual(1 not in {1: '2', '4': 8}, result)
+        path, _ = self.get_deploy_file_paths('DictNotIn.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', '1', {1: '2', '4': 8})
-        self.assertEqual('1' not in {1: '2', '4': 8}, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', 8, {1: '2', '4': 8})
-        self.assertEqual(8 not in {1: '2', '4': 8}, result)
+        invokes.append(runner.call_contract(path, 'main', 1, {1: '2', '4': 8}))
+        expected_results.append(1 not in {1: '2', '4': 8})
 
-        result = self.run_smart_contract(engine, path, 'main', '4', {1: '2', '4': 8})
-        self.assertEqual('4' not in {1: '2', '4': 8}, result)
+        invokes.append(runner.call_contract(path, 'main', '1', {1: '2', '4': 8}))
+        expected_results.append('1' not in {1: '2', '4': 8})
+
+        invokes.append(runner.call_contract(path, 'main', 8, {1: '2', '4': 8}))
+        expected_results.append(8 not in {1: '2', '4': 8})
+
+        invokes.append(runner.call_contract(path, 'main', '4', {1: '2', '4': 8}))
+        expected_results.append('4' not in {1: '2', '4': 8})
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_not_in_list(self):
-        path = self.get_contract_path('ListNotIn.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', 1, [1, 2, '3', '4'])
-        self.assertEqual(1 not in [1, 2, '3', '4'], result)
+        path, _ = self.get_deploy_file_paths('ListNotIn.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', 3, [1, 2, '3', '4'])
-        self.assertEqual(3 not in [1, 2, '3', '4'], result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', '4', [1, 2, '3', '4'])
-        self.assertEqual('4' not in [1, 2, '3', '4'], result)
+        invokes.append(runner.call_contract(path, 'main', 1, [1, 2, '3', '4']))
+        expected_results.append(1 not in [1, 2, '3', '4'])
+
+        invokes.append(runner.call_contract(path, 'main', 3, [1, 2, '3', '4']))
+        expected_results.append(3 not in [1, 2, '3', '4'])
+
+        invokes.append(runner.call_contract(path, 'main', '4', [1, 2, '3', '4']))
+        expected_results.append('4' not in [1, 2, '3', '4'])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_not_in_str(self):
-        path = self.get_contract_path('StringNotIn.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('StringNotIn.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', '123', '1234')
-        self.assertEqual('123' not in '1234', result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', '42', '1234')
-        self.assertEqual('42' not in '1234', result)
+        invokes.append(runner.call_contract(path, 'main', '123', '1234'))
+        expected_results.append('123' not in '1234')
+
+        invokes.append(runner.call_contract(path, 'main', '42', '1234'))
+        expected_results.append('42' not in '1234')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_not_in_tuple(self):
-        path = self.get_contract_path('TupleNotIn.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', 1, (1, 2, '3', '4'))
-        self.assertEqual(1 not in (1, 2, '3', '4'), result)
+        path, _ = self.get_deploy_file_paths('TupleNotIn.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', 3, (1, 2, '3', '4'))
-        self.assertEqual(3 not in (1, 2, '3', '4'), result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', '4', (1, 2, '3', '4'))
-        self.assertEqual('4' not in (1, 2, '3', '4'), result)
+        invokes.append(runner.call_contract(path, 'main', 1, (1, 2, '3', '4')))
+        expected_results.append(1 not in (1, 2, '3', '4'))
+
+        invokes.append(runner.call_contract(path, 'main', 3, (1, 2, '3', '4')))
+        expected_results.append(3 not in (1, 2, '3', '4'))
+
+        invokes.append(runner.call_contract(path, 'main', '4', (1, 2, '3', '4')))
+        expected_results.append('4' not in (1, 2, '3', '4'))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_not_in_typed_dict_builtin_type(self):
-        path = self.get_contract_path('TypedDictBuiltinTypeNotIn.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('TypedDictBuiltinTypeNotIn.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         element = FindOptions.VALUES_ONLY
         dict_ = {FindOptions.NONE: 'FindOptions.NONE', FindOptions.DESERIALIZE_VALUES: 'FindOptions.DESERIALIZE_VALUES'}
-        result = self.run_smart_contract(engine, path, 'main', element, dict_)
-        self.assertEqual(element not in dict_, result)
+        invokes.append(runner.call_contract(path, 'main', element, dict_))
+        expected_results.append(element not in dict_)
 
         element = FindOptions.PICK_FIELD_0
         dict_ = {FindOptions.NONE: 'FindOptions.NONE', FindOptions.DESERIALIZE_VALUES: 'FindOptions.DESERIALIZE_VALUES'}
-        result = self.run_smart_contract(engine, path, 'main', element, dict_)
-        self.assertEqual(element not in dict_, result)
+        invokes.append(runner.call_contract(path, 'main', element, dict_))
+        expected_results.append(element not in dict_)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_not_in_typed_dict(self):
-        path = self.get_contract_path('TypedDictNotIn.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', 1, {1: '2', 4: '8'})
-        self.assertEqual(1 not in {1: '2', 4: '8'}, result)
+        path, _ = self.get_deploy_file_paths('TypedDictNotIn.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', 3, {1: '2', 4: '8'})
-        self.assertEqual(3 not in {1: '2', 4: '8'}, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', 1, {1: '2', 4: '8'}))
+        expected_results.append(1 not in {1: '2', 4: '8'})
+
+        invokes.append(runner.call_contract(path, 'main', 3, {1: '2', 4: '8'}))
+        expected_results.append(3 not in {1: '2', 4: '8'})
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_not_in_typed_list_builtin_type(self):
-        path = self.get_contract_path('TypedListBuiltinTypeNotIn.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('TypedListBuiltinTypeNotIn.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         element = FindOptions.VALUES_ONLY
         list_ = [FindOptions.NONE, FindOptions.VALUES_ONLY, FindOptions.DESERIALIZE_VALUES, FindOptions.KEYS_ONLY]
-        result = self.run_smart_contract(engine, path, 'main', element, list_)
-        self.assertEqual(element not in list_, result)
+        invokes.append(runner.call_contract(path, 'main', element, list_))
+        expected_results.append(element not in list_)
 
         element = FindOptions.PICK_FIELD_0
         list_ = [FindOptions.NONE, FindOptions.VALUES_ONLY, FindOptions.DESERIALIZE_VALUES, FindOptions.KEYS_ONLY]
-        result = self.run_smart_contract(engine, path, 'main', element, list_)
-        self.assertEqual(element not in list_, result)
+        invokes.append(runner.call_contract(path, 'main', element, list_))
+        expected_results.append(element not in list_)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_not_in_typed_list(self):
-        path = self.get_contract_path('TypedListNotIn.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', 1, [1, 2, 3, 4])
-        self.assertEqual(1 not in [1, 2, 3, 4], result)
+        path, _ = self.get_deploy_file_paths('TypedListNotIn.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', 6, [1, 2, 3, 4])
-        self.assertEqual(6 not in [1, 2, 3, 4], result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', 1, [1, 2, 3, 4]))
+        expected_results.append(1 not in [1, 2, 3, 4])
+
+        invokes.append(runner.call_contract(path, 'main', 6, [1, 2, 3, 4]))
+        expected_results.append(6 not in [1, 2, 3, 4])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_not_in_typed_tuple_builtin_type(self):
-        path = self.get_contract_path('TypedTupleBuiltinTypeNotIn.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('TypedTupleBuiltinTypeNotIn.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         element = FindOptions.VALUES_ONLY
         tuple_ = (FindOptions.NONE, FindOptions.VALUES_ONLY, FindOptions.DESERIALIZE_VALUES, FindOptions.KEYS_ONLY)
-        result = self.run_smart_contract(engine, path, 'main', element, tuple_)
-        self.assertEqual(element not in tuple_, result)
+        invokes.append(runner.call_contract(path, 'main', element, tuple_))
+        expected_results.append(element not in tuple_)
 
         element = FindOptions.PICK_FIELD_0
         tuple_ = (FindOptions.NONE, FindOptions.VALUES_ONLY, FindOptions.DESERIALIZE_VALUES, FindOptions.KEYS_ONLY)
-        result = self.run_smart_contract(engine, path, 'main', element, tuple_)
-        self.assertEqual(element not in tuple_, result)
+        invokes.append(runner.call_contract(path, 'main', element, tuple_))
+        expected_results.append(element not in tuple_)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_not_in_typed_tuple(self):
-        path = self.get_contract_path('TypedTupleNotIn.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', 1, (1, 2, 3, 4))
-        self.assertEqual(1 not in (1, 2, 3, 4), result)
+        path, _ = self.get_deploy_file_paths('TypedTupleNotIn.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', 6, (1, 2, 3, 4))
-        self.assertEqual(6 not in (1, 2, 3, 4), result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', 1, (1, 2, 3, 4)))
+        expected_results.append(1 not in (1, 2, 3, 4))
+
+        invokes.append(runner.call_contract(path, 'main', 6, (1, 2, 3, 4)))
+        expected_results.append(6 not in (1, 2, 3, 4))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     # endregion

--- a/boa3_test/tests/compiler_tests/test_relational.py
+++ b/boa3_test/tests/compiler_tests/test_relational.py
@@ -3,9 +3,9 @@ from boa3.exception import CompilerError
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3.neo3.contracts import FindOptions
+from boa3.neo3.vm import VMState
+from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.boa_test import BoaTest
-from boa3_test.tests.test_classes.TestExecutionException import TestExecutionException
-from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestRelational(BoaTest):
@@ -14,11 +14,20 @@ class TestRelational(BoaTest):
     # region GreaterThan
 
     def test_builtin_type_greater_than_operation(self):
-        path = self.get_contract_path('BuiltinTypeGreaterThan.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('BuiltinTypeGreaterThan.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', FindOptions.VALUES_ONLY, FindOptions.DESERIALIZE_VALUES)
-        self.assertEqual(FindOptions.VALUES_ONLY > FindOptions.DESERIALIZE_VALUES, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', FindOptions.VALUES_ONLY, FindOptions.DESERIALIZE_VALUES))
+        expected_results.append(FindOptions.VALUES_ONLY > FindOptions.DESERIALIZE_VALUES)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_mixed_greater_than_operation(self):
         path = self.get_contract_path('MixedGreaterThan.py')
@@ -39,13 +48,24 @@ class TestRelational(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', 1, 2)
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'Main', 2, 2)
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'Main', 2, 1)
-        self.assertEqual(True, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', 1, 2))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'Main', 2, 2))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'Main', 2, 1))
+        expected_results.append(True)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_string_greater_than_operation(self):
         expected_output = (
@@ -62,24 +82,44 @@ class TestRelational(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', 'test', 'unit')
-        self.assertEqual(True, result)
-        result = self.run_smart_contract(engine, path, 'Main', 'unit', 'unit')
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'Main', 'unit', 'test')
-        self.assertEqual(False, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', 'test', 'unit'))
+        expected_results.append(True)
+        invokes.append(runner.call_contract(path, 'Main', 'unit', 'unit'))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'Main', 'unit', 'test'))
+        expected_results.append(False)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     # endregion
 
     # region GreaterThanOrEqual
 
     def test_builtin_type_greater_than_or_equal_operation(self):
-        path = self.get_contract_path('BuiltinTypeGreaterThanOrEqual.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('BuiltinTypeGreaterThanOrEqual.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', FindOptions.VALUES_ONLY, FindOptions.VALUES_ONLY)
-        self.assertEqual(FindOptions.VALUES_ONLY >= FindOptions.VALUES_ONLY, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', FindOptions.VALUES_ONLY, FindOptions.VALUES_ONLY))
+        expected_results.append(FindOptions.VALUES_ONLY >= FindOptions.VALUES_ONLY)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_mixed_greater_or_equal_than_operation(self):
         path = self.get_contract_path('MixedGreaterOrEqual.py')
@@ -100,13 +140,24 @@ class TestRelational(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', 1, 2)
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'Main', 2, 2)
-        self.assertEqual(True, result)
-        result = self.run_smart_contract(engine, path, 'Main', 2, 1)
-        self.assertEqual(True, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', 1, 2))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'Main', 2, 2))
+        expected_results.append(True)
+        invokes.append(runner.call_contract(path, 'Main', 2, 1))
+        expected_results.append(True)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_string_greater_or_equal_than_operation(self):
         expected_output = (
@@ -123,152 +174,223 @@ class TestRelational(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', 'test', 'unit')
-        self.assertEqual(True, result)
-        result = self.run_smart_contract(engine, path, 'Main', 'unit', 'unit')
-        self.assertEqual(True, result)
-        result = self.run_smart_contract(engine, path, 'Main', 'unit', 'test')
-        self.assertEqual(False, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', 'test', 'unit'))
+        expected_results.append(True)
+        invokes.append(runner.call_contract(path, 'Main', 'unit', 'unit'))
+        expected_results.append(True)
+        invokes.append(runner.call_contract(path, 'Main', 'unit', 'test'))
+        expected_results.append(False)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     # endregion
 
     # region Identity
 
     def test_boolean_identity_operation(self):
-        path = self.get_contract_path('BoolIdentity.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('BoolIdentity.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         a = True
         b = True
-        expected_result = a is b
-        result = self.run_smart_contract(engine, path, 'without_attribution_true')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'without_attribution_true'))
+        expected_results.append(a is b)
 
         a = True
         b = False
-        expected_result = a is b
-        result = self.run_smart_contract(engine, path, 'without_attribution_false')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'without_attribution_false'))
+        expected_results.append(a is b)
 
         c = True
         d = c
-        expected_result = c is d
-        result = self.run_smart_contract(engine, path, 'with_attribution')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'with_attribution'))
+        expected_results.append(c is d)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_list_identity(self):
-        path = self.get_contract_path('ListIdentity.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ListIdentity.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         a = [1, 2, 3]
         b = a
-        expected_result = a is b
-        result = self.run_smart_contract(engine, path, 'with_attribution')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'with_attribution'))
+        expected_results.append(a is b)
 
         a = [1, 2, 3]
         b = [1, 2, 3]
-        expected_result = a is b
-        result = self.run_smart_contract(engine, path, 'without_attribution')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'without_attribution'))
+        expected_results.append(a is b)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_mixed_identity(self):
-        path = self.get_contract_path('MixedIdentity.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('MixedIdentity.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         # a mixed identity should always result in False, but will compile
-        result = self.run_smart_contract(engine, path, 'mixed')
-        self.assertEqual(False, result)
+        invokes.append(runner.call_contract(path, 'mixed'))
+        expected_results.append(False)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_none_identity_operation(self):
-        path = self.get_contract_path('NoneIdentity.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('NoneIdentity.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', 1)
-        self.assertEqual(False, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', True)
-        self.assertEqual(False, result)
+        invokes.append(runner.call_contract(path, 'main', 1))
+        expected_results.append(False)
 
-        result = self.run_smart_contract(engine, path, 'main', 'string')
-        self.assertEqual(False, result)
+        invokes.append(runner.call_contract(path, 'main', True))
+        expected_results.append(False)
 
-        result = self.run_smart_contract(engine, path, 'main', b'bytes')
-        self.assertEqual(False, result)
+        invokes.append(runner.call_contract(path, 'main', 'string'))
+        expected_results.append(False)
 
-        result = self.run_smart_contract(engine, path, 'main', None)
-        self.assertEqual(True, result)
+        invokes.append(runner.call_contract(path, 'main', b'bytes'))
+        expected_results.append(False)
+
+        invokes.append(runner.call_contract(path, 'main', None))
+        expected_results.append(True)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_number_identity_operation(self):
-        path = self.get_contract_path('NumIdentity.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('NumIdentity.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         a = 1
         b = 1
-        expected_result = a is b
-        result = self.run_smart_contract(engine, path, 'without_attribution_true')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'without_attribution_true'))
+        expected_results.append(a is b)
 
         a = 1
         b = 2
-        expected_result = a is b
-        result = self.run_smart_contract(engine, path, 'without_attribution_false')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'without_attribution_false'))
+        expected_results.append(a is b)
 
         c = 1
         d = c
-        expected_result = c is d
-        result = self.run_smart_contract(engine, path, 'with_attribution')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'with_attribution'))
+        expected_results.append(c is d)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_string_identity_operation(self):
-        path = self.get_contract_path('StrIdentity.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('StrIdentity.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         a = 'unit'
         b = 'unit'
-        expected_result = a is b
-        result = self.run_smart_contract(engine, path, 'without_attribution_true')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'without_attribution_true'))
+        expected_results.append(a is b)
 
         a = 'unit'
         b = 'test'
-        expected_result = a is b
-        result = self.run_smart_contract(engine, path, 'without_attribution_false')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'without_attribution_false'))
+        expected_results.append(a is b)
 
         c = 'unit'
         d = c
-        expected_result = c is d
-        result = self.run_smart_contract(engine, path, 'with_attribution')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'with_attribution'))
+        expected_results.append(c is d)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_tuple_identity(self):
-        path = self.get_contract_path('TupleIdentity.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('TupleIdentity.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         a = (1, 2, 3)
         b = a
-        expected_result = a is b
-        result = self.run_smart_contract(engine, path, 'with_attribution')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'with_attribution'))
+        expected_results.append(a is b)
 
         # Python will try conserve memory and will make a and b reference the same position, since Tuples are immutable
         # this will deviate from Neo's expected behavior
-        result = self.run_smart_contract(engine, path, 'without_attribution')
-        self.assertEqual(False, result)
+        invokes.append(runner.call_contract(path, 'without_attribution'))
+        expected_results.append(False)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     # endregion
 
     # region LessThan
 
     def test_builtin_type_less_than_operation(self):
-        path = self.get_contract_path('BuiltinTypeLessThan.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('BuiltinTypeLessThan.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', FindOptions.VALUES_ONLY, FindOptions.VALUES_ONLY)
-        self.assertEqual(FindOptions.VALUES_ONLY < FindOptions.VALUES_ONLY, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', FindOptions.VALUES_ONLY, FindOptions.VALUES_ONLY))
+        expected_results.append(FindOptions.VALUES_ONLY < FindOptions.VALUES_ONLY)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_mixed_less_than_operation(self):
         path = self.get_contract_path('MixedLessThan.py')
@@ -289,13 +411,24 @@ class TestRelational(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', 1, 2)
-        self.assertEqual(True, result)
-        result = self.run_smart_contract(engine, path, 'Main', 2, 2)
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'Main', 2, 1)
-        self.assertEqual(False, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', 1, 2))
+        expected_results.append(True)
+        invokes.append(runner.call_contract(path, 'Main', 2, 2))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'Main', 2, 1))
+        expected_results.append(False)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_string_less_than_operation(self):
         expected_output = (
@@ -312,24 +445,44 @@ class TestRelational(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', 'test', 'unit')
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'Main', 'unit', 'unit')
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'Main', 'unit', 'test')
-        self.assertEqual(True, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', 'test', 'unit'))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'Main', 'unit', 'unit'))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'Main', 'unit', 'test'))
+        expected_results.append(True)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     # endregion
 
     # region LessThanOrEqual
 
     def test_builtin_type_less_than_or_equal_operation(self):
-        path = self.get_contract_path('BuiltinTypeLessThanOrEqual.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('BuiltinTypeLessThanOrEqual.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', FindOptions.VALUES_ONLY, FindOptions.VALUES_ONLY)
-        self.assertEqual(FindOptions.VALUES_ONLY <= FindOptions.VALUES_ONLY, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', FindOptions.VALUES_ONLY, FindOptions.VALUES_ONLY))
+        expected_results.append(FindOptions.VALUES_ONLY <= FindOptions.VALUES_ONLY)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_mixed_less_or_equal_than_operation(self):
         path = self.get_contract_path('MixedLessOrEqual.py')
@@ -350,13 +503,24 @@ class TestRelational(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', 1, 2)
-        self.assertEqual(True, result)
-        result = self.run_smart_contract(engine, path, 'Main', 2, 2)
-        self.assertEqual(True, result)
-        result = self.run_smart_contract(engine, path, 'Main', 2, 1)
-        self.assertEqual(False, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', 1, 2))
+        expected_results.append(True)
+        invokes.append(runner.call_contract(path, 'Main', 2, 2))
+        expected_results.append(True)
+        invokes.append(runner.call_contract(path, 'Main', 2, 1))
+        expected_results.append(False)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_string_less_or_equal_than_operation(self):
         expected_output = (
@@ -373,13 +537,24 @@ class TestRelational(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', 'test', 'unit')
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'Main', 'unit', 'unit')
-        self.assertEqual(True, result)
-        result = self.run_smart_contract(engine, path, 'Main', 'unit', 'test')
-        self.assertEqual(True, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', 'test', 'unit'))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'Main', 'unit', 'unit'))
+        expected_results.append(True)
+        invokes.append(runner.call_contract(path, 'Main', 'unit', 'test'))
+        expected_results.append(True)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     # endregion
 
@@ -400,38 +575,58 @@ class TestRelational(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', 1, 'unit')
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'Main', 123, '123')
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'Main', Integer.from_bytes(b'123'), '123')
-        self.assertEqual(False, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', 1, 'unit'))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'Main', 123, '123'))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'Main', Integer.from_bytes(b'123'), '123'))
+        expected_results.append(False)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_boa2_equality_test2(self):
-        path = self.get_contract_path('Equality2Boa2Test.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Equality2Boa2Test.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', 1)
-        self.assertEqual(False, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', 2)
-        self.assertEqual(False, result)
+        invokes.append(runner.call_contract(path, 'main', 1))
+        expected_results.append(False)
 
-        result = self.run_smart_contract(engine, path, 'main', 3)
-        self.assertEqual(True, result)
+        invokes.append(runner.call_contract(path, 'main', 2))
+        expected_results.append(False)
 
-        result = self.run_smart_contract(engine, path, 'main', 4)
-        self.assertEqual(False, result)
+        invokes.append(runner.call_contract(path, 'main', 3))
+        expected_results.append(True)
 
-        result = self.run_smart_contract(engine, path, 'main', 5)
-        self.assertEqual(False, result)
+        invokes.append(runner.call_contract(path, 'main', 4))
+        expected_results.append(False)
 
-        result = self.run_smart_contract(engine, path, 'main', 6)
-        self.assertEqual(False, result)
+        invokes.append(runner.call_contract(path, 'main', 5))
+        expected_results.append(False)
 
-        result = self.run_smart_contract(engine, path, 'main', 7)
-        self.assertEqual(False, result)
+        invokes.append(runner.call_contract(path, 'main', 6))
+        expected_results.append(False)
+
+        invokes.append(runner.call_contract(path, 'main', 7))
+        expected_results.append(False)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     # endregion
 
@@ -452,133 +647,186 @@ class TestRelational(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', 1, 'unit')
-        self.assertEqual(True, result)
-        result = self.run_smart_contract(engine, path, 'Main', 123, '123')
-        self.assertEqual(True, result)
-        result = self.run_smart_contract(engine, path, 'Main', Integer.from_bytes(b'123'), '123')
-        self.assertEqual(True, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', 1, 'unit'))
+        expected_results.append(True)
+        invokes.append(runner.call_contract(path, 'Main', 123, '123'))
+        expected_results.append(True)
+        invokes.append(runner.call_contract(path, 'Main', Integer.from_bytes(b'123'), '123'))
+        expected_results.append(True)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     # endregion
 
     # region NotIdentity
 
     def test_boolean_not_identity_operation(self):
-        path = self.get_contract_path('BoolNotIdentity.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('BoolNotIdentity.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         a = True
         b = False
-        expected_result = a is not b
-        result = self.run_smart_contract(engine, path, 'without_attribution_true')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'without_attribution_true'))
+        expected_results.append(a is not b)
 
         a = True
         b = True
-        expected_result = a is not b
-        result = self.run_smart_contract(engine, path, 'without_attribution_false')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'without_attribution_false'))
+        expected_results.append(a is not b)
 
         c = True
         d = c
-        expected_result = c is not d
-        result = self.run_smart_contract(engine, path, 'with_attribution')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'with_attribution'))
+        expected_results.append(c is not d)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_list_not_identity(self):
-        path = self.get_contract_path('ListNotIdentity.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ListNotIdentity.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         a = [1, 2, 3]
         b = a
-        expected_result = a is not b
-        result = self.run_smart_contract(engine, path, 'with_attribution')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'with_attribution'))
+        expected_results.append(a is not b)
 
         a = [1, 2, 3]
         b = [1, 2, 3]
-        expected_result = a is not b
-        result = self.run_smart_contract(engine, path, 'without_attribution')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'without_attribution'))
+        expected_results.append(a is not b)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_none_not_identity_operation(self):
-        path = self.get_contract_path('NoneNotIdentity.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('NoneNotIdentity.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', 1)
-        self.assertEqual(True, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', True)
-        self.assertEqual(True, result)
+        invokes.append(runner.call_contract(path, 'main', 1))
+        expected_results.append(True)
 
-        result = self.run_smart_contract(engine, path, 'main', 'string')
-        self.assertEqual(True, result)
+        invokes.append(runner.call_contract(path, 'main', True))
+        expected_results.append(True)
 
-        result = self.run_smart_contract(engine, path, 'main', b'bytes')
-        self.assertEqual(True, result)
+        invokes.append(runner.call_contract(path, 'main', 'string'))
+        expected_results.append(True)
 
-        result = self.run_smart_contract(engine, path, 'main', None)
-        self.assertEqual(False, result)
+        invokes.append(runner.call_contract(path, 'main', b'bytes'))
+        expected_results.append(True)
+
+        invokes.append(runner.call_contract(path, 'main', None))
+        expected_results.append(False)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_number_not_identity_operation(self):
-        path = self.get_contract_path('NumNotIdentity.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('NumNotIdentity.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         a = 1
         b = 2
-        expected_result = a is not b
-        result = self.run_smart_contract(engine, path, 'without_attribution_true')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'without_attribution_true'))
+        expected_results.append(a is not b)
 
         a = 1
         b = 1
-        expected_result = a is not b
-        result = self.run_smart_contract(engine, path, 'without_attribution_false')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'without_attribution_false'))
+        expected_results.append(a is not b)
 
         c = 1
         d = c
-        expected_result = c is not d
-        result = self.run_smart_contract(engine, path, 'with_attribution')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'with_attribution'))
+        expected_results.append(c is not d)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_string_not_identity_operation(self):
-        path = self.get_contract_path('StrNotIdentity.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('StrNotIdentity.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         a = 'unit'
         b = 'test'
-        expected_result = a is not b
-        result = self.run_smart_contract(engine, path, 'without_attribution_true')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'without_attribution_true'))
+        expected_results.append(a is not b)
 
         a = 'unit'
         b = 'unit'
-        expected_result = a is not b
-        result = self.run_smart_contract(engine, path, 'without_attribution_false')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'without_attribution_false'))
+        expected_results.append(a is not b)
 
         c = 'unit'
         d = c
-        expected_result = c is not d
-        result = self.run_smart_contract(engine, path, 'with_attribution')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'with_attribution'))
+        expected_results.append(c is not d)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_tuple_not_identity(self):
-        path = self.get_contract_path('TupleNotIdentity.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('TupleNotIdentity.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         a = (1, 2, 3)
         b = a
-        expected_result = a is not b
-        result = self.run_smart_contract(engine, path, 'with_attribution')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'with_attribution'))
+        expected_results.append(a is not b)
 
         # Python will try conserve memory and will make a and b reference the same position, since Tuples are immutable
         # this will deviate from Neo's expected behavior
-        result = self.run_smart_contract(engine, path, 'without_attribution')
-        self.assertEqual(True, result)
+        invokes.append(runner.call_contract(path, 'without_attribution'))
+        expected_results.append(True)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     # endregion
 
@@ -599,18 +847,38 @@ class TestRelational(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', True, False)
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'Main', True, True)
-        self.assertEqual(True, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', True, False))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'Main', True, True))
+        expected_results.append(True)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_builtin_equality_operation(self):
-        path = self.get_contract_path('BuiltinTypeEquality.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('BuiltinTypeEquality.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', FindOptions.VALUES_ONLY, FindOptions.VALUES_ONLY)
-        self.assertEqual(FindOptions.VALUES_ONLY == FindOptions.VALUES_ONLY, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', FindOptions.VALUES_ONLY, FindOptions.VALUES_ONLY))
+        expected_results.append(FindOptions.VALUES_ONLY == FindOptions.VALUES_ONLY)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_multiple_comparisons(self):
         expected_output = (
@@ -631,15 +899,26 @@ class TestRelational(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', 1, 2, 5)
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'Main', 2, 1, 5)
-        self.assertEqual(True, result)
-        result = self.run_smart_contract(engine, path, 'Main', 5, 1, 2)
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'Main', 2, 5, 1)
-        self.assertEqual(False, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', 1, 2, 5))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'Main', 2, 1, 5))
+        expected_results.append(True)
+        invokes.append(runner.call_contract(path, 'Main', 5, 1, 2))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'Main', 2, 5, 1))
+        expected_results.append(False)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_number_equality_operation(self):
         expected_output = (
@@ -656,11 +935,22 @@ class TestRelational(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', 1, 2)
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'Main', 2, 2)
-        self.assertEqual(True, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', 1, 2))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'Main', 2, 2))
+        expected_results.append(True)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     # endregion
 
@@ -681,18 +971,38 @@ class TestRelational(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', True, False)
-        self.assertEqual(True, result)
-        result = self.run_smart_contract(engine, path, 'Main', True, True)
-        self.assertEqual(False, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', True, False))
+        expected_results.append(True)
+        invokes.append(runner.call_contract(path, 'Main', True, True))
+        expected_results.append(False)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_builtin_inequality_operation(self):
-        path = self.get_contract_path('BuiltinTypeInequality.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('BuiltinTypeInequality.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', FindOptions.VALUES_ONLY, FindOptions.VALUES_ONLY)
-        self.assertEqual(FindOptions.VALUES_ONLY != FindOptions.VALUES_ONLY, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', FindOptions.VALUES_ONLY, FindOptions.VALUES_ONLY))
+        expected_results.append(FindOptions.VALUES_ONLY != FindOptions.VALUES_ONLY)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_number_inequality_operation(self):
         expected_output = (
@@ -709,11 +1019,22 @@ class TestRelational(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', 1, 2)
-        self.assertEqual(True, result)
-        result = self.run_smart_contract(engine, path, 'Main', 2, 2)
-        self.assertEqual(False, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', 1, 2))
+        expected_results.append(True)
+        invokes.append(runner.call_contract(path, 'Main', 2, 2))
+        expected_results.append(False)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_number_inequality_operation_2(self):
         path = self.get_contract_path('NumInequalityPython2.py')
@@ -726,44 +1047,85 @@ class TestRelational(BoaTest):
     # region ObjectEquality
 
     def test_compare_same_value_argument(self):
-        path = self.get_contract_path('CompareSameValueArgument.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'testing_something', bytes(20))
-        self.assertEqual(True, result)
+        path, _ = self.get_deploy_file_paths('CompareSameValueArgument.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'testing_something', bytes(20)))
+        expected_results.append(True)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_compare_same_value_hard_coded(self):
-        path = self.get_contract_path('CompareSameValueHardCoded.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'testing_something')
-        self.assertEqual(True, result)
+        path, _ = self.get_deploy_file_paths('CompareSameValueHardCoded.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'testing_something'))
+        expected_results.append(True)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_compare_string(self):
-        path = self.get_contract_path('CompareString.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'test1', '|')
-        self.assertEqual(True, result)
+        path, _ = self.get_deploy_file_paths('CompareString.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'test2', '|')
-        self.assertEqual(True, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'test3', '|')
-        self.assertEqual(True, result)
+        invokes.append(runner.call_contract(path, 'test1', '|'))
+        expected_results.append(True)
 
-        result = self.run_smart_contract(engine, path, 'test4', '|')
-        self.assertEqual(True, result)
+        invokes.append(runner.call_contract(path, 'test2', '|'))
+        expected_results.append(True)
+
+        invokes.append(runner.call_contract(path, 'test3', '|'))
+        expected_results.append(True)
+
+        invokes.append(runner.call_contract(path, 'test4', '|'))
+        expected_results.append(True)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_list_equality_with_slice(self):
-        path = self.get_contract_path('ListEqualityWithSlice.py')
+        path, _ = self.get_deploy_file_paths('ListEqualityWithSlice.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', ['unittest', '123'], 'unittest')
-        self.assertEqual(True, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', ['unittest', '123'], '123')
-        self.assertEqual(False, result)
+        invokes.append(runner.call_contract(path, 'main', ['unittest', '123'], 'unittest'))
+        expected_results.append(True)
 
-        with self.assertRaisesRegex(TestExecutionException, self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX):
-            self.run_smart_contract(engine, path, 'main', [], '')
+        invokes.append(runner.call_contract(path, 'main', ['unittest', '123'], '123'))
+        expected_results.append(False)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        runner.call_contract(path, 'main', [], '')
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX)
 
     def test_string_equality_operation(self):
         expected_output = (
@@ -780,11 +1142,22 @@ class TestRelational(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', 'unit', 'test')
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'Main', 'unit', 'unit')
-        self.assertEqual(True, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', 'unit', 'test'))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'Main', 'unit', 'unit'))
+        expected_results.append(True)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     # endregion
 
@@ -805,10 +1178,21 @@ class TestRelational(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', 'unit', 'test')
-        self.assertEqual(True, result)
-        result = self.run_smart_contract(engine, path, 'Main', 'unit', 'unit')
-        self.assertEqual(False, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', 'unit', 'test'))
+        expected_results.append(True)
+        invokes.append(runner.call_contract(path, 'Main', 'unit', 'unit'))
+        expected_results.append(False)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     # endregion

--- a/boa3_test/tests/compiler_tests/test_variable.py
+++ b/boa3_test/tests/compiler_tests/test_variable.py
@@ -9,8 +9,9 @@ from boa3.model.variable import Variable
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.String import String
+from boa3.neo3.vm import VMState
+from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.boa_test import BoaTest
-from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestVariable(BoaTest):
@@ -254,12 +255,23 @@ class TestVariable(BoaTest):
         path = self.get_contract_path('ReturnArgument.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
+        
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', 10)
-        self.assertEqual(10, result)
-        result = self.run_smart_contract(engine, path, 'Main', -140)
-        self.assertEqual(-140, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', 10))
+        expected_results.append(10)
+        invokes.append(runner.call_contract(path, 'Main', -140))
+        expected_results.append(-140)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_return_local_var_value(self):
         expected_output = (
@@ -276,11 +288,22 @@ class TestVariable(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', 10)
-        self.assertEqual(1, result)
-        result = self.run_smart_contract(engine, path, 'Main', -140)
-        self.assertEqual(1, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', 10))
+        expected_results.append(1)
+        invokes.append(runner.call_contract(path, 'Main', -140))
+        expected_results.append(1)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_assign_local_with_arg_value(self):
         expected_output = (
@@ -297,11 +320,22 @@ class TestVariable(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', 10)
-        self.assertEqual(10, result)
-        result = self.run_smart_contract(engine, path, 'Main', -140)
-        self.assertEqual(-140, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+        
+        invokes.append(runner.call_contract(path, 'Main', 10))
+        expected_results.append(10)
+        invokes.append(runner.call_contract(path, 'Main', -140))
+        expected_results.append(-140)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_using_undeclared_variable(self):
         path = self.get_contract_path('UsingUndeclaredVariable.py')
@@ -433,9 +467,20 @@ class TestVariable(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(10, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append(10)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_global_declaration_without_assignment(self):
         path = self.get_contract_path('GlobalDeclarationWithoutAssignment.py')
@@ -455,9 +500,20 @@ class TestVariable(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(10, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append(10)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_global_assignment_without_type(self):
         expected_output = (
@@ -473,29 +529,49 @@ class TestVariable(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(10, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append(10)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_global_tuple_multiple_assignments(self):
         path = self.get_contract_path('GlobalAssignmentWithTuples.py')
         self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
 
     def test_global_chained_multiple_assignments(self):
-        path = self.get_contract_path('GlobalMultipleAssignments.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('GlobalMultipleAssignments.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'get_a')
-        self.assertEqual(10, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'get_c')
-        self.assertEqual(15, result)
+        invokes.append(runner.call_contract(path, 'get_a'))
+        expected_results.append(10)
 
-        result = self.run_smart_contract(engine, path, 'set_a', 100)
-        self.assertIsVoid(result)
+        invokes.append(runner.call_contract(path, 'get_c'))
+        expected_results.append(15)
 
-        result = self.run_smart_contract(engine, path, 'get_a')
-        self.assertEqual(100, result)
+        invokes.append(runner.call_contract(path, 'set_a', 100))
+        expected_results.append(None)
+
+        invokes.append(runner.call_contract(path, 'get_a'))
+        expected_results.append(100)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_many_global_assignments(self):
         expected_output = (
@@ -535,23 +611,43 @@ class TestVariable(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual([0, 1, 2, 3, 4, 5, 6, 7], result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append([0, 1, 2, 3, 4, 5, 6, 7])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_list_global_assignment(self):
-        path = self.get_contract_path('ListGlobalAssignment.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ListGlobalAssignment.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         expected_value = [1, 2, 3, 4]
-        result = self.run_smart_contract(engine, path, 'get_from_global')
-        self.assertEqual(expected_value, result)
+        invokes.append(runner.call_contract(path, 'get_from_global'))
+        expected_results.append(expected_value)
 
-        result = self.run_smart_contract(engine, path, 'get_from_class')
-        self.assertEqual(expected_value, result)
+        invokes.append(runner.call_contract(path, 'get_from_class'))
+        expected_results.append(expected_value)
 
-        result = self.run_smart_contract(engine, path, 'get_from_class_without_assigning')
-        self.assertEqual([], result)
+        invokes.append(runner.call_contract(path, 'get_from_class_without_assigning'))
+        expected_results.append([])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_global_assignment_between_functions(self):
         expected_output = (
@@ -571,21 +667,41 @@ class TestVariable(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(10, result)
-        result = self.run_smart_contract(engine, path, 'example')
-        self.assertEqual(5, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append(10)
+        invokes.append(runner.call_contract(path, 'example'))
+        expected_results.append(5)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_global_variable_in_class_method(self):
-        path = self.get_contract_path('GlobalVariableInClassMethod.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('GlobalVariableInClassMethod.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'use_variable_in_func')
-        self.assertEqual(42, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'use_variable_in_map')
-        self.assertEqual({'val1': 1, 'val2': 2, 'bar': 42}, result)
+        invokes.append(runner.call_contract(path, 'use_variable_in_func'))
+        expected_results.append(42)
+
+        invokes.append(runner.call_contract(path, 'use_variable_in_map'))
+        expected_results.append({'val1': 1, 'val2': 2, 'bar': 42})
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_get_global_variable_value_written_after(self):
         expected_output = (
@@ -624,9 +740,20 @@ class TestVariable(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual([0, 1, 2, 3, 4, 5, 6, 7], result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append([0, 1, 2, 3, 4, 5, 6, 7])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_assign_local_shadowing_global_with_arg_value(self):
         expected_output = (
@@ -647,67 +774,136 @@ class TestVariable(BoaTest):
         output = self.assertCompilerLogs(CompilerWarning.NameShadowing, path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', 10)
-        self.assertEqual(10, result)
-        result = self.run_smart_contract(engine, path, 'Main', -140)
-        self.assertEqual(-140, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', 10))
+        expected_results.append(10)
+        invokes.append(runner.call_contract(path, 'Main', -140))
+        expected_results.append(-140)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_assign_global_in_function_with_global_keyword(self):
-        path = self.get_contract_path('GlobalAssignmentInFunctionWithArgument.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('GlobalAssignmentInFunctionWithArgument.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'get_b')
-        self.assertEqual(0, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'Main', 10)
-        self.assertEqual(10, result)
+        invokes.append(runner.call_contract(path, 'get_b'))
+        expected_results.append(0)
 
-        result = self.run_smart_contract(engine, path, 'get_b')
-        self.assertEqual(10, result)
+        invokes.append(runner.call_contract(path, 'Main', 10))
+        expected_results.append(10)
 
-        result = self.run_smart_contract(engine, path, 'Main', -140)
-        self.assertEqual(-140, result)
+        invokes.append(runner.call_contract(path, 'get_b'))
+        expected_results.append(10)
 
-        result = self.run_smart_contract(engine, path, 'get_b')
-        self.assertEqual(-140, result)
+        invokes.append(runner.call_contract(path, 'Main', -140))
+        expected_results.append(-140)
+
+        invokes.append(runner.call_contract(path, 'get_b'))
+        expected_results.append(-140)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_assign_void_function_call(self):
         path = self.get_contract_path('AssignVoidFunctionCall.py')
-        engine = TestEngine()
-
         output = Boa3.compile(path)
         self.assertIn(Opcode.NOP, output)
 
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(None, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+        
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append(None)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_anonymous_variable(self):
-        path = self.get_contract_path('AnonymousVariable')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(400, result)
+        path, _ = self.get_deploy_file_paths('AnonymousVariable')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append(400)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_assign_starred_variable(self):
         path = self.get_contract_path('AssignStarredVariable.py')
         self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
 
     def test_variables_in_different_scope_with_same_name(self):
-        path = self.get_contract_path('DifferentScopesWithSameName.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'test')
-        self.assertEqual(1_000, result)
+        path, _ = self.get_deploy_file_paths('DifferentScopesWithSameName.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'test'))
+        expected_results.append(1_000)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_instance_variable_and_variable_with_same_name(self):
-        path = self.get_contract_path('InstanceVariableAndVariableWithSameName.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'test')
-        self.assertEqual([10], result)
+        path, _ = self.get_deploy_file_paths('InstanceVariableAndVariableWithSameName.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'test'))
+        expected_results.append([10])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_inner_object_variable_access(self):
-        path = self.get_contract_path('InnerObjectVariableAccess.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('InnerObjectVariableAccess.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         expected_return = 'InnerObjectVariableAccess'
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(expected_return, result)
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(expected_return)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)


### PR DESCRIPTION
**Summary or solution description**
Part of an overall refactoring. Changed the execution tests of the compiled smart contracts to use TestRunner instead of TestEngine

**Tests**
Rerun the modified unit tests