### PR TITLE
Refactor Neo interop functions unit tests to use test runner

### DIFF
--- a/boa3_test/test_drive/neoxp/utils.py
+++ b/boa3_test/test_drive/neoxp/utils.py
@@ -31,6 +31,10 @@ def get_address_version() -> int:
     return _NEOXP_CONFIG.version
 
 
+def get_magic() -> int:
+    return _NEOXP_CONFIG.magic
+
+
 def get_account_identifier_from_script_hash_or_name(script_hash_or_address: Union[bytes, str]) -> str:
     if isinstance(script_hash_or_address, bytes):
         address = wallet_utils.address_from_script_hash(script_hash_or_address, _NEOXP_CONFIG.version)

--- a/boa3_test/test_drive/testrunner/neo_test_runner.py
+++ b/boa3_test/test_drive/testrunner/neo_test_runner.py
@@ -45,6 +45,7 @@ class NeoTestRunner:
         if not isinstance(neoxp_path, str):
             neoxp_path = f'{env.NEO_EXPRESS_INSTANCE_DIRECTORY}{os.path.sep}default.neo-express'
         self._neoxp_abs_path = os.path.abspath(neoxp_path)
+        self._file_name = self._FOLDER_NAME
 
         self._batch = NeoExpressBatch()
         self._batch_size_since_last_update = -1
@@ -52,6 +53,18 @@ class NeoTestRunner:
         self._contracts = ContractCollection()
         self._invokes = NeoInvokeCollection()
         self._last_execution_results: List[NeoInvokeResult] = []
+
+    @property
+    def file_name(self) -> str:
+        return self._file_name
+
+    @file_name.setter
+    def file_name(self, value: str):
+        if isinstance(value, str) and not value.isspace():
+            self._file_name = value
+            self._INVOKE_FILE = f'{value}.neo-invoke.json'
+            self._BATCH_FILE = f'{value}.batch'
+            self._CHECKPOINT_FILE = f'{value}.neoxp-checkpoint'
 
     @property
     def vm_state(self) -> VMState:

--- a/boa3_test/test_drive/testrunner/neo_test_runner.py
+++ b/boa3_test/test_drive/testrunner/neo_test_runner.py
@@ -171,7 +171,8 @@ class NeoTestRunner:
                 self._contracts.replace(deployed_contracts)
             self._batch_size_since_last_update = cur_batch_size
 
-    def execute(self, account: Account = None, get_storage_from: Union[str, TestContract] = None):
+    def execute(self, account: Account = None, get_storage_from: Union[str, TestContract] = None,
+                clear_invokes: bool = True):
         self._generate_files()
         cli_args = ['neo-test-runner', self.get_full_path(self._INVOKE_FILE)
                     ]
@@ -181,6 +182,7 @@ class NeoTestRunner:
 
         if isinstance(account, Account):
             cli_args.extend(['--account', account.get_identifier()])
+            cli_args.extend(['--express', self._neoxp_abs_path])
         elif account is not None:
             account = None
         self._calling_account = account
@@ -194,7 +196,8 @@ class NeoTestRunner:
         try:
             result = json.loads(stdout)
             self._update_runner(result)
-            self._invokes.clear()
+            if clear_invokes:
+                self._invokes.clear()
         except BaseException:
             self._error_message = stdout
 

--- a/boa3_test/test_sc/interop_test/runtime/ImportInteropRuntime.py
+++ b/boa3_test/test_sc/interop_test/runtime/ImportInteropRuntime.py
@@ -4,4 +4,4 @@ from boa3.builtin.compile_time import public
 
 @public
 def main() -> int:
-    return interop.runtime.time + interop.runtime.gas_left + interop.runtime.invocation_counter
+    return interop.runtime.gas_left + interop.runtime.invocation_counter

--- a/boa3_test/test_sc/interop_test/runtime/ImportRuntime.py
+++ b/boa3_test/test_sc/interop_test/runtime/ImportRuntime.py
@@ -4,4 +4,4 @@ from boa3.builtin.interop import runtime
 
 @public
 def main() -> int:
-    return runtime.time + runtime.gas_left + runtime.invocation_counter
+    return runtime.gas_left + runtime.invocation_counter

--- a/boa3_test/tests/boa_test.py
+++ b/boa3_test/tests/boa_test.py
@@ -30,8 +30,9 @@ class BoaTest(TestCase):
     GIVEN_KEY_NOT_PRESENT_IN_DICT_MSG_REGEX = "The given key '\\S+' was not present in the dictionary."
     MAP_KEY_NOT_FOUND_ERROR_MSG = 'Key not found in Map'
     MAX_ITEM_SIZE_EXCEED_MSG_PREFIX = 'MaxItemSize exceed'
-    METHOD_DOESNT_EXIST_IN_CONTRACT_MSG_REGEX_PREFIX = r'^Method "\S+" with \d+ parameter\(s\) ' \
-                                                       r"doesn't exist in the contract"
+    FORMAT_METHOD_DOESNT_EXIST_IN_CONTRACT_MSG_REGEX_PREFIX = r'^Method "{0}" with \d+ parameter\(s\) ' \
+                                                              r"doesn't exist in the contract"
+    METHOD_DOESNT_EXIST_IN_CONTRACT_MSG_REGEX_PREFIX = FORMAT_METHOD_DOESNT_EXIST_IN_CONTRACT_MSG_REGEX_PREFIX.format(r'\S+')
     NULL_POINTER_MSG = 'Object reference not set to an instance of an object.'
     UNHANDLED_EXCEPTION_MSG_PREFIX = "An unhandled exception was thrown."
     VALUE_CANNOT_BE_NEGATIVE_MSG = 'value can not be negative'

--- a/boa3_test/tests/compiler_tests/test_interop/test_contract.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_contract.py
@@ -26,7 +26,7 @@ class TestContractInterop(BoaTest):
 
         contract_call = runner.call_contract(call_contract_path, 'add', 1, 2)
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
         expected_output = contract_call.result
         call_hash = contract_call.invoke.contract.script_hash
 
@@ -38,7 +38,7 @@ class TestContractInterop(BoaTest):
         expected_results.append(-18)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -65,7 +65,7 @@ class TestContractInterop(BoaTest):
         expected_results.append(True)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -86,7 +86,7 @@ class TestContractInterop(BoaTest):
 
         contract_call = runner.call_contract(call_contract_path, 'Main')
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
         expected_output = contract_call.result
         call_hash = contract_call.invoke.contract.script_hash
 
@@ -94,7 +94,7 @@ class TestContractInterop(BoaTest):
         expected_results.append(expected_output)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -144,7 +144,7 @@ class TestContractInterop(BoaTest):
         expected_results.append(0)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -202,7 +202,7 @@ class TestContractInterop(BoaTest):
         invoke = runner.call_contract(path, 'Main', nef_file, arg_manifest, None)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         result = invoke.result
         self.assertEqual(5, len(result))
@@ -218,12 +218,13 @@ class TestContractInterop(BoaTest):
         arg_manifest = String(json.dumps(manifest, separators=(',', ':'))).to_bytes()
 
         runner = NeoTestRunner()
+        runner.file_name = 'test_create_contract'
 
         data = 'some sort of data'
         invoke = runner.call_contract(path, 'Main', nef_file, arg_manifest, data)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         result = invoke.result
         self.assertEqual(5, len(result))
@@ -247,6 +248,7 @@ class TestContractInterop(BoaTest):
     def test_update_contract(self):
         path, _ = self.get_deploy_file_paths('UpdateContract.py')
         runner = NeoTestRunner()
+        runner.file_name = 'test_update_contract'
 
         invokes = []
         expected_results = []
@@ -267,7 +269,7 @@ class TestContractInterop(BoaTest):
         expected_results.append(42)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -293,7 +295,7 @@ class TestContractInterop(BoaTest):
         expected_results.append(None)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -323,7 +325,7 @@ class TestContractInterop(BoaTest):
         expected_results.append(None)
 
         runner.execute(clear_invokes=False)
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
         script_hash = call.invoke.contract.script_hash
 
         for x in range(len(invokes)):
@@ -363,7 +365,7 @@ class TestContractInterop(BoaTest):
         expected_results.append(value)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -405,7 +407,7 @@ class TestContractInterop(BoaTest):
         expected_results.append(value)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -449,7 +451,7 @@ class TestContractInterop(BoaTest):
         expected_results.append(0)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -486,7 +488,7 @@ class TestContractInterop(BoaTest):
         expected_results.append(CallFlags.ALLOW_NOTIFY)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -507,7 +509,7 @@ class TestContractInterop(BoaTest):
 
         contract_call = runner.call_contract(call_contract_path, 'add', 1, 2)
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         call_hash = contract_call.invoke.contract.script_hash
         expected_output = contract_call.result
@@ -520,7 +522,7 @@ class TestContractInterop(BoaTest):
         expected_results.append(CallFlags.ALL)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -535,7 +537,7 @@ class TestContractInterop(BoaTest):
 
         contract_call = runner.call_contract(call_contract_path, 'add', 1, 2)
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         call_hash = contract_call.invoke.contract.script_hash
         expected_output = contract_call.result
@@ -548,7 +550,7 @@ class TestContractInterop(BoaTest):
         expected_results.append(CallFlags.ALL)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -600,7 +602,7 @@ class TestContractInterop(BoaTest):
         expected_results.append(minimum_cost)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)

--- a/boa3_test/tests/compiler_tests/test_interop/test_contract.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_contract.py
@@ -7,124 +7,181 @@ from boa3.model.builtin.interop.interop import Interop
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.String import String
+from boa3.neo3.vm import VMState
+from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.boa_test import BoaTest
-from boa3_test.tests.test_classes.TestExecutionException import TestExecutionException
 from boa3_test.tests.test_classes.contract.neomanifeststruct import NeoManifestStruct
-from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestContractInterop(BoaTest):
     default_folder: str = 'test_sc/interop_test/contract'
 
     def test_call_contract(self):
-        path = self.get_contract_path('CallScriptHash.py')
-        call_contract_path = self.get_contract_path('test_sc/arithmetic_test', 'Addition.py')
+        path, _ = self.get_deploy_file_paths('CallScriptHash.py')
+        call_contract_path, _ = self.get_deploy_file_paths('test_sc/arithmetic_test', 'Addition.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        expected_output = self.run_smart_contract(engine, call_contract_path, 'add', 1, 2)
-        call_hash = engine.executed_script_hash.to_array()
+        invokes = []
+        expected_results = []
 
-        engine.reset_engine()
-        call_contract_path = call_contract_path.replace('.py', '.nef')
-        with self.assertRaisesRegex(TestExecutionException, self.CALLED_CONTRACT_DOES_NOT_EXIST_MSG):
-            self.run_smart_contract(engine, path, 'Main', call_hash, 'add', [1, 2])
-        engine.add_contract(call_contract_path)
+        contract_call = runner.call_contract(call_contract_path, 'add', 1, 2)
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+        expected_output = contract_call.result
+        call_hash = contract_call.invoke.contract.script_hash
 
-        result = self.run_smart_contract(engine, path, 'Main', call_hash, 'add', [1, 2])
-        self.assertEqual(expected_output, result)
-        result = self.run_smart_contract(engine, path, 'Main', call_hash, 'add', [-42, -24])
-        self.assertEqual(-66, result)
-        result = self.run_smart_contract(engine, path, 'Main', call_hash, 'add', [-42, 24])
-        self.assertEqual(-18, result)
+        invokes.append(runner.call_contract(path, 'Main', call_hash, 'add', [1, 2]))
+        expected_results.append(expected_output)
+        invokes.append(runner.call_contract(path, 'Main', call_hash, 'add', [-42, -24]))
+        expected_results.append(-66)
+        invokes.append(runner.call_contract(path, 'Main', call_hash, 'add', [-42, 24]))
+        expected_results.append(-18)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        runner.reset()
+        runner.call_contract(path, 'Main', call_hash, 'add', [1, 2])
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.CALLED_CONTRACT_DOES_NOT_EXIST_MSG)
 
     def test_call_contract_with_cast(self):
-        path = self.get_contract_path('CallScriptHashWithCast.py')
-        call_contract_path = self.get_contract_path('test_sc/arithmetic_test', 'Addition.py')
+        path, _ = self.get_deploy_file_paths('CallScriptHashWithCast.py')
+        call_contract_path, _ = self.get_deploy_file_paths('test_sc/arithmetic_test', 'Addition.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        self.run_smart_contract(engine, call_contract_path, 'add', 1, 2)
-        call_hash = engine.executed_script_hash.to_array()
+        invokes = []
+        expected_results = []
 
-        engine.reset_engine()
-        call_contract_path = call_contract_path.replace('.py', '.nef')
-        with self.assertRaisesRegex(TestExecutionException, self.CALLED_CONTRACT_DOES_NOT_EXIST_MSG):
-            self.run_smart_contract(engine, path, 'Main', call_hash, 'add', [1, 2])
-        engine.add_contract(call_contract_path)
+        contract = runner.deploy_contract(call_contract_path)
+        runner.update_contracts()
+        call_hash = contract.script_hash
 
-        result = self.run_smart_contract(engine, path, 'Main', call_hash, 'add', [1, 2])
-        self.assertEqual(True, result)
+        invokes.append(runner.call_contract(path, 'Main', call_hash, 'add', [1, 2]))
+        expected_results.append(True)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        runner.reset()
+        runner.call_contract(path, 'Main', call_hash, 'add', [1, 2])
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.CALLED_CONTRACT_DOES_NOT_EXIST_MSG)
 
     def test_call_contract_without_args(self):
-        path = self.get_contract_path('CallScriptHashWithoutArgs.py')
-        call_contract_path = self.get_contract_path('test_sc/list_test', 'IntList.py')
-        Boa3.compile_and_save(call_contract_path)
+        path, _ = self.get_deploy_file_paths('CallScriptHashWithoutArgs.py')
+        call_contract_path, _ = self.get_deploy_file_paths('test_sc/list_test', 'IntList.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        expected_output = self.run_smart_contract(engine, call_contract_path, 'Main')
-        call_hash = engine.executed_script_hash.to_array()
+        invokes = []
+        expected_results = []
 
-        engine.reset_engine()
-        call_contract_path = call_contract_path.replace('.py', '.nef')
-        with self.assertRaisesRegex(TestExecutionException, self.CALLED_CONTRACT_DOES_NOT_EXIST_MSG):
-            self.run_smart_contract(engine, path, 'Main', call_hash, 'Main')
-        engine.add_contract(call_contract_path)
+        contract_call = runner.call_contract(call_contract_path, 'Main')
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+        expected_output = contract_call.result
+        call_hash = contract_call.invoke.contract.script_hash
 
-        result = self.run_smart_contract(engine, path, 'Main', call_hash, 'Main')
-        self.assertEqual(expected_output, result)
+        invokes.append(runner.call_contract(path, 'Main', call_hash, 'Main'))
+        expected_results.append(expected_output)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        runner.reset()
+        runner.call_contract(path, 'Main', call_hash, 'Main')
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.CALLED_CONTRACT_DOES_NOT_EXIST_MSG)
 
     def test_call_contract_with_flags(self):
