### PR TITLE
CPM install script

### DIFF
--- a/boa3/cpm.py
+++ b/boa3/cpm.py
@@ -1,10 +1,10 @@
 import sys
-
 import requests
 import platform
 import os
 import stat
 import logging
+
 
 logging.getLogger("requests").setLevel(logging.WARNING)
 logging.getLogger("urllib3").setLevel(logging.WARNING)
@@ -14,22 +14,24 @@ def get_umask():
     os.umask(umask)
     return umask
 
+
 def chmod_plus_x(path):
     os.chmod(
         path,
         os.stat(path).st_mode |
         (
-            (
-                stat.S_IXUSR |
-                stat.S_IXGRP |
-                stat.S_IXOTH
-            )
-            & ~get_umask()
+                (
+                        stat.S_IXUSR |
+                        stat.S_IXGRP |
+                        stat.S_IXOTH
+                )
+                & ~get_umask()
         )
     )
 
+
 def main():
-    if not sys.maxsize > 2**32:
+    if not sys.maxsize > 2 ** 32:
         print("CPM is not supported on 32-bit platforms")
 
     r = requests.get("https://api.github.com/repos/CityOfZion/cpm/releases")
@@ -37,26 +39,32 @@ def main():
     for release in r.json():
         tag = release['tag_name']
         version = tag[1:]
-        if "x86_64" == platform.machine().lower():
+        if platform.machine().lower() in ["x86_64", "amd64"]:
             arch = "amd64"
         else:
-            # TODO: need somebody with ARM cpu to tell me what "machine()" prints because now 32-bit intel will also be labelled as arm
             arch = "arm64"
         system = platform.system().lower()
         asset_needle = f"cpm_{version}_{system}_{arch}"
+        if system == "windows":
+            asset_needle += ".exe"
+
         for asset in release['assets']:
             if asset['name'] == asset_needle:
                 r = requests.get(asset['browser_download_url'], stream=True)
+                print(f"Found release! Downloading {asset['browser_download_url']}...", end='')
+
                 cpm_filename = f"{os.path.dirname(sys.argv[0])}/cpm"
+                if system == "windows":
+                    cpm_filename += ".exe"
+
                 with open(cpm_filename, 'wb') as f:
                     for chunk in r.iter_content(chunk_size=1024):
                         if chunk:  # filter out keep-alive new chunks
                             f.write(chunk)
                 if system in ["darwin", "linux"]:
                     chmod_plus_x(cpm_filename)
-                else:
-                    # TODO: check permissions windows
-                    print("yikes, this is windows. Is it executable?")
+                print("done")
+                return
 
 
 if __name__ == "__main__":

--- a/boa3/cpm.py
+++ b/boa3/cpm.py
@@ -29,6 +29,9 @@ def chmod_plus_x(path):
     )
 
 def main():
+    if not sys.maxsize > 2**32:
+        print("CPM is not supported on 32-bit platforms")
+
     r = requests.get("https://api.github.com/repos/CityOfZion/cpm/releases")
 
     for release in r.json():

--- a/boa3/cpm.py
+++ b/boa3/cpm.py
@@ -4,6 +4,10 @@ import requests
 import platform
 import os
 import stat
+import logging
+
+logging.getLogger("requests").setLevel(logging.WARNING)
+logging.getLogger("urllib3").setLevel(logging.WARNING)
 
 def get_umask():
     umask = os.umask(0)

--- a/boa3/cpm.py
+++ b/boa3/cpm.py
@@ -1,0 +1,56 @@
+import sys
+
+import requests
+import platform
+import os
+import stat
+
+def get_umask():
+    umask = os.umask(0)
+    os.umask(umask)
+    return umask
+
+def chmod_plus_x(path):
+    os.chmod(
+        path,
+        os.stat(path).st_mode |
+        (
+            (
+                stat.S_IXUSR |
+                stat.S_IXGRP |
+                stat.S_IXOTH
+            )
+            & ~get_umask()
+        )
+    )
+
+def main():
+    r = requests.get("https://api.github.com/repos/CityOfZion/cpm/releases")
+
+    for release in r.json():
+        tag = release['tag_name']
+        version = tag[1:]
+        if "x86_64" == platform.machine().lower():
+            arch = "amd64"
+        else:
+            # TODO: need somebody with ARM cpu to tell me what "machine()" prints because now 32-bit intel will also be labelled as arm
+            arch = "arm64"
+        system = platform.system().lower()
+        asset_needle = f"cpm_{version}_{system}_{arch}"
+        for asset in release['assets']:
+            if asset['name'] == asset_needle:
+                r = requests.get(asset['browser_download_url'], stream=True)
+                cpm_filename = f"{os.path.dirname(sys.argv[0])}/cpm"
+                with open(cpm_filename, 'wb') as f:
+                    for chunk in r.iter_content(chunk_size=1024):
+                        if chunk:  # filter out keep-alive new chunks
+                            f.write(chunk)
+                if system in ["darwin", "linux"]:
+                    chmod_plus_x(cpm_filename)
+                else:
+                    # TODO: check permissions windows
+                    print("yikes, this is windows. Is it executable?")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 base58>=1.0.3
 wheel>=0.30.0
+requests==2.28.2

--- a/setup.py
+++ b/setup.py
@@ -133,6 +133,7 @@ setup(
     entry_points={
        'console_scripts': [
            'neo3-boa=boa3.cli:main',
+           'install_cpm=boa3.cpm:main',
        ],
     },
 )


### PR DESCRIPTION
**Related issue**
N/A

**Summary or solution description**
@lllwvlvwlll mentioned that [CPM](https://github.com/CityOfZion/cpm) installation is one of hurdles for usage. While there are multiple installation options for CPM (`brew` for OSX, `dpkg` for linux and more), non are integrated with boa. Since he's doing workshops with Python/boa it seemed logical to at least integrate it here.

I've looked into making it a pip installable package that could become a simple dependency in the `requirements.txt` file. Apparently I was not the only one who tried packaging a binary on pip (by looking at the google/SO results), but nobody had a solution. The problem is not in packaging it, the problem is in automatically moving it into a location on the user path to allow execution after installation. There is no `post_install` like hook when pip installing.

This PR add a console script called `install_cpm` that will find the latest CPM release for the platform, downloads it and puts it in the console scripts dir. I've tested this on Linux and OSX (Intel  CPU's only). I choose `install_cpm` as name such that after installation you'd only have `cpm` in the auto complete, not `cpm_install`.

**TODO:**
- [x] Test on Windows (need help)
- [x] Get platform information for ARM based users (e.g. Macbook M1/M2) and fix `arch` variable setting
   - [x] Test on ARM system (will need @lllwvlvwlll for this)
