### PR TITLE
Refactor Python built-in types unit tests to use test runner

### DIFF
--- a/boa3_test/tests/compiler_tests/test_bytes.py
+++ b/boa3_test/tests/compiler_tests/test_bytes.py
@@ -3,10 +3,9 @@ from boa3.exception import CompilerError, CompilerWarning
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.StackItem import StackItemType
-from boa3.neo.vm.type.String import String
+from boa3.neo3.vm import VMState
+from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.boa_test import BoaTest
-from boa3_test.tests.test_classes.TestExecutionException import TestExecutionException
-from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestBytes(BoaTest):
@@ -54,11 +53,22 @@ class TestBytes(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', bytes([1, 2, 3]))
-        self.assertEqual(1, result)
-        result = self.run_smart_contract(engine, path, 'Main', b'0')
-        self.assertEqual(48, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', bytes([1, 2, 3])))
+        expected_results.append(1)
+        invokes.append(runner.call_contract(path, 'Main', b'0'))
+        expected_results.append(48)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_bytes_get_value_negative_index(self):
         expected_output = (
@@ -83,11 +93,22 @@ class TestBytes(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', bytes([1, 2, 3]))
-        self.assertEqual(3, result)
-        result = self.run_smart_contract(engine, path, 'Main', b'0')
-        self.assertEqual(48, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', bytes([1, 2, 3])))
+        expected_results.append(3)
+        invokes.append(runner.call_contract(path, 'Main', b'0'))
+        expected_results.append(48)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_bytes_set_value(self):
         path = self.get_contract_path('BytesSetValue.py')
@@ -102,18 +123,36 @@ class TestBytes(BoaTest):
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_bytes_to_int(self):
-        path = self.get_contract_path('BytesToInt.py')
+        path, _ = self.get_deploy_file_paths('BytesToInt.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'bytes_to_int')
-        self.assertEqual(513, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'bytes_to_int'))
+        expected_results.append(513)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_bytes_to_int_with_builtin(self):
-        path = self.get_contract_path('BytesToIntWithBuiltin.py')
+        path, _ = self.get_deploy_file_paths('BytesToIntWithBuiltin.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'bytes_to_int')
-        self.assertEqual(513, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'bytes_to_int'))
+        expected_results.append(513)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_bytes_to_int_mismatched_types(self):
         path = self.get_contract_path('BytesToIntWithBuiltinMismatchedTypes.py')
@@ -124,62 +163,116 @@ class TestBytes(BoaTest):
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_bytes_to_bool(self):
-        path = self.get_contract_path('BytesToBool.py')
+        path, _ = self.get_deploy_file_paths('BytesToBool.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'bytes_to_bool', b'\x00')
-        self.assertEqual(False, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'bytes_to_bool', b'\x01')
-        self.assertEqual(True, result)
+        invokes.append(runner.call_contract(path, 'bytes_to_bool', b'\x00'))
+        expected_results.append(False)
 
-        result = self.run_smart_contract(engine, path, 'bytes_to_bool', b'\x02')
-        self.assertEqual(True, result)
+        invokes.append(runner.call_contract(path, 'bytes_to_bool', b'\x01'))
+        expected_results.append(True)
+
+        invokes.append(runner.call_contract(path, 'bytes_to_bool', b'\x02'))
+        expected_results.append(True)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_bytes_to_bool_with_builtin(self):
-        path = self.get_contract_path('BytesToBoolWithBuiltin.py')
+        path, _ = self.get_deploy_file_paths('BytesToBoolWithBuiltin.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'bytes_to_bool', b'\x00')
-        self.assertEqual(False, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'bytes_to_bool', b'\x01')
-        self.assertEqual(True, result)
+        invokes.append(runner.call_contract(path, 'bytes_to_bool', b'\x00'))
+        expected_results.append(False)
 
-        result = self.run_smart_contract(engine, path, 'bytes_to_bool', b'\x02')
-        self.assertEqual(True, result)
+        invokes.append(runner.call_contract(path, 'bytes_to_bool', b'\x01'))
+        expected_results.append(True)
+
+        invokes.append(runner.call_contract(path, 'bytes_to_bool', b'\x02'))
+        expected_results.append(True)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_bytes_to_bool_with_builtin_hard_coded_false(self):
-        path = self.get_contract_path('BytesToBoolWithBuiltinHardCodedFalse.py')
+        path, _ = self.get_deploy_file_paths('BytesToBoolWithBuiltinHardCodedFalse.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'bytes_to_bool')
-        self.assertEqual(False, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'bytes_to_bool'))
+        expected_results.append(False)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_bytes_to_bool_with_builtin_hard_coded_true(self):
-        path = self.get_contract_path('BytesToBoolWithBuiltinHardCodedTrue.py')
+        path, _ = self.get_deploy_file_paths('BytesToBoolWithBuiltinHardCodedTrue.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'bytes_to_bool')
-        self.assertEqual(True, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'bytes_to_bool'))
+        expected_results.append(True)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_bytes_to_bool_mismatched_types(self):
         path = self.get_contract_path('BytesToBoolWithBuiltinMismatchedTypes.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_bytes_to_str(self):
-        path = self.get_contract_path('BytesToStr.py')
+        path, _ = self.get_deploy_file_paths('BytesToStr.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'bytes_to_str')
-        self.assertEqual('abc', result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'bytes_to_str'))
+        expected_results.append('abc')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_bytes_to_str_with_builtin(self):
-        path = self.get_contract_path('BytesToStrWithBuiltin.py')
+        path, _ = self.get_deploy_file_paths('BytesToStrWithBuiltin.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'bytes_to_str')
-        self.assertEqual('123', result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'bytes_to_str'))
+        expected_results.append('123')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_bytes_to_str_mismatched_types(self):
         path = self.get_contract_path('BytesToStrWithBuiltinMismatchedTypes.py')
@@ -206,283 +299,346 @@ class TestBytes(BoaTest):
         self.assertEqual(expected_output, output)
 
     def test_assign_with_slice(self):
-        path = self.get_contract_path('AssignSlice.py')
+        path, _ = self.get_deploy_file_paths('AssignSlice.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', b'unittest',
-                                         expected_result_type=bytearray)
-        self.assertEqual(b'unittest'[1:2], result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', b'123',
-                                         expected_result_type=bytearray)
-        self.assertEqual(b'123'[1:2], result)
+        invokes.append(runner.call_contract(path, 'main', b'unittest',
+                                            expected_result_type=bytearray))
+        expected_results.append(b'unittest'[1:2])
 
-        result = self.run_smart_contract(engine, path, 'main', bytearray(),
-                                         expected_result_type=bytearray)
-        self.assertEqual(bytearray()[1:2], result)
+        invokes.append(runner.call_contract(path, 'main', b'123',
+                                            expected_result_type=bytearray))
+        expected_results.append(b'123'[1:2])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        # TODO: fix on #864dzfnew
+        runner.call_contract(path, 'main', bytearray(),
+                             expected_result_type=bytearray)
+        # expected_results.append(bytearray()[1:2])
+
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
 
     def test_slice_with_cast(self):
-        path = self.get_contract_path('SliceWithCast.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', b'unittest',
-                                         expected_result_type=bytes)
-        self.assertEqual(b'unittest'[1:2], result)
+        path, _ = self.get_deploy_file_paths('SliceWithCast.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', '123',
-                                         expected_result_type=bytes)
-        self.assertEqual(b'123'[1:2], result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', bytearray(),
-                                         expected_result_type=bytearray)
-        self.assertEqual(bytearray()[1:2], result)
+        invokes.append(runner.call_contract(path, 'main', b'unittest',
+                                            expected_result_type=bytes))
+        expected_results.append(b'unittest'[1:2])
 
-        result = self.run_smart_contract(engine, path, 'main', 12345,
-                                         expected_result_type=bytes)
-        self.assertEqual(Integer(12345).to_byte_array()[1:2], result)
+        invokes.append(runner.call_contract(path, 'main', '123',
+                                            expected_result_type=bytes))
+        expected_results.append(b'123'[1:2])
+
+        invokes.append(runner.call_contract(path, 'main', 12345,
+                                            expected_result_type=bytes))
+        expected_results.append(Integer(12345).to_byte_array()[1:2])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        # TODO: fix on #864dzfnew
+        runner.call_contract(path, 'main', bytearray(),
+                             expected_result_type=bytearray)
+        # expected_results.append(bytearray()[1:2])
+
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
 
     def test_slice_with_stride(self):
-        path = self.get_contract_path('SliceWithStride.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('SliceWithStride.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         a = b'unit_test'
         expected_result = a[2:5:2]
-        result = self.run_smart_contract(engine, path, 'literal_values',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'literal_values',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         a = b'unit_test'
         expected_result = a[-6:5:2]
-        result = self.run_smart_contract(engine, path, 'negative_start',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_start',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         a = b'unit_test'
         expected_result = a[0:-1:2]
-        result = self.run_smart_contract(engine, path, 'negative_end',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_end',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         a = b'unit_test'
         expected_result = a[-6:-1:2]
-        result = self.run_smart_contract(engine, path, 'negative_values',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_values',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         a = b'unit_test'
         expected_result = a[-999:5:2]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_start',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_really_low_start',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         a = b'unit_test'
         expected_result = a[0:-999:2]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_end',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_really_low_end',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         a = b'unit_test'
         expected_result = a[-999:-999:2]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_values',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_really_low_values',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         a = b'unit_test'
         expected_result = a[999:5:2]
-        result = self.run_smart_contract(engine, path, 'really_high_start',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'really_high_start',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         a = b'unit_test'
         expected_result = a[0:999:2]
-        result = self.run_smart_contract(engine, path, 'really_high_end',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'really_high_end',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         a = b'unit_test'
         expected_result = a[999:999:2]
-        result = self.run_smart_contract(engine, path, 'really_high_values',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'really_high_values',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_slice_with_negative_stride(self):
-        path = self.get_contract_path('SliceWithNegativeStride.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('SliceWithNegativeStride.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         a = b'unit_test'
         expected_result = a[2:5:-1]
-        result = self.run_smart_contract(engine, path, 'literal_values',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'literal_values',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         a = b'unit_test'
         expected_result = a[-6:5:-1]
-        result = self.run_smart_contract(engine, path, 'negative_start',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_start',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         a = b'unit_test'
         expected_result = a[0:-1:-1]
-        result = self.run_smart_contract(engine, path, 'negative_end',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_end',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         a = b'unit_test'
         expected_result = a[-6:-1:-1]
-        result = self.run_smart_contract(engine, path, 'negative_values',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_values',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         a = b'unit_test'
         expected_result = a[-999:5:-1]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_start',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_really_low_start',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         a = b'unit_test'
         expected_result = a[0:-999:-1]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_end',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_really_low_end',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         a = b'unit_test'
         expected_result = a[-999:-999:-1]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_values',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_really_low_values',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         a = b'unit_test'
         expected_result = a[999:5:-1]
-        result = self.run_smart_contract(engine, path, 'really_high_start',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'really_high_start',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         a = b'unit_test'
         expected_result = a[0:999:-1]
-        result = self.run_smart_contract(engine, path, 'really_high_end',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'really_high_end',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         a = b'unit_test'
         expected_result = a[999:999:-1]
-        result = self.run_smart_contract(engine, path, 'really_high_values',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'really_high_values',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_slice_omitted_with_stride(self):
-        path = self.get_contract_path('SliceOmittedWithStride.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('SliceOmittedWithStride.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         a = b'unit_test'
         expected_result = a[::2]
-        result = self.run_smart_contract(engine, path, 'omitted_values',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'omitted_values',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         a = b'unit_test'
         expected_result = a[:5:2]
-        result = self.run_smart_contract(engine, path, 'omitted_start',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'omitted_start',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         a = b'unit_test'
         expected_result = a[2::2]
-        result = self.run_smart_contract(engine, path, 'omitted_end',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'omitted_end',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         a = b'unit_test'
         expected_result = a[-6::2]
-        result = self.run_smart_contract(engine, path, 'negative_start',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_start',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         a = b'unit_test'
         expected_result = a[:-1:2]
-        result = self.run_smart_contract(engine, path, 'negative_end',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_end',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         a = b'unit_test'
         expected_result = a[-999::2]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_start',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_really_low_start',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         a = b'unit_test'
         expected_result = a[:-999:2]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_end',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_really_low_end',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         a = b'unit_test'
         expected_result = a[999::2]
-        result = self.run_smart_contract(engine, path, 'really_high_start',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'really_high_start',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         a = b'unit_test'
         expected_result = a[:999:2]
-        result = self.run_smart_contract(engine, path, 'really_high_end',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'really_high_end',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_slice_omitted_with_negative_stride(self):
-        path = self.get_contract_path('SliceOmittedWithNegativeStride.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('SliceOmittedWithNegativeStride.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         a = b'unit_test'
         expected_result = a[::-2]
-        result = self.run_smart_contract(engine, path, 'omitted_values',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'omitted_values',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         a = b'unit_test'
         expected_result = a[:5:-2]
-        result = self.run_smart_contract(engine, path, 'omitted_start',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'omitted_start',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         a = b'unit_test'
         expected_result = a[2::-2]
-        result = self.run_smart_contract(engine, path, 'omitted_end',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'omitted_end',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         a = b'unit_test'
         expected_result = a[-6::-2]
-        result = self.run_smart_contract(engine, path, 'negative_start',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_start',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         a = b'unit_test'
         expected_result = a[:-1:-2]
-        result = self.run_smart_contract(engine, path, 'negative_end',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_end',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         a = b'unit_test'
         expected_result = a[-999::-2]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_start',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_really_low_start',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         a = b'unit_test'
         expected_result = a[:-999:-2]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_end',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_really_low_end',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         a = b'unit_test'
         expected_result = a[999::-2]
-        result = self.run_smart_contract(engine, path, 'really_high_start',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'really_high_start',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         a = b'unit_test'
         expected_result = a[:999:-2]
-        result = self.run_smart_contract(engine, path, 'really_high_end',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'really_high_end',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_byte_array_get_value(self):
         expected_output = (
@@ -507,11 +663,22 @@ class TestBytes(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', bytes([1, 2, 3]))
-        self.assertEqual(1, result)
-        result = self.run_smart_contract(engine, path, 'Main', b'0')
-        self.assertEqual(48, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', bytes([1, 2, 3])))
+        expected_results.append(1)
+        invokes.append(runner.call_contract(path, 'Main', b'0'))
+        expected_results.append(48)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_byte_array_get_value_negative_index(self):
         expected_output = (
@@ -536,11 +703,22 @@ class TestBytes(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', bytes([1, 2, 3]))
-        self.assertEqual(3, result)
-        result = self.run_smart_contract(engine, path, 'Main', b'0')
-        self.assertEqual(48, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', bytes([1, 2, 3])))
+        expected_results.append(3)
+        invokes.append(runner.call_contract(path, 'Main', b'0'))
+        expected_results.append(48)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_byte_array_set_value(self):
         expected_output = (
@@ -570,13 +748,24 @@ class TestBytes(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', b'123',
-                                         expected_result_type=bytes)
-        self.assertEqual(b'\x0123', result)
-        result = self.run_smart_contract(engine, path, 'Main', b'0',
-                                         expected_result_type=bytes)
-        self.assertEqual(b'\x01', result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', b'123',
+                                            expected_result_type=bytes))
+        expected_results.append(b'\x0123')
+        invokes.append(runner.call_contract(path, 'Main', b'0',
+                                            expected_result_type=bytes))
+        expected_results.append(b'\x01')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_byte_array_set_value_negative_index(self):
         expected_output = (
@@ -606,13 +795,24 @@ class TestBytes(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', b'123',
-                                         expected_result_type=bytes)
-        self.assertEqual(b'12\x01', result)
-        result = self.run_smart_contract(engine, path, 'Main', b'0',
-                                         expected_result_type=bytes)
-        self.assertEqual(b'\x01', result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', b'123',
+                                            expected_result_type=bytes))
+        expected_results.append(b'12\x01')
+        invokes.append(runner.call_contract(path, 'Main', b'0',
+                                            expected_result_type=bytes))
+        expected_results.append(b'\x01')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_byte_array_literal_value(self):
         data = b'\x01\x02\x03'
@@ -642,10 +842,21 @@ class TestBytes(BoaTest):
         output, manifest = self.compile_and_save(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'create_bytearray',
-                                         expected_result_type=bytearray)
-        self.assertEqual(bytearray(), result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'create_bytearray',
+                                            expected_result_type=bytearray))
+        expected_results.append(bytearray())
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_byte_array_from_literal_bytes(self):
         data = b'\x01\x02\x03'
@@ -701,19 +912,32 @@ class TestBytes(BoaTest):
         output, manifest = self.compile_and_save(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'create_bytearray', 10,
-                                         expected_result_type=bytearray)
-        self.assertEqual(bytearray(10), result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'create_bytearray', 0,
-                                         expected_result_type=bytearray)
-        self.assertEqual(bytearray(0), result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'create_bytearray', 10,
+                                            expected_result_type=bytearray))
+        expected_results.append(bytearray(10))
+
+        invokes.append(runner.call_contract(path, 'create_bytearray', 0,
+                                            expected_result_type=bytearray))
+        expected_results.append(bytearray(0))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
         # cannot build with negative size
-        with self.assertRaisesRegex(TestExecutionException, f'^{self.MAX_ITEM_SIZE_EXCEED_MSG_PREFIX}'):
-            result = self.run_smart_contract(engine, path, 'create_bytearray', -10,
-                                             expected_result_type=bytes)
+        runner.call_contract(path, 'create_bytearray', -10,
+                             expected_result_type=bytes)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'^{self.MAX_ITEM_SIZE_EXCEED_MSG_PREFIX}')
 
     def test_byte_array_from_list_of_int(self):
         path = self.get_contract_path('BytearrayFromListOfInt.py')
@@ -726,536 +950,833 @@ class TestBytes(BoaTest):
         self.assertEqual(expected_error._error_message, compiler_error_message)
 
     def test_byte_array_string(self):
-        path = self.get_contract_path('BytearrayFromString.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('BytearrayFromString.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         # Neo3-boa's bytearray only converts with utf-8 encoding
         string = 'string value'
-        result = self.run_smart_contract(engine, path, 'main', string, expected_result_type=bytearray)
-        self.assertEqual(bytearray(string, 'utf-8'), result)
+        invokes.append(runner.call_contract(path, 'main', string, expected_result_type=bytearray))
+        expected_results.append(bytearray(string, 'utf-8'))
 
         string = 'áãõ😀'
-        result = self.run_smart_contract(engine, path, 'main', string, expected_result_type=bytearray)
-        self.assertEqual(bytearray(string, 'utf-8'), result)
+        invokes.append(runner.call_contract(path, 'main', string, expected_result_type=bytearray))
+        expected_results.append(bytearray(string, 'utf-8'))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_byte_array_string_with_encoding(self):
         path = self.get_contract_path('BytearrayFromStringWithEncoding.py')
         self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
 
     def test_byte_array_append(self):
-        path = self.get_contract_path('BytearrayAppend.py')
+        path, _ = self.get_deploy_file_paths('BytearrayAppend.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main',
-                                         expected_result_type=bytes)
-        self.assertEqual(b'\x01\x02\x03\x04', result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main',
+                                            expected_result_type=bytes))
+        expected_results.append(b'\x01\x02\x03\x04')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_byte_array_append_with_builtin(self):
-        path = self.get_contract_path('BytearrayAppendWithBuiltin.py')
+        path, _ = self.get_deploy_file_paths('BytearrayAppendWithBuiltin.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main',
-                                         expected_result_type=bytes)
-        self.assertEqual(b'\x01\x02\x03\x04', result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main',
+                                            expected_result_type=bytes))
+        expected_results.append(b'\x01\x02\x03\x04')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_byte_array_append_mutable_sequence_with_builtin(self):
-        path = self.get_contract_path('BytearrayAppendWithMutableSequence.py')
+        path, _ = self.get_deploy_file_paths('BytearrayAppendWithMutableSequence.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main',
-                                         expected_result_type=bytes)
-        self.assertEqual(b'\x01\x02\x03\x04', result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main',
+                                            expected_result_type=bytes))
+        expected_results.append(b'\x01\x02\x03\x04')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_byte_array_clear(self):
-        path = self.get_contract_path('BytearrayClear.py')
+        path, _ = self.get_deploy_file_paths('BytearrayClear.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main',
-                                         expected_result_type=bytes)
-        self.assertEqual(b'', result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main',
+                                            expected_result_type=bytes))
+        expected_results.append(b'')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_byte_array_reverse(self):
-        path = self.get_contract_path('BytearrayReverse.py')
-        Boa3.compile(path)
+        path, _ = self.get_deploy_file_paths('BytearrayReverse.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main',
-                                         expected_result_type=bytes)
-        self.assertEqual(b'\x03\x02\x01', result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main',
+                                            expected_result_type=bytes))
+        expected_results.append(b'\x03\x02\x01')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_byte_array_extend(self):
-        path = self.get_contract_path('BytearrayExtend.py')
-        Boa3.compile(path)
+        path, _ = self.get_deploy_file_paths('BytearrayExtend.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main',
-                                         expected_result_type=bytes)
-        self.assertEqual(b'\x01\x02\x03\x04\x05\x06', result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main',
+                                            expected_result_type=bytes))
+        expected_results.append(b'\x01\x02\x03\x04\x05\x06')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_byte_array_extend_with_builtin(self):
-        path = self.get_contract_path('BytearrayExtendWithBuiltin.py')
-        Boa3.compile(path)
+        path, _ = self.get_deploy_file_paths('BytearrayExtendWithBuiltin.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main',
-                                         expected_result_type=bytes)
-        self.assertEqual(b'\x01\x02\x03\x04\x05\x06', result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main',
+                                            expected_result_type=bytes))
+        expected_results.append(b'\x01\x02\x03\x04\x05\x06')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_byte_array_to_int(self):
-        path = self.get_contract_path('BytearrayToInt.py')
+        path, _ = self.get_deploy_file_paths('BytearrayToInt.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'bytes_to_int')
-        self.assertEqual(513, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'bytes_to_int'))
+        expected_results.append(513)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_byte_array_to_int_with_builtin(self):
-        path = self.get_contract_path('BytearrayToIntWithBuiltin.py')
+        path, _ = self.get_deploy_file_paths('BytearrayToIntWithBuiltin.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'bytes_to_int')
-        self.assertEqual(513, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'bytes_to_int'))
+        expected_results.append(513)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_byte_array_to_int_with_bytes_builtin(self):
-        path = self.get_contract_path('BytearrayToIntWithBytesBuiltin.py')
+        path, _ = self.get_deploy_file_paths('BytearrayToIntWithBytesBuiltin.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'bytes_to_int')
-        self.assertEqual(513, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'bytes_to_int'))
+        expected_results.append(513)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_boa2_byte_array_test(self):
-        path = self.get_contract_path('BytearrayBoa2Test.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main',
-                                         expected_result_type=bytes)
-        self.assertEqual(b'\t\x01\x02', result)
+        path, _ = self.get_deploy_file_paths('BytearrayBoa2Test.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main',
+                                            expected_result_type=bytes))
+        expected_results.append(b'\t\x01\x02')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_boa2_byte_array_test2(self):
         path = self.get_contract_path('BytearrayBoa2Test2.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_boa2_byte_array_test3(self):
-        path = self.get_contract_path('BytearrayBoa2Test3.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(b'\x01\x02\xaa\xfe', result)
+        path, _ = self.get_deploy_file_paths('BytearrayBoa2Test3.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(b'\x01\x02\xaa\xfe')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_boa2_slice_test(self):
-        path = self.get_contract_path('SliceBoa2Test.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main',
-                                         expected_result_type=bytes)
-        self.assertEqual(b'\x01\x02\x03\x04', result)
+        path, _ = self.get_deploy_file_paths('SliceBoa2Test.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main',
+                                            expected_result_type=bytes))
+        expected_results.append(b'\x01\x02\x03\x04')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_boa2_slice_test2(self):
-        path = self.get_contract_path('SliceBoa2Test2.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main',
-                                         expected_result_type=bytes)
-        self.assertEqual(b'\x02\x03\x04\x02\x03\x04\x05\x06\x01\x02\x03\x04\x03\x04', result)
+        path, _ = self.get_deploy_file_paths('SliceBoa2Test2.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main',
+                                            expected_result_type=bytes))
+        expected_results.append(b'\x02\x03\x04\x02\x03\x04\x05\x06\x01\x02\x03\x04\x03\x04')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_uint160_bytes(self):
-        path = self.get_contract_path('UInt160Bytes.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main')
-        if isinstance(result, str):
-            from boa3.neo.vm.type.String import String
-            result = String(result).to_bytes()
-        self.assertEqual(b'0123456789abcdefghij', result)
+        path, _ = self.get_deploy_file_paths('UInt160Bytes.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main',
+                                            expected_result_type=bytes))
+        expected_results.append(b'0123456789abcdefghij')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_uint160_int(self):
-        path = self.get_contract_path('UInt160Int.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main')
-        if isinstance(result, str):
-            from boa3.neo.vm.type.String import String
-            result = String(result).to_bytes()
-        self.assertEqual((160).to_bytes(2, 'little') + bytes(18), result)
+        path, _ = self.get_deploy_file_paths('UInt160Int.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main',
+                                            expected_result_type=bytes))
+        expected_results.append((160).to_bytes(2, 'little') + bytes(18))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_uint256_bytes(self):
-        path = self.get_contract_path('UInt256Bytes.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main')
-        if isinstance(result, str):
-            result = String(result).to_bytes()
-        self.assertEqual(b'0123456789abcdefghijklmnopqrstuv', result)
+        path, _ = self.get_deploy_file_paths('UInt256Bytes.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main',
+                                            expected_result_type=bytes))
+        expected_results.append(b'0123456789abcdefghijklmnopqrstuv')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_uint256_int(self):
-        path = self.get_contract_path('UInt256Int.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main')
-        if isinstance(result, str):
-            result = String(result).to_bytes()
-        self.assertEqual((256).to_bytes(2, 'little') + bytes(30), result)
+        path, _ = self.get_deploy_file_paths('UInt256Int.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main',
+                                            expected_result_type=bytes))
+        expected_results.append((256).to_bytes(2, 'little') + bytes(30))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_bytes_upper(self):
-        path = self.get_contract_path('UpperBytesMethod.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('UpperBytesMethod.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         bytes_value = b'abcdefghijklmnopqrstuvwxyz'
-        result = self.run_smart_contract(engine, path, 'main', bytes_value, expected_result_type=bytes)
-        self.assertEqual(bytes_value.upper(), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value, expected_result_type=bytes))
+        expected_results.append(bytes_value.upper())
 
         bytes_value = b'a1b123y3z'
-        result = self.run_smart_contract(engine, path, 'main', bytes_value, expected_result_type=bytes)
-        self.assertEqual(bytes_value.upper(), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value, expected_result_type=bytes))
+        expected_results.append(bytes_value.upper())
 
         bytes_value = b'!@#$%123*-/'
-        result = self.run_smart_contract(engine, path, 'main', bytes_value, expected_result_type=bytes)
-        self.assertEqual(bytes_value.upper(), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value, expected_result_type=bytes))
+        expected_results.append(bytes_value.upper())
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_bytes_lower(self):
-        path = self.get_contract_path('LowerBytesMethod.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('LowerBytesMethod.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         bytes_value = b'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
-        result = self.run_smart_contract(engine, path, 'main', bytes_value, expected_result_type=bytes)
-        self.assertEqual(bytes_value.lower(), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value, expected_result_type=bytes))
+        expected_results.append(bytes_value.lower())
 
         bytes_value = b'A1B123Y3Z'
-        result = self.run_smart_contract(engine, path, 'main', bytes_value, expected_result_type=bytes)
-        self.assertEqual(bytes_value.lower(), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value, expected_result_type=bytes))
+        expected_results.append(bytes_value.lower())
 
         bytes_value = b'!@#$%123*-/'
-        result = self.run_smart_contract(engine, path, 'main', bytes_value, expected_result_type=bytes)
-        self.assertEqual(bytes_value.lower(), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value, expected_result_type=bytes))
+        expected_results.append(bytes_value.lower())
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_bytes_startswith_method(self):
-        path = self.get_contract_path('StartswithBytesMethod.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('StartswithBytesMethod.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         bytes_value = b'unit_test'
         subbytes_value = b'unit'
         start = 0
         end = len(bytes_value)
-        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value, start, end)
-        self.assertEqual(bytes_value.startswith(subbytes_value, start, end), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value, subbytes_value, start, end))
+        expected_results.append(bytes_value.startswith(subbytes_value, start, end))
 
         bytes_value = b'unit_test'
         subbytes_value = b'unit'
         start = 2
         end = 6
-        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value, start, end)
-        self.assertEqual(bytes_value.startswith(subbytes_value, start, end), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value, subbytes_value, start, end))
+        expected_results.append(bytes_value.startswith(subbytes_value, start, end))
 
         bytes_value = b'unit_test'
         subbytes_value = b'it'
         start = 2
         end = 6
-        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value, start, end)
-        self.assertEqual(bytes_value.startswith(subbytes_value, start, end), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value, subbytes_value, start, end))
+        expected_results.append(bytes_value.startswith(subbytes_value, start, end))
 
         bytes_value = b'unit_test'
         subbytes_value = b'it'
         start = 2
         end = 3
-        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value, start, end)
-        self.assertEqual(bytes_value.startswith(subbytes_value, start, end), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value, subbytes_value, start, end))
+        expected_results.append(bytes_value.startswith(subbytes_value, start, end))
 
         bytes_value = b'unit_test'
         subbytes_value = b'unit_tes'
         start = -99
         end = -1
-        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value, start, end)
-        self.assertEqual(bytes_value.startswith(subbytes_value, start, end), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value, subbytes_value, start, end))
+        expected_results.append(bytes_value.startswith(subbytes_value, start, end))
 
         bytes_value = b'unit_test'
         subbytes_value = b''
         start = 0
         end = 0
-        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value, start, end)
-        self.assertEqual(bytes_value.startswith(subbytes_value, start, end), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value, subbytes_value, start, end))
+        expected_results.append(bytes_value.startswith(subbytes_value, start, end))
 
         bytes_value = b'unit_test'
         subbytes_value = b'unit_test'
         start = 0
         end = 99
-        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value, start, end)
-        self.assertEqual(bytes_value.startswith(subbytes_value, start, end), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value, subbytes_value, start, end))
+        expected_results.append(bytes_value.startswith(subbytes_value, start, end))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_bytes_startswith_method_default_end(self):
-        path = self.get_contract_path('StartswithBytesMethodDefaultEnd.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('StartswithBytesMethodDefaultEnd.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         bytes_value = b'unit_test'
         subbytes_value = b'unit'
         start = 0
-        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value, start)
-        self.assertEqual(bytes_value.startswith(subbytes_value, start), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value, subbytes_value, start))
+        expected_results.append(bytes_value.startswith(subbytes_value, start))
 
         bytes_value = b'unit_test'
         subbytes_value = b'unit'
         start = 2
-        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value, start)
-        self.assertEqual(bytes_value.startswith(subbytes_value, start), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value, subbytes_value, start))
+        expected_results.append(bytes_value.startswith(subbytes_value, start))
 
         bytes_value = b'unit_test'
         subbytes_value = b'it'
         start = 2
-        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value, start)
-        self.assertEqual(bytes_value.startswith(subbytes_value, start), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value, subbytes_value, start))
+        expected_results.append(bytes_value.startswith(subbytes_value, start))
 
         bytes_value = b'unit_test'
         subbytes_value = b'it'
         start = 3
-        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value, start)
-        self.assertEqual(bytes_value.startswith(subbytes_value, start), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value, subbytes_value, start))
+        expected_results.append(bytes_value.startswith(subbytes_value, start))
 
         bytes_value = b'unit_test'
         subbytes_value = b'unit_tes'
         start = -99
-        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value, start)
-        self.assertEqual(bytes_value.startswith(subbytes_value, start), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value, subbytes_value, start))
+        expected_results.append(bytes_value.startswith(subbytes_value, start))
 
         bytes_value = b'unit_test'
         subbytes_value = b''
         start = 0
-        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value, start)
-        self.assertEqual(bytes_value.startswith(subbytes_value, start), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value, subbytes_value, start))
+        expected_results.append(bytes_value.startswith(subbytes_value, start))
 
         bytes_value = b'unit_test'
         subbytes_value = b''
         start = 99
-        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value, start)
-        self.assertEqual(bytes_value.startswith(subbytes_value, start), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value, subbytes_value, start))
+        expected_results.append(bytes_value.startswith(subbytes_value, start))
 
         bytes_value = b'unit_test'
         subbytes_value = b'unit_test'
         start = 0
-        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value, start)
-        self.assertEqual(bytes_value.startswith(subbytes_value, start), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value, subbytes_value, start))
+        expected_results.append(bytes_value.startswith(subbytes_value, start))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_bytes_startswith_method_defaults(self):
-        path = self.get_contract_path('StartswithBytesMethodDefaults.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('StartswithBytesMethodDefaults.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         bytes_value = b'unit_test'
         subbytes_value = b'unit'
-        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value)
-        self.assertEqual(bytes_value.startswith(subbytes_value), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value, subbytes_value))
+        expected_results.append(bytes_value.startswith(subbytes_value))
 
         bytes_value = b'unit_test'
         subbytes_value = b'unit_test'