-        path = self.get_contract_path('CallScriptHashWithFlags.py')
-        call_contract_path = self.get_contract_path('CallFlagsUsage.py')
+        path, _ = self.get_deploy_file_paths('CallScriptHashWithFlags.py')
+        call_contract_path, _ = self.get_deploy_file_paths('CallFlagsUsage.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        self.run_smart_contract(engine, call_contract_path, 'notify_user')
-        call_hash = engine.executed_script_hash.to_array()
+        invokes = []
+        expected_results = []
 
-        engine.reset_engine()
-        call_contract_path = call_contract_path.replace('.py', '.nef')
-        with self.assertRaisesRegex(TestExecutionException, f'^{self.ARGUMENT_OUT_OF_RANGE_MSG_PREFIX}'):
-            self.run_smart_contract(engine, path, 'Main', call_hash, 'Main')
-        engine.add_contract(call_contract_path)
+        contract = runner.deploy_contract(call_contract_path)
+        runner.update_contracts()
+        call_hash = contract.script_hash
 
         from boa3.neo3.contracts import CallFlags
 
-        with self.assertRaisesRegex(TestExecutionException, f'^{self.CANT_CALL_SYSCALL_WITH_FLAG_MSG_PREFIX}'):
-            self.run_smart_contract(engine, path, 'Main', call_hash, 'get_value', ['num'], CallFlags.NONE)
+        invokes.append(runner.call_contract(path, 'Main', call_hash, 'get_value', ['num'], CallFlags.READ_ONLY))
+        expected_results.append(0)
 
-        result = self.run_smart_contract(engine, path, 'Main', call_hash, 'get_value', ['num'], CallFlags.READ_ONLY)
-        self.assertEqual(0, result)
+        invokes.append(runner.call_contract(path, 'Main', call_hash, 'put_value', ['num', 10], CallFlags.STATES))
+        expected_results.append(None)
 
-        with self.assertRaisesRegex(TestExecutionException, f'^{self.CANT_CALL_SYSCALL_WITH_FLAG_MSG_PREFIX}'):
-            self.run_smart_contract(engine, path, 'Main', call_hash, 'put_value', ['num', 10], CallFlags.READ_ONLY)
-            self.run_smart_contract(engine, path, 'Main', call_hash, 'put_value', ['num', 10], CallFlags.NONE)
+        invokes.append(runner.call_contract(path, 'Main', call_hash, 'get_value', ['num'], CallFlags.READ_ONLY))
+        expected_results.append(10)
 
-        result = self.run_smart_contract(engine, path, 'Main', call_hash, 'put_value', ['num', 10], CallFlags.STATES)
-        self.assertEqual(None, result)
-        result = self.run_smart_contract(engine, path, 'Main', call_hash, 'get_value', ['num'], CallFlags.READ_ONLY)
-        self.assertEqual(10, result)
-        result = self.run_smart_contract(engine, path, 'Main', call_hash, 'put_value', ['num', 99], CallFlags.ALL)
-        self.assertEqual(None, result)
-        result = self.run_smart_contract(engine, path, 'Main', call_hash, 'get_value', ['num'], CallFlags.READ_ONLY)
-        self.assertEqual(99, result)
+        invokes.append(runner.call_contract(path, 'Main', call_hash, 'put_value', ['num', 99], CallFlags.ALL))
+        expected_results.append(None)
 
-        with self.assertRaisesRegex(TestExecutionException, f'^{self.CANT_CALL_SYSCALL_WITH_FLAG_MSG_PREFIX}'):
-            self.run_smart_contract(engine, path, 'Main', call_hash, 'notify_user', [], CallFlags.READ_ONLY)
-            self.run_smart_contract(engine, path, 'Main', call_hash, 'notify_user', [], CallFlags.STATES)
-            self.run_smart_contract(engine, path, 'Main', call_hash, 'notify_user', [], CallFlags.NONE)
-        result = self.run_smart_contract(engine, path, 'Main', call_hash, 'notify_user', [], CallFlags.ALL)
-        self.assertEqual(None, result)
-        notify = engine.get_events(origin=call_hash)
+        invokes.append(runner.call_contract(path, 'Main', call_hash, 'get_value', ['num'], CallFlags.READ_ONLY))
+        expected_results.append(99)
+
+        invokes.append(runner.call_contract(path, 'Main', call_hash, 'notify_user', [], CallFlags.ALL))
+        expected_results.append(None)
+
+        invokes.append(runner.call_contract(path, 'Main', call_hash, 'call_another_contract', [], CallFlags.ALL))
+        expected_results.append(0)
+
+        invokes.append(runner.call_contract(path, 'Main', call_hash, 'call_another_contract', [], CallFlags.READ_ONLY))
+        expected_results.append(0)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        notify = runner.get_events(origin=call_hash)
         self.assertEqual(1, len(notify))
         self.assertEqual('Notify was called', notify[0].arguments[0])
 
-        with self.assertRaisesRegex(TestExecutionException, f'^{self.CANT_CALL_SYSCALL_WITH_FLAG_MSG_PREFIX}'):
-            self.run_smart_contract(engine, path, 'Main', call_hash, 'call_another_contract', [], CallFlags.STATES)
-            self.run_smart_contract(engine, path, 'Main', call_hash, 'call_another_contract', [], CallFlags.NONE)
-        result = self.run_smart_contract(engine, path, 'Main', call_hash, 'call_another_contract', [], CallFlags.ALL)
-        self.assertEqual(0, result)
-        result = self.run_smart_contract(engine, path, 'Main', call_hash, 'call_another_contract',
-                                         [], CallFlags.READ_ONLY)
-        self.assertEqual(0, result)
+        runner.call_contract(path, 'Main', call_hash, 'get_value', ['num'], CallFlags.NONE)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'^{self.CANT_CALL_SYSCALL_WITH_FLAG_MSG_PREFIX}')
+
+        runner.call_contract(path, 'Main', call_hash, 'put_value', ['num', 10], CallFlags.READ_ONLY)
+        runner.call_contract(path, 'Main', call_hash, 'put_value', ['num', 10], CallFlags.NONE)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'^{self.CANT_CALL_SYSCALL_WITH_FLAG_MSG_PREFIX}')
+
+        runner.call_contract(path, 'Main', call_hash, 'notify_user', [], CallFlags.READ_ONLY)
+        runner.call_contract(path, 'Main', call_hash, 'notify_user', [], CallFlags.STATES)
+        runner.call_contract(path, 'Main', call_hash, 'notify_user', [], CallFlags.NONE)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'^{self.CANT_CALL_SYSCALL_WITH_FLAG_MSG_PREFIX}')
+
+        runner.call_contract(path, 'Main', call_hash, 'call_another_contract', [], CallFlags.STATES)
+        runner.call_contract(path, 'Main', call_hash, 'call_another_contract', [], CallFlags.NONE)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'^{self.CANT_CALL_SYSCALL_WITH_FLAG_MSG_PREFIX}')
+
+        runner.reset()
+        runner.call_contract(path, 'Main', call_hash, 'Main')
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.METHOD_DOESNT_EXIST_IN_CONTRACT_MSG_REGEX_PREFIX)
 
     def test_call_contract_too_many_parameters(self):
         path = self.get_contract_path('CallScriptHashTooManyArguments.py')
@@ -135,44 +192,49 @@ class TestContractInterop(BoaTest):
         self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
 
     def test_create_contract(self):
-        path = self.get_contract_path('CreateContract.py')
+        path, _ = self.get_deploy_file_paths('CreateContract.py')
         call_contract_path = self.get_contract_path('test_sc/arithmetic_test', 'Addition.py')
-        Boa3.compile_and_save(call_contract_path)
 
         nef_file, manifest = self.get_bytes_output(call_contract_path)
         arg_manifest = String(json.dumps(manifest, separators=(',', ':'))).to_bytes()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', nef_file, arg_manifest, None)
+        runner = NeoTestRunner()
+        invoke = runner.call_contract(path, 'Main', nef_file, arg_manifest, None)
 
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        result = invoke.result
         self.assertEqual(5, len(result))
         self.assertEqual(nef_file, result[3])
         manifest_struct = NeoManifestStruct.from_json(manifest)
         self.assertEqual(manifest_struct, result[4])
 
     def test_create_contract_data_deploy(self):
-        path = self.get_contract_path('CreateContract.py')
+        path, _ = self.get_deploy_file_paths('CreateContract.py')
         call_contract_path = self.get_contract_path('NewContract.py')
-        Boa3.compile_and_save(call_contract_path)
 
         nef_file, manifest = self.get_bytes_output(call_contract_path)
         arg_manifest = String(json.dumps(manifest, separators=(',', ':'))).to_bytes()
 
-        engine = TestEngine()
-        data = 'some sort of data'
-        result = self.run_smart_contract(engine, path, 'Main', nef_file, arg_manifest, data)
+        runner = NeoTestRunner()
 
+        data = 'some sort of data'
+        invoke = runner.call_contract(path, 'Main', nef_file, arg_manifest, data)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        result = invoke.result
         self.assertEqual(5, len(result))
         self.assertEqual(nef_file, result[3])
         manifest_struct = NeoManifestStruct.from_json(manifest)
         self.assertEqual(manifest_struct, result[4])
 
-        notifies = engine.get_events('notify')
+        notifies = runner.get_events('notify')
         self.assertEqual(2, len(notifies))
         self.assertEqual(False, notifies[0].arguments[0])  # not updated
         self.assertEqual(data, notifies[1].arguments[0])  # data
-        result = self.run_smart_contract(engine, call_contract_path, 'main')
-        self.assertEqual(data, result)
 
     def test_create_contract_too_many_parameters(self):
         path = self.get_contract_path('CreateContractTooManyArguments.py')
@@ -183,37 +245,60 @@ class TestContractInterop(BoaTest):
         self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
 
     def test_update_contract(self):
-        path = self.get_contract_path('UpdateContract.py')
-        engine = TestEngine()
-        with self.assertRaisesRegex(TestExecutionException, f'{self.CANT_FIND_METHOD_MSG_PREFIX} : new_method'):
-            self.run_smart_contract(engine, path, 'new_method')
+        path, _ = self.get_deploy_file_paths('UpdateContract.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        runner.call_contract(path, 'new_method')
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.FORMAT_METHOD_DOESNT_EXIST_IN_CONTRACT_MSG_REGEX_PREFIX.format('new_method'))
 
         new_path = self.get_contract_path('test_sc/interop_test', 'UpdateContract.py')
-        self.compile_and_save(new_path)
         new_nef, new_manifest = self.get_bytes_output(new_path)
         arg_manifest = String(json.dumps(new_manifest, separators=(',', ':'))).to_bytes()
 
-        result = self.run_smart_contract(engine, path, 'update', new_nef, arg_manifest, None)
-        self.assertIsVoid(result)
+        invokes.append(runner.call_contract(path, 'update', new_nef, arg_manifest, None))
+        expected_results.append(None)
 
-        result = self.run_smart_contract(engine, path, 'new_method')
-        self.assertEqual(42, result)
+        invokes.append(runner.call_contract(path, 'new_method'))
+        expected_results.append(42)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_update_contract_data_deploy(self):
-        path = self.get_contract_path('UpdateContract.py')
-        engine = TestEngine()
-        with self.assertRaisesRegex(TestExecutionException, f'{self.CANT_FIND_METHOD_MSG_PREFIX} : new_method'):
-            self.run_smart_contract(engine, path, 'new_method')
+        path, _ = self.get_deploy_file_paths('UpdateContract.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        runner.call_contract(path, 'new_method')
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.FORMAT_METHOD_DOESNT_EXIST_IN_CONTRACT_MSG_REGEX_PREFIX.format('new_method'))
 
         new_path = self.get_contract_path('test_sc/interop_test', 'UpdateContract.py')
-        self.compile_and_save(new_path)
         new_nef, new_manifest = self.get_bytes_output(new_path)
         arg_manifest = String(json.dumps(new_manifest, separators=(',', ':'))).to_bytes()
 
         data = 'this function was deployed'
-        result = self.run_smart_contract(engine, path, 'update', new_nef, arg_manifest, data)
-        self.assertIsVoid(result)
-        notifies = engine.get_events('notify')
+        invokes.append(runner.call_contract(path, 'update', new_nef, arg_manifest, data))
+        expected_results.append(None)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        notifies = runner.get_events('notify')
         self.assertEqual(2, len(notifies))
         self.assertEqual(True, notifies[0].arguments[0])
         self.assertEqual(data, notifies[1].arguments[0])
@@ -227,16 +312,29 @@ class TestContractInterop(BoaTest):
         self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
 
     def test_destroy_contract(self):
-        path = self.get_contract_path('DestroyContract.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertIsVoid(result)
+        path, _ = self.get_deploy_file_paths('DestroyContract.py')
+        runner = NeoTestRunner()
 
-        script_hash = engine.executed_script_hash.to_array()
-        call_contract_path = self.get_contract_path('CallScriptHash.py')
-        with self.assertRaisesRegex(TestExecutionException, f'^{self.CALLED_CONTRACT_DOES_NOT_EXIST_MSG}'):
-            self.run_smart_contract(engine, call_contract_path, 'Main',
-                                    script_hash, 'Main', [])
+        invokes = []
+        expected_results = []
+
+        call = runner.call_contract(path, 'Main')
+        invokes.append(call)
+        expected_results.append(None)
+
+        runner.execute(clear_invokes=False)
+        self.assertEqual(VMState.HALT, runner.vm_state)
+        script_hash = call.invoke.contract.script_hash
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        call_contract_path, _ = self.get_deploy_file_paths('CallScriptHash.py')
+        runner.call_contract(call_contract_path, 'Main',
+                             script_hash, 'Main', [])
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'^{self.CALLED_CONTRACT_DOES_NOT_EXIST_MSG}')
 
     def test_destroy_contract_too_many_parameters(self):
         path = self.get_contract_path('DestroyContractTooManyArguments.py')
