### PR TITLE
refactor storage unit tests to use test runner

### DIFF
--- a/boa3/neo/utils/__init__.py
+++ b/boa3/neo/utils/__init__.py
@@ -13,10 +13,16 @@ def stack_item_from_json(item: Dict[str, Any]) -> Any:
 
     item_type: StackItemType = StackItemType.get_stack_item_type(item['type'])
     if item_type is StackItemType.InteropInterface:
-        if 'iterator' in item:
-            return [stack_item_from_json(value) for value in item['iterator']]
+        if 'value' in item:
+            interop_interface = item['value']
+        else:
+            interop_interface = item
+
+        if isinstance(interop_interface, dict) and 'iterator' in interop_interface:
+            return [stack_item_from_json(value) for value in interop_interface['iterator']]
         else:
             return InteropInterface
+
     if item_type is StackItemType.Any or 'value' not in item:
         return None
 

--- a/boa3_test/test_drive/model/invoker/neoinvokeresult.py
+++ b/boa3_test/test_drive/model/invoker/neoinvokeresult.py
@@ -28,14 +28,15 @@ class NeoInvokeResult:
                 from boa3.neo.vm.type.String import String
                 result = String(result).to_bytes()
 
-            if self._expected_result_type is bool:
+            if self._expected_result_type in (bool, int):
                 if isinstance(result, bytes):
                     from boa3.neo.vm.type.Integer import Integer
                     result = Integer.from_bytes(result, signed=True)
-                if isinstance(result, int) and result in (False, True):
+
+                if self._expected_result_type is bool and isinstance(result, int) and result in (False, True):
                     result = bool(result)
 
-            if self._expected_result_type is bytearray and isinstance(result, bytes):
+            elif self._expected_result_type is bytearray and isinstance(result, bytes):
                 result = bytearray(result)
 
         return result

--- a/boa3_test/test_drive/testrunner/blockchain/storagecollection.py
+++ b/boa3_test/test_drive/testrunner/blockchain/storagecollection.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Union
 
 from boa3_test.test_drive.model.smart_contract.testcontract import TestContract
 from boa3_test.test_drive.testrunner.blockchain.storage import TestRunnerStorage, StorageKey
@@ -21,9 +21,13 @@ class StorageCollection:
         except BaseException as e:
             raise e  # try except just to ensure that the value will be removed from both lists
 
-    def get(self, storage_contract: TestContract, key: bytes):
+    def get(self, storage_contract: TestContract, key: Union[bytes, str]):
         if isinstance(key, str):
-            key = bytes(key)
+            try:
+                key = bytes(key)
+            except TypeError:
+                from boa3 import constants
+                key = key.encode(encoding=constants.ENCODING)
 
         index = self._storage_contracts.index(storage_contract)
         try:

--- a/boa3_test/test_sc/interop_test/storage/StorageDeleteBytesKey.py
+++ b/boa3_test/test_sc/interop_test/storage/StorageDeleteBytesKey.py
@@ -1,7 +1,21 @@
+from typing import Any
+
 from boa3.builtin.compile_time import public
+from boa3.builtin.interop import storage
 from boa3.builtin.interop.storage import delete
 
 
 @public
 def Main(key: bytes):
     delete(key)
+
+
+@public
+def has_key(key: bytes) -> bool:
+    return len(storage.get(key)) > 0
+
+
+@public
+def _deploy(data: Any, update: bool):
+    # test data to test in unit tests
+    storage.put('example', 23)

--- a/boa3_test/test_sc/interop_test/storage/StorageDeleteStrKey.py
+++ b/boa3_test/test_sc/interop_test/storage/StorageDeleteStrKey.py
@@ -1,7 +1,21 @@
+from typing import Any
+
 from boa3.builtin.compile_time import public
+from boa3.builtin.interop import storage
 from boa3.builtin.interop.storage import delete
 
 
 @public
 def Main(key: str):
     delete(key)
+
+
+@public
+def has_key(key: bytes) -> bool:
+    return len(storage.get(key)) > 0
+
+
+@public
+def _deploy(data: Any, update: bool):
+    # test data to test in unit tests
+    storage.put('example', 23)

--- a/boa3_test/test_sc/interop_test/storage/StorageDeleteWithContext.py
+++ b/boa3_test/test_sc/interop_test/storage/StorageDeleteWithContext.py
@@ -1,4 +1,7 @@
+from typing import Any
+
 from boa3.builtin.compile_time import public
+from boa3.builtin.interop import storage
 from boa3.builtin.interop.storage import delete, get_context
 from boa3.builtin.type import ByteString
 
@@ -7,3 +10,16 @@ from boa3.builtin.type import ByteString
 def Main(key: ByteString):
     context = get_context()
     delete(key, context)
+
+
+@public
+def has_key(key: bytes) -> bool:
+    context = get_context()
+    return len(storage.get(key, context)) > 0
+
+
+@public
+def _deploy(data: Any, update: bool):
+    # test data to test in unit tests
+    context = get_context()
+    storage.put('example', 23, context)

--- a/boa3_test/test_sc/interop_test/storage/StorageGetStrKey.py
+++ b/boa3_test/test_sc/interop_test/storage/StorageGetStrKey.py
@@ -1,7 +1,17 @@
+from typing import Any
+
 from boa3.builtin.compile_time import public
+from boa3.builtin.interop import storage
 from boa3.builtin.interop.storage import get
 
 
 @public
 def Main(key: str) -> bytes:
     return get(key)
+
+
+@public
+def _deploy(data: Any, update: bool):
+    # test data to test in unit tests
+    storage.put('example', 23)
+    storage.put('test', 42)

--- a/boa3_test/test_sc/interop_test/storage/StorageGetWithContext.py
+++ b/boa3_test/test_sc/interop_test/storage/StorageGetWithContext.py
@@ -1,4 +1,7 @@
+from typing import Any
+
 from boa3.builtin.compile_time import public
+from boa3.builtin.interop import storage
 from boa3.builtin.interop.storage import get, get_context
 from boa3.builtin.type import ByteString
 
@@ -7,3 +10,12 @@ from boa3.builtin.type import ByteString
 def Main(key: ByteString) -> bytes:
     context = get_context()
     return get(key, context)
+
+
+@public
+def _deploy(data: Any, update: bool):
+    # test data to test in unit tests
+    context = get_context()
+    storage.put('example', 23, context)
+    storage.put('test', 42, context)
+

--- a/boa3_test/tests/boa_test.py
+++ b/boa3_test/tests/boa_test.py
@@ -111,6 +111,10 @@ class BoaTest(TestCase):
         if obj is not VoidType:
             self.fail('{0} is not Void'.format(obj))
 
+    def assertStartsWith(self, first: Any, second: Any):
+        if not (hasattr(first, 'startswith') and first.startswith(second)):
+            self.fail(f'{first} != {second}')
+
     def get_dir_path(self, *args: str) -> str:
         type_error_message = 'get_contract_path() takes {0} positional argument but {1} were given'
         num_args = len(args)


### PR DESCRIPTION
**Summary or solution description**
Part of an overall refactoring. 
Changed the execution tests of the compiled smart contracts related to storage operations to use TestRunner instead of TestEngine

**Tests**
Rerun the modified unit tests

**(Optional) Additional context**
Due to an error in the Test Runner output related to return Iterator values, the tests related to `find` method still use TestEngine