-        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value)
-        self.assertEqual(bytes_value.startswith(subbytes_value), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value, subbytes_value))
+        expected_results.append(bytes_value.startswith(subbytes_value))
 
         bytes_value = b'unit_test'
         subbytes_value = b''
-        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value)
-        self.assertEqual(bytes_value.startswith(subbytes_value), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value, subbytes_value))
+        expected_results.append(bytes_value.startswith(subbytes_value))
 
         bytes_value = b'unit_test'
         subbytes_value = b'12345'
-        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value)
-        self.assertEqual(bytes_value.startswith(subbytes_value), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value, subbytes_value))
+        expected_results.append(bytes_value.startswith(subbytes_value))
 
         bytes_value = b'unit_test'
         subbytes_value = b'bigger subbytes_value'
-        result = self.run_smart_contract(engine, path, 'main', bytes_value, subbytes_value)
-        self.assertEqual(bytes_value.startswith(subbytes_value), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value, subbytes_value))
+        expected_results.append(bytes_value.startswith(subbytes_value))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_bytes_strip(self):
-        path = self.get_contract_path('StripBytesMethod.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('StripBytesMethod.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         bytes_value = b'abcdefghijklmnopqrstuvwxyz'
         sub_bytes = b'abcxyz'
-        result = self.run_smart_contract(engine, path, 'main', bytes_value, sub_bytes,
-                                         expected_result_type=bytes)
-        self.assertEqual(bytes_value.strip(sub_bytes), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value, sub_bytes,
+                                            expected_result_type=bytes))
+        expected_results.append(bytes_value.strip(sub_bytes))
 
         bytes_value = b'abcdefghijklmnopqrsvwxyz unit test abcdefghijklmnopqrsvwxyz'
         sub_bytes = b'abcdefghijklmnopqrsvwxyz '
-        result = self.run_smart_contract(engine, path, 'main', bytes_value, sub_bytes,
-                                         expected_result_type=bytes)
-        self.assertEqual(bytes_value.strip(sub_bytes), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value, sub_bytes,
+                                            expected_result_type=bytes))
+        expected_results.append(bytes_value.strip(sub_bytes))
 
         bytes_value = b'0123456789hello world987654310'
         sub_bytes = b'0987654321'
-        result = self.run_smart_contract(engine, path, 'main', bytes_value, sub_bytes,
-                                         expected_result_type=bytes)
-        self.assertEqual(bytes_value.strip(sub_bytes), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value, sub_bytes,
+                                            expected_result_type=bytes))
+        expected_results.append(bytes_value.strip(sub_bytes))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_bytes_strip_default(self):
-        path = self.get_contract_path('StripBytesMethodDefault.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('StripBytesMethodDefault.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         bytes_value = b'     unit test    '
-        result = self.run_smart_contract(engine, path, 'main', bytes_value,
-                                         expected_result_type=bytes)
-        self.assertEqual(bytes_value.strip(), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value,
+                                            expected_result_type=bytes))
+        expected_results.append(bytes_value.strip())
 
         bytes_value = b'unit test    '
-        result = self.run_smart_contract(engine, path, 'main', bytes_value,
-                                         expected_result_type=bytes)
-        self.assertEqual(bytes_value.strip(), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value,
+                                            expected_result_type=bytes))
+        expected_results.append(bytes_value.strip())
 
         bytes_value = b'    unit test'
-        result = self.run_smart_contract(engine, path, 'main', bytes_value,
-                                         expected_result_type=bytes)
-        self.assertEqual(bytes_value.strip(), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value,
+                                            expected_result_type=bytes))
+        expected_results.append(bytes_value.strip())
 
         bytes_value = b' \t\n\r\f\vunit test \t\n\r\f\v'
-        result = self.run_smart_contract(engine, path, 'main', bytes_value,
-                                         expected_result_type=bytes)
-        self.assertEqual(bytes_value.strip(), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value,
+                                            expected_result_type=bytes))
+        expected_results.append(bytes_value.strip())
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_isdigit_method(self):
-        path = self.get_contract_path('IsdigitMethod.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('IsdigitMethod.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         bytes_value = b'0123456789'
-        result = self.run_smart_contract(engine, path, 'main', bytes_value)
-        self.assertEqual(bytes_value.isdigit(), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value))
+        expected_results.append(bytes_value.isdigit())
 
         bytes_value = b'23mixed01'
-        result = self.run_smart_contract(engine, path, 'main', bytes_value)
-        self.assertEqual(bytes_value.isdigit(), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value))
+        expected_results.append(bytes_value.isdigit())
 
         bytes_value = b'no digits here'
-        result = self.run_smart_contract(engine, path, 'main', bytes_value)
-        self.assertEqual(bytes_value.isdigit(), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value))
+        expected_results.append(bytes_value.isdigit())
 
         bytes_value = b''
-        result = self.run_smart_contract(engine, path, 'main', bytes_value)
-        self.assertEqual(bytes_value.isdigit(), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value))
+        expected_results.append(bytes_value.isdigit())
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_bytes_join_with_sequence(self):
-        path = self.get_contract_path('JoinBytesMethodWithSequence.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('JoinBytesMethodWithSequence.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         bytes_value = b' '
         sequence = [b"Unit", b"Test", b"Neo3-boa"]
-        result = self.run_smart_contract(engine, path, 'main', bytes_value, sequence,
-                                         expected_result_type=bytes)
-        self.assertEqual(bytes_value.join(sequence), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value, sequence,
+                                            expected_result_type=bytes))
+        expected_results.append(bytes_value.join(sequence))
 
         bytes_value = b' '
         sequence = []
