### PR TITLE
Couldn't use Optional typing to define a Dict

### DIFF
--- a/boa3/analyser/typeanalyser.py
+++ b/boa3/analyser/typeanalyser.py
@@ -25,6 +25,7 @@ from boa3.model.operation.unaryop import UnaryOp
 from boa3.model.property import Property
 from boa3.model.symbol import ISymbol
 from boa3.model.type.annotation.metatype import MetaType
+from boa3.model.type.annotation.uniontype import UnionType
 from boa3.model.type.classes.classtype import ClassType
 from boa3.model.type.classes.pythonclass import PythonClass
 from boa3.model.type.classes.userclass import UserClass
@@ -515,6 +516,8 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
         if isinstance(value, IType) and all(isinstance(i, IType) for i in index):
             if isinstance(value, Collection):
                 value = value.build_collection(*index)
+            elif isinstance(value, UnionType):
+                value = value.build(index)
 
             value_to_be_built = index if isinstance(value, MetaType) else value
             if not isinstance(value_to_be_built, tuple):

--- a/boa3/model/type/annotation/optionaltype.py
+++ b/boa3/model/type/annotation/optionaltype.py
@@ -22,7 +22,7 @@ class OptionalType(UnionType):
 
         super().__init__(union_types)
         self._identifier = 'Optional'
-        self._optional_type = optional_types
+        self._optional_type = optional_types if optional_types is not None else set()
 
     @property
     def identifier(self) -> str:
@@ -34,7 +34,7 @@ class OptionalType(UnionType):
         return list(self._optional_type)
 
     def _is_type_of(self, value: Any) -> bool:
-        if not isinstance(self._optional_type, Iterable):
+        if not isinstance(self._optional_type, Iterable) or len(self._optional_type) == 0:
             return False
         if isinstance(value, UnionType):
             return all(self._is_type_of(x) for x in value._union_types)

--- a/boa3/model/type/annotation/uniontype.py
+++ b/boa3/model/type/annotation/uniontype.py
@@ -13,7 +13,7 @@ class UnionType(IType):
     def __init__(self, union_types: Set[IType] = None):
         identifier: str = 'Union'
         super().__init__(identifier)
-        self._union_types: Set[IType] = union_types
+        self._union_types: Set[IType] = union_types if union_types is not None else set()
 
         # variables to not reevaluate everytime we need to access
         self._abi_type: AbiType = None
@@ -41,7 +41,7 @@ class UnionType(IType):
         return self._stack_item
 
     def _is_type_of(self, value: Any) -> bool:
-        if not isinstance(self._union_types, Iterable):
+        if not isinstance(self._union_types, Iterable) or len(self._union_types) == 0:
             return False
         if isinstance(value, UnionType):
             return all(self._is_type_of(x) for x in value._union_types)

--- a/boa3_test/test_sc/optional_test/OptionalArgumentInsideDict.py
+++ b/boa3_test/test_sc/optional_test/OptionalArgumentInsideDict.py
@@ -1,0 +1,8 @@
+from typing import Optional, Union, Dict
+
+from boa3.builtin.compile_time import public
+
+
+@public
+def main(a: Dict[str, Optional[int]]) -> dict:
+    return a

--- a/boa3_test/tests/compiler_tests/test_optional.py
+++ b/boa3_test/tests/compiler_tests/test_optional.py
@@ -80,3 +80,20 @@ class TestOptional(BoaTest):
         self.assertEqual('int', result)
         result = self.run_smart_contract(engine, path, 'union_test', None)
         self.assertEqual('None', result)
+
+    def test_optional_inside_dict(self):
+        expected_output = (
+            Opcode.INITSLOT
+            + b'\x00'
+            + b'\x01'
+            + Opcode.LDARG0  # return a
+            + Opcode.RET
+        )
+
+        path = self.get_contract_path('OptionalArgumentInsideDict.py')
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+        engine = TestEngine()
+        result = self.run_smart_contract(engine, path, 'main', {})
+        self.assertEqual({}, result)


### PR DESCRIPTION
**Summary or solution description**
The compilation would fail when setting a function argument type as a collection of nullable values. Using both `Optional[some_type]` and `Union[None, some_type]` caused an `Internal compiler error`.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/c2f11f52a4f6c308bcd1f40f2316ef1cc203bd58/boa3_test/test_sc/optional_test/OptionalArgumentInsideDict.py#L6-L8

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/c2f11f52a4f6c308bcd1f40f2316ef1cc203bd58/boa3_test/tests/compiler_tests/test_optional.py#L84-L99

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7+
