### PR TITLE
Can't use an empty dict if the type hint not any is inside another type

### DIFF
--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -59,6 +59,17 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
         self._super_calls: List[IBuiltinMethod] = []
         self.visit(self._tree)
 
+    def visit(self, node: ast.AST, get_literal_value: bool = False):
+        if get_literal_value:
+            node.get_literal_value = True
+
+        result = super().visit(node)
+
+        if hasattr(node, 'get_literal_value'):
+            delattr(node, 'get_literal_value')
+
+        return result
+
     @property
     def _current_method_id(self) -> str:
         """
@@ -247,7 +258,9 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
 
         :param ret: the python ast return node
         """
-        ret_value: Any = self.visit(ret.value) if ret.value is not None else None
+        ret_value: Any = (self.visit(ret.value, get_literal_value=True)
+                          if ret.value is not None
+                          else None)
         if ret.value is not None and self.get_type(ret.value) is not Type.none:
             # multiple returns are not allowed
             if isinstance(ret.value, ast.Tuple):
@@ -422,7 +435,7 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
                         self._current_scope.include_symbol(node.id, Variable(value_type),
                                                            reassign_original=can_change_original)
 
-        if not target_type.is_type_of(value_type) and value != target_type.default_value:
+        if not target_type.is_type_of(value_type) and not self._has_only_default_values(value, target_type):
             if not implicit_cast:
                 self._log_error(
                     CompilerError.MismatchedTypes(
@@ -441,6 +454,35 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
                 )
 
         return True
+
+    def _has_only_default_values(self, value: Any, target_type: Optional[IType] = None) -> bool:
+        has_only_default_values = False
+        if not isinstance(target_type, IType):
+            target_type = self.get_type(value)
+
+        if value == target_type.default_value:
+            has_only_default_values = True
+
+        elif isinstance(target_type, Collection) and hasattr(value, '__len__'):
+            has_only_default_values = True
+            if isinstance(value, dict):
+                for key, item in value.items():
+                    if not self._has_only_default_values(key):
+                        has_only_default_values = False
+                        break
+
+                    if not self._has_only_default_values(item):
+                        has_only_default_values = False
+                        break
+            else:
+                for item in value:
+                    if not self._has_only_default_values(item):
+                        has_only_default_values = False
+                        break
+        else:
+            has_only_default_values = value == target_type.default_value
+
+        return has_only_default_values
 
     def visit_Subscript(self, subscript: ast.Subscript) -> IType:
         """
@@ -1706,7 +1748,19 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
         :param tup_node: the python ast tuple node
         :return: the value of the tuple
         """
-        return tuple(self.get_type(value) for value in tup_node.elts)
+        get_literal_values = hasattr(tup_node, 'get_literal_value') and tup_node.get_literal_value
+        result = []
+        for value in tup_node.elts:
+            if get_literal_values:
+                item = self.visit(value, get_literal_value=True)
+                if item is None or isinstance(item, ast.AST):
+                    item = self.get_type(value)
+            else:
+                item = self.get_type(value)
+
+            result.append(item)
+
+        return tuple(result)
 
     def visit_List(self, list_node: ast.List) -> List[Any]:
         """
@@ -1715,7 +1769,19 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
         :param list_node: the python ast list node
         :return: the value of the list
         """
-        return [self.get_type(value) for value in list_node.elts]
+        get_literal_values = hasattr(list_node, 'get_literal_value') and list_node.get_literal_value
+        result = []
+        for value in list_node.elts:
+            if get_literal_values:
+                item = self.visit(value, get_literal_value=True)
+                if item is None or isinstance(item, ast.AST):
+                    item = self.get_type(value)
+            else:
+                item = self.get_type(value)
+
+            result.append(item)
+
+        return result
 
     def visit_Dict(self, dict_node: ast.Dict) -> Dict[Any, Any]:
         """
@@ -1724,11 +1790,22 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
         :param dict_node: the python ast dict node
         :return: a list with each key and value type
         """
+        get_literal_values = hasattr(dict_node, 'get_literal_value') and dict_node.get_literal_value
         dictionary = {}
         size = min(len(dict_node.keys), len(dict_node.values))
         for index in range(size):
-            key = self.get_type(dict_node.keys[index])
-            value = self.get_type(dict_node.values[index])
+            if get_literal_values:
+                key = self.visit(dict_node.keys[index], get_literal_value=True)
+                if key is None or isinstance(key, ast.AST):
+                    key = self.get_type(dict_node.keys[index])
+
+                value = self.visit(dict_node.values[index], get_literal_value=True)
+                if value is None or isinstance(value, ast.AST):
+                    value = self.get_type(dict_node.values[index])
+            else:
+                key = self.get_type(dict_node.keys[index])
+                value = self.get_type(dict_node.values[index])
+
             if key in dictionary and dictionary[key] != value:
                 dictionary[key] = Type.get_generic_type(dictionary[key], value)
             else:

--- a/boa3_test/test_sc/list_test/ListWithEmptyTypedDict.py
+++ b/boa3_test/test_sc/list_test/ListWithEmptyTypedDict.py
@@ -1,0 +1,8 @@
+from typing import List, Dict
+
+from boa3.builtin.compile_time import public
+
+
+@public
+def Main() -> List[Dict[str, bool]]:
+    return [{}]

--- a/boa3_test/tests/compiler_tests/test_list.py
+++ b/boa3_test/tests/compiler_tests/test_list.py
@@ -101,6 +101,18 @@ class TestList(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
+    def test_list_empty_dict(self):
+        expected_output = (
+            Opcode.NEWMAP      # return [{}]
+            + Opcode.PUSH1      # array length
+            + Opcode.PACK
+            + Opcode.RET
+        )
+
+        path = self.get_contract_path('ListWithEmptyTypedDict.py')
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
     def test_non_sequence_get_value(self):
         path = self.get_contract_path('MismatchedTypeGetValue.py')
         self.assertCompilerLogs(CompilerError.UnresolvedOperation, path)


### PR DESCRIPTION
**Summary or solution description**
Hinting the type of a `Dict` that has keys and values that are not `Any` inside another type, like `List` and returning an empty dict was not compiling, raising an error `Expected type 'list[dict[str, bool]]', got 'list[dict[any, any]]' instead`.

This was caused because empty dict `{}` is typed by the compiler as `Dict[Any, Any]`, but it should be assigned to any `dict` type, since it's empty. The same error didn't happen when the expected type is `Dict[str, bool]` for example, only when it's encapsulated inside another type (i.e. `List[Dict[str, bool]]`)

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/d82842a2bfd16855b81754d5b44d8b53bee34ed6/boa3_test/test_sc/list_test/ListWithEmptyTypedDict.py#L1-L8

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/d82842a2bfd16855b81754d5b44d8b53bee34ed6/boa3_test/tests/compiler_tests/test_list.py#L104-L114

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7+