-        result = self.run_smart_contract(engine, path, 'main', bytes_value, sequence,
-                                         expected_result_type=bytes)
-        self.assertEqual(bytes_value.join(sequence), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value, sequence,
+                                            expected_result_type=bytes))
+        expected_results.append(bytes_value.join(sequence))
 
         bytes_value = b' '
         sequence = [b"UnitTest"]
-        result = self.run_smart_contract(engine, path, 'main', bytes_value, sequence,
-                                         expected_result_type=bytes)
-        self.assertEqual(bytes_value.join(sequence), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value, sequence,
+                                            expected_result_type=bytes))
+        expected_results.append(bytes_value.join(sequence))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_bytes_join_with_dictionary(self):
-        path = self.get_contract_path('JoinBytesMethodWithDictionary.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('JoinBytesMethodWithDictionary.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         bytes_value = b' '
         dictionary = {b"Unit": 1, b"Test": 2, b"Neo3-boa": 3}
-        result = self.run_smart_contract(engine, path, 'main', bytes_value, dictionary,
-                                         expected_result_type=bytes)
-        self.assertEqual(bytes_value.join(dictionary), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value, dictionary,
+                                            expected_result_type=bytes))
+        expected_results.append(bytes_value.join(dictionary))
 
         bytes_value = b' '
         dictionary = {}
-        result = self.run_smart_contract(engine, path, 'main', bytes_value, dictionary,
-                                         expected_result_type=bytes)
-        self.assertEqual(bytes_value.join(dictionary), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value, dictionary,
+                                            expected_result_type=bytes))
+        expected_results.append(bytes_value.join(dictionary))
 
         bytes_value = b' '
         dictionary = {b"UnitTest": 1}
-        result = self.run_smart_contract(engine, path, 'main', bytes_value, dictionary,
-                                         expected_result_type=bytes)
-        self.assertEqual(bytes_value.join(dictionary), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_value, dictionary,
+                                            expected_result_type=bytes))
+        expected_results.append(bytes_value.join(dictionary))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_bytes_index(self):
-        path = self.get_contract_path('IndexBytes.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('IndexBytes.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         bytes_ = b'unit test'
         subsequence = b'i'
         start = 0
         end = 4
-        result = self.run_smart_contract(engine, path, 'main', bytes_, subsequence, start, end)
-        self.assertEqual(bytes_.index(subsequence, start, end), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_, subsequence, start, end))
+        expected_results.append(bytes_.index(subsequence, start, end))
 
         bytes_ = b'unit test'
         bytes_sequence = b'i'
         start = 2
         end = 4
-        result = self.run_smart_contract(engine, path, 'main', bytes_, bytes_sequence, start, end)
-        self.assertEqual(bytes_.index(bytes_sequence, start, end), result)
-
-        with self.assertRaisesRegex(TestExecutionException, f'{self.SUBSEQUENCE_NOT_FOUND_MSG}$'):
-            self.run_smart_contract(engine, path, 'main', 'unit test', 'i', 3, 4)
-
-        with self.assertRaisesRegex(TestExecutionException, f'{self.SUBSEQUENCE_NOT_FOUND_MSG}$'):
-            self.run_smart_contract(engine, path, 'main', 'unit test', 'i', 4, -1)
-
-        with self.assertRaisesRegex(TestExecutionException, f'{self.SUBSEQUENCE_NOT_FOUND_MSG}$'):
-            self.run_smart_contract(engine, path, 'main', 'unit test', 'i', 0, -99)
+        invokes.append(runner.call_contract(path, 'main', bytes_, bytes_sequence, start, end))
+        expected_results.append(bytes_.index(bytes_sequence, start, end))
 
         bytes_ = b'unit test'
         bytes_sequence = b'i'
         start = 0
         end = -1
-        result = self.run_smart_contract(engine, path, 'main', bytes_, bytes_sequence, start, end)
-        self.assertEqual(bytes_.index(bytes_sequence, start, end), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_, bytes_sequence, start, end))
+        expected_results.append(bytes_.index(bytes_sequence, start, end))
 
         bytes_ = b'unit test'
         bytes_sequence = b'n'
         start = 0
         end = 99
-        result = self.run_smart_contract(engine, path, 'main', bytes_, bytes_sequence, start, end)
-        self.assertEqual(bytes_.index(bytes_sequence, start, end), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_, bytes_sequence, start, end))
+        expected_results.append(bytes_.index(bytes_sequence, start, end))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        invokes.append(runner.call_contract(path, 'main', 'unit test', 'i', 3, 4))
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'{self.SUBSEQUENCE_NOT_FOUND_MSG}$')
+
+        invokes.append(runner.call_contract(path, 'main', 'unit test', 'i', 4, -1))
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'{self.SUBSEQUENCE_NOT_FOUND_MSG}$')
+
+        invokes.append(runner.call_contract(path, 'main', 'unit test', 'i', 0, -99))
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'{self.SUBSEQUENCE_NOT_FOUND_MSG}$')
 
     def test_bytes_index_end_default(self):
-        path = self.get_contract_path('IndexBytesEndDefault.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('IndexBytesEndDefault.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         bytes_ = b'unit test'
         bytes_sequence = b't'
         start = 0
-        result = self.run_smart_contract(engine, path, 'main', bytes_, bytes_sequence, start)
-        self.assertEqual(bytes_.index(bytes_sequence, start), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_, bytes_sequence, start))
+        expected_results.append(bytes_.index(bytes_sequence, start))
 
         bytes_ = b'unit test'
         bytes_sequence = b't'
         start = 4
-        result = self.run_smart_contract(engine, path, 'main', bytes_, bytes_sequence, start)
-        self.assertEqual(bytes_.index(bytes_sequence, start), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_, bytes_sequence, start))
+        expected_results.append(bytes_.index(bytes_sequence, start))
 
         bytes_ = b'unit test'
         bytes_sequence = b't'
         start = 6
-        result = self.run_smart_contract(engine, path, 'main', bytes_, bytes_sequence, start)
-        self.assertEqual(bytes_.index(bytes_sequence, start), result)
-
-        with self.assertRaisesRegex(TestExecutionException, f'{self.SUBSEQUENCE_NOT_FOUND_MSG}$'):
-            self.run_smart_contract(engine, path, 'main', 'unit test', 'i', 99)
-
-        with self.assertRaisesRegex(TestExecutionException, f'{self.SUBSEQUENCE_NOT_FOUND_MSG}$'):
-            self.run_smart_contract(engine, path, 'main', 'unit test', 't', -1)
+        invokes.append(runner.call_contract(path, 'main', bytes_, bytes_sequence, start))
+        expected_results.append(bytes_.index(bytes_sequence, start))
 
         bytes_ = b'unit test'
         bytes_sequence = b'i'
         start = -10
-        result = self.run_smart_contract(engine, path, 'main', bytes_, bytes_sequence, start)
-        self.assertEqual(bytes_.index(bytes_sequence, start), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_, bytes_sequence, start))
+        expected_results.append(bytes_.index(bytes_sequence, start))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        invokes.append(runner.call_contract(path, 'main', 'unit test', 'i', 99))
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'{self.SUBSEQUENCE_NOT_FOUND_MSG}$')
+
+        invokes.append(runner.call_contract(path, 'main', 'unit test', 't', -1))
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'{self.SUBSEQUENCE_NOT_FOUND_MSG}$')
 
     def test_bytes_index_defaults(self):
-        path = self.get_contract_path('IndexBytesDefaults.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('IndexBytesDefaults.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         bytes_ = b'unit test'
         bytes_sequence = b'u'
-        result = self.run_smart_contract(engine, path, 'main', bytes_, bytes_sequence)
-        self.assertEqual(bytes_.index(bytes_sequence), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_, bytes_sequence))
+        expected_results.append(bytes_.index(bytes_sequence))
 
         bytes_ = b'unit test'
         bytes_sequence = b't'
-        result = self.run_smart_contract(engine, path, 'main', bytes_, bytes_sequence)
-        self.assertEqual(bytes_.index(bytes_sequence), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_, bytes_sequence))
+        expected_results.append(bytes_.index(bytes_sequence))
 
         bytes_ = b'unit test'
         bytes_sequence = b' '
-        result = self.run_smart_contract(engine, path, 'main', bytes_, bytes_sequence)
-        self.assertEqual(bytes_.index(bytes_sequence), result)
+        invokes.append(runner.call_contract(path, 'main', bytes_, bytes_sequence))
+        expected_results.append(bytes_.index(bytes_sequence))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_bytes_index_mismatched_type(self):
         path = self.get_contract_path('IndexBytesMismatchedType.py')

--- a/boa3_test/tests/compiler_tests/test_list.py
+++ b/boa3_test/tests/compiler_tests/test_list.py
@@ -4,9 +4,9 @@ from boa3.model.type.type import Type
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.String import String
+from boa3.neo3.vm import VMState
+from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.boa_test import BoaTest
-from boa3_test.tests.test_classes.TestExecutionException import TestExecutionException
-from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestList(BoaTest):
@@ -140,14 +140,28 @@ class TestList(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', [1, 2, 3, 4])
-        self.assertEqual(1, result)
-        result = self.run_smart_contract(engine, path, 'Main', [5, 3, 2])
-        self.assertEqual(5, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
 
-        with self.assertRaisesRegex(TestExecutionException, self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX):
-            self.run_smart_contract(engine, path, 'Main', [])
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', [1, 2, 3, 4]))
+        expected_results.append(1)
+        invokes.append(runner.call_contract(path, 'Main', [5, 3, 2]))
+        expected_results.append(5)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        runner.call_contract(path, 'Main', [])
+        runner.execute()
+
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX)
 
     def test_list_get_value_with_negative_index(self):
         expected_output = (
@@ -172,14 +186,28 @@ class TestList(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', [1, 2, 3, 4])
-        self.assertEqual(4, result)
-        result = self.run_smart_contract(engine, path, 'Main', [5, 3, 2])
-        self.assertEqual(2, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
 
-        with self.assertRaisesRegex(TestExecutionException, self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX):
-            self.run_smart_contract(engine, path, 'Main', [])
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', [1, 2, 3, 4]))
+        expected_results.append(4)
+        invokes.append(runner.call_contract(path, 'Main', [5, 3, 2]))
+        expected_results.append(2)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        runner.call_contract(path, 'Main', [])
+        runner.execute()
+
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX)
 
     def test_list_type_hint(self):
         expected_output = (
@@ -217,27 +245,55 @@ class TestList(BoaTest):
         path = self.get_contract_path('SetValue.py')
         self.assertCompilerNotLogs(CompilerWarning.NameShadowing, path)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', [1, 2, 3, 4])
-        self.assertEqual([1, 2, 3, 4], result)
-        result = self.run_smart_contract(engine, path, 'Main', [5, 3, 2])
-        self.assertEqual([1, 3, 2], result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
 
-        with self.assertRaisesRegex(TestExecutionException, self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX):
-            self.run_smart_contract(engine, path, 'Main', [])
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', [1, 2, 3, 4]))
+        expected_results.append([1, 2, 3, 4])
+        invokes.append(runner.call_contract(path, 'Main', [5, 3, 2]))
+        expected_results.append([1, 3, 2])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        runner.call_contract(path, 'Main', [])
+        runner.execute()
+
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX)
 
     def test_list_set_value_with_negative_index(self):
         path = self.get_contract_path('SetValueNegativeIndex.py')
         self.assertCompilerNotLogs(CompilerWarning.NameShadowing, path)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', [1, 2, 3, 4])
-        self.assertEqual([1, 2, 3, 1], result)
-        result = self.run_smart_contract(engine, path, 'Main', [5, 3, 2])
-        self.assertEqual([5, 3, 1], result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
 
-        with self.assertRaisesRegex(TestExecutionException, self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX):
-            self.run_smart_contract(engine, path, 'Main', [])
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', [1, 2, 3, 4]))
+        expected_results.append([1, 2, 3, 1])
+        invokes.append(runner.call_contract(path, 'Main', [5, 3, 2]))
+        expected_results.append([5, 3, 1])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        runner.call_contract(path, 'Main', [])
+        runner.execute()
+
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX)
 
     def test_non_sequence_set_value(self):
         path = self.get_contract_path('MismatchedTypeSetValue.py')
@@ -248,43 +304,80 @@ class TestList(BoaTest):
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_array_boa2_test1(self):
-        path = self.get_contract_path('ArrayBoa2Test1.py')
-        Boa3.compile(path)
+        path, _ = self.get_deploy_file_paths('ArrayBoa2Test1.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(True, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append(True)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_boa2_array_test(self):
-        path = self.get_contract_path('ArrayBoa2Test.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ArrayBoa2Test.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', 0)
-        self.assertEqual(1, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', 1)
-        self.assertEqual(6, result)
+        invokes.append(runner.call_contract(path, 'main', 0))
+        expected_results.append(1)
 
-        result = self.run_smart_contract(engine, path, 'main', 2)
-        self.assertEqual(3, result)
+        invokes.append(runner.call_contract(path, 'main', 1))
+        expected_results.append(6)
 
-        result = self.run_smart_contract(engine, path, 'main', 4)
-        self.assertEqual(8, result)
+        invokes.append(runner.call_contract(path, 'main', 2))
+        expected_results.append(3)
 
-        result = self.run_smart_contract(engine, path, 'main', 8)
-        self.assertEqual(9, result)
+        invokes.append(runner.call_contract(path, 'main', 4))
+        expected_results.append(8)
+
+        invokes.append(runner.call_contract(path, 'main', 8))
+        expected_results.append(9)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_boa2_array_test2(self):
-        path = self.get_contract_path('ArrayBoa2Test2.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(b'\xa0', result)
+        path, _ = self.get_deploy_file_paths('ArrayBoa2Test2.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(b'\xa0')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_boa2_array_test3(self):
-        path = self.get_contract_path('ArrayBoa2Test3.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual([1, 2, 3], result)
+        path, _ = self.get_deploy_file_paths('ArrayBoa2Test3.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append([1, 2, 3])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_list_of_list(self):
         expected_output = (
@@ -319,15 +412,26 @@ class TestList(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', [[1, 2], [3, 4]])
-        self.assertEqual(result, 1)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
 
-        with self.assertRaisesRegex(TestExecutionException, self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX):
-            self.run_smart_contract(engine, path, 'Main', [])
+        invokes = []
+        expected_results = []
 
-        with self.assertRaisesRegex(TestExecutionException, self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX):
-            self.run_smart_contract(engine, path, 'Main', [[], [1, 2], [3, 4]])
+        invokes.append(runner.call_contract(path, 'Main', [[1, 2], [3, 4]]))
+        expected_results.append(1)
+
+        runner.call_contract(path, 'Main', [])
+        runner.execute()
+
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX)
+
+        runner.call_contract(path, 'Main', [[], [1, 2], [3, 4]])
+        runner.execute()
+
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX)
 
     def test_nep5_main(self):
         expected_output = (
@@ -352,288 +456,419 @@ class TestList(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', 'op', [1, 2, 3, 4])
-        self.assertEqual(1, result)
-        result = self.run_smart_contract(engine, path, 'Main', 'op', ['a', False])
-        self.assertEqual('a', result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
 
-        with self.assertRaisesRegex(TestExecutionException, self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX):
-            self.run_smart_contract(engine, path, 'Main', 'op', [])
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', 'op', [1, 2, 3, 4]))
+        expected_results.append(1)
+        invokes.append(runner.call_contract(path, 'Main', 'op', ['a', False]))
+        expected_results.append('a')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        runner.call_contract(path, 'Main', 'op', [])
+        runner.execute()
+
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX)
 
     def test_boa2_demo1(self):
-        path = self.get_contract_path('Demo1Boa2.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Demo1Boa2.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', 'add', 1, 3)
-        self.assertEqual(7, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', 'add', 2, 3)
-        self.assertEqual(8, result)
+        invokes.append(runner.call_contract(path, 'main', 'add', 1, 3))
+        expected_results.append(7)
+
+        invokes.append(runner.call_contract(path, 'main', 'add', 2, 3))
+        expected_results.append(8)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     # region TestSlicing
 
     def test_list_slicing(self):
-        path = self.get_contract_path('ListSlicingLiteralValues.py')
+        path, _ = self.get_deploy_file_paths('ListSlicingLiteralValues.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual([2], result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append([2])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_list_slicing_start_larger_than_ending(self):
-        path = self.get_contract_path('ListSlicingStartLargerThanEnding.py')
+        path, _ = self.get_deploy_file_paths('ListSlicingStartLargerThanEnding.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual([], result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append([])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_list_slicing_with_variables(self):
-        path = self.get_contract_path('ListSlicingVariableValues.py')
+        path, _ = self.get_deploy_file_paths('ListSlicingVariableValues.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual([2], result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append([2])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_list_slicing_negative_start(self):
-        path = self.get_contract_path('ListSlicingNegativeStart.py')
+        path, _ = self.get_deploy_file_paths('ListSlicingNegativeStart.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual([2, 3, 4, 5], result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append([2, 3, 4, 5])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_list_slicing_negative_end(self):
-        path = self.get_contract_path('ListSlicingNegativeEnd.py')
+        path, _ = self.get_deploy_file_paths('ListSlicingNegativeEnd.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual([0, 1], result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append([0, 1])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_list_slicing_start_omitted(self):
-        path = self.get_contract_path('ListSlicingStartOmitted.py')
+        path, _ = self.get_deploy_file_paths('ListSlicingStartOmitted.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual([0, 1, 2], result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append([0, 1, 2])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_list_slicing_omitted(self):
-        path = self.get_contract_path('ListSlicingOmitted.py')
+        path, _ = self.get_deploy_file_paths('ListSlicingOmitted.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual([0, 1, 2, 3, 4, 5], result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append([0, 1, 2, 3, 4, 5])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_list_slicing_end_omitted(self):
-        path = self.get_contract_path('ListSlicingEndOmitted.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ListSlicingEndOmitted.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual([2, 3, 4, 5], result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append([2, 3, 4, 5])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_list_slicing_with_stride(self):
-        path = self.get_contract_path('ListSlicingWithStride.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ListSlicingWithStride.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         a = [0, 1, 2, 3, 4, 5]
         expected_result = a[2:5:2]
-        result = self.run_smart_contract(engine, path, 'literal_values')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'literal_values'))
+        expected_results.append(expected_result)
 
         a = [0, 1, 2, 3, 4, 5]
         expected_result = a[-6:5:2]
-        result = self.run_smart_contract(engine, path, 'negative_start')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_start'))
+        expected_results.append(expected_result)
 
         a = [0, 1, 2, 3, 4, 5]
         expected_result = a[0:-1:2]
-        result = self.run_smart_contract(engine, path, 'negative_end')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_end'))
+        expected_results.append(expected_result)
 
         a = [0, 1, 2, 3, 4, 5]
         expected_result = a[-6:-1:2]
-        result = self.run_smart_contract(engine, path, 'negative_values')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_values'))
+        expected_results.append(expected_result)
 
         a = [0, 1, 2, 3, 4, 5]
         expected_result = a[-999:5:2]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_start')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_really_low_start'))
+        expected_results.append(expected_result)
 
         a = [0, 1, 2, 3, 4, 5]
         expected_result = a[0:-999:2]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_end')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_really_low_end'))
+        expected_results.append(expected_result)
 
         a = [0, 1, 2, 3, 4, 5]
         expected_result = a[-999:-999:2]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_values')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_really_low_values'))
+        expected_results.append(expected_result)
 
         a = [0, 1, 2, 3, 4, 5]
         expected_result = a[999:5:2]
-        result = self.run_smart_contract(engine, path, 'really_high_start')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'really_high_start'))
+        expected_results.append(expected_result)
 
         a = [0, 1, 2, 3, 4, 5]
         expected_result = a[0:999:2]
-        result = self.run_smart_contract(engine, path, 'really_high_end')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'really_high_end'))
+        expected_results.append(expected_result)
 
         a = [0, 1, 2, 3, 4, 5]
         expected_result = a[999:999:2]
-        result = self.run_smart_contract(engine, path, 'really_high_values')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'really_high_values'))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_list_slicing_with_negative_stride(self):
-        path = self.get_contract_path('ListSlicingWithNegativeStride.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ListSlicingWithNegativeStride.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         a = [0, 1, 2, 3, 4, 5]
         expected_result = a[2:5:-1]
-        result = self.run_smart_contract(engine, path, 'literal_values')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'literal_values'))
+        expected_results.append(expected_result)
 
         a = [0, 1, 2, 3, 4, 5]
         expected_result = a[-6:5:-1]
-        result = self.run_smart_contract(engine, path, 'negative_start')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_start'))
+        expected_results.append(expected_result)
 
         a = [0, 1, 2, 3, 4, 5]
         expected_result = a[0:-1:-1]
-        result = self.run_smart_contract(engine, path, 'negative_end')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_end'))
+        expected_results.append(expected_result)
 
         a = [0, 1, 2, 3, 4, 5]
         expected_result = a[-6:-1:-1]
-        result = self.run_smart_contract(engine, path, 'negative_values')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_values'))
+        expected_results.append(expected_result)
 
         a = [0, 1, 2, 3, 4, 5]
         expected_result = a[-999:5:-1]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_start')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_really_low_start'))
+        expected_results.append(expected_result)
 
         a = [0, 1, 2, 3, 4, 5]
         expected_result = a[0:-999:-1]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_end')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_really_low_end'))
+        expected_results.append(expected_result)
 
         a = [0, 1, 2, 3, 4, 5]
         expected_result = a[-999:-999:-1]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_values')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_really_low_values'))
+        expected_results.append(expected_result)
 
         a = [0, 1, 2, 3, 4, 5]
         expected_result = a[999:5:-1]
-        result = self.run_smart_contract(engine, path, 'really_high_start')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'really_high_start'))
+        expected_results.append(expected_result)
 
         a = [0, 1, 2, 3, 4, 5]
         expected_result = a[0:999:-1]