@@ -255,9 +353,20 @@ class TestContractInterop(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(value, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append(value)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_neo_native_script_hash_cant_assign(self):
         expected_output = (
@@ -286,9 +395,20 @@ class TestContractInterop(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(value, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append(value)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_gas_native_script_hash_cant_assign(self):
         expected_output = (
@@ -305,97 +425,133 @@ class TestContractInterop(BoaTest):
         self.assertEqual(expected_output, output)
 
     def test_call_flags_type(self):
-        path = self.get_contract_path('CallFlagsType.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('CallFlagsType.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', 'ALL')
-        self.assertEqual(0b00001111, result)
-        result = self.run_smart_contract(engine, path, 'main', 'READ_ONLY')
-        self.assertEqual(0b00000101, result)
-        result = self.run_smart_contract(engine, path, 'main', 'STATES')
-        self.assertEqual(0b00000011, result)
-        result = self.run_smart_contract(engine, path, 'main', 'ALLOW_NOTIFY')
-        self.assertEqual(0b00001000, result)
-        result = self.run_smart_contract(engine, path, 'main', 'ALLOW_CALL')
-        self.assertEqual(0b00000100, result)
-        result = self.run_smart_contract(engine, path, 'main', 'WRITE_STATES')
-        self.assertEqual(0b00000010, result)
-        result = self.run_smart_contract(engine, path, 'main', 'READ_STATES')
-        self.assertEqual(0b00000001, result)
-        result = self.run_smart_contract(engine, path, 'main', 'NONE')
-        self.assertEqual(0, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', 'ALL'))
+        expected_results.append(0b00001111)
+        invokes.append(runner.call_contract(path, 'main', 'READ_ONLY'))
+        expected_results.append(0b00000101)
+        invokes.append(runner.call_contract(path, 'main', 'STATES'))
+        expected_results.append(0b00000011)
+        invokes.append(runner.call_contract(path, 'main', 'ALLOW_NOTIFY'))
+        expected_results.append(0b00001000)
+        invokes.append(runner.call_contract(path, 'main', 'ALLOW_CALL'))
+        expected_results.append(0b00000100)
+        invokes.append(runner.call_contract(path, 'main', 'WRITE_STATES'))
+        expected_results.append(0b00000010)
+        invokes.append(runner.call_contract(path, 'main', 'READ_STATES'))
+        expected_results.append(0b00000001)
+        invokes.append(runner.call_contract(path, 'main', 'NONE'))
+        expected_results.append(0)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_get_call_flags(self):
-        path = self.get_contract_path('CallScriptHashWithFlags.py')
-        call_contract_path = self.get_contract_path('GetCallFlags.py')
-        Boa3.compile_and_save(call_contract_path)
+        path, _ = self.get_deploy_file_paths('CallScriptHashWithFlags.py')
+        call_contract_path, _ = self.get_deploy_file_paths('GetCallFlags.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        self.run_smart_contract(engine, call_contract_path, 'main')
-        call_hash = engine.executed_script_hash.to_array()
+        invokes = []
+        expected_results = []
 
-        engine.reset_engine()
-        call_contract_path = call_contract_path.replace('.py', '.nef')
-        with self.assertRaisesRegex(TestExecutionException, f'^{self.ARGUMENT_OUT_OF_RANGE_MSG_PREFIX}'):
-            self.run_smart_contract(engine, path, 'Main', call_hash, 'main')
-        engine.add_contract(call_contract_path)
+        contract = runner.deploy_contract(call_contract_path)
+        runner.update_contracts()
+        call_hash = contract.script_hash
 
         from boa3.neo3.contracts import CallFlags
 
-        result = self.run_smart_contract(engine, path, 'Main', call_hash, 'main', [], CallFlags.ALL)
-        self.assertEqual(CallFlags.ALL, result)
-        result = self.run_smart_contract(engine, path, 'Main', call_hash, 'main', [], CallFlags.READ_ONLY)
-        self.assertEqual(CallFlags.READ_ONLY, result)
-        result = self.run_smart_contract(engine, path, 'Main', call_hash, 'main', [], CallFlags.STATES)
-        self.assertEqual(CallFlags.STATES, result)
-        result = self.run_smart_contract(engine, path, 'Main', call_hash, 'main', [], CallFlags.NONE)
-        self.assertEqual(CallFlags.NONE, result)
-        result = self.run_smart_contract(engine, path, 'Main', call_hash, 'main', [], CallFlags.READ_STATES)
-        self.assertEqual(CallFlags.READ_STATES, result)
-        result = self.run_smart_contract(engine, path, 'Main', call_hash, 'main', [], CallFlags.WRITE_STATES)
-        self.assertEqual(CallFlags.WRITE_STATES, result)
-        result = self.run_smart_contract(engine, path, 'Main', call_hash, 'main', [], CallFlags.ALLOW_CALL)
-        self.assertEqual(CallFlags.ALLOW_CALL, result)
-        result = self.run_smart_contract(engine, path, 'Main', call_hash, 'main', [], CallFlags.ALLOW_NOTIFY)
-        self.assertEqual(CallFlags.ALLOW_NOTIFY, result)
+        invokes.append(runner.call_contract(path, 'Main', call_hash, 'main', [], CallFlags.ALL))
+        expected_results.append(CallFlags.ALL)
+        invokes.append(runner.call_contract(path, 'Main', call_hash, 'main', [], CallFlags.READ_ONLY))
+        expected_results.append(CallFlags.READ_ONLY)
+        invokes.append(runner.call_contract(path, 'Main', call_hash, 'main', [], CallFlags.STATES))
+        expected_results.append(CallFlags.STATES)
+        invokes.append(runner.call_contract(path, 'Main', call_hash, 'main', [], CallFlags.NONE))
+        expected_results.append(CallFlags.NONE)
+        invokes.append(runner.call_contract(path, 'Main', call_hash, 'main', [], CallFlags.READ_STATES))
+        expected_results.append(CallFlags.READ_STATES)
+        invokes.append(runner.call_contract(path, 'Main', call_hash, 'main', [], CallFlags.WRITE_STATES))
+        expected_results.append(CallFlags.WRITE_STATES)
+        invokes.append(runner.call_contract(path, 'Main', call_hash, 'main', [], CallFlags.ALLOW_CALL))
+        expected_results.append(CallFlags.ALLOW_CALL)
+        invokes.append(runner.call_contract(path, 'Main', call_hash, 'main', [], CallFlags.ALLOW_NOTIFY))
+        expected_results.append(CallFlags.ALLOW_NOTIFY)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        runner.reset()
+        runner.call_contract(path, 'Main', call_hash, 'main', [])  # missing argument
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.FORMAT_METHOD_DOESNT_EXIST_IN_CONTRACT_MSG_REGEX_PREFIX.format('Main'))
 
     def test_import_contract(self):
-        path = self.get_contract_path('ImportContract.py')
-        call_contract_path = self.get_contract_path('test_sc/arithmetic_test', 'Addition.py')
+        path, _ = self.get_deploy_file_paths('ImportContract.py')
+        call_contract_path, _ = self.get_deploy_file_paths('test_sc/arithmetic_test', 'Addition.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        expected_output = self.run_smart_contract(engine, call_contract_path, 'add', 1, 2)
-        call_hash = engine.executed_script_hash.to_array()
+        invokes = []
+        expected_results = []
 
-        engine.reset_engine()
-        call_contract_path = call_contract_path.replace('.py', '.nef')
-        engine.add_contract(call_contract_path)
+        contract_call = runner.call_contract(call_contract_path, 'add', 1, 2)
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
 
-        result = self.run_smart_contract(engine, path, 'main', call_hash, 'add', [1, 2])
-        self.assertEqual(expected_output, result)
+        call_hash = contract_call.invoke.contract.script_hash
+        expected_output = contract_call.result
 
-        result = self.run_smart_contract(engine, path, 'call_flags_all')
+        invokes.append(runner.call_contract(path, 'main', call_hash, 'add', [1, 2]))
+        expected_results.append(expected_output)
+
+        invokes.append(runner.call_contract(path, 'call_flags_all'))
         from boa3.neo3.contracts import CallFlags
-        self.assertEqual(CallFlags.ALL, result)
+        expected_results.append(CallFlags.ALL)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_import_interop_contract(self):
-        path = self.get_contract_path('ImportInteropContract.py')
-        call_contract_path = self.get_contract_path('test_sc/arithmetic_test', 'Addition.py')
+        path, _ = self.get_deploy_file_paths('ImportInteropContract.py')
+        call_contract_path, _ = self.get_deploy_file_paths('test_sc/arithmetic_test', 'Addition.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        expected_output = self.run_smart_contract(engine, call_contract_path, 'add', 1, 2)
-        call_hash = engine.executed_script_hash.to_array()
+        invokes = []
+        expected_results = []
 
-        engine.reset_engine()
-        call_contract_path = call_contract_path.replace('.py', '.nef')
-        engine.add_contract(call_contract_path)
+        contract_call = runner.call_contract(call_contract_path, 'add', 1, 2)
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
 
-        result = self.run_smart_contract(engine, path, 'main', call_hash, 'add', [1, 2])
-        self.assertEqual(expected_output, result)
+        call_hash = contract_call.invoke.contract.script_hash
+        expected_output = contract_call.result
 
-        result = self.run_smart_contract(engine, path, 'call_flags_all')
+        invokes.append(runner.call_contract(path, 'main', call_hash, 'add', [1, 2]))
+        expected_results.append(expected_output)
+
+        invokes.append(runner.call_contract(path, 'call_flags_all'))
         from boa3.neo3.contracts import CallFlags
-        self.assertEqual(CallFlags.ALL, result)
+        expected_results.append(CallFlags.ALL)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_create_standard_account(self):
         from boa3.neo.vm.type.StackItem import StackItemType
@@ -433,12 +589,21 @@ class TestContractInterop(BoaTest):
         self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
 
     def test_get_minimum_deployment_fee(self):
-        path = self.get_contract_path('GetMinimumDeploymentFee.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('GetMinimumDeploymentFee.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         minimum_cost = 10 * 10 ** 8  # minimum deployment cost is 10 GAS right now
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(minimum_cost, result)
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(minimum_cost)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_get_minimum_deployment_fee_too_many_parameters(self):
         path = self.get_contract_path('GetMinimumDeploymentFeeTooManyArguments.py')

--- a/boa3_test/tests/compiler_tests/test_interop/test_contract.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_contract.py
@@ -214,6 +214,7 @@ class TestContractInterop(BoaTest):
         path, _ = self.get_deploy_file_paths('CreateContract.py')
         call_contract_path = self.get_contract_path('NewContract.py')
 
+        self.compile_and_save(call_contract_path)
         nef_file, manifest = self.get_bytes_output(call_contract_path)
         arg_manifest = String(json.dumps(manifest, separators=(',', ':'))).to_bytes()
 
@@ -259,6 +260,7 @@ class TestContractInterop(BoaTest):
         self.assertRegex(runner.error, self.FORMAT_METHOD_DOESNT_EXIST_IN_CONTRACT_MSG_REGEX_PREFIX.format('new_method'))
 
         new_path = self.get_contract_path('test_sc/interop_test', 'UpdateContract.py')
+        self.compile_and_save(new_path)
         new_nef, new_manifest = self.get_bytes_output(new_path)
         arg_manifest = String(json.dumps(new_manifest, separators=(',', ':'))).to_bytes()
 

--- a/boa3_test/tests/compiler_tests/test_interop/test_crypto.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_crypto.py
@@ -9,8 +9,9 @@ from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.String import String
 from boa3.neo3.contracts.contracttypes import CallFlags
 from boa3.neo3.contracts.namedcurve import NamedCurve
+from boa3.neo3.vm import VMState
+from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.boa_test import BoaTest
-from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestCryptoInterop(BoaTest):
@@ -28,36 +29,76 @@ class TestCryptoInterop(BoaTest):
     )
 
     def test_ripemd160_str(self):
-        path = self.get_contract_path('Ripemd160Str.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Ripemd160Str.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         expected_result = hashlib.new('ripemd160', b'unit test')
-        result = self.run_smart_contract(engine, path, 'Main', 'unit test')
-        self.assertEqual(expected_result.digest(), result)
+        invokes.append(runner.call_contract(path, 'Main', 'unit test'))
+        expected_results.append(expected_result.digest())
 
         expected_result = hashlib.new('ripemd160', b'')
-        result = self.run_smart_contract(engine, path, 'Main', '')
-        self.assertEqual(expected_result.digest(), result)
+        invokes.append(runner.call_contract(path, 'Main', ''))
+        expected_results.append(expected_result.digest())
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_ripemd160_int(self):
-        path = self.get_contract_path('Ripemd160Int.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Ripemd160Int.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         expected_result = hashlib.new('ripemd160', Integer(10).to_byte_array())
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(expected_result.digest(), result)
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append(expected_result.digest())
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_ripemd160_bool(self):
-        path = self.get_contract_path('Ripemd160Bool.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Ripemd160Bool.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         expected_result = hashlib.new('ripemd160', Integer(1).to_byte_array())
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(expected_result.digest(), result)
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append(expected_result.digest())
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_ripemd160_bytes(self):
-        path = self.get_contract_path('Ripemd160Bytes.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Ripemd160Bytes.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         expected_result = hashlib.new('ripemd160', b'unit test')
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(expected_result.digest(), result)
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append(expected_result.digest())
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_ripemd160_too_many_parameters(self):
         path = self.get_contract_path('Ripemd160TooManyArguments.py')
@@ -68,64 +109,144 @@ class TestCryptoInterop(BoaTest):
         self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
 
     def test_hash160_str(self):
-        path = self.get_contract_path('Hash160Str.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Hash160Str.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         expected_result = hashlib.new('ripemd160', (hashlib.sha256(b'unit test').digest())).digest()
-        result = self.run_smart_contract(engine, path, 'Main', 'unit test')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'Main', 'unit test'))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_hash160_int(self):
-        path = self.get_contract_path('Hash160Int.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Hash160Int.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         expected_result = hashlib.new('ripemd160', (hashlib.sha256(Integer(10).to_byte_array()).digest())).digest()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_hash160_bool(self):
-        path = self.get_contract_path('Hash160Bool.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Hash160Bool.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         expected_result = hashlib.new('ripemd160', (hashlib.sha256(Integer(1).to_byte_array()).digest())).digest()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_hash160_bytes(self):
-        path = self.get_contract_path('Hash160Bytes.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Hash160Bytes.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         expected_result = hashlib.new('ripemd160', (hashlib.sha256(b'unit test').digest())).digest()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_sha256_str(self):
-        path = self.get_contract_path('Sha256Str.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Sha256Str.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         expected_result = hashlib.sha256(b'unit test')
-        result = self.run_smart_contract(engine, path, 'Main', 'unit test')
-        self.assertEqual(expected_result.digest(), result)
+        invokes.append(runner.call_contract(path, 'Main', 'unit test'))
+        expected_results.append(expected_result.digest())
 
         expected_result = hashlib.sha256(b'')
-        result = self.run_smart_contract(engine, path, 'Main', '')
-        self.assertEqual(expected_result.digest(), result)
+        invokes.append(runner.call_contract(path, 'Main', ''))
+        expected_results.append(expected_result.digest())
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_sha256_int(self):
-        path = self.get_contract_path('Sha256Int.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Sha256Int.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         expected_result = hashlib.sha256(Integer(10).to_byte_array())
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(expected_result.digest(), result)
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append(expected_result.digest())
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_sha256_bool(self):
-        path = self.get_contract_path('Sha256Bool.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Sha256Bool.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         expected_result = hashlib.sha256(Integer(1).to_byte_array())
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(expected_result.digest(), result)
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append(expected_result.digest())
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_sha256_bytes(self):
-        path = self.get_contract_path('Sha256Bytes.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Sha256Bytes.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         expected_result = hashlib.sha256(b'unit test')
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(expected_result.digest(), result)
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append(expected_result.digest())
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_sha256_too_many_parameters(self):
         path = self.get_contract_path('Sha256TooManyArguments.py')
@@ -136,32 +257,72 @@ class TestCryptoInterop(BoaTest):
         self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
 
     def test_hash256_str(self):
-        path = self.get_contract_path('Hash256Str.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Hash256Str.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         expected_result = hashlib.sha256(hashlib.sha256(b'unit test').digest()).digest()
-        result = self.run_smart_contract(engine, path, 'Main', 'unit test')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'Main', 'unit test'))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_hash256_int(self):
-        path = self.get_contract_path('Hash256Int.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Hash256Int.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         expected_result = hashlib.sha256(hashlib.sha256(Integer(10).to_byte_array()).digest()).digest()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_hash256_bool(self):
-        path = self.get_contract_path('Hash256Bool.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Hash256Bool.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         expected_result = hashlib.sha256(hashlib.sha256(Integer(1).to_byte_array()).digest()).digest()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_hash256_bytes(self):
-        path = self.get_contract_path('Hash256Bytes.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Hash256Bytes.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         expected_result = hashlib.sha256(hashlib.sha256(b'unit test').digest()).digest()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_check_sig(self):
         byte_input0 = b'\x03\x5a\x92\x8f\x20\x16\x39\x20\x4e\x06\xb4\x36\x8b\x1a\x93\x36\x54\x62\xa8\xeb\xbf\xf0\xb8\x81\x81\x51\xb7\x4f\xaa\xb3\xa2\xb6\x1a'
@@ -193,9 +354,20 @@ class TestCryptoInterop(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(False, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(False)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_check_multisig(self):
         byte_input0 = b'\x03\xcd\xb0g\xd90\xfdZ\xda\xa6\xc6\x85E\x01`D\xaa\xdd\xecd\xba9\xe5H%\x0e\xae\xa5Q\x17.S\\'
@@ -238,9 +410,20 @@ class TestCryptoInterop(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(False, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(False)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_verify_with_ecdsa(self):
         path = self.get_contract_path('VerifyWithECDsa.py')
@@ -475,18 +658,38 @@ class TestCryptoInterop(BoaTest):
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_import_crypto(self):
-        path = self.get_contract_path('ImportCrypto.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ImportCrypto.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         expected_result = hashlib.new('ripemd160', (hashlib.sha256(b'unit test').digest())).digest()
-        result = self.run_smart_contract(engine, path, 'main', 'unit test')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'main', 'unit test'))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_import_interop_crypto(self):
-        path = self.get_contract_path('ImportInteropCrypto.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ImportInteropCrypto.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         expected_result = hashlib.new('ripemd160', (hashlib.sha256(b'unit test').digest())).digest()
-        result = self.run_smart_contract(engine, path, 'main', 'unit test')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'main', 'unit test'))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_murmur32(self):
         function_id = String(Interop.Murmur32._sys_call).to_bytes()

--- a/boa3_test/tests/compiler_tests/test_interop/test_crypto.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_crypto.py
@@ -44,7 +44,7 @@ class TestCryptoInterop(BoaTest):
         expected_results.append(expected_result.digest())
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -61,7 +61,7 @@ class TestCryptoInterop(BoaTest):
         expected_results.append(expected_result.digest())
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -78,7 +78,7 @@ class TestCryptoInterop(BoaTest):
         expected_results.append(expected_result.digest())
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -95,7 +95,7 @@ class TestCryptoInterop(BoaTest):
         expected_results.append(expected_result.digest())
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -120,7 +120,7 @@ class TestCryptoInterop(BoaTest):
         expected_results.append(expected_result)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -137,7 +137,7 @@ class TestCryptoInterop(BoaTest):
         expected_results.append(expected_result)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -154,7 +154,7 @@ class TestCryptoInterop(BoaTest):
         expected_results.append(expected_result)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -171,7 +171,7 @@ class TestCryptoInterop(BoaTest):
         expected_results.append(expected_result)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -192,7 +192,7 @@ class TestCryptoInterop(BoaTest):
         expected_results.append(expected_result.digest())
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -209,7 +209,7 @@ class TestCryptoInterop(BoaTest):
         expected_results.append(expected_result.digest())
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -226,7 +226,7 @@ class TestCryptoInterop(BoaTest):
         expected_results.append(expected_result.digest())
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -243,7 +243,7 @@ class TestCryptoInterop(BoaTest):
         expected_results.append(expected_result.digest())
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -268,7 +268,7 @@ class TestCryptoInterop(BoaTest):
         expected_results.append(expected_result)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -285,7 +285,7 @@ class TestCryptoInterop(BoaTest):
         expected_results.append(expected_result)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -302,7 +302,7 @@ class TestCryptoInterop(BoaTest):
         expected_results.append(expected_result)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -319,7 +319,7 @@ class TestCryptoInterop(BoaTest):
         expected_results.append(expected_result)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -364,7 +364,7 @@ class TestCryptoInterop(BoaTest):
         expected_results.append(False)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -420,7 +420,7 @@ class TestCryptoInterop(BoaTest):
         expected_results.append(False)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -669,7 +669,7 @@ class TestCryptoInterop(BoaTest):
         expected_results.append(expected_result)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -686,7 +686,7 @@ class TestCryptoInterop(BoaTest):
         expected_results.append(expected_result)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)

--- a/boa3_test/tests/compiler_tests/test_interop/test_json.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_json.py
@@ -22,7 +22,7 @@ class TestJsonInterop(BoaTest):
         expected_results.append(expected_result)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -39,7 +39,7 @@ class TestJsonInterop(BoaTest):
         expected_results.append(expected_result)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -56,7 +56,7 @@ class TestJsonInterop(BoaTest):
         expected_results.append(expected_result)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -73,7 +73,7 @@ class TestJsonInterop(BoaTest):
         expected_results.append(expected_result)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -92,7 +92,7 @@ class TestJsonInterop(BoaTest):
         expected_results.append(expected_result)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -120,7 +120,7 @@ class TestJsonInterop(BoaTest):
         expected_results.append(expected_result)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -141,7 +141,7 @@ class TestJsonInterop(BoaTest):
         expected_results.append(value)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -162,7 +162,7 @@ class TestJsonInterop(BoaTest):
         expected_results.append(value)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)

--- a/boa3_test/tests/compiler_tests/test_interop/test_json.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_json.py
@@ -1,95 +1,168 @@
 import json
 
 from boa3.neo.vm.type.String import String
+from boa3.neo3.vm import VMState
+from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.boa_test import BoaTest
-from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestJsonInterop(BoaTest):
     default_folder: str = 'test_sc/interop_test/json'
 
     def test_json_serialize(self):
-        path = self.get_contract_path('JsonSerialize.py')
+        path, _ = self.get_deploy_file_paths('JsonSerialize.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
+        invokes = []
+        expected_results = []
+
         test_input = {"one": 1, "two": 2, "three": 3}
         expected_result = json.dumps(test_input, separators=(',', ':'))
-        result = self.run_smart_contract(engine, path, 'main', test_input)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'main', test_input))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_json_serialize_int(self):
-        path = self.get_contract_path('JsonSerializeInt.py')
+        path, _ = self.get_deploy_file_paths('JsonSerializeInt.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
+        invokes = []
+        expected_results = []
+
         expected_result = json.dumps(10)
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_json_serialize_bool(self):
-        path = self.get_contract_path('JsonSerializeBool.py')
+        path, _ = self.get_deploy_file_paths('JsonSerializeBool.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
+        invokes = []
+        expected_results = []
+
         expected_result = json.dumps(True)
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_json_serialize_str(self):
-        path = self.get_contract_path('JsonSerializeStr.py')
+        path, _ = self.get_deploy_file_paths('JsonSerializeStr.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
+        invokes = []
+        expected_results = []
+
         expected_result = json.dumps('unit test')
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_json_serialize_bytes(self):
-        path = self.get_contract_path('JsonSerializeBytes.py')
+        path, _ = self.get_deploy_file_paths('JsonSerializeBytes.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
+        invokes = []
+        expected_results = []
+
         # Python does not accept bytes as parameter for json.dumps() method, since string and bytes ends up being the
         # same on Neo, it's being converted to string, before using dumps
         expected_result = json.dumps(String().from_bytes(b'unit test'))
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_json_deserialize(self):
-        path = self.get_contract_path('JsonDeserialize.py')
+        path, _ = self.get_deploy_file_paths('JsonDeserialize.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
+        invokes = []
+        expected_results = []
+
         test_input = json.dumps(12345)
         expected_result = json.loads(test_input)
-        result = self.run_smart_contract(engine, path, 'main', test_input)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'main', test_input))
+        expected_results.append(expected_result)
 
         test_input = json.dumps('unit test')
         expected_result = json.loads(test_input)
-        result = self.run_smart_contract(engine, path, 'main', test_input)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'main', test_input))
+        expected_results.append(expected_result)
 
         test_input = json.dumps(True)
         expected_result = json.loads(test_input)
-        result = self.run_smart_contract(engine, path, 'main', test_input)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'main', test_input))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_import_json(self):
-        path = self.get_contract_path('ImportJson.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ImportJson.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         value = 123
-        result = self.run_smart_contract(engine, path, 'main', value)
-        self.assertEqual(value, result)
+        invokes.append(runner.call_contract(path, 'main', value))
+        expected_results.append(value)
 
         value = 'string'
-        result = self.run_smart_contract(engine, path, 'main', value)
-        self.assertEqual(value, result)
+        invokes.append(runner.call_contract(path, 'main', value))
+        expected_results.append(value)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_import_interop_json(self):
-        path = self.get_contract_path('ImportInteropJson.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ImportInteropJson.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         value = 123
-        result = self.run_smart_contract(engine, path, 'main', value)
-        self.assertEqual(value, result)
+        invokes.append(runner.call_contract(path, 'main', value))
+        expected_results.append(value)
 
         value = 'string'
-        result = self.run_smart_contract(engine, path, 'main', value)
-        self.assertEqual(value, result)
+        invokes.append(runner.call_contract(path, 'main', value))
+        expected_results.append(value)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)

--- a/boa3_test/tests/compiler_tests/test_interop/test_policy.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_policy.py
@@ -1,50 +1,66 @@
 from boa3.exception import CompilerError
+from boa3.neo3.vm import VMState
+from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.boa_test import BoaTest
-from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestPolicyInterop(BoaTest):
     default_folder: str = 'test_sc/interop_test/policy'
 
     def test_get_exec_fee_factor(self):
-        path = self.get_contract_path('GetExecFeeFactor.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('GetExecFeeFactor.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertIsInstance(result, int)
+        invoke = runner.call_contract(path, 'main')
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertIsInstance(invoke.result, int)
 
     def test_get_exec_fee_too_many_parameters(self):
         path = self.get_contract_path('GetExecFeeFactorTooManyArguments.py')
         self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
 
     def test_get_fee_per_byte(self):
-        path = self.get_contract_path('GetFeePerByte.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('GetFeePerByte.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertIsInstance(result, int)
+        invoke = runner.call_contract(path, 'main')
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertIsInstance(invoke.result, int)
 
     def test_get_fee_per_byte_too_many_parameters(self):
         path = self.get_contract_path('GetFeePerByteTooManyArguments.py')
         self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
 
     def test_get_storage_price(self):
-        path = self.get_contract_path('GetStoragePrice.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('GetStoragePrice.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertIsInstance(result, int)
+        invoke = runner.call_contract(path, 'main')
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertIsInstance(invoke.result, int)
 
     def test_get_storage_price_too_many_parameters(self):
         path = self.get_contract_path('GetStoragePriceTooManyArguments.py')
         self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
 
     def test_is_blocked(self):
-        path = self.get_contract_path('IsBlocked.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('IsBlocked.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', bytes(20))
-        self.assertEqual(False, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', bytes(20)))
+        expected_results.append(False)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_is_blocked_mismatched_type(self):
         path = self.get_contract_path('IsBlockedMismatchedTypeInt.py')
@@ -65,15 +81,19 @@ class TestPolicyInterop(BoaTest):
         self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
 
     def test_import_policy(self):
-        path = self.get_contract_path('ImportPolicy.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ImportPolicy.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertIsInstance(result, int)
+        invoke = runner.call_contract(path, 'main')
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertIsInstance(invoke.result, int)
 
     def test_import_interop_policy(self):
-        path = self.get_contract_path('ImportInteropPolicy.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ImportInteropPolicy.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertIsInstance(result, int)
+        invoke = runner.call_contract(path, 'main')
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertIsInstance(invoke.result, int)

--- a/boa3_test/tests/compiler_tests/test_interop/test_policy.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_policy.py
@@ -13,7 +13,7 @@ class TestPolicyInterop(BoaTest):
 
         invoke = runner.call_contract(path, 'main')
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
         self.assertIsInstance(invoke.result, int)
 
     def test_get_exec_fee_too_many_parameters(self):
@@ -26,7 +26,7 @@ class TestPolicyInterop(BoaTest):
 
         invoke = runner.call_contract(path, 'main')
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
         self.assertIsInstance(invoke.result, int)
 
     def test_get_fee_per_byte_too_many_parameters(self):
@@ -39,7 +39,7 @@ class TestPolicyInterop(BoaTest):
 
         invoke = runner.call_contract(path, 'main')
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
         self.assertIsInstance(invoke.result, int)
 
     def test_get_storage_price_too_many_parameters(self):
@@ -57,7 +57,7 @@ class TestPolicyInterop(BoaTest):
         expected_results.append(False)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -86,7 +86,7 @@ class TestPolicyInterop(BoaTest):
 
         invoke = runner.call_contract(path, 'main')
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
         self.assertIsInstance(invoke.result, int)
 
     def test_import_interop_policy(self):
@@ -95,5 +95,5 @@ class TestPolicyInterop(BoaTest):
 
         invoke = runner.call_contract(path, 'main')
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
         self.assertIsInstance(invoke.result, int)

--- a/boa3_test/tests/compiler_tests/test_interop/test_runtime.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_runtime.py
@@ -28,13 +28,13 @@ class TestRuntimeInterop(BoaTest):
         expected_results.append(False)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         invokes.append(runner.call_contract(path, 'Main', account_hash))
         expected_results.append(True)
 
         runner.execute(account=account)
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -56,7 +56,7 @@ class TestRuntimeInterop(BoaTest):
         expected_results.append(False)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
         contract_hash = first_call.invoke.contract.script_hash
 
         invokes.append(runner.call_contract(call_contract_path, contract_method, *contract_args))
@@ -67,7 +67,7 @@ class TestRuntimeInterop(BoaTest):
         expected_results.append(False)  # fail because the signer have CalledByEntry scope
 
         runner.execute(account=account)
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -85,13 +85,13 @@ class TestRuntimeInterop(BoaTest):
         expected_results.append(False)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         invokes.append(runner.call_contract(path, 'Main', account_hash))
         expected_results.append(True)
 
         runner.execute(account=account)
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -133,7 +133,7 @@ class TestRuntimeInterop(BoaTest):
         expected_results.append(None)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -171,7 +171,7 @@ class TestRuntimeInterop(BoaTest):
         expected_results.append(None)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -209,7 +209,7 @@ class TestRuntimeInterop(BoaTest):
         expected_results.append(None)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -247,7 +247,7 @@ class TestRuntimeInterop(BoaTest):
         expected_results.append(None)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -290,7 +290,7 @@ class TestRuntimeInterop(BoaTest):
         expected_results.append(None)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -327,7 +327,7 @@ class TestRuntimeInterop(BoaTest):
         expected_results.append(None)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -365,7 +365,7 @@ class TestRuntimeInterop(BoaTest):
         expected_results.append(None)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -391,7 +391,7 @@ class TestRuntimeInterop(BoaTest):
         expected_results.append(TriggerType.APPLICATION)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -420,7 +420,7 @@ class TestRuntimeInterop(BoaTest):
         expected_results.append(True)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -449,7 +449,7 @@ class TestRuntimeInterop(BoaTest):
         expected_results.append(False)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -472,7 +472,7 @@ class TestRuntimeInterop(BoaTest):
                                              expected_result_type=bytes)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         # cannot get calling script hash directly from test runner to check the value
         result = contract_call.result
@@ -531,7 +531,7 @@ class TestRuntimeInterop(BoaTest):
         expected_results.append(call.invoke.contract.script_hash)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -655,7 +655,7 @@ class TestRuntimeInterop(BoaTest):
         expected_results.append([])
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -706,7 +706,7 @@ class TestRuntimeInterop(BoaTest):
         expected_results.append('NEO')
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -741,7 +741,7 @@ class TestRuntimeInterop(BoaTest):
         expected_results.append(None)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -786,7 +786,7 @@ class TestRuntimeInterop(BoaTest):
         expected_results.append(TriggerType.APPLICATION)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -816,7 +816,7 @@ class TestRuntimeInterop(BoaTest):
         expected_results.append(-1)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -827,7 +827,7 @@ class TestRuntimeInterop(BoaTest):
 
         invoke = runner.call_contract(path, 'main')
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
         self.assertIsNotNone(invoke.result)
 
     def test_get_script_container_as_transaction(self):
@@ -836,7 +836,7 @@ class TestRuntimeInterop(BoaTest):
 
         invoke = runner.call_contract(path, 'main')
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
         result = invoke.result
 
         self.assertEqual(8, len(result))
@@ -866,7 +866,7 @@ class TestRuntimeInterop(BoaTest):
         expected_results.append(neoxp_utils.get_magic())
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -881,7 +881,7 @@ class TestRuntimeInterop(BoaTest):
 
         invoke = runner.call_contract(path, 'main')
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
         self.assertIsInstance(invoke.result, int)
 
     def test_import_interop_runtime(self):
@@ -890,7 +890,7 @@ class TestRuntimeInterop(BoaTest):
 
         invoke = runner.call_contract(path, 'main')
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
         self.assertIsInstance(invoke.result, int)
 
     def test_get_random(self):
@@ -899,7 +899,7 @@ class TestRuntimeInterop(BoaTest):
 
         invoke = runner.call_contract(path, 'main')
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
         self.assertIsInstance(invoke.result, int)
 
     def test_get_random_too_many_parameters(self):
@@ -917,7 +917,7 @@ class TestRuntimeInterop(BoaTest):
         expected_results.append(53)    # current Neo protocol version is 53
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -946,7 +946,7 @@ class TestRuntimeInterop(BoaTest):
         expected_results.append(expected_result)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)

--- a/boa3_test/tests/compiler_tests/test_interop/test_runtime.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_runtime.py
@@ -2,69 +2,99 @@ from boa3 import constants
 from boa3.boa3 import Boa3
 from boa3.exception import CompilerError, CompilerWarning
 from boa3.model.builtin.interop.interop import Interop
-from boa3.neo import to_script_hash
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.String import String
 from boa3.neo3.contracts import TriggerType
+from boa3.neo3.vm import VMState
+from boa3_test.test_drive.neoxp import utils as neoxp_utils
+from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.boa_test import BoaTest
-from boa3_test.tests.test_classes.TestExecutionException import TestExecutionException
-from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestRuntimeInterop(BoaTest):
     default_folder: str = 'test_sc/interop_test/runtime'
 
     def test_check_witness(self):
-        path = self.get_contract_path('CheckWitness.py')
-        account = to_script_hash(b'NiNmXL8FjEUEs1nfX9uHFBNaenxDHJtmuB')
+        path, _ = self.get_deploy_file_paths('CheckWitness.py')
+        account = neoxp_utils.get_account_by_name('testAccount1')
+        account_hash = account.script_hash.to_array()
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', account)
-        self.assertEqual(False, result)
+        invokes = []
+        expected_results = []
 
-        engine.add_signer_account(account)
-        result = self.run_smart_contract(engine, path, 'Main', account)
-        self.assertEqual(True, result)
+        invokes.append(runner.call_contract(path, 'Main', account_hash))
+        expected_results.append(False)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        invokes.append(runner.call_contract(path, 'Main', account_hash))
+        expected_results.append(True)
+
+        runner.execute(account=account)
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_contract_with_check_witness(self):
-        path = self.get_contract_path('test_sc/interop_test/contract', 'CallScriptHash.py')
-        call_contract_path = self.get_contract_path('CheckWitness.py')
-        account = to_script_hash(b'NiNmXL8FjEUEs1nfX9uHFBNaenxDHJtmuB')
+        path, _ = self.get_deploy_file_paths('test_sc/interop_test/contract', 'CallScriptHash.py')
+        call_contract_path, _ = self.get_deploy_file_paths('CheckWitness.py')
+        account = neoxp_utils.get_account_by_name('testAccount1')
+        account_hash = account.script_hash.to_array()
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
+        invokes = []
+        expected_results = []
+
         contract_method = 'Main'
-        contract_args = [account]
-        result = self.run_smart_contract(engine, call_contract_path, contract_method, *contract_args)
-        contract_hash = engine.executed_script_hash.to_array()
-        self.assertEqual(False, result)
+        contract_args = [account_hash]
+        first_call = runner.call_contract(call_contract_path, contract_method, *contract_args)
+        invokes.append(first_call)
+        expected_results.append(False)
 
-        engine.add_signer_account(account)
-        result = self.run_smart_contract(engine, call_contract_path, contract_method, *contract_args)
-        self.assertEqual(True, result)
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+        contract_hash = first_call.invoke.contract.script_hash
 
-        engine.add_signer_account(account)
-        result = self.run_smart_contract(engine, path, 'Main',
-                                         contract_hash, contract_method, contract_args)
-        self.assertEqual(False, result)  # fail because the signer have CalledByEntry scope
+        invokes.append(runner.call_contract(call_contract_path, contract_method, *contract_args))
+        expected_results.append(True)
 
-        from boa3_test.tests.test_classes.witnessscope import WitnessScope
-        engine.add_signer_account(account, WitnessScope.Global)
-        result = self.run_smart_contract(engine, path, 'Main',
-                                         contract_hash, contract_method, contract_args)
-        self.assertEqual(True, result)
+        invokes.append(runner.call_contract(path, 'Main',
+                                            contract_hash, contract_method, contract_args))
+        expected_results.append(False)  # fail because the signer have CalledByEntry scope
+
+        runner.execute(account=account)
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_check_witness_imported_as(self):
-        path = self.get_contract_path('CheckWitnessImportedAs.py')
-        account = to_script_hash(b'NiNmXL8FjEUEs1nfX9uHFBNaenxDHJtmuB')
+        path, _ = self.get_deploy_file_paths('CheckWitnessImportedAs.py')
+        account = neoxp_utils.get_account_by_name('testAccount1')
+        account_hash = account.script_hash.to_array()
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', account)
-        self.assertEqual(False, result)
+        invokes = []
+        expected_results = []
 
-        engine.add_signer_account(account)
-        result = self.run_smart_contract(engine, path, 'Main', account)
-        self.assertEqual(True, result)
+        invokes.append(runner.call_contract(path, 'Main', account_hash))
+        expected_results.append(False)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        invokes.append(runner.call_contract(path, 'Main', account_hash))
+        expected_results.append(True)
+
+        runner.execute(account=account)
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_check_witness_mismatched_type(self):
         path = self.get_contract_path('CheckWitnessMismatchedType.py')
@@ -93,12 +123,22 @@ class TestRuntimeInterop(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertIsVoid(result)
-        self.assertGreater(len(engine.notifications), 0)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
 
-        event_notifications = engine.get_events(event_name=Interop.Notify.name)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append(None)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        event_notifications = runner.get_events(event_name=Interop.Notify.name)
         self.assertEqual(1, len(event_notifications))
         self.assertEqual((message,), event_notifications[0].arguments)
 
@@ -121,12 +161,22 @@ class TestRuntimeInterop(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertIsVoid(result)
-        self.assertGreater(len(engine.notifications), 0)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
 
-        event_notifications = engine.get_events(event_name=Interop.Notify.name)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append(None)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        event_notifications = runner.get_events(event_name=Interop.Notify.name)
         self.assertEqual(1, len(event_notifications))
         self.assertEqual((15,), event_notifications[0].arguments)
 
@@ -149,12 +199,22 @@ class TestRuntimeInterop(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertIsVoid(result)
-        self.assertGreater(len(engine.notifications), 0)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
 
-        event_notifications = engine.get_events(event_name=Interop.Notify.name)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append(None)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        event_notifications = runner.get_events(event_name=Interop.Notify.name)
         self.assertEqual(1, len(event_notifications))
         self.assertEqual((True,), event_notifications[0].arguments)
 
@@ -177,12 +237,22 @@ class TestRuntimeInterop(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertIsVoid(result)
-        self.assertGreater(len(engine.notifications), 0)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
 
-        event_notifications = engine.get_events(event_name=Interop.Notify.name)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append(None)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        event_notifications = runner.get_events(event_name=Interop.Notify.name)
         self.assertEqual(1, len(event_notifications))
         self.assertEqual((None,), event_notifications[0].arguments)
 
@@ -210,12 +280,22 @@ class TestRuntimeInterop(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertIsVoid(result)
-        self.assertGreater(len(engine.notifications), 0)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
 
-        event_notifications = engine.get_events(event_name=Interop.Notify.name)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append(None)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        event_notifications = runner.get_events(event_name=Interop.Notify.name)
         self.assertEqual(1, len(event_notifications))
         self.assertEqual(([2, 3, 5, 7],), event_notifications[0].arguments)
 
@@ -237,12 +317,22 @@ class TestRuntimeInterop(BoaTest):
         output, manifest = self.compile_and_save(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', 'unit_test')
-        self.assertIsVoid(result)
-        self.assertGreater(len(engine.notifications), 0)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
 
-        event_notifications = engine.get_events(event_name='unit_test')
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main', 'unit_test'))
+        expected_results.append(None)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        event_notifications = runner.get_events(event_name='unit_test')
         self.assertEqual(1, len(event_notifications))
         self.assertEqual((10,), event_notifications[0].arguments)
 
@@ -265,9 +355,20 @@ class TestRuntimeInterop(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertIsVoid(result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append(None)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_get_trigger(self):
         expected_output = (
@@ -280,9 +381,20 @@ class TestRuntimeInterop(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(TriggerType.APPLICATION, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append(TriggerType.APPLICATION)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_is_application_trigger(self):
         application = Integer(TriggerType.APPLICATION.value).to_byte_array()
@@ -298,9 +410,20 @@ class TestRuntimeInterop(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(True, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append(True)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_is_verification_trigger(self):
         verification = Integer(TriggerType.VERIFICATION.value).to_byte_array()
@@ -316,9 +439,20 @@ class TestRuntimeInterop(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(False, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append(False)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_get_calling_script_hash(self):
         expected_output = (
@@ -331,12 +465,19 @@ class TestRuntimeInterop(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        calling_hash = bytes(range(20))
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main',
-                                         calling_script_hash=calling_hash,
-                                         expected_result_type=bytes)
-        self.assertEqual(calling_hash, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        contract_call = runner.call_contract(path, 'Main',
+                                             expected_result_type=bytes)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        # cannot get calling script hash directly from test runner to check the value
+        result = contract_call.result
+        self.assertIsInstance(result, bytes)
+        self.assertEqual(constants.SIZE_OF_INT160, len(result))
 
     def test_calling_script_hash_cant_assign(self):
         expected_output = (
@@ -378,11 +519,22 @@ class TestRuntimeInterop(BoaTest):
         self.assertEqual(expected_output, output)
 
     def test_get_executing_script_hash_on_deploy(self):
-        path = self.get_contract_path('ExecutingScriptHashOnDeploy.py')
+        path, _ = self.get_deploy_file_paths('ExecutingScriptHashOnDeploy.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'get_script')
-        self.assertEqual(engine.executed_script_hash.to_array(), result)
+        invokes = []
+        expected_results = []
+
+        call = runner.call_contract(path, 'get_script')
+        runner.update_contracts()
+        invokes.append(call)
+        expected_results.append(call.invoke.contract.script_hash)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_get_block_time(self):
         expected_output = (
@@ -395,10 +547,16 @@ class TestRuntimeInterop(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        new_block = engine.increase_block()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(new_block.timestamp, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invoke = runner.call_contract(path, 'Main')
+        runner.execute()
+
+        # Test Runner has an error when returning block time
+        # it returns None instead of the actual timestamp and raises NullPointerException
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.NULL_POINTER_MSG)
 
     def test_block_time_cant_assign(self):
         expected_output = (
@@ -465,50 +623,42 @@ class TestRuntimeInterop(BoaTest):
         self.assertEqual(expected_output, output)
 
     def test_get_notifications(self):
-        path = self.get_contract_path('GetNotifications.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('GetNotifications.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'without_param', [])
-        self.assertEqual(1, len(result))
+        invokes = []
+        expected_results = []
 
-        self.assertEqual(3, len(result[0]))
-        # the Deploy parameter should have been the smart contract address, but the deploy method does uses a
-        # ReferenceCounter and the test engine didn't replicate this behavior
-        # new VM.Types.Array(engine.ReferenceCounter) { contract.Hash.ToArray() }
-        event_script, event_name = result[0][:2]
-        self.assertEqual(constants.MANAGEMENT_SCRIPT, event_script)
-        self.assertEqual('Deploy', event_name)
-        script = engine.executed_script_hash.to_array()
+        notify_call = runner.call_contract(path, 'without_param', [])
+        runner.update_contracts()
 
-        engine.reset_engine()
-        result = self.run_smart_contract(engine, path, 'without_param', [1, 2, 3])
-        expected_result = [
-            [constants.MANAGEMENT_SCRIPT, 'Deploy', script]
-        ]
+        script = notify_call.invoke.contract.script_hash
+        invokes.append(notify_call)
+        expected_results.append([])
+
+        invokes.append(runner.call_contract(path, 'without_param', [1, 2, 3]))
+        expected_result_1 = []
         for x in [1, 2, 3]:
-            expected_result.append([script, 'notify', [x]])
+            expected_result_1.append([script, 'notify', [x]])
+        expected_results.append(expected_result_1)
 
-        self.assertEqual(expected_result[1:], result[1:])
+        invokes.append(runner.call_contract(path, 'with_param', [], constants.MANAGEMENT_SCRIPT))
+        expected_results.append([])
 
-        # it's the same Deploy error
-        self.assertEqual(expected_result[0][:2], result[0][:2])
-
-        engine.reset_engine()
-        result = self.run_smart_contract(engine, path, 'with_param', [], script)
-        self.assertEqual([], result)
-
-        engine.reset_engine()
-        result = self.run_smart_contract(engine, path, 'with_param', [1, 2, 3], script)
-        expected_result = []
+        invokes.append(runner.call_contract(path, 'with_param', [1, 2, 3], script))
+        expected_result_2 = []
         for x in [1, 2, 3]:
-            expected_result.append([script,
-                                    'notify',
-                                    [x]])
-        self.assertEqual(expected_result, result)
+            expected_result_2.append([script, 'notify', [x]])
+        expected_results.append(expected_result_1 + expected_result_2)
 
-        engine.reset_engine()
-        result = self.run_smart_contract(engine, path, 'with_param', [1, 2, 3], b'\x01' * 20)
-        self.assertEqual([], result)
+        invokes.append(runner.call_contract(path, 'with_param', [1, 2, 3], b'\x01' * 20))
+        expected_results.append([])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_get_entry_script_hash(self):
         expected_output = (
@@ -546,9 +696,20 @@ class TestRuntimeInterop(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual('NEO', result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append('NEO')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_platform_cant_assign(self):
         expected_output = (
@@ -565,85 +726,119 @@ class TestRuntimeInterop(BoaTest):
         self.assertEqual(expected_output, output)
 
     def test_burn_gas(self):
-        path = self.get_contract_path('BurnGas.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('BurnGas.py')
+        runner = NeoTestRunner()
 
-        burn_gas_cost = 2460  # 2460 * 10^-8 GAS
+        invokes = []
+        expected_results = []
+
+        burned_gas_1 = 1 * 10 ** 8  # 1 GAS
+        invokes.append(runner.call_contract(path, 'main', burned_gas_1))
+        expected_results.append(None)
+
+        burned_gas_2 = 123 * 10 ** 5  # 0.123 GAS
+        invokes.append(runner.call_contract(path, 'main', burned_gas_2))
+        expected_results.append(None)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
         # can not burn negative GAS
-        with self.assertRaisesRegex(TestExecutionException, self.GAS_MUST_BE_POSITIVE_MSG):
-            self.run_smart_contract(engine, path, 'main', -10 ** 8)
-        self.assertEqual(engine.gas_consumed - burn_gas_cost, 0)
+        runner.call_contract(path, 'main', -10 ** 8)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.GAS_MUST_BE_POSITIVE_MSG)
 
         # can not burn no GAS
-        with self.assertRaisesRegex(TestExecutionException, self.GAS_MUST_BE_POSITIVE_MSG):
-            self.run_smart_contract(engine, path, 'main', 0)
-        self.assertEqual(engine.gas_consumed - burn_gas_cost, 0)
-
-        burned_gas = 1 * 10 ** 8  # 1 GAS
-        result = self.run_smart_contract(engine, path, 'main', burned_gas)
-        self.assertIsVoid(result)
-        self.assertEqual(engine.gas_consumed - burn_gas_cost, burned_gas)
-
-        burned_gas = 123 * 10 ** 5  # 0.123 GAS
-        result = self.run_smart_contract(engine, path, 'main', burned_gas)
-        self.assertIsVoid(result)
-        self.assertEqual(engine.gas_consumed - burn_gas_cost, burned_gas)
+        runner.call_contract(path, 'main', 0)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.GAS_MUST_BE_POSITIVE_MSG)
 
     def test_boa2_runtime_test(self):
-        path = self.get_contract_path('RuntimeBoa2Test.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('RuntimeBoa2Test.py')
+        account = neoxp_utils.get_account_by_name('testAccount1').script_hash.to_array()
+        runner = NeoTestRunner()
 
-        new_block = engine.increase_block()
-        result = self.run_smart_contract(engine, path, 'main', 'time', 1)
-        self.assertEqual(new_block.timestamp, result)
+        invokes = []
+        expected_results = []
 
-        from boa3.builtin.type import UInt160
-        result = self.run_smart_contract(engine, path, 'main', 'check_witness', UInt160(bytes(20)))
-        self.assertEqual(False, result)
+        # Test Runner has an error when returning block time
+        # it returns None instead of the actual timestamp and raises NullPointerException
+        invoke = runner.call_contract(path, 'main', 'time', 1)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.NULL_POINTER_MSG)
 
-        result = self.run_smart_contract(engine, path, 'main', 'log', 'hello')
-        self.assertEqual(True, result)
+        invokes.append(runner.call_contract(path, 'main', 'check_witness', account))
+        expected_results.append(False)
 
-        result = self.run_smart_contract(engine, path, 'main', 'notify', 1234)
-        self.assertEqual(True, result)
-        event_notifications = engine.get_events(event_name=Interop.Notify.name)
+        invokes.append(runner.call_contract(path, 'main', 'log', 'hello'))
+        expected_results.append(True)
+
+        invokes.append(runner.call_contract(path, 'main', 'notify', 1234))
+        expected_results.append(True)
+
+        invokes.append(runner.call_contract(path, 'main', 'get_trigger', 1234))
+        expected_results.append(TriggerType.APPLICATION)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        event_notifications = runner.get_events(event_name=Interop.Notify.name)
         self.assertEqual(1, len(event_notifications))
         self.assertEqual((1234,), event_notifications[0].arguments)
 
-        result = self.run_smart_contract(engine, path, 'main', 'get_trigger', 1234)
-        self.assertEqual(TriggerType.APPLICATION, result)
-
     def test_boa2_trigger_type_test(self):
-        path = self.get_contract_path('TriggerTypeBoa2Test.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('TriggerTypeBoa2Test.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', 1)
-        self.assertEqual(0x40, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', 2)
-        self.assertEqual(0x20, result)
+        invokes.append(runner.call_contract(path, 'main', 1))
+        expected_results.append(0x40)
 
-        result = self.run_smart_contract(engine, path, 'main', 3)
-        if isinstance(result, str):
-            result = String(result).to_bytes()
-        self.assertEqual(b'\x20', result)
+        invokes.append(runner.call_contract(path, 'main', 2))
+        expected_results.append(0x20)
 
-        result = self.run_smart_contract(engine, path, 'main', 0)
-        self.assertEqual(-1, result)
+        invokes.append(runner.call_contract(path, 'main', 3,
+                                            expected_result_type=bytes))
+        expected_results.append(b'\x20')
+
+        invokes.append(runner.call_contract(path, 'main', 0))
+        expected_results.append(-1)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_get_script_container(self):
-        path = self.get_contract_path('ScriptContainer.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ScriptContainer.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertIsNotNone(result)
+        invoke = runner.call_contract(path, 'main')
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertIsNotNone(invoke.result)
 
     def test_get_script_container_as_transaction(self):
-        path = self.get_contract_path('ScriptContainerAsTransaction.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ScriptContainerAsTransaction.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main')
+        invoke = runner.call_contract(path, 'main')
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+        result = invoke.result
+
         self.assertEqual(8, len(result))
         if isinstance(result[0], str):
             result[0] = String(result[0]).to_bytes()
@@ -656,70 +851,102 @@ class TestRuntimeInterop(BoaTest):
         self.assertIsInstance(result[4], int)
         self.assertIsInstance(result[5], int)
         self.assertIsInstance(result[6], int)
-        if isinstance(result[6], str):
-            result[6] = String(result[6]).to_bytes()
+        if isinstance(result[7], str):
+            result[7] = String(result[7]).to_bytes()
         self.assertIsInstance(result[7], bytes)
 
     def test_get_network(self):
-        path = self.get_contract_path('GetNetwork.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('GetNetwork.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(0x334F454E, result)  # Neo3 main net's magic number
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(neoxp_utils.get_magic())
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_get_network_too_many_parameters(self):
         path = self.get_contract_path('GetNetworkTooManyArguments.py')
         self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
 
     def test_import_runtime(self):
-        path = self.get_contract_path('ImportRuntime.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ImportRuntime.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertIsInstance(result, int)
+        invoke = runner.call_contract(path, 'main')
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertIsInstance(invoke.result, int)
 
     def test_import_interop_runtime(self):
-        path = self.get_contract_path('ImportInteropRuntime.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ImportInteropRuntime.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertIsInstance(result, int)
+        invoke = runner.call_contract(path, 'main')
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertIsInstance(invoke.result, int)
 
     def test_get_random(self):
-        path = self.get_contract_path('GetRandom.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('GetRandom.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertIsInstance(result, int)
+        invoke = runner.call_contract(path, 'main')
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertIsInstance(invoke.result, int)
 
     def test_get_random_too_many_parameters(self):
         path = self.get_contract_path('GetRandomTooManyArguments.py')
         self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
 
     def test_address_version(self):
-        path = self.get_contract_path('AddressVersion.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('AddressVersion.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(53, result)    # current Neo protocol version is 53
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(53)    # current Neo protocol version is 53
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_address_version_cant_assign(self):
         path = self.get_contract_path('AddressVersionCantAssign.py')
         self.assertCompilerLogs(CompilerWarning.NameShadowing, path)
 
     def test_load_script(self):
-        path = self.get_contract_path('LoadScriptDynamicCall.py')
-        self.compile_and_save(path)
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('LoadScriptDynamicCall.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         operand_1 = 1
         operand_2 = 2
         expected_result = operand_1 + operand_2
-        result = self.run_smart_contract(engine, path, 'dynamic_sum',
-                                         operand_1, operand_2)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'dynamic_sum',
+                                            operand_1, operand_2))
+        expected_results.append(expected_result)
 
         from boa3.neo3.contracts import CallFlags
-        result = self.run_smart_contract(engine, path, 'dynamic_sum_with_flags',
-                                         operand_1, operand_2, CallFlags.READ_ONLY)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'dynamic_sum_with_flags',
+                                            operand_1, operand_2, CallFlags.READ_ONLY))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)

--- a/boa3_test/tests/compiler_tests/test_interop/test_stdlib.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_stdlib.py
@@ -1,9 +1,9 @@
 from boa3.exception import CompilerError
 from boa3.neo.vm.type.StackItem import StackItemType, serialize
 from boa3.neo.vm.type.String import String
+from boa3.neo3.vm import VMState
+from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.boa_test import BoaTest
-from boa3_test.tests.test_classes.TestExecutionException import TestExecutionException
-from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestStdlibInterop(BoaTest):
@@ -11,17 +11,21 @@ class TestStdlibInterop(BoaTest):
 
     def test_base64_encode(self):
         import base64
-        path = self.get_contract_path('Base64Encode.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Base64Encode.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         expected_result = base64.b64encode(b'unit test')
-        result = self.run_smart_contract(engine, path, 'Main', b'unit test',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'Main', b'unit test',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         expected_result = base64.b64encode(b'')
-        result = self.run_smart_contract(engine, path, 'Main', b'',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'Main', b'',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         long_byte_string = (b'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam accumsan magna eu massa '
                             b'vulputate bibendum. Aliquam commodo euismod tristique. Sed purus erat, pretium ut interdum '
@@ -32,9 +36,15 @@ class TestStdlibInterop(BoaTest):
                             b'dolor sit amet, consectetur adipiscing elit. Ut tincidunt, nisi in ullamcorper ornare, '
                             b'est enim dictum massa, id aliquet justo magna in purus.')
         expected_result = base64.b64encode(long_byte_string)
-        result = self.run_smart_contract(engine, path, 'Main', long_byte_string,
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'Main', long_byte_string,
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_base64_encode_mismatched_type(self):
         path = self.get_contract_path('Base64EncodeMismatchedType.py')
@@ -42,17 +52,21 @@ class TestStdlibInterop(BoaTest):
 
     def test_base64_decode(self):
         import base64
-        path = self.get_contract_path('Base64Decode.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Base64Decode.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         arg = String.from_bytes(base64.b64encode(b'unit test'))
-        result = self.run_smart_contract(engine, path, 'Main', arg,
-                                         expected_result_type=bytes)
-        self.assertEqual(b'unit test', result)
+        invokes.append(runner.call_contract(path, 'Main', arg,
+                                            expected_result_type=bytes))
+        expected_results.append(b'unit test')
 
         arg = String.from_bytes(base64.b64encode(b''))
-        result = self.run_smart_contract(engine, path, 'Main', arg,
-                                         expected_result_type=bytes)
-        self.assertEqual(b'', result)
+        invokes.append(runner.call_contract(path, 'Main', arg,
+                                            expected_result_type=bytes))
+        expected_results.append(b'')
 
         long_string = ('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam accumsan magna eu massa '
                        'vulputate bibendum. Aliquam commodo euismod tristique. Sed purus erat, pretium ut interdum '
@@ -63,9 +77,15 @@ class TestStdlibInterop(BoaTest):
                        'dolor sit amet, consectetur adipiscing elit. Ut tincidunt, nisi in ullamcorper ornare, '
                        'est enim dictum massa, id aliquet justo magna in purus.')
         arg = String.from_bytes(base64.b64encode(String(long_string).to_bytes()))
-        result = self.run_smart_contract(engine, path, 'Main', arg,
-                                         expected_result_type=bytes)
-        self.assertEqual(String(long_string).to_bytes(), result)
+        invokes.append(runner.call_contract(path, 'Main', arg,
+                                            expected_result_type=bytes))
+        expected_results.append(String(long_string).to_bytes())
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_base64_decode_mismatched_type(self):
         path = self.get_contract_path('Base64DecodeMismatchedType.py')
@@ -73,17 +93,21 @@ class TestStdlibInterop(BoaTest):
 
     def test_base58_encode(self):
         import base58
-        path = self.get_contract_path('Base58Encode.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Base58Encode.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         expected_result = base58.b58encode('unit test')
-        result = self.run_smart_contract(engine, path, 'Main', 'unit test',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'Main', 'unit test',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         expected_result = base58.b58encode('')
-        result = self.run_smart_contract(engine, path, 'Main', '',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'Main', '',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         long_string = ('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam accumsan magna eu massa '
                        'vulputate bibendum. Aliquam commodo euismod tristique. Sed purus erat, pretium ut interdum '
@@ -94,9 +118,15 @@ class TestStdlibInterop(BoaTest):
                        'dolor sit amet, consectetur adipiscing elit. Ut tincidunt, nisi in ullamcorper ornare, '
                        'est enim dictum massa, id aliquet justo magna in purus.')
         expected_result = base58.b58encode(long_string)
-        result = self.run_smart_contract(engine, path, 'Main', long_string,
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'Main', long_string,
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_base58_encode_mismatched_type(self):
         path = self.get_contract_path('Base58EncodeMismatchedType.py')
@@ -104,15 +134,19 @@ class TestStdlibInterop(BoaTest):
 
     def test_base58_decode(self):
         import base58
-        path = self.get_contract_path('Base58Decode.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Base58Decode.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         arg = base58.b58encode('unit test')
-        result = self.run_smart_contract(engine, path, 'Main', arg)
-        self.assertEqual('unit test', result)
+        invokes.append(runner.call_contract(path, 'Main', arg))
+        expected_results.append('unit test')
 
         arg = base58.b58encode('')
-        result = self.run_smart_contract(engine, path, 'Main', arg)
-        self.assertEqual('', result)
+        invokes.append(runner.call_contract(path, 'Main', arg))
+        expected_results.append('')
 
         long_string = ('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam accumsan magna eu massa '
                        'vulputate bibendum. Aliquam commodo euismod tristique. Sed purus erat, pretium ut interdum '
@@ -123,8 +157,14 @@ class TestStdlibInterop(BoaTest):
                        'dolor sit amet, consectetur adipiscing elit. Ut tincidunt, nisi in ullamcorper ornare, '
                        'est enim dictum massa, id aliquet justo magna in purus.')
         arg = base58.b58encode(long_string)
-        result = self.run_smart_contract(engine, path, 'Main', arg)
-        self.assertEqual(long_string, result)
+        invokes.append(runner.call_contract(path, 'Main', arg))
+        expected_results.append(long_string)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_base58_decode_mismatched_type(self):
         path = self.get_contract_path('Base58DecodeMismatchedType.py')
@@ -132,15 +172,19 @@ class TestStdlibInterop(BoaTest):
 
     def test_base58_check_decode(self):
         import base58
-        path = self.get_contract_path('Base58CheckDecode.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Base58CheckDecode.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         arg = base58.b58encode_check('unit test'.encode('utf-8'))
-        result = self.run_smart_contract(engine, path, 'main', arg)
-        self.assertEqual('unit test', result)
+        invokes.append(runner.call_contract(path, 'main', arg))
+        expected_results.append('unit test')
 
         arg = base58.b58encode_check(''.encode('utf-8'))
-        result = self.run_smart_contract(engine, path, 'main', arg)
-        self.assertEqual('', result)
+        invokes.append(runner.call_contract(path, 'main', arg))
+        expected_results.append('')
 
         long_string = ('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam accumsan magna eu massa '
                        'vulputate bibendum. Aliquam commodo euismod tristique. Sed purus erat, pretium ut interdum '
@@ -151,8 +195,14 @@ class TestStdlibInterop(BoaTest):
                        'dolor sit amet, consectetur adipiscing elit. Ut tincidunt, nisi in ullamcorper ornare, '
                        'est enim dictum massa, id aliquet justo magna in purus.')
         arg = base58.b58encode_check(long_string.encode('utf-8'))
-        result = self.run_smart_contract(engine, path, 'main', arg)
-        self.assertEqual(long_string, result)
+        invokes.append(runner.call_contract(path, 'main', arg))
+        expected_results.append(long_string)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_base58_check_decode_mismatched_type(self):
         path = self.get_contract_path('Base58CheckDecodeMismatchedType.py')
@@ -160,17 +210,21 @@ class TestStdlibInterop(BoaTest):
 
     def test_base58_check_encode(self):
         import base58
-        path = self.get_contract_path('Base58CheckEncode.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Base58CheckEncode.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         expected_result = base58.b58encode_check('unit test'.encode('utf-8'))
-        result = self.run_smart_contract(engine, path, 'main', 'unit test',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'main', 'unit test',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         expected_result = base58.b58encode_check(''.encode('utf-8'))
-        result = self.run_smart_contract(engine, path, 'main', '',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'main', '',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         long_string = ('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam accumsan magna eu massa '
                        'vulputate bibendum. Aliquam commodo euismod tristique. Sed purus erat, pretium ut interdum '
@@ -181,192 +235,340 @@ class TestStdlibInterop(BoaTest):
                        'dolor sit amet, consectetur adipiscing elit. Ut tincidunt, nisi in ullamcorper ornare, '
                        'est enim dictum massa, id aliquet justo magna in purus.')
         expected_result = base58.b58encode_check(long_string.encode('utf-8'))
-        result = self.run_smart_contract(engine, path, 'main', long_string,
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'main', long_string,
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_base58_check_encode_mismatched_type(self):
         path = self.get_contract_path('Base58CheckEncodeMismatchedType.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_serialize_int(self):
-        path = self.get_contract_path('SerializeInt.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'serialize_int',
-                                         expected_result_type=bytes)
+        path, _ = self.get_deploy_file_paths('SerializeInt.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'serialize_int',
+                                            expected_result_type=bytes))
         expected_result = serialize(42)
-        self.assertEqual(expected_result, result)
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_serialize_bool(self):
-        path = self.get_contract_path('SerializeBool.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'serialize_bool',
-                                         expected_result_type=bytes)
+        path, _ = self.get_deploy_file_paths('SerializeBool.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'serialize_bool',
+                                            expected_result_type=bytes))
         expected_result = serialize(True)
-        self.assertEqual(expected_result, result)
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_serialize_str(self):
-        path = self.get_contract_path('SerializeStr.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'serialize_str',
-                                         expected_result_type=bytes)
+        path, _ = self.get_deploy_file_paths('SerializeStr.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'serialize_str',
+                                            expected_result_type=bytes))
         expected_result = serialize('42')
-        self.assertEqual(expected_result, result)
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_serialize_sequence(self):
-        path = self.get_contract_path('SerializeSequence.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'serialize_sequence',
-                                         expected_result_type=bytes)
+        path, _ = self.get_deploy_file_paths('SerializeSequence.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'serialize_sequence',
+                                            expected_result_type=bytes))
         expected_result = serialize([2, 3, 5, 7])
-        self.assertEqual(expected_result, result)
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_serialize_dict(self):
-        path = self.get_contract_path('SerializeDict.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'serialize_dict',
-                                         expected_result_type=bytes)
+        path, _ = self.get_deploy_file_paths('SerializeDict.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'serialize_dict',
+                                            expected_result_type=bytes))
         expected_result = serialize({1: 1, 2: 1, 3: 2})
-        self.assertEqual(expected_result, result)
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_deserialize(self):
-        path = self.get_contract_path('Deserialize.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Deserialize.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         expected_result = 42
         value = serialize(expected_result)
-        result = self.run_smart_contract(engine, path, 'deserialize_arg', value,
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'deserialize_arg', value,
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         expected_result = True
         value = serialize(expected_result)
-        result = self.run_smart_contract(engine, path, 'deserialize_arg', value)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'deserialize_arg', value))
+        expected_results.append(expected_result)
 
         value = StackItemType.Boolean + value[1:]
-        result = self.run_smart_contract(engine, path, 'deserialize_arg', value)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'deserialize_arg', value))
+        expected_results.append(expected_result)
 
         expected_result = '42'
         value = serialize(expected_result)
-        result = self.run_smart_contract(engine, path, 'deserialize_arg', value)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'deserialize_arg', value))
+        expected_results.append(expected_result)
 
         expected_result = b'42'
         value = serialize(expected_result)
-        result = self.run_smart_contract(engine, path, 'deserialize_arg', value,
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'deserialize_arg', value,
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         expected_result = [1, '2', b'3']
         value = serialize(expected_result)
-        result = self.run_smart_contract(engine, path, 'deserialize_arg', value)
+        invokes.append(runner.call_contract(path, 'deserialize_arg', value))
         expected_result[2] = String.from_bytes(expected_result[2])
-        self.assertEqual(expected_result, result)
+        expected_results.append(expected_result)
 
         expected_result = {'int': 1, 'str': '2', 'bytes': b'3'}
         value = serialize(expected_result)
-        result = self.run_smart_contract(engine, path, 'deserialize_arg', value)
+        invokes.append(runner.call_contract(path, 'deserialize_arg', value))
         expected_result['bytes'] = String.from_bytes(expected_result['bytes'])
-        self.assertEqual(expected_result, result)
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_deserialize_mismatched_type(self):
         path = self.get_contract_path('DeserializeMismatchedType.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_boa2_serialization_test1(self):
-        path = self.get_contract_path('SerializationBoa2Test.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', 1, expected_result_type=bytes)
+        path, _ = self.get_deploy_file_paths('SerializationBoa2Test.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', 1, expected_result_type=bytes))
         expected_result = serialize(['a', 3, ['j', 3, 5], 'jk', 'lmnopqr'])
-        self.assertEqual(expected_result, result)
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_boa2_serialization_test2(self):
-        path = self.get_contract_path('SerializationBoa2Test.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', 2, expected_result_type=bytes)
+        path, _ = self.get_deploy_file_paths('SerializationBoa2Test.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', 2, expected_result_type=bytes))
         expected_result = serialize(['a', 3, ['j', 3, 5], 'jk', 'lmnopqr'])
-        self.assertEqual(expected_result, result)
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_boa2_serialization_test3(self):
-        path = self.get_contract_path('SerializationBoa2Test.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', 3)
-        self.assertEqual(['a', 3, ['j', 3, 5], 'jk', 'lmnopqr'], result)
+        path, _ = self.get_deploy_file_paths('SerializationBoa2Test.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', 3))
+        expected_results.append(['a', 3, ['j', 3, 5], 'jk', 'lmnopqr'])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_boa2_serialization_test4(self):
-        path = self.get_contract_path('SerializationBoa2Test.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', 4)
-        self.assertEqual(['j', 3, 5], result)
+        path, _ = self.get_deploy_file_paths('SerializationBoa2Test.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', 4))
+        expected_results.append(['j', 3, 5])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_user_class_serialization(self):
-        path = self.get_contract_path('SerializationUserClass.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('SerializationUserClass.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         expected_class = [2, 4]
-        serialized = self.run_smart_contract(engine, path, 'serialize_user_class',
+        contract_call = runner.call_contract(path, 'serialize_user_class',
                                              expected_result_type=bytes)
+
         expected_result = serialize(expected_class)
-        self.assertEqual(expected_result, serialized)
+        invokes.append(contract_call)
+        expected_results.append(expected_result)
 
-        result = self.run_smart_contract(engine, path, 'deserialize_user_class', serialized,
-                                         expected_result_type=list)
-        self.assertEqual(expected_class, result)
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+        serialized = contract_call.result
 
-        result = self.run_smart_contract(engine, path, 'get_variable_from_deserialized', serialized)
-        self.assertEqual(2, result)
+        invokes.append(runner.call_contract(path, 'deserialize_user_class', serialized,
+                                            expected_result_type=list))
+        expected_results.append(expected_class)
 
-        result = self.run_smart_contract(engine, path, 'call_method_from_deserialized', serialized)
-        self.assertEqual(42, result)
+        invokes.append(runner.call_contract(path, 'get_variable_from_deserialized', serialized))
+        expected_results.append(2)
+
+        invokes.append(runner.call_contract(path, 'call_method_from_deserialized', serialized))
+        expected_results.append(42)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_atoi(self):
-        path = self.get_contract_path('Atoi.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Atoi.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', '10', 10)
-        self.assertEqual(10, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', '10', 16)
-        self.assertEqual(16, result)
+        invokes.append(runner.call_contract(path, 'main', '10', 10))
+        expected_results.append(10)
 
-        result = self.run_smart_contract(engine, path, 'main', '123', 10)
-        self.assertEqual(123, result)
+        invokes.append(runner.call_contract(path, 'main', '10', 16))
+        expected_results.append(16)
 
-        result = self.run_smart_contract(engine, path, 'main', '123', 16)
-        self.assertEqual(291, result)
+        invokes.append(runner.call_contract(path, 'main', '123', 10))
+        expected_results.append(123)
 
-        result = self.run_smart_contract(engine, path, 'main', '1f', 16)
-        self.assertEqual(31, result)
+        invokes.append(runner.call_contract(path, 'main', '123', 16))
+        expected_results.append(291)
 
-        result = self.run_smart_contract(engine, path, 'main', 'ff', 16)
-        self.assertEqual(-1, result)
+        invokes.append(runner.call_contract(path, 'main', '1f', 16))
+        expected_results.append(31)
 
-        with self.assertRaisesRegex(TestExecutionException, self.CANT_PARSE_VALUE_MSG):
-            self.run_smart_contract(engine, path, 'main', 'string', 10)
+        invokes.append(runner.call_contract(path, 'main', 'ff', 16))
+        expected_results.append(-1)
 
-        with self.assertRaisesRegex(TestExecutionException, self.CANT_PARSE_VALUE_MSG):
-            self.run_smart_contract(engine, path, 'main', 'string', 16)
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
 
-        with self.assertRaisesRegex(TestExecutionException, self.CANT_PARSE_VALUE_MSG):
-            self.run_smart_contract(engine, path, 'main', 'abc', 10)
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
-        with self.assertRaisesRegex(TestExecutionException, f'^{self.ARGUMENT_OUT_OF_RANGE_MSG_PREFIX}'):
-            self.run_smart_contract(engine, path, 'main', '10', 2)
+        runner.call_contract(path, 'main', 'string', 10)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.CANT_PARSE_VALUE_MSG)
+
+        runner.call_contract(path, 'main', 'string', 16)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.CANT_PARSE_VALUE_MSG)
+
+        runner.call_contract(path, 'main', 'abc', 10)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.CANT_PARSE_VALUE_MSG)
+
+        runner.call_contract(path, 'main', '10', 2)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'^{self.ARGUMENT_OUT_OF_RANGE_MSG_PREFIX}')
 
     def test_atoi_default(self):
-        path = self.get_contract_path('AtoiDefault.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('AtoiDefault.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', '10')
-        self.assertEqual(10, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', '123')
-        self.assertEqual(123, result)
+        invokes.append(runner.call_contract(path, 'main', '10'))
+        expected_results.append(10)
 
-        with self.assertRaisesRegex(TestExecutionException, self.CANT_PARSE_VALUE_MSG):
-            self.run_smart_contract(engine, path, 'main', 'string')
+        invokes.append(runner.call_contract(path, 'main', '123'))
+        expected_results.append(123)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        runner.call_contract(path, 'main', 'string')
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.CANT_PARSE_VALUE_MSG)
 
     def test_atoi_too_few_parameters(self):
         path = self.get_contract_path('AtoiTooFewArguments.py')
@@ -381,31 +583,51 @@ class TestStdlibInterop(BoaTest):
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_itoa(self):
-        path = self.get_contract_path('Itoa')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Itoa')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', 10, 10)
-        self.assertEqual('10', result)
-        result = self.run_smart_contract(engine, path, 'main', 16, 16)
-        self.assertEqual('10', result)
-        result = self.run_smart_contract(engine, path, 'main', -1, 10)
-        self.assertEqual('-1', result)
-        result = self.run_smart_contract(engine, path, 'main', -1, 16)
-        self.assertEqual('f', result)
-        result = self.run_smart_contract(engine, path, 'main', 15, 16)
-        self.assertEqual('0f', result)
+        invokes = []
+        expected_results = []
 
-        with self.assertRaisesRegex(TestExecutionException, f'^{self.ARGUMENT_OUT_OF_RANGE_MSG_PREFIX}'):
-            self.run_smart_contract(engine, path, 'main', 10, 2)
+        invokes.append(runner.call_contract(path, 'main', 10, 10))
+        expected_results.append('10')
+        invokes.append(runner.call_contract(path, 'main', 16, 16))
+        expected_results.append('10')
+        invokes.append(runner.call_contract(path, 'main', -1, 10))
+        expected_results.append('-1')
+        invokes.append(runner.call_contract(path, 'main', -1, 16))
+        expected_results.append('f')
+        invokes.append(runner.call_contract(path, 'main', 15, 16))
+        expected_results.append('0f')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        runner.call_contract(path, 'main', 10, 2)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'^{self.ARGUMENT_OUT_OF_RANGE_MSG_PREFIX}')
 
     def test_itoa_default(self):
-        path = self.get_contract_path('ItoaDefault')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ItoaDefault')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', 10)
-        self.assertEqual('10', result)
-        result = self.run_smart_contract(engine, path, 'main', -1)
-        self.assertEqual('-1', result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', 10))
+        expected_results.append('10')
+        invokes.append(runner.call_contract(path, 'main', -1))
+        expected_results.append('-1')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_itoa_too_few_arguments(self):
         path = self.get_contract_path('ItoaTooFewArguments')
@@ -420,154 +642,214 @@ class TestStdlibInterop(BoaTest):
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_import_stdlib(self):
-        path = self.get_contract_path('ImportStdlib')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ImportStdlib')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', '10', 10)
-        self.assertEqual(10, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', '10', 16)
-        self.assertEqual(16, result)
+        invokes.append(runner.call_contract(path, 'main', '10', 10))
+        expected_results.append(10)
+
+        invokes.append(runner.call_contract(path, 'main', '10', 16))
+        expected_results.append(16)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_import_interop_binary(self):
-        path = self.get_contract_path('ImportInteropStdlib')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ImportInteropStdlib')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', '10', 10)
-        self.assertEqual(10, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', '10', 16)
-        self.assertEqual(16, result)
+        invokes.append(runner.call_contract(path, 'main', '10', 10))
+        expected_results.append(10)
+
+        invokes.append(runner.call_contract(path, 'main', '10', 16))
+        expected_results.append(16)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_memory_search(self):
-        path = self.get_contract_path('MemorySearch')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('MemorySearch')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', 'abcde', 'a', 0, False)
-        self.assertEqual(0, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'a', 0, False)
-        self.assertEqual(0, result)
+        invokes.append(runner.call_contract(path, 'main', 'abcde', 'a', 0, False))
+        expected_results.append(0)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'b', 0, False)
-        self.assertEqual(1, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'a', 0, False))
+        expected_results.append(0)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'c', 0, False)
-        self.assertEqual(2, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'b', 0, False))
+        expected_results.append(1)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'd', 0, False)
-        self.assertEqual(3, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'c', 0, False))
+        expected_results.append(2)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'e', 0, False)
-        self.assertEqual(4, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'd', 0, False))
+        expected_results.append(3)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'a', 1, False)
-        self.assertEqual(-1, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'e', 0, False))
+        expected_results.append(4)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'cd', 0, False)
-        self.assertEqual(2, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'a', 1, False))
+        expected_results.append(-1)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'abe', 0, False)
-        self.assertEqual(-1, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'cd', 0, False))
+        expected_results.append(2)
 
-        result = self.run_smart_contract(engine, path, 'main', b'aaaaa', b'a', 0, False)
-        self.assertEqual(0, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'abe', 0, False))
+        expected_results.append(-1)
 
-        with self.assertRaisesRegex(TestExecutionException, f'^{self.ARGUMENT_OUT_OF_RANGE_MSG_PREFIX}'):
-            self.run_smart_contract(engine, path, 'main', b'abcde', b'a', 20, False)
+        invokes.append(runner.call_contract(path, 'main', b'aaaaa', b'a', 0, False))
+        expected_results.append(0)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        runner.call_contract(path, 'main', b'abcde', b'a', 20, False)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'^{self.ARGUMENT_OUT_OF_RANGE_MSG_PREFIX}')
 
     def test_memory_search_backward(self):
-        path = self.get_contract_path('MemorySearch')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('MemorySearch')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', 'abcde', 'a', 5, True)
-        self.assertEqual(0, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'a', 5, True)
-        self.assertEqual(0, result)
+        invokes.append(runner.call_contract(path, 'main', 'abcde', 'a', 5, True))
+        expected_results.append(0)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'b', 5, True)
-        self.assertEqual(1, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'a', 5, True))
+        expected_results.append(0)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'c', 5, True)
-        self.assertEqual(2, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'b', 5, True))
+        expected_results.append(1)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'd', 5, True)
-        self.assertEqual(3, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'c', 5, True))
+        expected_results.append(2)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'e', 5, True)
-        self.assertEqual(4, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'd', 5, True))
+        expected_results.append(3)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'a', 0, True)
-        self.assertEqual(-1, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'e', 5, True))
+        expected_results.append(4)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'cd', 5, True)
-        self.assertEqual(2, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'a', 0, True))
+        expected_results.append(-1)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'abe', 5, True)
-        self.assertEqual(-1, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'cd', 5, True))
+        expected_results.append(2)
 
-        result = self.run_smart_contract(engine, path, 'main', b'aaaaa', b'a', 5, True)
-        self.assertEqual(4, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'abe', 5, True))
+        expected_results.append(-1)
 
-        with self.assertRaisesRegex(TestExecutionException, f'^{self.ARGUMENT_OUT_OF_RANGE_MSG_PREFIX}'):
-            self.run_smart_contract(engine, path, 'main', b'abcde', b'a', 20, True)
+        invokes.append(runner.call_contract(path, 'main', b'aaaaa', b'a', 5, True))
+        expected_results.append(4)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        runner.call_contract(path, 'main', b'abcde', b'a', 20, True)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'^{self.ARGUMENT_OUT_OF_RANGE_MSG_PREFIX}')
 
     def test_memory_search_start(self):
-        path = self.get_contract_path('MemorySearchStart')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('MemorySearchStart')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', 'abcde', 'a', 0)
-        self.assertEqual(0, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'a', 0)
-        self.assertEqual(0, result)
+        invokes.append(runner.call_contract(path, 'main', 'abcde', 'a', 0))
+        expected_results.append(0)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'e', 0)
-        self.assertEqual(4, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'a', 0))
+        expected_results.append(0)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'a', 1)
-        self.assertEqual(-1, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'e', 0))
+        expected_results.append(4)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'cd', 0)
-        self.assertEqual(2, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'a', 1))
+        expected_results.append(-1)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'abe', 0)
-        self.assertEqual(-1, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'cd', 0))
+        expected_results.append(2)
 
-        result = self.run_smart_contract(engine, path, 'main', b'aaaaa', b'a', 0)
-        self.assertEqual(0, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'abe', 0))
+        expected_results.append(-1)
 
-        with self.assertRaisesRegex(TestExecutionException, f'^{self.ARGUMENT_OUT_OF_RANGE_MSG_PREFIX}'):
-            self.run_smart_contract(engine, path, 'main', b'abcde', b'a', 20)
+        invokes.append(runner.call_contract(path, 'main', b'aaaaa', b'a', 0))
+        expected_results.append(0)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        runner.call_contract(path, 'main', b'abcde', b'a', 20)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'^{self.ARGUMENT_OUT_OF_RANGE_MSG_PREFIX}')
 
     def test_memory_search_default_values(self):
-        path = self.get_contract_path('MemorySearchDefault')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('MemorySearchDefault')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', 'abcde', 'a')
-        self.assertEqual(0, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'a')
-        self.assertEqual(0, result)
+        invokes.append(runner.call_contract(path, 'main', 'abcde', 'a'))
+        expected_results.append(0)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'b')
-        self.assertEqual(1, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'a'))
+        expected_results.append(0)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'c')
-        self.assertEqual(2, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'b'))
+        expected_results.append(1)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'd')
-        self.assertEqual(3, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'c'))
+        expected_results.append(2)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'e')
-        self.assertEqual(4, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'd'))
+        expected_results.append(3)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'cd')
-        self.assertEqual(2, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'e'))
+        expected_results.append(4)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'aa')
-        self.assertEqual(-1, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'cd'))
+        expected_results.append(2)
+
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'aa'))
+        expected_results.append(-1)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_memory_search_mismatched_type(self):
         path = self.get_contract_path('MemorySearchMismatchedType.py')
@@ -582,26 +864,35 @@ class TestStdlibInterop(BoaTest):
         self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
 
     def test_memory_compare(self):
-        path = self.get_contract_path('MemoryCompare')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('MemoryCompare')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', 'abc', 'abc')
-        self.assertEqual(0, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', 'abc', 'ABC')
-        self.assertEqual(1, result)
+        invokes.append(runner.call_contract(path, 'main', 'abc', 'abc'))
+        expected_results.append(0)
 
-        result = self.run_smart_contract(engine, path, 'main', 'ABC', 'abc')
-        self.assertEqual(-1, result)
+        invokes.append(runner.call_contract(path, 'main', 'abc', 'ABC'))
+        expected_results.append(1)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abc', b'abc')
-        self.assertEqual(0, result)
+        invokes.append(runner.call_contract(path, 'main', 'ABC', 'abc'))
+        expected_results.append(-1)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abc', b'ABC')
-        self.assertEqual(1, result)
+        invokes.append(runner.call_contract(path, 'main', b'abc', b'abc'))
+        expected_results.append(0)
 
-        result = self.run_smart_contract(engine, path, 'main', b'ABC', b'abc')
-        self.assertEqual(-1, result)
+        invokes.append(runner.call_contract(path, 'main', b'abc', b'ABC'))
+        expected_results.append(1)
+
+        invokes.append(runner.call_contract(path, 'main', b'ABC', b'abc'))
+        expected_results.append(-1)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_memory_compare_too_few_parameters(self):
         path = self.get_contract_path('MemoryCompareTooFewArguments.py')

--- a/boa3_test/tests/compiler_tests/test_interop/test_stdlib.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_stdlib.py
@@ -41,7 +41,7 @@ class TestStdlibInterop(BoaTest):
         expected_results.append(expected_result)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -82,7 +82,7 @@ class TestStdlibInterop(BoaTest):
         expected_results.append(String(long_string).to_bytes())
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -123,7 +123,7 @@ class TestStdlibInterop(BoaTest):
         expected_results.append(expected_result)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -161,7 +161,7 @@ class TestStdlibInterop(BoaTest):
         expected_results.append(long_string)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -199,7 +199,7 @@ class TestStdlibInterop(BoaTest):
         expected_results.append(long_string)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -240,7 +240,7 @@ class TestStdlibInterop(BoaTest):
         expected_results.append(expected_result)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -262,7 +262,7 @@ class TestStdlibInterop(BoaTest):
         expected_results.append(expected_result)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -280,7 +280,7 @@ class TestStdlibInterop(BoaTest):
         expected_results.append(expected_result)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -298,7 +298,7 @@ class TestStdlibInterop(BoaTest):
         expected_results.append(expected_result)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -316,7 +316,7 @@ class TestStdlibInterop(BoaTest):
         expected_results.append(expected_result)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -334,7 +334,7 @@ class TestStdlibInterop(BoaTest):
         expected_results.append(expected_result)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -385,7 +385,7 @@ class TestStdlibInterop(BoaTest):
         expected_results.append(expected_result)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -406,7 +406,7 @@ class TestStdlibInterop(BoaTest):
         expected_results.append(expected_result)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -423,7 +423,7 @@ class TestStdlibInterop(BoaTest):
         expected_results.append(expected_result)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -439,7 +439,7 @@ class TestStdlibInterop(BoaTest):
         expected_results.append(['a', 3, ['j', 3, 5], 'jk', 'lmnopqr'])
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -455,7 +455,7 @@ class TestStdlibInterop(BoaTest):
         expected_results.append(['j', 3, 5])
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -476,7 +476,7 @@ class TestStdlibInterop(BoaTest):
         expected_results.append(expected_result)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
         serialized = contract_call.result
 
         invokes.append(runner.call_contract(path, 'deserialize_user_class', serialized,
@@ -490,7 +490,7 @@ class TestStdlibInterop(BoaTest):
         expected_results.append(42)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -521,7 +521,7 @@ class TestStdlibInterop(BoaTest):
         expected_results.append(-1)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -560,7 +560,7 @@ class TestStdlibInterop(BoaTest):
         expected_results.append(123)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -601,7 +601,7 @@ class TestStdlibInterop(BoaTest):
         expected_results.append('0f')
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -624,7 +624,7 @@ class TestStdlibInterop(BoaTest):
         expected_results.append('-1')
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -655,7 +655,7 @@ class TestStdlibInterop(BoaTest):
         expected_results.append(16)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -674,7 +674,7 @@ class TestStdlibInterop(BoaTest):
         expected_results.append(16)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -717,7 +717,7 @@ class TestStdlibInterop(BoaTest):
         expected_results.append(0)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -765,7 +765,7 @@ class TestStdlibInterop(BoaTest):
         expected_results.append(4)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -804,7 +804,7 @@ class TestStdlibInterop(BoaTest):
         expected_results.append(0)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -846,7 +846,7 @@ class TestStdlibInterop(BoaTest):
         expected_results.append(-1)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -889,7 +889,7 @@ class TestStdlibInterop(BoaTest):
         expected_results.append(-1)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)

--- a/boa3_test/tests/compiler_tests/test_interop/test_storage.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_storage.py
@@ -90,7 +90,7 @@ class TestStorageInterop(BoaTest):
 
         storage_contract = invokes[0].invoke.contract
         runner.execute(get_storage_from=storage_contract)
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -129,7 +129,7 @@ class TestStorageInterop(BoaTest):
 
         storage_contract = invokes[0].invoke.contract
         runner.execute(get_storage_from=storage_contract)
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -182,7 +182,7 @@ class TestStorageInterop(BoaTest):
 
         storage_contract = invokes[0].invoke.contract
         runner.execute(get_storage_from=storage_contract)
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -239,7 +239,7 @@ class TestStorageInterop(BoaTest):
 
         storage_contract = invokes[0].invoke.contract
         runner.execute(get_storage_from=storage_contract)
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -272,7 +272,7 @@ class TestStorageInterop(BoaTest):
 
         storage_contract = invokes[0].invoke.contract
         runner.execute(get_storage_from=storage_contract)
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -325,7 +325,7 @@ class TestStorageInterop(BoaTest):
 
         storage_contract = invokes[0].invoke.contract
         runner.execute(get_storage_from=storage_contract)
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -382,7 +382,7 @@ class TestStorageInterop(BoaTest):
 
         storage_contract = invokes[0].invoke.contract
         runner.execute(get_storage_from=storage_contract)
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -444,7 +444,7 @@ class TestStorageInterop(BoaTest):
 
         storage_contract = invokes[0].invoke.contract
         runner.execute(get_storage_from=storage_contract)
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -495,7 +495,7 @@ class TestStorageInterop(BoaTest):
 
         storage_contract = invokes[0].invoke.contract
         runner.execute(get_storage_from=storage_contract)
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -559,7 +559,7 @@ class TestStorageInterop(BoaTest):
         expected_results.append(InteropInterface)  # returns an interop interface
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -584,7 +584,7 @@ class TestStorageInterop(BoaTest):
         expected_results.append(InteropInterface)  # returns an interop interface
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -613,7 +613,7 @@ class TestStorageInterop(BoaTest):
 
         storage_contract = invokes[0].invoke.contract
         runner.execute(get_storage_from=storage_contract)
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -648,7 +648,7 @@ class TestStorageInterop(BoaTest):
 
         storage_contract = invokes[0].invoke.contract
         runner.execute(get_storage_from=storage_contract)
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -704,7 +704,7 @@ class TestStorageInterop(BoaTest):
 
         storage_contract = invokes[0].invoke.contract
         runner.execute(get_storage_from=storage_contract)
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -772,7 +772,7 @@ class TestStorageInterop(BoaTest):
 
         storage_contract = invokes[0].invoke.contract
         runner.execute(get_storage_from=storage_contract)
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -807,7 +807,7 @@ class TestStorageInterop(BoaTest):
 
         storage_contract = invokes[0].invoke.contract
         runner.execute(get_storage_from=storage_contract)
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -836,7 +836,7 @@ class TestStorageInterop(BoaTest):
         expected_results.append(value)
 
         runner.execute(get_storage_from=contract_1)
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -868,7 +868,7 @@ class TestStorageInterop(BoaTest):
         expected_results.append(stored_value)
 
         runner.execute(get_storage_from=storage_contract)
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         self.assertIsNone(runner.storages.get(storage_contract, storage_key))
         storage_result = runner.storages.get(storage_contract, map_key + storage_key)
@@ -882,7 +882,7 @@ class TestStorageInterop(BoaTest):
         expected_results.append(b'')
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
@@ -985,7 +985,7 @@ class TestStorageInterop(BoaTest):
         expected_results.append(value_old)
 
         runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)

--- a/boa3_test/tests/default.neo-express
+++ b/boa3_test/tests/default.neo-express
@@ -1,5 +1,5 @@
 {
-  "magic": 752710861,
+  "magic": 860243278,
   "address-version": 53,
   "consensus-nodes": [
     {


### PR DESCRIPTION
**Summary or solution description**
Part of an overall refactoring. 
Changed the execution tests of the compiled smart contracts related to Neo interop functions to use TestRunner instead of TestEngine

**Tests**
Rerun the modified unit tests