-        result = self.run_smart_contract(engine, path, 'really_high_end')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'really_high_end'))
+        expected_results.append(expected_result)
 
         a = [0, 1, 2, 3, 4, 5]
         expected_result = a[999:999:-1]
-        result = self.run_smart_contract(engine, path, 'really_high_values')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'really_high_values'))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_list_slicing_omitted_with_stride(self):
-        path = self.get_contract_path('ListSlicingOmittedWithStride.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ListSlicingOmittedWithStride.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         a = [0, 1, 2, 3, 4, 5]
         expected_result = a[::2]
-        result = self.run_smart_contract(engine, path, 'omitted_values')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'omitted_values'))
+        expected_results.append(expected_result)
 
         a = [0, 1, 2, 3, 4, 5]
         expected_result = a[:5:2]
-        result = self.run_smart_contract(engine, path, 'omitted_start')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'omitted_start'))
+        expected_results.append(expected_result)
 
         a = [0, 1, 2, 3, 4, 5, 6]
         expected_result = a[2::2]
-        result = self.run_smart_contract(engine, path, 'omitted_end')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'omitted_end'))
+        expected_results.append(expected_result)
 
         a = [0, 1, 2, 3, 4, 5]
         expected_result = a[-6::2]
-        result = self.run_smart_contract(engine, path, 'negative_start')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_start'))
+        expected_results.append(expected_result)
 
         a = [0, 1, 2, 3, 4, 5]
         expected_result = a[:-1:2]
-        result = self.run_smart_contract(engine, path, 'negative_end')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_end'))
+        expected_results.append(expected_result)
 
         a = [0, 1, 2, 3, 4, 5]
         expected_result = a[-999::2]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_start')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_really_low_start'))
+        expected_results.append(expected_result)
 
         a = [0, 1, 2, 3, 4, 5]
         expected_result = a[:-999:2]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_end')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_really_low_end'))
+        expected_results.append(expected_result)
 
         a = [0, 1, 2, 3, 4, 5]
         expected_result = a[999::2]
-        result = self.run_smart_contract(engine, path, 'really_high_start')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'really_high_start'))
+        expected_results.append(expected_result)
 
         a = [0, 1, 2, 3, 4, 5]
         expected_result = a[:999:2]
-        result = self.run_smart_contract(engine, path, 'really_high_end')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'really_high_end'))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_list_slicing_omitted_with_negative_stride(self):
-        path = self.get_contract_path('ListSlicingOmittedWithNegativeStride.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ListSlicingOmittedWithNegativeStride.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         a = [0, 1, 2, 3, 4, 5]
         expected_result = a[::-2]
-        result = self.run_smart_contract(engine, path, 'omitted_values')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'omitted_values'))
+        expected_results.append(expected_result)
 
         a = [0, 1, 2, 3, 4, 5]
         expected_result = a[:5:-2]
-        result = self.run_smart_contract(engine, path, 'omitted_start')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'omitted_start'))
+        expected_results.append(expected_result)
 
         a = [0, 1, 2, 3, 4, 5, 6]
         expected_result = a[2::-2]
-        result = self.run_smart_contract(engine, path, 'omitted_end')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'omitted_end'))
+        expected_results.append(expected_result)
 
         a = [0, 1, 2, 3, 4, 5]
         expected_result = a[-6::-2]
-        result = self.run_smart_contract(engine, path, 'negative_start')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_start'))
+        expected_results.append(expected_result)
 
         a = [0, 1, 2, 3, 4, 5]
         expected_result = a[:-1:-2]
-        result = self.run_smart_contract(engine, path, 'negative_end')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_end'))
+        expected_results.append(expected_result)
 
         a = [0, 1, 2, 3, 4, 5]
         expected_result = a[-999::-2]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_start')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_really_low_start'))
+        expected_results.append(expected_result)
 
         a = [0, 1, 2, 3, 4, 5]
         expected_result = a[:-999:-2]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_end')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_really_low_end'))
+        expected_results.append(expected_result)
 
         a = [0, 1, 2, 3, 4, 5]
         expected_result = a[999::-2]
-        result = self.run_smart_contract(engine, path, 'really_high_start')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'really_high_start'))
+        expected_results.append(expected_result)
 
         a = [0, 1, 2, 3, 4, 5]
         expected_result = a[:999:-2]
-        result = self.run_smart_contract(engine, path, 'really_high_end')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'really_high_end'))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     # endregion
 
@@ -672,9 +907,20 @@ class TestList(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual([1, 2, 3, 4], result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append([1, 2, 3, 4])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_list_append_any_value(self):
         four = String('4').to_bytes(min_length=1)
@@ -713,9 +959,20 @@ class TestList(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual([1, 2, 3, '4'], result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append([1, 2, 3, '4'])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_list_append_mismatched_type(self):
         path = self.get_contract_path('MismatchedTypeAppendValue.py')
@@ -754,33 +1011,62 @@ class TestList(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual([1, 2, 3, 4], result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append([1, 2, 3, 4])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_list_append_with_builtin_mismatched_type(self):
         path = self.get_contract_path('MismatchedTypeAppendWithBuiltin.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_boa2_list_append_test(self):
-        path = self.get_contract_path('AppendBoa2Test.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual([6, 7], result)
+        path, _ = self.get_deploy_file_paths('AppendBoa2Test.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append([6, 7])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_list_append_in_class_variable(self):
-        path = self.get_contract_path('AppendInClassVariable.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual([1, 2, 3, 4], result)
+        path, _ = self.get_deploy_file_paths('AppendInClassVariable.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append([1, 2, 3, 4])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     # endregion
 
     # region TestClear
 
     def test_list_clear(self):
-        path = self.get_contract_path('ClearList.py')
-
         expected_output = (
             Opcode.INITSLOT     # function signature
             + b'\x01'
@@ -811,12 +1097,12 @@ class TestList(BoaTest):
             + Opcode.LDLOC0     # return a
             + Opcode.RET
         )
+
+        path = self.get_contract_path('ClearList.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
     def test_list_reverse(self):
-        path = self.get_contract_path('ReverseList.py')
-
         expected_output = (
             Opcode.INITSLOT     # function signature
             + b'\x01'
@@ -832,32 +1118,62 @@ class TestList(BoaTest):
             + Opcode.LDLOC0     # return a
             + Opcode.RET
         )
+
+        path = self.get_contract_path('ReverseList.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
     def test_boa2_list_reverse_test(self):
-        path = self.get_contract_path('ReverseBoa2Test.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(['blah', 4, 2, 1], result)
+        path, _ = self.get_deploy_file_paths('ReverseBoa2Test.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(['blah', 4, 2, 1])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     # endregion
 
     # region TestExtend
 
     def test_list_extend_tuple_value(self):
-        path = self.get_contract_path('ExtendTupleValue.py')
+        path, _ = self.get_deploy_file_paths('ExtendTupleValue.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual([1, 2, 3, 4, 5, 6], result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append([1, 2, 3, 4, 5, 6])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_list_extend_any_value(self):
-        path = self.get_contract_path('ExtendAnyValue.py')
+        path, _ = self.get_deploy_file_paths('ExtendAnyValue.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual([1, 2, 3, '4', 5, 1], result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append([1, 2, 3, '4', 5, 1])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_list_extend_mismatched_type(self):
         path = self.get_contract_path('MismatchedTypeExtendValue.py')
@@ -868,11 +1184,20 @@ class TestList(BoaTest):
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_list_extend_with_builtin(self):
-        path = self.get_contract_path('ExtendWithBuiltin.py')
+        path, _ = self.get_deploy_file_paths('ExtendWithBuiltin.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual([1, 2, 3, 4, 5, 6], result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append([1, 2, 3, 4, 5, 6])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_list_extend_with_builtin_mismatched_type(self):
         path = self.get_contract_path('MismatchedTypeExtendWithBuiltin.py')
@@ -1109,278 +1434,485 @@ class TestList(BoaTest):
         output = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'pop_test')
-        self.assertEqual(3, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'pop_test'))
+        expected_results.append(3)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_list_pop_too_many_arguments(self):
         path = self.get_contract_path('PopListTooManyArguments.py')
         self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
 
     def test_boa2_list_remove_test(self):
-        path = self.get_contract_path('RemoveBoa2Test.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual([16, 3, 4], result)
+        path, _ = self.get_deploy_file_paths('RemoveBoa2Test.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append([16, 3, 4])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     # endregion
 
     # region TestInsert
 
     def test_list_insert_int_value(self):
-        path = self.get_contract_path('InsertIntValue.py')
+        path, _ = self.get_deploy_file_paths('InsertIntValue.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual([1, 2, 4, 3], result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append([1, 2, 4, 3])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_list_insert_any_value(self):
-        path = self.get_contract_path('InsertAnyValue.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('InsertAnyValue.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         list_ = [1, 2, 3]
         pos = 0
         value = '0'
-        result = self.run_smart_contract(engine, path, 'Main', list_, pos, value)
+        invokes.append(runner.call_contract(path, 'Main', list_, pos, value))
         list_.insert(pos, value)
-        self.assertEqual(list_, result)
+        expected_results.append(list_)
 
         list_ = [1, 2, 3]
         pos = 1
         value = '1'
-        result = self.run_smart_contract(engine, path, 'Main', list_, pos, value)
+        invokes.append(runner.call_contract(path, 'Main', list_, pos, value))
         list_.insert(pos, value)
-        self.assertEqual(list_, result)
+        expected_results.append(list_)
 
         list_ = [1, 2, 3]
         pos = 3
         value = '4'
-        result = self.run_smart_contract(engine, path, 'Main', list_, pos, value)
+        invokes.append(runner.call_contract(path, 'Main', list_, pos, value))
         list_.insert(pos, value)
-        self.assertEqual(list_, result)
+        expected_results.append(list_)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_list_insert_int_negative_index(self):
-        path = self.get_contract_path('InsertIntNegativeIndex.py')
+        path, _ = self.get_deploy_file_paths('InsertIntNegativeIndex.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual([1, 4, 2, 3], result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append([1, 4, 2, 3])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_list_insert_int_with_builtin(self):
-        path = self.get_contract_path('InsertIntWithBuiltin.py')
+        path, _ = self.get_deploy_file_paths('InsertIntWithBuiltin.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual([1, 2, 4, 3], result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append([1, 2, 4, 3])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     # endregion
 
     # region TestRemove
 
     def test_list_remove_value(self):
-        path = self.get_contract_path('RemoveValue.py')
+        path, _ = self.get_deploy_file_paths('RemoveValue.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', [1, 2, 3, 4], 3)
-        self.assertEqual([1, 2, 4], result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'Main', [1, 2, 3, 2, 3], 3)
-        self.assertEqual([1, 2, 2, 3], result)
+        invokes.append(runner.call_contract(path, 'Main', [1, 2, 3, 4], 3))
+        expected_results.append([1, 2, 4])
 
-        with self.assertRaisesRegex(TestExecutionException, self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX):
-            self.run_smart_contract(engine, path, 'Main', [1, 2, 3, 4], 6)
+        invokes.append(runner.call_contract(path, 'Main', [1, 2, 3, 2, 3], 3))
+        expected_results.append([1, 2, 2, 3])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        runner.call_contract(path, 'Main', [1, 2, 3, 4], 6)
+        runner.execute()
+
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX)
 
     def test_list_remove_int_value(self):
-        path = self.get_contract_path('RemoveIntValue.py')
+        path, _ = self.get_deploy_file_paths('RemoveIntValue.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual([10, 30], result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append([10, 30])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_list_remove_int_with_builtin(self):
-        path = self.get_contract_path('RemoveIntWithBuiltin.py')
+        path, _ = self.get_deploy_file_paths('RemoveIntWithBuiltin.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual([10, 20], result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append([10, 20])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     # endregion
 
     # region TestCopy
 
     def test_list_copy(self):
-        path = self.get_contract_path('Copy.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Copy.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'copy_list', [1, 2, 3, 4], 5)
-        self.assertEqual([1, 2, 3, 4], result[0])
-        self.assertEqual([1, 2, 3, 4, 5], result[1])
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'copy_list', ['list', 'unit', 'test'], 'copy')
-        self.assertEqual(['list', 'unit', 'test'], result[0])
-        self.assertEqual(['list', 'unit', 'test', 'copy'], result[1])
+        invokes.append(runner.call_contract(path, 'copy_list', [1, 2, 3, 4], 5))
+        expected_results.append([[1, 2, 3, 4],
+                                 [1, 2, 3, 4, 5]
+                                 ])
 
-        result = self.run_smart_contract(engine, path, 'copy_list', [True, False], True)
-        self.assertEqual([True, False], result[0])
-        self.assertEqual([True, False, True], result[1])
+        invokes.append(runner.call_contract(path, 'copy_list', ['list', 'unit', 'test'], 'copy'))
+        expected_results.append([['list', 'unit', 'test'],
+                                 ['list', 'unit', 'test', 'copy']
+                                 ])
 
-        result = self.run_smart_contract(engine, path, 'attribution', [1, 2, 3, 4], 5)
-        self.assertEqual(False, result)
+        invokes.append(runner.call_contract(path, 'copy_list', [True, False], True))
+        expected_results.append([[True, False],
+                                 [True, False, True]
+                                 ])
 
-        result = self.run_smart_contract(engine, path, 'attribution', ['list', 'unit', 'test'], 'copy')
-        self.assertEqual(False, result)
+        invokes.append(runner.call_contract(path, 'attribution', [1, 2, 3, 4], 5))
+        expected_results.append(False)
 
-        result = self.run_smart_contract(engine, path, 'attribution', [True, False], True)
-        self.assertEqual(False, result)
+        invokes.append(runner.call_contract(path, 'attribution', ['list', 'unit', 'test'], 'copy'))
+        expected_results.append(False)
+
+        invokes.append(runner.call_contract(path, 'attribution', [True, False], True))
+        expected_results.append(False)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_int_list_copy(self):
-        path = self.get_contract_path('CopyInt.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('CopyInt.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'copy_int_list', [1, 2, 3, 4], 5)
-        self.assertEqual([1, 2, 3, 4], result[0])
-        self.assertEqual([1, 2, 3, 4, 5], result[1])
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'copy_int_list', [1, 2, 3, 4], 5))
+        expected_results.append([[1, 2, 3, 4],
+                                 [1, 2, 3, 4, 5]])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_str_list_copy(self):
-        path = self.get_contract_path('CopyStr.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('CopyStr.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'copy_str_list', ['list', 'unit', 'test'], 'copy')
-        self.assertEqual(['list', 'unit', 'test'], result[0])
-        self.assertEqual(['list', 'unit', 'test', 'copy'], result[1])
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'copy_str_list', ['list', 'unit', 'test'], 'copy'))
+        expected_results.append([['list', 'unit', 'test'],
+                                 ['list', 'unit', 'test', 'copy']
+                                 ])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_bool_list_copy(self):
-        path = self.get_contract_path('CopyBool.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('CopyBool.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'copy_bool_list', [True, False], True)
-        self.assertEqual([True, False], result[0])
-        self.assertEqual([True, False, True], result[1])
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'copy_bool_list', [True, False], True))
+        expected_results.append([[True, False],
+                                 [True, False, True]
+                                 ])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_list_copy_builtin_call(self):
-        path = self.get_contract_path('CopyListBuiltinCall.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('CopyListBuiltinCall.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'copy_list', [1, 2, 3, 4], 5)
-        self.assertEqual([1, 2, 3, 4], result[0])
-        self.assertEqual([1, 2, 3, 4, 5], result[1])
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'copy_list', ['list', 'unit', 'test'], 'copy')
-        self.assertEqual(['list', 'unit', 'test'], result[0])
-        self.assertEqual(['list', 'unit', 'test', 'copy'], result[1])
+        invokes.append(runner.call_contract(path, 'copy_list', [1, 2, 3, 4], 5))
+        expected_results.append([[1, 2, 3, 4],
+                                 [1, 2, 3, 4, 5]
+                                 ])
 
-        result = self.run_smart_contract(engine, path, 'copy_list', [True, False], True)
-        self.assertEqual([True, False], result[0])
-        self.assertEqual([True, False, True], result[1])
+        invokes.append(runner.call_contract(path, 'copy_list', ['list', 'unit', 'test'], 'copy'))
+        expected_results.append([['list', 'unit', 'test'],
+                                 ['list', 'unit', 'test', 'copy']])
+
+        invokes.append(runner.call_contract(path, 'copy_list', [True, False], True))
+        expected_results.append([[True, False],
+                                 [True, False, True]])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     # endregion
 
     # region TestIndex
 
     def test_list_index(self):
-        path = self.get_contract_path('IndexList.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('IndexList.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         list_ = [1, 2, 3, 4]
         value = 3
         start = 0
         end = 4
-        result = self.run_smart_contract(engine, path, 'main', list_, value, start, end)
-        self.assertEqual(list_.index(value, start, end), result)
+        invokes.append(runner.call_contract(path, 'main', list_, value, start, end))
+        expected_results.append(list_.index(value, start, end))
 
         list_ = [1, 2, 3, 4]
         value = 3
         start = 2
         end = 4
-        result = self.run_smart_contract(engine, path, 'main', list_, value, start, end)
-        self.assertEqual(list_.index(value, start, end), result)
-
-        from boa3.model.builtin.builtin import Builtin
-        with self.assertRaisesRegex(TestExecutionException, f'{Builtin.SequenceIndex.exception_message}$'):
-            self.run_smart_contract(engine, path, 'main', [1, 2, 3, 4], 3, 3, 4)
-
-        with self.assertRaisesRegex(TestExecutionException, f'{Builtin.SequenceIndex.exception_message}$'):
-            self.run_smart_contract(engine, path, 'main', [1, 2, 3, 4], 3, 4, -1)
-
-        with self.assertRaisesRegex(TestExecutionException, f'{Builtin.SequenceIndex.exception_message}$'):
-            self.run_smart_contract(engine, path, 'main', [1, 2, 3, 4], 3, 0, -99)
+        invokes.append(runner.call_contract(path, 'main', list_, value, start, end))
+        expected_results.append(list_.index(value, start, end))
 
         list_ = [1, 2, 3, 4]
         value = 3
         start = 0
         end = -1
-        result = self.run_smart_contract(engine, path, 'main', list_, value, start, end)
-        self.assertEqual(list_.index(value, start, end), result)
+        invokes.append(runner.call_contract(path, 'main', list_, value, start, end))
+        expected_results.append(list_.index(value, start, end))
 
         list_ = [1, 2, 3, 4]
         value = 2
         start = 0
         end = 99
-        result = self.run_smart_contract(engine, path, 'main', list_, value, start, end)
-        self.assertEqual(list_.index(value, start, end), result)
+        invokes.append(runner.call_contract(path, 'main', list_, value, start, end))
+        expected_results.append(list_.index(value, start, end))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        from boa3.model.builtin.builtin import Builtin
+        runner.call_contract(path, 'main', [1, 2, 3, 4], 3, 3, 4)
+        runner.execute()
+
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'{Builtin.SequenceIndex.exception_message}$')
+
+        runner.call_contract(path, 'main', [1, 2, 3, 4], 3, 4, -1)
+        runner.execute()
+
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'{Builtin.SequenceIndex.exception_message}$')
+
+        runner.call_contract(path, 'main', [1, 2, 3, 4], 3, 0, -99)
+        runner.execute()
+
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'{Builtin.SequenceIndex.exception_message}$')
 
     def test_list_index_end_default(self):
-        path = self.get_contract_path('IndexListEndDefault.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('IndexListEndDefault.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         list_ = [1, 2, 3, 4]
         value = 3
         start = 0
-        result = self.run_smart_contract(engine, path, 'main', list_, value, start)
-        self.assertEqual(list_.index(value, start), result)
-
-        from boa3.model.builtin.builtin import Builtin
-        with self.assertRaisesRegex(TestExecutionException, f'{Builtin.SequenceIndex.exception_message}$'):
-            self.run_smart_contract(engine, path, 'main', [1, 2, 3, 4], 2, 99)
-
-        with self.assertRaisesRegex(TestExecutionException, f'{Builtin.SequenceIndex.exception_message}$'):
-            self.run_smart_contract(engine, path, 'main', [1, 2, 3, 4], 4, -1)
+        invokes.append(runner.call_contract(path, 'main', list_, value, start))
+        expected_results.append(list_.index(value, start))
 
         list_ = [1, 2, 3, 4]
         value = 2
         start = -10
-        result = self.run_smart_contract(engine, path, 'main', list_, value, start)
-        self.assertEqual(list_.index(value, start), result)
+        invokes.append(runner.call_contract(path, 'main', list_, value, start))
+        expected_results.append(list_.index(value, start))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        from boa3.model.builtin.builtin import Builtin
+        runner.call_contract(path, 'main', [1, 2, 3, 4], 2, 99)
+        runner.execute()
+
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'{Builtin.SequenceIndex.exception_message}$')
+
+        runner.call_contract(path, 'main', [1, 2, 3, 4], 4, -1)
+        runner.execute()
+
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'{Builtin.SequenceIndex.exception_message}$')
 
     def test_list_index_defaults(self):
-        path = self.get_contract_path('IndexListDefaults.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('IndexListDefaults.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         list_ = [1, 2, 3, 4]
         value = 3
-        result = self.run_smart_contract(engine, path, 'main', list_, value)
-        self.assertEqual(list_.index(value), result)
+        invokes.append(runner.call_contract(path, 'main', list_, value))
+        expected_results.append(list_.index(value))
 
         list_ = [1, 2, 3, 4]
         value = 1
-        result = self.run_smart_contract(engine, path, 'main', list_, value)
-        self.assertEqual(list_.index(value), result)
+        invokes.append(runner.call_contract(path, 'main', list_, value))
+        expected_results.append(list_.index(value))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_list_index_int(self):
-        path = self.get_contract_path('IndexListInt.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('IndexListInt.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         list_ = [1, 2, 3, 4]
         value = 3
-        result = self.run_smart_contract(engine, path, 'main', list_, value)
-        self.assertEqual(list_.index(value), result)
+        invokes.append(runner.call_contract(path, 'main', list_, value))
+        expected_results.append(list_.index(value))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_list_index_str(self):
-        path = self.get_contract_path('IndexListStr.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('IndexListStr.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         list_ = ['unit', 'test', 'neo3-boa']
         value = 'test'
-        result = self.run_smart_contract(engine, path, 'main', list_, value)
-        self.assertEqual(list_.index(value), result)
+        invokes.append(runner.call_contract(path, 'main', list_, value))
+        expected_results.append(list_.index(value))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_list_index_bool(self):
-        path = self.get_contract_path('IndexListBool.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('IndexListBool.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         list_ = [True, True, False]
         value = False
-        result = self.run_smart_contract(engine, path, 'main', list_, value)
-        self.assertEqual(list_.index(value), result)
+        invokes.append(runner.call_contract(path, 'main', list_, value))
+        expected_results.append(list_.index(value))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     # endregion

--- a/boa3_test/tests/compiler_tests/test_none.py
+++ b/boa3_test/tests/compiler_tests/test_none.py
@@ -1,16 +1,15 @@
 from boa3.boa3 import Boa3
 from boa3.exception import CompilerError
 from boa3.neo.vm.opcode.Opcode import Opcode
+from boa3.neo3.vm import VMState
+from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.boa_test import BoaTest
-from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestNone(BoaTest):
     default_folder: str = 'test_sc/none_test'
 
     def test_variable_none(self):
-        path = self.get_contract_path('VariableNone.py')
-
         expected_output = (
             Opcode.INITSLOT     # function signature
             + b'\x01'
@@ -19,12 +18,12 @@ class TestNone(BoaTest):
             + Opcode.STLOC0
             + Opcode.RET        # return
         )
+
+        path = self.get_contract_path('VariableNone.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
     def test_none_tuple(self):
-        path = self.get_contract_path('NoneTuple.py')
-
         expected_output = (
             Opcode.INITSLOT     # function signature
             + b'\x01'
@@ -37,6 +36,8 @@ class TestNone(BoaTest):
             + Opcode.STLOC0
             + Opcode.RET        # return
         )
+
+        path = self.get_contract_path('NoneTuple.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
@@ -54,13 +55,24 @@ class TestNone(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', None)
-        self.assertEqual(True, result)
-        result = self.run_smart_contract(engine, path, 'Main', 5)
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'Main', '5')
-        self.assertEqual(False, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', None))
+        expected_results.append(True)
+        invokes.append(runner.call_contract(path, 'Main', 5))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'Main', '5'))
+        expected_results.append(False)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_none_not_identity(self):
         expected_output = (
@@ -77,13 +89,24 @@ class TestNone(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', None)
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'Main', 5)
-        self.assertEqual(True, result)
-        result = self.run_smart_contract(engine, path, 'Main', '5')
-        self.assertEqual(True, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', None))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'Main', 5))
+        expected_results.append(True)
+        invokes.append(runner.call_contract(path, 'Main', '5'))
+        expected_results.append(True)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_none_equality(self):
         path = self.get_contract_path('NoneEquality.py')
@@ -111,9 +134,20 @@ class TestNone(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertIsVoid(result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append(None)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_reassign_variable_after_none(self):
         expected_output = (
@@ -132,9 +166,20 @@ class TestNone(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertIsVoid(result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append(None)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_boa2_none_test(self):
         path = self.get_contract_path('NoneBoa2Test.py')

--- a/boa3_test/tests/compiler_tests/test_optional.py
+++ b/boa3_test/tests/compiler_tests/test_optional.py
@@ -1,29 +1,39 @@
 from boa3.boa3 import Boa3
 from boa3.neo.vm.opcode.Opcode import Opcode
+from boa3.neo3.vm import VMState
+from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.boa_test import BoaTest
-from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestOptional(BoaTest):
     default_folder: str = 'test_sc/optional_test'
 
     def test_optional_return(self):
-        path = self.get_contract_path('OptionalReturn.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('OptionalReturn.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', 1)
-        self.assertEqual('str', result)
-        result = self.run_smart_contract(engine, path, 'main', 2)
-        self.assertEqual(123, result)
-        result = self.run_smart_contract(engine, path, 'main', 3)
-        self.assertEqual(None, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'union_test', 1)
-        self.assertEqual('str', result)
-        result = self.run_smart_contract(engine, path, 'union_test', 2)
-        self.assertEqual(123, result)
-        result = self.run_smart_contract(engine, path, 'union_test', 3)
-        self.assertEqual(None, result)
+        invokes.append(runner.call_contract(path, 'main', 1))
+        expected_results.append('str')
+        invokes.append(runner.call_contract(path, 'main', 2))
+        expected_results.append(123)
+        invokes.append(runner.call_contract(path, 'main', 3))
+        expected_results.append(None)
+
+        invokes.append(runner.call_contract(path, 'union_test', 1))
+        expected_results.append('str')
+        invokes.append(runner.call_contract(path, 'union_test', 2))
+        expected_results.append(123)
+        invokes.append(runner.call_contract(path, 'union_test', 3))
+        expected_results.append(None)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_optional_variable_reassign(self):
         expected_output = (
@@ -46,40 +56,58 @@ class TestOptional(BoaTest):
         self.assertEqual(expected_output, output)
 
     def test_optional_variable_argument(self):
-        path = self.get_contract_path('OptionalVariableArgument.py')
+        path, _ = self.get_deploy_file_paths('OptionalVariableArgument.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', 'unittest')
-        self.assertEqual('string', result)
-        result = self.run_smart_contract(engine, path, 'main', 123)
-        self.assertEqual('int', result)
-        result = self.run_smart_contract(engine, path, 'main', None)
-        self.assertEqual('None', result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'union_test', 'unittest')
-        self.assertEqual('string', result)
-        result = self.run_smart_contract(engine, path, 'union_test', 123)
-        self.assertEqual('int', result)
-        result = self.run_smart_contract(engine, path, 'union_test', None)
-        self.assertEqual('None', result)
+        invokes.append(runner.call_contract(path, 'main', 'unittest'))
+        expected_results.append('string')
+        invokes.append(runner.call_contract(path, 'main', 123))
+        expected_results.append('int')
+        invokes.append(runner.call_contract(path, 'main', None))
+        expected_results.append('None')
+
+        invokes.append(runner.call_contract(path, 'union_test', 'unittest'))
+        expected_results.append('string')
+        invokes.append(runner.call_contract(path, 'union_test', 123))
+        expected_results.append('int')
+        invokes.append(runner.call_contract(path, 'union_test', None))
+        expected_results.append('None')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_optional_isinstance_validation(self):
-        path = self.get_contract_path('OptionalIsInstanceValidation.py')
+        path, _ = self.get_deploy_file_paths('OptionalIsInstanceValidation.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', 'unittest')
-        self.assertEqual('unittest', result)
-        result = self.run_smart_contract(engine, path, 'main', 123)
-        self.assertEqual('int', result)
-        result = self.run_smart_contract(engine, path, 'main', None)
-        self.assertEqual('None', result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'union_test', 'unittest')
-        self.assertEqual('unittest', result)
-        result = self.run_smart_contract(engine, path, 'union_test', 123)
-        self.assertEqual('int', result)
-        result = self.run_smart_contract(engine, path, 'union_test', None)
-        self.assertEqual('None', result)
+        invokes.append(runner.call_contract(path, 'main', 'unittest'))
+        expected_results.append('unittest')
+        invokes.append(runner.call_contract(path, 'main', 123))
+        expected_results.append('int')
+        invokes.append(runner.call_contract(path, 'main', None))
+        expected_results.append('None')
+
+        invokes.append(runner.call_contract(path, 'union_test', 'unittest'))
+        expected_results.append('unittest')
+        invokes.append(runner.call_contract(path, 'union_test', 123))
+        expected_results.append('int')
+        invokes.append(runner.call_contract(path, 'union_test', None))
+        expected_results.append('None')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_optional_inside_dict(self):
         expected_output = (
@@ -94,6 +122,17 @@ class TestOptional(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', {})
-        self.assertEqual({}, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', {}))
+        expected_results.append({})
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)

--- a/boa3_test/tests/compiler_tests/test_string.py
+++ b/boa3_test/tests/compiler_tests/test_string.py
@@ -3,9 +3,9 @@ from boa3.exception import CompilerError
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.String import String
+from boa3.neo3.vm import VMState
+from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.boa_test import BoaTest
-from boa3_test.tests.test_classes.TestExecutionException import TestExecutionException
-from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestString(BoaTest):
@@ -14,77 +14,154 @@ class TestString(BoaTest):
     SUBSTRING_NOT_FOUND_MSG = 'substring not found'
 
     def test_string_get_value(self):
-        path = self.get_contract_path('GetValue.py')
-        output = Boa3.compile(path)
+        path, _ = self.get_deploy_file_paths('GetValue.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', 'unit')
-        self.assertEqual('u', result)
-        result = self.run_smart_contract(engine, path, 'Main', '123')
-        self.assertEqual('1', result)
+        invokes = []
+        expected_results = []
 
-        with self.assertRaisesRegex(TestExecutionException, self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX):
-            self.run_smart_contract(engine, path, 'Main', '')
+        invokes.append(runner.call_contract(path, 'Main', 'unit'))
+        expected_results.append('u')
+        invokes.append(runner.call_contract(path, 'Main', '123'))
+        expected_results.append('1')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        runner.call_contract(path, 'Main', '')
+        runner.execute()
+
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX)
 
     def test_string_get_value_to_variable(self):
-        path = self.get_contract_path('GetValueToVariable.py')
-        output = Boa3.compile(path)
+        path, _ = self.get_deploy_file_paths('GetValueToVariable.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', 'unit')
-        self.assertEqual('u', result)
-        result = self.run_smart_contract(engine, path, 'Main', '123')
-        self.assertEqual('1', result)
+        invokes = []
+        expected_results = []
 
-        with self.assertRaisesRegex(TestExecutionException, self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX):
-            self.run_smart_contract(engine, path, 'Main', '')
+        invokes.append(runner.call_contract(path, 'Main', 'unit'))
+        expected_results.append('u')
+        invokes.append(runner.call_contract(path, 'Main', '123'))
+        expected_results.append('1')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        runner.call_contract(path, 'Main', '')
+        runner.execute()
+
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX)
 
     def test_string_set_value(self):
         path = self.get_contract_path('SetValue.py')
         self.assertCompilerLogs(CompilerError.UnresolvedOperation, path)
 
     def test_string_slicing(self):
-        path = self.get_contract_path('StringSlicingLiteralValues.py')
+        path, _ = self.get_deploy_file_paths('StringSlicingLiteralValues.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual('i', result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append('i')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_string_slicing_start_larger_than_ending(self):
-        path = self.get_contract_path('StringSlicingStartLargerThanEnding.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual('', result)
+        path, _ = self.get_deploy_file_paths('StringSlicingStartLargerThanEnding.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append('')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_string_slicing_with_variables(self):
-        path = self.get_contract_path('StringSlicingVariableValues.py')
+        path, _ = self.get_deploy_file_paths('StringSlicingVariableValues.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual('i', result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append('i')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_string_slicing_negative_start(self):
-        path = self.get_contract_path('StringSlicingNegativeStart.py')
+        path, _ = self.get_deploy_file_paths('StringSlicingNegativeStart.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main',
-                                         expected_result_type=bytes)
-        self.assertEqual(b'unit_', result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main',
+                                            expected_result_type=bytes))
+        expected_results.append(b'unit_')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_string_slicing_negative_end_omitted(self):
-        path = self.get_contract_path('StringSlicingNegativeEndOmitted.py')
+        path, _ = self.get_deploy_file_paths('StringSlicingNegativeEndOmitted.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual('test', result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append('test')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_string_slicing_start_omitted(self):
-        path = self.get_contract_path('StringSlicingStartOmitted.py')
+        path, _ = self.get_deploy_file_paths('StringSlicingStartOmitted.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main',
-                                         expected_result_type=bytes)
-        self.assertEqual(b'uni', result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main',
+                                            expected_result_type=bytes))
+        expected_results.append(b'uni')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_string_slicing_omitted(self):
         string_value = 'unit_test'
@@ -107,655 +184,878 @@ class TestString(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual('unit_test', result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append('unit_test')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_string_slicing_end_omitted(self):
-        path = self.get_contract_path('StringSlicingEndOmitted.py')
+        path, _ = self.get_deploy_file_paths('StringSlicingEndOmitted.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main',
-                                         expected_result_type=bytes)
-        self.assertEqual(b'it_test', result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main',
+                                            expected_result_type=bytes))
+        expected_results.append(b'it_test')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_string_slicing_with_stride(self):
-        path = self.get_contract_path('StringSlicingWithStride.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('StringSlicingWithStride.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         a = 'unit_test'
         expected_result = a[2:5:2]
-        result = self.run_smart_contract(engine, path, 'literal_values')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'literal_values'))
+        expected_results.append(expected_result)
 
         a = 'unit_test'
         expected_result = a[-6:5:2]
-        result = self.run_smart_contract(engine, path, 'negative_start')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_start'))
+        expected_results.append(expected_result)
 
         a = 'unit_test'
         expected_result = a[0:-1:2]
-        result = self.run_smart_contract(engine, path, 'negative_end')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_end'))
+        expected_results.append(expected_result)
 
         a = 'unit_test'
         expected_result = a[-6:-1:2]
-        result = self.run_smart_contract(engine, path, 'negative_values')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_values'))
+        expected_results.append(expected_result)
 
         a = 'unit_test'
         expected_result = a[-999:5:2]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_start')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_really_low_start'))
+        expected_results.append(expected_result)
 
         a = 'unit_test'
         expected_result = a[0:-999:2]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_end')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_really_low_end'))
+        expected_results.append(expected_result)
 
         a = 'unit_test'
         expected_result = a[-999:-999:2]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_values')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_really_low_values'))
+        expected_results.append(expected_result)
 
         a = 'unit_test'
         expected_result = a[999:5:2]
-        result = self.run_smart_contract(engine, path, 'really_high_start')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'really_high_start'))
+        expected_results.append(expected_result)
 
         a = 'unit_test'
         expected_result = a[0:999:2]
-        result = self.run_smart_contract(engine, path, 'really_high_end')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'really_high_end'))
+        expected_results.append(expected_result)
 
         a = 'unit_test'
         expected_result = a[999:999:2]
-        result = self.run_smart_contract(engine, path, 'really_high_values')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'really_high_values'))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_string_slicing_with_negative_stride(self):
-        path = self.get_contract_path('StringSlicingWithNegativeStride.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('StringSlicingWithNegativeStride.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         a = 'unit_test'
         expected_result = a[2:5:-1]
-        result = self.run_smart_contract(engine, path, 'literal_values')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'literal_values'))
+        expected_results.append(expected_result)
 
         a = 'unit_test'
         expected_result = a[-6:5:-1]
-        result = self.run_smart_contract(engine, path, 'negative_start')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_start'))
+        expected_results.append(expected_result)
 
         a = 'unit_test'
         expected_result = a[0:-1:-1]
-        result = self.run_smart_contract(engine, path, 'negative_end')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_end'))
+        expected_results.append(expected_result)
 
         a = 'unit_test'
         expected_result = a[-6:-1:-1]
-        result = self.run_smart_contract(engine, path, 'negative_values')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_values'))
+        expected_results.append(expected_result)
 
         a = 'unit_test'
         expected_result = a[-999:5:-1]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_start')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_really_low_start'))
+        expected_results.append(expected_result)
 
         a = 'unit_test'
         expected_result = a[0:-999:-1]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_end')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_really_low_end'))
+        expected_results.append(expected_result)
 
         a = 'unit_test'
         expected_result = a[-999:-999:-1]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_values')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_really_low_values'))
+        expected_results.append(expected_result)
 
         a = 'unit_test'
         expected_result = a[999:5:-1]
-        result = self.run_smart_contract(engine, path, 'really_high_start')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'really_high_start'))
+        expected_results.append(expected_result)
 
         a = 'unit_test'
         expected_result = a[0:999:-1]
-        result = self.run_smart_contract(engine, path, 'really_high_end')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'really_high_end'))
+        expected_results.append(expected_result)
 
         a = 'unit_test'
         expected_result = a[999:999:-1]
-        result = self.run_smart_contract(engine, path, 'really_high_values')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'really_high_values'))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_string_slicing_omitted_with_stride(self):
-        path = self.get_contract_path('StringSlicingOmittedWithStride.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('StringSlicingOmittedWithStride.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         a = 'unit_test'
         expected_result = a[::2]
-        result = self.run_smart_contract(engine, path, 'omitted_values')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'omitted_values'))
+        expected_results.append(expected_result)
 
         a = 'unit_test'
         expected_result = a[:5:2]
-        result = self.run_smart_contract(engine, path, 'omitted_start')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'omitted_start'))
+        expected_results.append(expected_result)
 
         a = 'unit_test'
         expected_result = a[2::2]
-        result = self.run_smart_contract(engine, path, 'omitted_end')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'omitted_end'))
+        expected_results.append(expected_result)
 
         a = 'unit_test'
         expected_result = a[-6::2]
-        result = self.run_smart_contract(engine, path, 'negative_start')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_start'))
+        expected_results.append(expected_result)
 
         a = 'unit_test'
         expected_result = a[:-1:2]
-        result = self.run_smart_contract(engine, path, 'negative_end')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_end'))
+        expected_results.append(expected_result)
 
         a = 'unit_test'
         expected_result = a[-999::2]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_start')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_really_low_start'))
+        expected_results.append(expected_result)
 
         a = 'unit_test'
         expected_result = a[:-999:2]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_end')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_really_low_end'))
+        expected_results.append(expected_result)
 
         a = 'unit_test'
         expected_result = a[999::2]
-        result = self.run_smart_contract(engine, path, 'really_high_start')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'really_high_start'))
+        expected_results.append(expected_result)
 
         a = 'unit_test'
         expected_result = a[:999:2]
-        result = self.run_smart_contract(engine, path, 'really_high_end')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'really_high_end'))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_string_slicing_omitted_with_negative_stride(self):
-        path = self.get_contract_path('StringSlicingOmittedWithNegativeStride.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('StringSlicingOmittedWithNegativeStride.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         a = 'unit_test'
         expected_result = a[::-2]
-        result = self.run_smart_contract(engine, path, 'omitted_values')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'omitted_values'))
+        expected_results.append(expected_result)
 
         a = 'unit_test'
         expected_result = a[:5:-2]
-        result = self.run_smart_contract(engine, path, 'omitted_start')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'omitted_start'))
+        expected_results.append(expected_result)
 
         a = 'unit_test'
         expected_result = a[2::-2]
-        result = self.run_smart_contract(engine, path, 'omitted_end')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'omitted_end'))
+        expected_results.append(expected_result)
 
         a = 'unit_test'
         expected_result = a[-6::-2]
-        result = self.run_smart_contract(engine, path, 'negative_start')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_start'))
+        expected_results.append(expected_result)
 
         a = 'unit_test'
         expected_result = a[:-1:-2]
-        result = self.run_smart_contract(engine, path, 'negative_end')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_end'))
+        expected_results.append(expected_result)
 
         a = 'unit_test'
         expected_result = a[-999::-2]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_start')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_really_low_start'))
+        expected_results.append(expected_result)
 
         a = 'unit_test'
         expected_result = a[:-999:-2]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_end')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'negative_really_low_end'))
+        expected_results.append(expected_result)
 
         a = 'unit_test'
         expected_result = a[999::-2]
-        result = self.run_smart_contract(engine, path, 'really_high_start')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'really_high_start'))
+        expected_results.append(expected_result)
 
         a = 'unit_test'
         expected_result = a[:999:-2]
-        result = self.run_smart_contract(engine, path, 'really_high_end')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'really_high_end'))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_string_simple_concat(self):
-        path = self.get_contract_path('StringSimpleConcat.py')
+        path, _ = self.get_deploy_file_paths('StringSimpleConcat.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual('bye worldhi', result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append('bye worldhi')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_boa2_string_concat_test(self):
-        path = self.get_contract_path('ConcatBoa2Test.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual('helloworld', result)
+        path, _ = self.get_deploy_file_paths('ConcatBoa2Test.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append('helloworld')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_boa2_string_concat_test2(self):
-        path = self.get_contract_path('ConcatBoa2Test2.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ConcatBoa2Test2.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', 'concat', ['hello', 'world'])
-        self.assertEqual('helloworld', result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', 'blah', ['hello', 'world'])
-        self.assertEqual(False, result)
+        invokes.append(runner.call_contract(path, 'main', 'concat', ['hello', 'world']))
+        expected_results.append('helloworld')
 
-        result = self.run_smart_contract(engine, path, 'main', 'concat', ['blah'])
-        self.assertEqual(False, result)
+        invokes.append(runner.call_contract(path, 'main', 'blah', ['hello', 'world']))
+        expected_results.append(False)
 
-        result = self.run_smart_contract(engine, path, 'main', 'concat', ['hello', 'world', 'third'])
-        self.assertEqual('helloworld', result)
+        invokes.append(runner.call_contract(path, 'main', 'concat', ['blah']))
+        expected_results.append(False)
 
-        result = self.run_smart_contract(engine, path, 'main', 'concat', ['1', 'neo'])
-        self.assertEqual('1neo', result)
+        invokes.append(runner.call_contract(path, 'main', 'concat', ['hello', 'world', 'third']))
+        expected_results.append('helloworld')
 
-        result = self.run_smart_contract(engine, path, 'main', 'concat', ['', 'neo'])
-        self.assertEqual('neo', result)
+        invokes.append(runner.call_contract(path, 'main', 'concat', ['1', 'neo']))
+        expected_results.append('1neo')
+
+        invokes.append(runner.call_contract(path, 'main', 'concat', ['', 'neo']))
+        expected_results.append('neo')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_string_with_double_quotes(self):
-        path = self.get_contract_path('StringWithDoubleQuotes.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('StringWithDoubleQuotes.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'string_test', 'hello', 'world')
-        self.assertEqual('"hell"test_symbol":world}"', result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'string_test', '1', 'neo')
-        self.assertEqual('""test_symbol":neo}"', result)
+        invokes.append(runner.call_contract(path, 'string_test', 'hello', 'world'))
+        expected_results.append('"hell"test_symbol":world}"')
 
-        result = self.run_smart_contract(engine, path, 'string_test', 'neo', '')
-        self.assertEqual('"ne"test_symbol":}"', result)
+        invokes.append(runner.call_contract(path, 'string_test', '1', 'neo'))
+        expected_results.append('""test_symbol":neo}"')
+
+        invokes.append(runner.call_contract(path, 'string_test', 'neo', ''))
+        expected_results.append('"ne"test_symbol":}"')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_string_upper(self):
-        path = self.get_contract_path('UpperStringMethod.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('UpperStringMethod.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         string = 'abcdefghijklmnopqrstuvwxyz'
-        result = self.run_smart_contract(engine, path, 'main', string)
-        self.assertEqual(string.upper(), result)
+        invokes.append(runner.call_contract(path, 'main', string))
+        expected_results.append(string.upper())
 
         string = 'a1b123y3z'
-        result = self.run_smart_contract(engine, path, 'main', string)
-        self.assertEqual(string.upper(), result)
+        invokes.append(runner.call_contract(path, 'main', string))
+        expected_results.append(string.upper())
 
         string = '!@#$%123*-/'
-        result = self.run_smart_contract(engine, path, 'main', string)
-        self.assertEqual(string.upper(), result)
+        invokes.append(runner.call_contract(path, 'main', string))
+        expected_results.append(string.upper())
 
         string = 'áõèñ'
-        result = self.run_smart_contract(engine, path, 'main', string)
+        not_as_expected = runner.call_contract(path, 'main', string)
 
-        with self.assertRaises(AssertionError):
-            # TODO: upper was implemented for ASCII characters only
-            self.assertEqual(string.upper(), result)
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        # TODO: upper was implemented for ASCII characters only
+        self.assertNotEqual(string.upper(), not_as_expected.result)
 
     def test_string_lower(self):
-        path = self.get_contract_path('LowerStringMethod.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('LowerStringMethod.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         string = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
-        result = self.run_smart_contract(engine, path, 'main', string)
-        self.assertEqual(string.lower(), result)
+        invokes.append(runner.call_contract(path, 'main', string))
+        expected_results.append(string.lower())
 
         string = 'A1B123Y3Z'
-        result = self.run_smart_contract(engine, path, 'main', string)
-        self.assertEqual(string.lower(), result)
+        invokes.append(runner.call_contract(path, 'main', string))
+        expected_results.append(string.lower())
 
         string = '!@#$%123*-/'
-        result = self.run_smart_contract(engine, path, 'main', string)
-        self.assertEqual(string.lower(), result)
+        invokes.append(runner.call_contract(path, 'main', string))
+        expected_results.append(string.lower())
 
         string = 'ÁÕÈÑ'
-        result = self.run_smart_contract(engine, path, 'main', string)
+        not_as_expected = runner.call_contract(path, 'main', string)
 
-        with self.assertRaises(AssertionError):
-            # TODO: lower was implemented for ASCII characters only
-            self.assertEqual(string.lower(), result)
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        # TODO: lower was implemented for ASCII characters only
+        self.assertNotEqual(string.lower(), not_as_expected.result)
 
     def test_string_startswith_method(self):
-        path = self.get_contract_path('StartswithStringMethod.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('StartswithStringMethod.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         string = 'unit_test'
         substring = 'unit'
         start = 0
         end = len(string)
-        result = self.run_smart_contract(engine, path, 'main', string, substring, start, end)
-        self.assertEqual(string.startswith(substring, start, end), result)
+        invokes.append(runner.call_contract(path, 'main', string, substring, start, end))
+        expected_results.append(string.startswith(substring, start, end))
 
         string = 'unit_test'
         substring = 'unit'
         start = 2
         end = 6
-        result = self.run_smart_contract(engine, path, 'main', string, substring, start, end)
-        self.assertEqual(string.startswith(substring, start, end), result)
+        invokes.append(runner.call_contract(path, 'main', string, substring, start, end))
+        expected_results.append(string.startswith(substring, start, end))
 
         string = 'unit_test'
         substring = 'it'
         start = 2
         end = 6
-        result = self.run_smart_contract(engine, path, 'main', string, substring, start, end)
-        self.assertEqual(string.startswith(substring, start, end), result)
+        invokes.append(runner.call_contract(path, 'main', string, substring, start, end))
+        expected_results.append(string.startswith(substring, start, end))
 
         string = 'unit_test'
         substring = 'it'
         start = 2
         end = 3
-        result = self.run_smart_contract(engine, path, 'main', string, substring, start, end)
-        self.assertEqual(string.startswith(substring, start, end), result)
+        invokes.append(runner.call_contract(path, 'main', string, substring, start, end))
+        expected_results.append(string.startswith(substring, start, end))
 
         string = 'unit_test'
         substring = 'unit_tes'
         start = -99
         end = -1
-        result = self.run_smart_contract(engine, path, 'main', string, substring, start, end)
-        self.assertEqual(string.startswith(substring, start, end), result)
+        invokes.append(runner.call_contract(path, 'main', string, substring, start, end))
+        expected_results.append(string.startswith(substring, start, end))
 
         string = 'unit_test'
         substring = ''
         start = 0
         end = 0
-        result = self.run_smart_contract(engine, path, 'main', string, substring, start, end)
-        self.assertEqual(string.startswith(substring, start, end), result)
+        invokes.append(runner.call_contract(path, 'main', string, substring, start, end))
+        expected_results.append(string.startswith(substring, start, end))
 
         string = 'unit_test'
         substring = 'unit_test'
         start = 0
         end = 99
-        result = self.run_smart_contract(engine, path, 'main', string, substring, start, end)
-        self.assertEqual(string.startswith(substring, start, end), result)
+        invokes.append(runner.call_contract(path, 'main', string, substring, start, end))
+        expected_results.append(string.startswith(substring, start, end))
 
         string = 'unit_test'
         substring = 'unit_test'
         start = 100
         end = 99
-        result = self.run_smart_contract(engine, path, 'main', string, substring, start, end)
-        self.assertEqual(string.startswith(substring, start, end), result)
+        invokes.append(runner.call_contract(path, 'main', string, substring, start, end))
+        expected_results.append(string.startswith(substring, start, end))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_string_startswith_method_default_end(self):
-        path = self.get_contract_path('StartswithStringMethodDefaultEnd.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('StartswithStringMethodDefaultEnd.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         string = 'unit_test'
         substring = 'unit'
         start = 0
-        result = self.run_smart_contract(engine, path, 'main', string, substring, start)
-        self.assertEqual(string.startswith(substring, start), result)
+        invokes.append(runner.call_contract(path, 'main', string, substring, start))
+        expected_results.append(string.startswith(substring, start))
 
         string = 'unit_test'
         substring = 'unit'
         start = 2
-        result = self.run_smart_contract(engine, path, 'main', string, substring, start)
-        self.assertEqual(string.startswith(substring, start), result)
+        invokes.append(runner.call_contract(path, 'main', string, substring, start))
+        expected_results.append(string.startswith(substring, start))
 
         string = 'unit_test'
         substring = 'it'
         start = 2
-        result = self.run_smart_contract(engine, path, 'main', string, substring, start)
-        self.assertEqual(string.startswith(substring, start), result)
+        invokes.append(runner.call_contract(path, 'main', string, substring, start))
+        expected_results.append(string.startswith(substring, start))
 
         string = 'unit_test'
         substring = 'it'
         start = 3
-        result = self.run_smart_contract(engine, path, 'main', string, substring, start)
-        self.assertEqual(string.startswith(substring, start), result)
+        invokes.append(runner.call_contract(path, 'main', string, substring, start))
+        expected_results.append(string.startswith(substring, start))
 
         string = 'unit_test'
         substring = 'unit_tes'
         start = -99
-        result = self.run_smart_contract(engine, path, 'main', string, substring, start)
-        self.assertEqual(string.startswith(substring, start), result)
+        invokes.append(runner.call_contract(path, 'main', string, substring, start))
+        expected_results.append(string.startswith(substring, start))
 
         string = 'unit_test'
         substring = ''
         start = 0
-        result = self.run_smart_contract(engine, path, 'main', string, substring, start)
-        self.assertEqual(string.startswith(substring, start), result)
+        invokes.append(runner.call_contract(path, 'main', string, substring, start))
+        expected_results.append(string.startswith(substring, start))
 
         string = 'unit_test'
         substring = ''
         start = 99
-        result = self.run_smart_contract(engine, path, 'main', string, substring, start)
-        self.assertEqual(string.startswith(substring, start), result)
+        invokes.append(runner.call_contract(path, 'main', string, substring, start))
+        expected_results.append(string.startswith(substring, start))
 
         string = 'unit_test'
         substring = 'unit_test'
         start = 0
-        result = self.run_smart_contract(engine, path, 'main', string, substring, start)
-        self.assertEqual(string.startswith(substring, start), result)
+        invokes.append(runner.call_contract(path, 'main', string, substring, start))
+        expected_results.append(string.startswith(substring, start))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_string_startswith_method_defaults(self):
-        path = self.get_contract_path('StartswithStringMethodDefaults.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('StartswithStringMethodDefaults.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         string = 'unit_test'
         substring = 'unit'
-        result = self.run_smart_contract(engine, path, 'main', string, substring)
-        self.assertEqual(string.startswith(substring), result)
+        invokes.append(runner.call_contract(path, 'main', string, substring))
+        expected_results.append(string.startswith(substring))
 
         string = 'unit_test'
         substring = 'unit_test'
-        result = self.run_smart_contract(engine, path, 'main', string, substring)
-        self.assertEqual(string.startswith(substring), result)
+        invokes.append(runner.call_contract(path, 'main', string, substring))
+        expected_results.append(string.startswith(substring))
 
         string = 'unit_test'
         substring = ''
-        result = self.run_smart_contract(engine, path, 'main', string, substring)
-        self.assertEqual(string.startswith(substring), result)
+        invokes.append(runner.call_contract(path, 'main', string, substring))
+        expected_results.append(string.startswith(substring))
 
         string = 'unit_test'
         substring = '12345'
-        result = self.run_smart_contract(engine, path, 'main', string, substring)
-        self.assertEqual(string.startswith(substring), result)
+        invokes.append(runner.call_contract(path, 'main', string, substring))
+        expected_results.append(string.startswith(substring))
 
         string = 'unit_test'
         substring = 'bigger substring'
-        result = self.run_smart_contract(engine, path, 'main', string, substring)
-        self.assertEqual(string.startswith(substring), result)
+        invokes.append(runner.call_contract(path, 'main', string, substring))
+        expected_results.append(string.startswith(substring))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_string_strip(self):
-        path = self.get_contract_path('StripStringMethod.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('StripStringMethod.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         string = 'abcdefghijklmnopqrstuvwxyz'
         chars = 'abcxyz'
-        result = self.run_smart_contract(engine, path, 'main', string, chars)
-        self.assertEqual(string.strip(chars), result)
+        invokes.append(runner.call_contract(path, 'main', string, chars))
+        expected_results.append(string.strip(chars))
 
         string = 'abcdefghijklmnopqrsvwxyz unit test abcdefghijklmnopqrsvwxyz'
         chars = 'abcdefghijklmnopqrsvwxyz '
-        result = self.run_smart_contract(engine, path, 'main', string, chars)
-        self.assertEqual(string.strip(chars), result)
+        invokes.append(runner.call_contract(path, 'main', string, chars))
+        expected_results.append(string.strip(chars))
 
         string = '0123456789hello world987654310'
         chars = '0987654321'
-        result = self.run_smart_contract(engine, path, 'main', string, chars)
-        self.assertEqual(string.strip(chars), result)
+        invokes.append(runner.call_contract(path, 'main', string, chars))
+        expected_results.append(string.strip(chars))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_string_strip_default(self):
-        path = self.get_contract_path('StripStringMethodDefault.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('StripStringMethodDefault.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         string = '     unit test    '
-        result = self.run_smart_contract(engine, path, 'main', string)
-        self.assertEqual(string.strip(), result)
+        invokes.append(runner.call_contract(path, 'main', string))
+        expected_results.append(string.strip())
 
         string = 'unit test    '
-        result = self.run_smart_contract(engine, path, 'main', string)
-        self.assertEqual(string.strip(), result)
+        invokes.append(runner.call_contract(path, 'main', string))
+        expected_results.append(string.strip())
 
         string = '    unit test'
-        result = self.run_smart_contract(engine, path, 'main', string)
-        self.assertEqual(string.strip(), result)
+        invokes.append(runner.call_contract(path, 'main', string))
+        expected_results.append(string.strip())
 
         string = ' \t\n\r\f\vunit test \t\n\r\f\v'
-        result = self.run_smart_contract(engine, path, 'main', string)
-        self.assertEqual(string.strip(), result)
+        invokes.append(runner.call_contract(path, 'main', string))
+        expected_results.append(string.strip())
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_isdigit_method(self):
-        path = self.get_contract_path('IsdigitMethod.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('IsdigitMethod.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         string = '0123456789'
-        result = self.run_smart_contract(engine, path, 'main', string)
-        self.assertEqual(string.isdigit(), result)
+        invokes.append(runner.call_contract(path, 'main', string))
+        expected_results.append(string.isdigit())
 
         string = '23mixed01'
-        result = self.run_smart_contract(engine, path, 'main', string)
-        self.assertEqual(string.isdigit(), result)
+        invokes.append(runner.call_contract(path, 'main', string))
+        expected_results.append(string.isdigit())
 
         string = 'no digits here'
-        result = self.run_smart_contract(engine, path, 'main', string)
-        self.assertEqual(string.isdigit(), result)
+        invokes.append(runner.call_contract(path, 'main', string))
+        expected_results.append(string.isdigit())
 
         string = ''
-        result = self.run_smart_contract(engine, path, 'main', string)
-        self.assertEqual(string.isdigit(), result)
+        invokes.append(runner.call_contract(path, 'main', string))
+        expected_results.append(string.isdigit())
 
         string = '¹²³'
-        result = self.run_smart_contract(engine, path, 'main', string)
-        with self.assertRaises(AssertionError):
-            # neo3-boas isdigit implementation does not verify values that are not from the ASCII
-            self.assertEqual(string.isdigit(), result)
+        not_as_expected = runner.call_contract(path, 'main', string)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        # neo3-boas isdigit implementation does not verify values that are not from the ASCII
+        self.assertNotEqual(string.isdigit(), not_as_expected.result)
 
     def test_string_join_with_sequence(self):
-        path = self.get_contract_path('JoinStringMethodWithSequence.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('JoinStringMethodWithSequence.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         string = ' '
         sequence = ["Unit", "Test", "Neo3-boa"]
-        result = self.run_smart_contract(engine, path, 'main', string, sequence)
-        self.assertEqual(string.join(sequence), result)
+        invokes.append(runner.call_contract(path, 'main', string, sequence))
+        expected_results.append(string.join(sequence))
 
         string = ' '
         sequence = []
-        result = self.run_smart_contract(engine, path, 'main', string, sequence)
-        self.assertEqual(string.join(sequence), result)
+        invokes.append(runner.call_contract(path, 'main', string, sequence))
+        expected_results.append(string.join(sequence))
 
         string = ' '
         sequence = ["UnitTest"]
-        result = self.run_smart_contract(engine, path, 'main', string, sequence)
-        self.assertEqual(string.join(sequence), result)
+        invokes.append(runner.call_contract(path, 'main', string, sequence))
+        expected_results.append(string.join(sequence))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_string_join_with_dictionary(self):
-        path = self.get_contract_path('JoinStringMethodWithDictionary.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('JoinStringMethodWithDictionary.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         string = ' '
         dictionary = {"Unit": 1, "Test": 2, "Neo3-boa": 3}
-        result = self.run_smart_contract(engine, path, 'main', string, dictionary)
-        self.assertEqual(string.join(dictionary), result)
+        invokes.append(runner.call_contract(path, 'main', string, dictionary))
+        expected_results.append(string.join(dictionary))
 
         string = ' '
         dictionary = {}
-        result = self.run_smart_contract(engine, path, 'main', string, dictionary)
-        self.assertEqual(string.join(dictionary), result)
+        invokes.append(runner.call_contract(path, 'main', string, dictionary))
+        expected_results.append(string.join(dictionary))
 
         string = ' '
         dictionary = {"UnitTest": 1}
-        result = self.run_smart_contract(engine, path, 'main', string, dictionary)
-        self.assertEqual(string.join(dictionary), result)
+        invokes.append(runner.call_contract(path, 'main', string, dictionary))
+        expected_results.append(string.join(dictionary))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_string_index(self):
-        path = self.get_contract_path('IndexString.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('IndexString.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         string = 'unit test'
         substring = 'i'
         start = 0
         end = 4
-        result = self.run_smart_contract(engine, path, 'main', string, substring, start, end)
-        self.assertEqual(string.index(substring, start, end), result)
+        invokes.append(runner.call_contract(path, 'main', string, substring, start, end))
+        expected_results.append(string.index(substring, start, end))
 
         string = 'unit test'
         substring = 'i'
         start = 2
         end = 4
-        result = self.run_smart_contract(engine, path, 'main', string, substring, start, end)
-        self.assertEqual(string.index(substring, start, end), result)
-
-        with self.assertRaisesRegex(TestExecutionException, f'{self.SUBSTRING_NOT_FOUND_MSG}$'):
-            self.run_smart_contract(engine, path, 'main', 'unit test', 'i', 3, 4)
-
-        with self.assertRaisesRegex(TestExecutionException, f'{self.SUBSTRING_NOT_FOUND_MSG}$'):
-            self.run_smart_contract(engine, path, 'main', 'unit test', 'i', 4, -1)
-
-        with self.assertRaisesRegex(TestExecutionException, f'{self.SUBSTRING_NOT_FOUND_MSG}$'):
-            self.run_smart_contract(engine, path, 'main', 'unit test', 'i', 0, -99)
+        invokes.append(runner.call_contract(path, 'main', string, substring, start, end))
+        expected_results.append(string.index(substring, start, end))
 
         string = 'unit test'
         substring = 'i'
         start = 0
         end = -1
-        result = self.run_smart_contract(engine, path, 'main', string, substring, start, end)
-        self.assertEqual(string.index(substring, start, end), result)
+        invokes.append(runner.call_contract(path, 'main', string, substring, start, end))
+        expected_results.append(string.index(substring, start, end))
 
         string = 'unit test'
         substring = 'n'
         start = 0
         end = 99
-        result = self.run_smart_contract(engine, path, 'main', string, substring, start, end)
-        self.assertEqual(string.index(substring, start, end), result)
+        invokes.append(runner.call_contract(path, 'main', string, substring, start, end))
+        expected_results.append(string.index(substring, start, end))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        runner.call_contract(path, 'main', 'unit test', 'i', 3, 4)
+        runner.execute()
+
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'{self.SUBSTRING_NOT_FOUND_MSG}$')
+
+        runner.call_contract(path, 'main', 'unit test', 'i', 4, -1)
+        runner.execute()
+
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'{self.SUBSTRING_NOT_FOUND_MSG}$')
+
+        runner.call_contract(path, 'main', 'unit test', 'i', 0, -99)
+        runner.execute()
+
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'{self.SUBSTRING_NOT_FOUND_MSG}$')
 
     def test_string_index_end_default(self):
-        path = self.get_contract_path('IndexStringEndDefault.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('IndexStringEndDefault.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         string = 'unit test'
         substring = 't'
         start = 0
-        result = self.run_smart_contract(engine, path, 'main', string, substring, start)
-        self.assertEqual(string.index(substring, start), result)
+        invokes.append(runner.call_contract(path, 'main', string, substring, start))
+        expected_results.append(string.index(substring, start))
 
         string = 'unit test'
         substring = 't'
         start = 4
-        result = self.run_smart_contract(engine, path, 'main', string, substring, start)
-        self.assertEqual(string.index(substring, start), result)
+        invokes.append(runner.call_contract(path, 'main', string, substring, start))
+        expected_results.append(string.index(substring, start))
 
         string = 'unit test'
         substring = 't'
         start = 6
-        result = self.run_smart_contract(engine, path, 'main', string, substring, start)
-        self.assertEqual(string.index(substring, start), result)
-
-        with self.assertRaisesRegex(TestExecutionException, f'{self.SUBSTRING_NOT_FOUND_MSG}$'):
-            self.run_smart_contract(engine, path, 'main', 'unit test', 'i', 99)
-
-        with self.assertRaisesRegex(TestExecutionException, f'{self.SUBSTRING_NOT_FOUND_MSG}$'):
-            self.run_smart_contract(engine, path, 'main', 'unit test', 't', -1)
+        invokes.append(runner.call_contract(path, 'main', string, substring, start))
+        expected_results.append(string.index(substring, start))
 
         string = 'unit test'
         substring = 'i'
         start = -10
-        result = self.run_smart_contract(engine, path, 'main', string, substring, start)
-        self.assertEqual(string.index(substring, start), result)
+        invokes.append(runner.call_contract(path, 'main', string, substring, start))
+        expected_results.append(string.index(substring, start))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        runner.call_contract(path, 'main', 'unit test', 'i', 99)
+        runner.execute()
+
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'{self.SUBSTRING_NOT_FOUND_MSG}$')
+
+        runner.call_contract(path, 'main', 'unit test', 't', -1)
+        runner.execute()
+
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'{self.SUBSTRING_NOT_FOUND_MSG}$')
 
     def test_string_index_defaults(self):
-        path = self.get_contract_path('IndexStringDefaults.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('IndexStringDefaults.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         string = 'unit test'
         substring = 'u'
-        result = self.run_smart_contract(engine, path, 'main', string, substring)
-        self.assertEqual(string.index(substring), result)
+        invokes.append(runner.call_contract(path, 'main', string, substring))
+        expected_results.append(string.index(substring))
 
         string = 'unit test'
         substring = 't'
-        result = self.run_smart_contract(engine, path, 'main', string, substring)
-        self.assertEqual(string.index(substring), result)
+        invokes.append(runner.call_contract(path, 'main', string, substring))
+        expected_results.append(string.index(substring))
 
         string = 'unit test'
         substring = ' '
-        result = self.run_smart_contract(engine, path, 'main', string, substring)
-        self.assertEqual(string.index(substring), result)
+        invokes.append(runner.call_contract(path, 'main', string, substring))
+        expected_results.append(string.index(substring))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_string_index_mismatched_type(self):
         path = self.get_contract_path('IndexStringMismatchedType.py')

--- a/boa3_test/tests/compiler_tests/test_tuple.py
+++ b/boa3_test/tests/compiler_tests/test_tuple.py
@@ -3,9 +3,9 @@ from boa3.exception import CompilerError
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.String import String
+from boa3.neo3.vm import VMState
+from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.boa_test import BoaTest
-from boa3_test.tests.test_classes.TestExecutionException import TestExecutionException
-from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestTuple(BoaTest):
@@ -136,14 +136,28 @@ class TestTuple(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', [1, 2, 3, 4])
-        self.assertEqual(1, result)
-        result = self.run_smart_contract(engine, path, 'Main', [5, 3, 2])
-        self.assertEqual(5, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
 
-        with self.assertRaisesRegex(TestExecutionException, self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX):
-            self.run_smart_contract(engine, path, 'Main', [])
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', [1, 2, 3, 4]))
+        expected_results.append(1)
+        invokes.append(runner.call_contract(path, 'Main', [5, 3, 2]))
+        expected_results.append(5)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        runner.call_contract(path, 'Main', [])
+        runner.execute()
+
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX)
 
     def test_non_sequence_get_value(self):
         path = self.get_contract_path('MismatchedTypeGetValue.py')
@@ -194,15 +208,32 @@ class TestTuple(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', ((1, 2), (3, 4)))
-        self.assertEqual(result, 1)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
 
-        with self.assertRaisesRegex(TestExecutionException, self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX):
-            self.run_smart_contract(engine, path, 'Main', ())
+        invokes = []
+        expected_results = []
 
-        with self.assertRaisesRegex(TestExecutionException, self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX):
-            self.run_smart_contract(engine, path, 'Main', ((), (1, 2), (3, 4)))
+        invokes.append(runner.call_contract(path, 'Main', ((1, 2), (3, 4))))
+        expected_results.append(1)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        runner.call_contract(path, 'Main', ())
+        runner.execute()
+
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX)
+
+        runner.call_contract(path, 'Main', ((), (1, 2), (3, 4)))
+        runner.execute()
+
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX)
 
     def test_nep5_main(self):
         expected_output = (
@@ -227,56 +258,124 @@ class TestTuple(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', 'op', (1, 2, 3, 4))
-        self.assertEqual(1, result)
-        result = self.run_smart_contract(engine, path, 'Main', 'op', ('a', False))
-        self.assertEqual('a', result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
 
-        with self.assertRaisesRegex(TestExecutionException, self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX):
-            self.run_smart_contract(engine, path, 'Main', 'op', ())
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', 'op', (1, 2, 3, 4)))
+        expected_results.append(1)
+        invokes.append(runner.call_contract(path, 'Main', 'op', ('a', False)))
+        expected_results.append('a')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        runner.call_contract(path, 'Main', 'op', ())
+        runner.execute()
+
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX)
 
     def test_tuple_slicing(self):
-        path = self.get_contract_path('TupleSlicingLiteralValues.py')
+        path, _ = self.get_deploy_file_paths('TupleSlicingLiteralValues.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual([2], result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append([2])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_tuple_slicing_start_larger_than_ending(self):
-        path = self.get_contract_path('TupleSlicingStartLargerThanEnding.py')
+        path, _ = self.get_deploy_file_paths('TupleSlicingStartLargerThanEnding.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual([], result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append([])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_tuple_slicing_with_variables(self):
-        path = self.get_contract_path('TupleSlicingVariableValues.py')
+        path, _ = self.get_deploy_file_paths('TupleSlicingVariableValues.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual([2], result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append([2])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_tuple_slicing_negative_start(self):
-        path = self.get_contract_path('TupleSlicingNegativeStart.py')
+        path, _ = self.get_deploy_file_paths('TupleSlicingNegativeStart.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual([2, 3, 4, 5], result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append([2, 3, 4, 5])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_tuple_slicing_negative_end(self):
-        path = self.get_contract_path('TupleSlicingNegativeEnd.py')
+        path, _ = self.get_deploy_file_paths('TupleSlicingNegativeEnd.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual([0, 1], result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append([0, 1])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_tuple_slicing_start_omitted(self):
-        path = self.get_contract_path('TupleSlicingStartOmitted.py')
+        path, _ = self.get_deploy_file_paths('TupleSlicingStartOmitted.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual([0, 1, 2], result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append([0, 1, 2])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_tuple_slicing_omitted(self):
         expected_output = (
@@ -301,298 +400,434 @@ class TestTuple(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual([0, 1, 2, 3, 4, 5], result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append([0, 1, 2, 3, 4, 5])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_tuple_slicing_end_omitted(self):
-        path = self.get_contract_path('TupleSlicingEndOmitted.py')
+        path, _ = self.get_deploy_file_paths('TupleSlicingEndOmitted.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual([2, 3, 4, 5], result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append([2, 3, 4, 5])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_tuple_slicing_with_stride(self):
-        path = self.get_contract_path('TupleSlicingWithStride.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('TupleSlicingWithStride.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         a = (0, 1, 2, 3, 4, 5)
         expected_result = a[2:5:2]
-        result = self.run_smart_contract(engine, path, 'literal_values')
-        self.assertEqual(expected_result, tuple(result))
+        invokes.append(runner.call_contract(path, 'literal_values',
+                                            expected_result_type=tuple))
+        expected_results.append(expected_result)
 
         a = (0, 1, 2, 3, 4, 5)
         expected_result = a[-6:5:2]
-        result = self.run_smart_contract(engine, path, 'negative_start')
-        self.assertEqual(expected_result, tuple(result))
+        invokes.append(runner.call_contract(path, 'negative_start',
+                                            expected_result_type=tuple))
+        expected_results.append(expected_result)
 
         a = (0, 1, 2, 3, 4, 5)
         expected_result = a[0:-1:2]
-        result = self.run_smart_contract(engine, path, 'negative_end')
-        self.assertEqual(expected_result, tuple(result))
+        invokes.append(runner.call_contract(path, 'negative_end',
+                                            expected_result_type=tuple))
+        expected_results.append(expected_result)
 
         a = (0, 1, 2, 3, 4, 5)
         expected_result = a[-6:-1:2]
-        result = self.run_smart_contract(engine, path, 'negative_values')
-        self.assertEqual(expected_result, tuple(result))
+        invokes.append(runner.call_contract(path, 'negative_values',
+                                            expected_result_type=tuple))
+        expected_results.append(expected_result)
 
         a = (0, 1, 2, 3, 4, 5)
         expected_result = a[-999:5:2]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_start')
-        self.assertEqual(expected_result, tuple(result))
+        invokes.append(runner.call_contract(path, 'negative_really_low_start',
+                                            expected_result_type=tuple))
+        expected_results.append(expected_result)
 
         a = (0, 1, 2, 3, 4, 5)
         expected_result = a[0:-999:2]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_end')
-        self.assertEqual(expected_result, tuple(result))
+        invokes.append(runner.call_contract(path, 'negative_really_low_end',
+                                            expected_result_type=tuple))
+        expected_results.append(expected_result)
 
         a = (0, 1, 2, 3, 4, 5)
         expected_result = a[-999:-999:2]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_values')
-        self.assertEqual(expected_result, tuple(result))
+        invokes.append(runner.call_contract(path, 'negative_really_low_values',
+                                            expected_result_type=tuple))
+        expected_results.append(expected_result)
 
         a = (0, 1, 2, 3, 4, 5)
         expected_result = a[999:5:2]
-        result = self.run_smart_contract(engine, path, 'really_high_start')
-        self.assertEqual(expected_result, tuple(result))
+        invokes.append(runner.call_contract(path, 'really_high_start',
+                                            expected_result_type=tuple))
+        expected_results.append(expected_result)
 
         a = (0, 1, 2, 3, 4, 5)
         expected_result = a[0:999:2]
-        result = self.run_smart_contract(engine, path, 'really_high_end')
-        self.assertEqual(expected_result, tuple(result))
+        invokes.append(runner.call_contract(path, 'really_high_end',
+                                            expected_result_type=tuple))
+        expected_results.append(expected_result)
 
         a = (0, 1, 2, 3, 4, 5)
         expected_result = a[999:999:2]
-        result = self.run_smart_contract(engine, path, 'really_high_values')
-        self.assertEqual(expected_result, tuple(result))
+        invokes.append(runner.call_contract(path, 'really_high_values',
+                                            expected_result_type=tuple))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_tuple_slicing_with_negative_stride(self):
-        path = self.get_contract_path('TupleSlicingWithNegativeStride.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('TupleSlicingWithNegativeStride.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         a = (0, 1, 2, 3, 4, 5)
         expected_result = a[2:5:-1]
-        result = self.run_smart_contract(engine, path, 'literal_values')
-        self.assertEqual(expected_result, tuple(result))
+        invokes.append(runner.call_contract(path, 'literal_values',
+                                            expected_result_type=tuple))
+        expected_results.append(expected_result)
 
         a = (0, 1, 2, 3, 4, 5)
         expected_result = a[-6:5:-1]
-        result = self.run_smart_contract(engine, path, 'negative_start')
-        self.assertEqual(expected_result, tuple(result))
+        invokes.append(runner.call_contract(path, 'negative_start',
+                                            expected_result_type=tuple))
+        expected_results.append(expected_result)
 
         a = (0, 1, 2, 3, 4, 5)
         expected_result = a[0:-1:-1]
-        result = self.run_smart_contract(engine, path, 'negative_end')
-        self.assertEqual(expected_result, tuple(result))
+        invokes.append(runner.call_contract(path, 'negative_end',
+                                            expected_result_type=tuple))
+        expected_results.append(expected_result)
 
         a = (0, 1, 2, 3, 4, 5)
         expected_result = a[-6:-1:-1]
-        result = self.run_smart_contract(engine, path, 'negative_values')
-        self.assertEqual(expected_result, tuple(result))
+        invokes.append(runner.call_contract(path, 'negative_values',
+                                            expected_result_type=tuple))
+        expected_results.append(expected_result)
 
         a = (0, 1, 2, 3, 4, 5)
         expected_result = a[-999:5:-1]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_start')
-        self.assertEqual(expected_result, tuple(result))
+        invokes.append(runner.call_contract(path, 'negative_really_low_start',
+                                            expected_result_type=tuple))
+        expected_results.append(expected_result)
 
         a = (0, 1, 2, 3, 4, 5)
         expected_result = a[0:-999:-1]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_end')
-        self.assertEqual(expected_result, tuple(result))
+        invokes.append(runner.call_contract(path, 'negative_really_low_end',
+                                            expected_result_type=tuple))
+        expected_results.append(expected_result)
 
         a = (0, 1, 2, 3, 4, 5)
         expected_result = a[-999:-999:-1]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_values')
-        self.assertEqual(expected_result, tuple(result))
+        invokes.append(runner.call_contract(path, 'negative_really_low_values',
+                                            expected_result_type=tuple))
+        expected_results.append(expected_result)
 
         a = (0, 1, 2, 3, 4, 5)
         expected_result = a[999:5:-1]
-        result = self.run_smart_contract(engine, path, 'really_high_start')
-        self.assertEqual(expected_result, tuple(result))
+        invokes.append(runner.call_contract(path, 'really_high_start',
+                                            expected_result_type=tuple))
+        expected_results.append(expected_result)
 
         a = (0, 1, 2, 3, 4, 5)
         expected_result = a[0:999:-1]
-        result = self.run_smart_contract(engine, path, 'really_high_end')
-        self.assertEqual(expected_result, tuple(result))
+        invokes.append(runner.call_contract(path, 'really_high_end',
+                                            expected_result_type=tuple))
+        expected_results.append(expected_result)
 
         a = (0, 1, 2, 3, 4, 5)
         expected_result = a[999:999:-1]
-        result = self.run_smart_contract(engine, path, 'really_high_values')
-        self.assertEqual(expected_result, tuple(result))
+        invokes.append(runner.call_contract(path, 'really_high_values',
+                                            expected_result_type=tuple))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_tuple_slicing_omitted_with_stride(self):
-        path = self.get_contract_path('TupleSlicingOmittedWithStride.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('TupleSlicingOmittedWithStride.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         a = (0, 1, 2, 3, 4, 5)
         expected_result = a[::2]
-        result = self.run_smart_contract(engine, path, 'omitted_values')
-        self.assertEqual(expected_result, tuple(result))
+        invokes.append(runner.call_contract(path, 'omitted_values',
+                                            expected_result_type=tuple))
+        expected_results.append(expected_result)
 
         a = (0, 1, 2, 3, 4, 5)
         expected_result = a[:5:2]
-        result = self.run_smart_contract(engine, path, 'omitted_start')
-        self.assertEqual(expected_result, tuple(result))
+        invokes.append(runner.call_contract(path, 'omitted_start',
+                                            expected_result_type=tuple))
+        expected_results.append(expected_result)
 
         a = (0, 1, 2, 3, 4, 5)
         expected_result = a[2::2]
-        result = self.run_smart_contract(engine, path, 'omitted_end')
-        self.assertEqual(expected_result, tuple(result))
+        invokes.append(runner.call_contract(path, 'omitted_end',
+                                            expected_result_type=tuple))
+        expected_results.append(expected_result)
 
         a = (0, 1, 2, 3, 4, 5)
         expected_result = a[-6::2]
-        result = self.run_smart_contract(engine, path, 'negative_start')
-        self.assertEqual(expected_result, tuple(result))
+        invokes.append(runner.call_contract(path, 'negative_start',
+                                            expected_result_type=tuple))
+        expected_results.append(expected_result)
 
         a = (0, 1, 2, 3, 4, 5)
         expected_result = a[:-1:2]
-        result = self.run_smart_contract(engine, path, 'negative_end')
-        self.assertEqual(expected_result, tuple(result))
+        invokes.append(runner.call_contract(path, 'negative_end',
+                                            expected_result_type=tuple))
+        expected_results.append(expected_result)
 
         a = (0, 1, 2, 3, 4, 5)
         expected_result = a[-999::2]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_start')
-        self.assertEqual(expected_result, tuple(result))
+        invokes.append(runner.call_contract(path, 'negative_really_low_start',
+                                            expected_result_type=tuple))
+        expected_results.append(expected_result)
 
         a = (0, 1, 2, 3, 4, 5)
         expected_result = a[:-999:2]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_end')
-        self.assertEqual(expected_result, tuple(result))
+        invokes.append(runner.call_contract(path, 'negative_really_low_end',
+                                            expected_result_type=tuple))
+        expected_results.append(expected_result)
 
         a = (0, 1, 2, 3, 4, 5)
         expected_result = a[999::2]
-        result = self.run_smart_contract(engine, path, 'really_high_start')
-        self.assertEqual(expected_result, tuple(result))
+        invokes.append(runner.call_contract(path, 'really_high_start',
+                                            expected_result_type=tuple))
+        expected_results.append(expected_result)
 
         a = (0, 1, 2, 3, 4, 5)
         expected_result = a[:999:2]
-        result = self.run_smart_contract(engine, path, 'really_high_end')
-        self.assertEqual(expected_result, tuple(result))
+        invokes.append(runner.call_contract(path, 'really_high_end',
+                                            expected_result_type=tuple))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_tuple_slicing_omitted_with_negative_stride(self):
-        path = self.get_contract_path('TupleSlicingOmittedWithNegativeStride.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('TupleSlicingOmittedWithNegativeStride.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         a = (0, 1, 2, 3, 4, 5)
         expected_result = a[::-2]
-        result = self.run_smart_contract(engine, path, 'omitted_values')
-        self.assertEqual(expected_result, tuple(result))
+        invokes.append(runner.call_contract(path, 'omitted_values',
+                                            expected_result_type=tuple))
+        expected_results.append(expected_result)
 
         a = (0, 1, 2, 3, 4, 5)
         expected_result = a[:5:-2]
-        result = self.run_smart_contract(engine, path, 'omitted_start')
-        self.assertEqual(expected_result, tuple(result))
+        invokes.append(runner.call_contract(path, 'omitted_start',
+                                            expected_result_type=tuple))
+        expected_results.append(expected_result)
 
         a = (0, 1, 2, 3, 4, 5)
         expected_result = a[2::-2]
-        result = self.run_smart_contract(engine, path, 'omitted_end')
-        self.assertEqual(expected_result, tuple(result))
+        invokes.append(runner.call_contract(path, 'omitted_end',
+                                            expected_result_type=tuple))
+        expected_results.append(expected_result)
 
         a = (0, 1, 2, 3, 4, 5)
         expected_result = a[-6::-2]
-        result = self.run_smart_contract(engine, path, 'negative_start')
-        self.assertEqual(expected_result, tuple(result))
+        invokes.append(runner.call_contract(path, 'negative_start',
+                                            expected_result_type=tuple))
+        expected_results.append(expected_result)
 
         a = (0, 1, 2, 3, 4, 5)
         expected_result = a[:-1:-2]
-        result = self.run_smart_contract(engine, path, 'negative_end')
-        self.assertEqual(expected_result, tuple(result))
+        invokes.append(runner.call_contract(path, 'negative_end',
+                                            expected_result_type=tuple))
+        expected_results.append(expected_result)
 
         a = (0, 1, 2, 3, 4, 5)
         expected_result = a[-999::-2]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_start')
-        self.assertEqual(expected_result, tuple(result))
+        invokes.append(runner.call_contract(path, 'negative_really_low_start',
+                                            expected_result_type=tuple))
+        expected_results.append(expected_result)
 
         a = (0, 1, 2, 3, 4, 5)
         expected_result = a[:-999:-2]
-        result = self.run_smart_contract(engine, path, 'negative_really_low_end')
-        self.assertEqual(expected_result, tuple(result))
+        invokes.append(runner.call_contract(path, 'negative_really_low_end',
+                                            expected_result_type=tuple))
+        expected_results.append(expected_result)
 
         a = (0, 1, 2, 3, 4, 5)
         expected_result = a[999::-2]
-        result = self.run_smart_contract(engine, path, 'really_high_start')
-        self.assertEqual(expected_result, tuple(result))
+        invokes.append(runner.call_contract(path, 'really_high_start',
+                                            expected_result_type=tuple))
+        expected_results.append(expected_result)
 
         a = (0, 1, 2, 3, 4, 5)
         expected_result = a[:999:-2]
-        result = self.run_smart_contract(engine, path, 'really_high_end')
-        self.assertEqual(expected_result, tuple(result))
+        invokes.append(runner.call_contract(path, 'really_high_end',
+                                            expected_result_type=tuple))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_tuple_index(self):
-        path = self.get_contract_path('IndexTuple.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('IndexTuple.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         tuple_ = (1, 2, 3, 4)
         value = 3
         start = 0
         end = 4
-        result = self.run_smart_contract(engine, path, 'main', tuple_, value, start, end)
-        self.assertEqual(tuple_.index(value, start, end), result)
+        invokes.append(runner.call_contract(path, 'main', tuple_, value, start, end))
+        expected_results.append(tuple_.index(value, start, end))
 
         tuple_ = (1, 2, 3, 4)
         value = 3
         start = 2
         end = 4
-        result = self.run_smart_contract(engine, path, 'main', tuple_, value, start, end)
-        self.assertEqual(tuple_.index(value, start, end), result)
-
-        from boa3.model.builtin.builtin import Builtin
-        with self.assertRaisesRegex(TestExecutionException, f'{Builtin.SequenceIndex.exception_message}$'):
-            self.run_smart_contract(engine, path, 'main', (1, 2, 3, 4), 3, 3, 4)
-
-        with self.assertRaisesRegex(TestExecutionException, f'{Builtin.SequenceIndex.exception_message}$'):
-            self.run_smart_contract(engine, path, 'main', (1, 2, 3, 4), 3, 4, -1)
-
-        with self.assertRaisesRegex(TestExecutionException, f'{Builtin.SequenceIndex.exception_message}$'):
-            self.run_smart_contract(engine, path, 'main', (1, 2, 3, 4), 3, 0, -99)
+        invokes.append(runner.call_contract(path, 'main', tuple_, value, start, end))
+        expected_results.append(tuple_.index(value, start, end))
 
         tuple_ = (1, 2, 3, 4)
         value = 3
         start = 0
         end = -1
-        result = self.run_smart_contract(engine, path, 'main', tuple_, value, start, end)
-        self.assertEqual(tuple_.index(value, start, end), result)
+        invokes.append(runner.call_contract(path, 'main', tuple_, value, start, end))
+        expected_results.append(tuple_.index(value, start, end))
 
         tuple_ = (1, 2, 3, 4)
         value = 2
         start = 0
         end = 99
-        result = self.run_smart_contract(engine, path, 'main', tuple_, value, start, end)
-        self.assertEqual(tuple_.index(value, start, end), result)
+        invokes.append(runner.call_contract(path, 'main', tuple_, value, start, end))
+        expected_results.append(tuple_.index(value, start, end))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        from boa3.model.builtin.builtin import Builtin
+        runner.call_contract(path, 'main', (1, 2, 3, 4), 3, 3, 4)
+        runner.execute()
+
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'{Builtin.SequenceIndex.exception_message}$')
+
+        runner.call_contract(path, 'main', (1, 2, 3, 4), 3, 4, -1)
+        runner.execute()
+
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'{Builtin.SequenceIndex.exception_message}$')
+
+        runner.call_contract(path, 'main', (1, 2, 3, 4), 3, 0, -99)
+        runner.execute()
+
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'{Builtin.SequenceIndex.exception_message}$')
 
     def test_tuple_index_end_default(self):
-        path = self.get_contract_path('IndexTupleEndDefault.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('IndexTupleEndDefault.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         tuple_ = (1, 2, 3, 4)
         value = 3
         start = 0
-        result = self.run_smart_contract(engine, path, 'main', tuple_, value, start)
-        self.assertEqual(tuple_.index(value, start), result)
-
-        from boa3.model.builtin.builtin import Builtin
-        with self.assertRaisesRegex(TestExecutionException, f'{Builtin.SequenceIndex.exception_message}$'):
-            self.run_smart_contract(engine, path, 'main', (1, 2, 3, 4), 2, 99)
-
-        with self.assertRaisesRegex(TestExecutionException, f'{Builtin.SequenceIndex.exception_message}$'):
-            self.run_smart_contract(engine, path, 'main', (1, 2, 3, 4), 4, -1)
+        invokes.append(runner.call_contract(path, 'main', tuple_, value, start))
+        expected_results.append(tuple_.index(value, start))
 
         tuple_ = (1, 2, 3, 4)
         value = 2
         start = -10
-        result = self.run_smart_contract(engine, path, 'main', tuple_, value, start)
-        self.assertEqual(tuple_.index(value, start), result)
+        invokes.append(runner.call_contract(path, 'main', tuple_, value, start))
+        expected_results.append(tuple_.index(value, start))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        from boa3.model.builtin.builtin import Builtin
+        runner.call_contract(path, 'main', (1, 2, 3, 4), 2, 99)
+        runner.execute()
+
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'{Builtin.SequenceIndex.exception_message}$')
+
+        runner.call_contract(path, 'main', (1, 2, 3, 4), 4, -1)
+        runner.execute()
+
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'{Builtin.SequenceIndex.exception_message}$')
 
     def test_tuple_index_defaults(self):
-        path = self.get_contract_path('IndexTupleDefaults.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('IndexTupleDefaults.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         tuple_ = (1, 2, 3, 4)
         value = 3
-        result = self.run_smart_contract(engine, path, 'main', tuple_, value)
-        self.assertEqual(tuple_.index(value), result)
+        invokes.append(runner.call_contract(path, 'main', tuple_, value))
+        expected_results.append(tuple_.index(value))
 
         tuple_ = (1, 2, 3, 4)
         value = 1
-        result = self.run_smart_contract(engine, path, 'main', tuple_, value)
-        self.assertEqual(tuple_.index(value), result)
+        invokes.append(runner.call_contract(path, 'main', tuple_, value))
+        expected_results.append(tuple_.index(value))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)

--- a/boa3_test/tests/compiler_tests/test_typing.py
+++ b/boa3_test/tests/compiler_tests/test_typing.py
@@ -2,8 +2,9 @@ from boa3.exception import CompilerError, CompilerWarning
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.String import String
+from boa3.neo3.vm import VMState
+from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.boa_test import BoaTest
-from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestTyping(BoaTest):
@@ -122,11 +123,22 @@ class TestTyping(BoaTest):
         path = self.get_contract_path('CastToUInt160.py')
         self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
 
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         value = bytes(range(20))
-        result = self.run_smart_contract(engine, path, 'Main', value,
-                                         expected_result_type=bytes)
-        self.assertEqual(value, result)
+        invokes.append(runner.call_contract(path, 'Main', value,
+                                            expected_result_type=bytes))
+        expected_results.append(value)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_cast_to_transaction(self):
         expected_output = (
@@ -144,16 +156,34 @@ class TestTyping(BoaTest):
         self.assertEqual(expected_output, output)
 
     def test_cast_inside_if(self):
-        path = self.get_contract_path('CastInsideIf.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('CastInsideIf.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual('body', result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append('body')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_cast_persisted_in_scope(self):
-        path = self.get_contract_path('CastPersistedInScope.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('CastPersistedInScope.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         test_address = bytes(20)
-        result = self.run_smart_contract(engine, path, 'main', test_address, 10, None)
-        self.assertIsVoid(result)
+        invokes.append(runner.call_contract(path, 'main', test_address, 10, None))
+        expected_results.append(None)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)

--- a/boa3_test/tests/compiler_tests/test_union.py
+++ b/boa3_test/tests/compiler_tests/test_union.py
@@ -2,8 +2,9 @@ from boa3.boa3 import Boa3
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.String import String
+from boa3.neo3.vm import VMState
+from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.boa_test import BoaTest
-from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestUnion(BoaTest):
@@ -31,12 +32,23 @@ class TestUnion(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', True)
-        self.assertEqual(42, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', False)
-        self.assertEqual('42', result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', True))
+        expected_results.append(42)
+
+        invokes.append(runner.call_contract(path, 'main', False))
+        expected_results.append('42')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_union_variable_reassign(self):
         expected_output = (
@@ -62,28 +74,55 @@ class TestUnion(BoaTest):
         self.assertEqual(expected_output, output)
 
     def test_union_variable_argument(self):
-        path = self.get_contract_path('UnionVariableArgument.py')
+        path, _ = self.get_deploy_file_paths('UnionVariableArgument.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', 'unittest')
-        self.assertEqual('string', result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', False)
-        self.assertEqual('boolean', result)
+        invokes.append(runner.call_contract(path, 'main', 'unittest'))
+        expected_results.append('string')
+
+        invokes.append(runner.call_contract(path, 'main', False))
+        expected_results.append('boolean')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_union_isinstance_validation(self):
-        path = self.get_contract_path('UnionIsInstanceValidation.py')
+        path, _ = self.get_deploy_file_paths('UnionIsInstanceValidation.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', 'unittest')
-        self.assertEqual('unittest', result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', False)
-        self.assertEqual('boolean', result)
+        invokes.append(runner.call_contract(path, 'main', 'unittest'))
+        expected_results.append('unittest')
+
+        invokes.append(runner.call_contract(path, 'main', False))
+        expected_results.append('boolean')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_union_int_none(self):
-        path = self.get_contract_path('UnionIntNone.py')
+        path, _ = self.get_deploy_file_paths('UnionIntNone.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(42, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(42)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)


### PR DESCRIPTION
**Summary or solution description**
Part of an overall refactoring. 
Changed the execution tests of the compiled smart contracts related to Python built-in types to use TestRunner instead of TestEngine

**Tests**
Rerun the modified unit tests
