### PR TITLE
Refactor Boa built-in types unit tests to use test runner

### DIFF
--- a/boa3_test/test_drive/testrunner/neo_test_runner.py
+++ b/boa3_test/test_drive/testrunner/neo_test_runner.py
@@ -224,14 +224,14 @@ class NeoTestRunner:
         self._gas_consumed = 0
         self._result_stack = []
         self._last_execution_results = []
+        self._notifications.clear()
+        self._logs.clear()
         self._storages.clear()
         self._last_cli_log = None
         self._error_message = None
 
     def reset(self):
         self.reset_state()
-        self._notifications.clear()
-        self._logs.clear()
 
         self._batch.clear()
         self._batch_size_since_last_update = -1
@@ -271,7 +271,7 @@ class NeoTestRunner:
                 new = Notification.from_json(n)
                 if new is not None:
                     notifications.append(new)
-            self._notifications = notifications
+            self._notifications.extend(notifications)
 
         if 'logs' in result:
             json_logs = result['logs']
@@ -283,7 +283,7 @@ class NeoTestRunner:
                 new = Log.from_json(l)
                 if new is not None:
                     logs.append(new)
-            self._logs = logs
+            self._logs.extend(logs)
 
         if 'storages' in result:
             json_storages = result['storages']

--- a/boa3_test/tests/compiler_tests/test_event.py
+++ b/boa3_test/tests/compiler_tests/test_event.py
@@ -4,9 +4,9 @@ from boa3.model.builtin.interop.interop import Interop
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.String import String
+from boa3.neo3.vm import VMState
+from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.boa_test import BoaTest
-from boa3_test.tests.test_classes.TestExecutionException import TestExecutionException
-from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestEvent(BoaTest):
@@ -29,12 +29,16 @@ class TestEvent(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertIsVoid(result)
-        self.assertGreater(len(engine.notifications), 0)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+        invoke = runner.call_contract(path, 'Main')
 
-        event_notifications = engine.get_events(event_name=event_id)
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        self.assertIsNone(invoke.result)
+        self.assertGreater(len(runner.notifications), 0)
+
+        event_notifications = runner.get_events(event_name=event_id)
         self.assertEqual(1, len(event_notifications))
         self.assertEqual((), event_notifications[0].arguments)
 
@@ -57,12 +61,16 @@ class TestEvent(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertIsVoid(result)
-        self.assertGreater(len(engine.notifications), 0)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+        invoke = runner.call_contract(path, 'Main')
 
-        event_notifications = engine.get_events(event_name=event_id)
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        self.assertIsNone(invoke.result)
+        self.assertGreater(len(runner.notifications), 0)
+
+        event_notifications = runner.get_events(event_name=event_id)
         self.assertEqual(1, len(event_notifications))
         self.assertEqual((10,), event_notifications[0].arguments)
 
@@ -85,12 +93,16 @@ class TestEvent(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertIsVoid(result)
-        self.assertGreater(len(engine.notifications), 0)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+        invoke = runner.call_contract(path, 'Main')
 
-        event_notifications = engine.get_events(event_name=event_id)
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        self.assertIsNone(invoke.result)
+        self.assertGreater(len(runner.notifications), 0)
+
+        event_notifications = runner.get_events(event_name=event_id)
         self.assertEqual(1, len(event_notifications))
         self.assertEqual((10,), event_notifications[0].arguments)
 
@@ -113,12 +125,16 @@ class TestEvent(BoaTest):
         output, manifest = self.compile_and_save(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertIsVoid(result)
-        self.assertGreater(len(engine.notifications), 0)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+        invoke = runner.call_contract(path, 'Main')
 
-        event_notifications = engine.get_events(event_name=event_id)
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        self.assertIsNone(invoke.result)
+        self.assertGreater(len(runner.notifications), 0)
+
+        event_notifications = runner.get_events(event_name=event_id)
         self.assertEqual(1, len(event_notifications))
         self.assertEqual((10,), event_notifications[0].arguments)
 
@@ -145,12 +161,16 @@ class TestEvent(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', b'1', b'2', 10)
-        self.assertIsVoid(result)
-        self.assertGreater(len(engine.notifications), 0)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+        invoke = runner.call_contract(path, 'Main', b'1', b'2', 10)
 
-        event_notifications = engine.get_events(event_name=event_id)
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        self.assertIsNone(invoke.result)
+        self.assertGreater(len(runner.notifications), 0)
+
+        event_notifications = runner.get_events(event_name=event_id)
         self.assertEqual(1, len(event_notifications))
         self.assertEqual(('1', '2', 10), event_notifications[0].arguments)
 
@@ -177,12 +197,16 @@ class TestEvent(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', b'1', b'2', 10)
-        self.assertIsVoid(result)
-        self.assertGreater(len(engine.notifications), 0)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+        invoke = runner.call_contract(path, 'Main', b'1', b'2', 10)
 
-        event_notifications = engine.get_events(event_name=event_id)
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        self.assertIsNone(invoke.result)
+        self.assertGreater(len(runner.notifications), 0)
+
+        event_notifications = runner.get_events(event_name=event_id)
         self.assertEqual(1, len(event_notifications))
         self.assertEqual(('1', '2', 10), event_notifications[0].arguments)
 
@@ -209,12 +233,16 @@ class TestEvent(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', b'1', b'2', 10)
-        self.assertIsVoid(result)
-        self.assertGreater(len(engine.notifications), 0)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+        invoke = runner.call_contract(path, 'Main', b'1', b'2', 10)
 
-        event_notifications = engine.get_events(event_name=event_id)
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        self.assertIsNone(invoke.result)
+        self.assertGreater(len(runner.notifications), 0)
+
+        event_notifications = runner.get_events(event_name=event_id)
         self.assertEqual(1, len(event_notifications))
         self.assertEqual(('1', '2', 10), event_notifications[0].arguments)
 
@@ -242,12 +270,16 @@ class TestEvent(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', b'1', b'2', 10, b'someToken')
-        self.assertIsVoid(result)
-        self.assertGreater(len(engine.notifications), 0)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+        invoke = runner.call_contract(path, 'Main', b'1', b'2', 10, b'someToken')
 
-        event_notifications = engine.get_events(event_name=event_id)
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        self.assertIsNone(invoke.result)
+        self.assertGreater(len(runner.notifications), 0)
+
+        event_notifications = runner.get_events(event_name=event_id)
         self.assertEqual(1, len(event_notifications))
         self.assertEqual(('1', '2', 10, 'someToken'), event_notifications[0].arguments)
 
@@ -256,16 +288,19 @@ class TestEvent(BoaTest):
         self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
 
     def test_event_with_duplicated_name(self):
-        path = self.get_contract_path('EventWithDuplicatedName.py')
+        path, _ = self.get_deploy_file_paths('EventWithDuplicatedName.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
         arg = 10
         event_id = 'example'
-        result = self.run_smart_contract(engine, path, 'example', arg)
-        self.assertIsVoid(result)
-        self.assertGreater(len(engine.notifications), 0)
+        invoke = runner.call_contract(path, 'example', arg)
 
-        event_notifications = engine.get_events(event_name=event_id)
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        self.assertIsNone(invoke.result)
+        self.assertGreater(len(runner.notifications), 0)
+
+        event_notifications = runner.get_events(event_name=event_id)
         self.assertEqual(1, len(event_notifications))
         self.assertEqual((arg,), event_notifications[0].arguments)
 
@@ -276,34 +311,34 @@ class TestEvent(BoaTest):
     def test_event_with_abort(self):
         path = self.get_contract_path('EventWithAbort.py')
         self.compile_and_save(path)
+        path, _ = self.get_deploy_file_paths(path)
 
-        engine = TestEngine()
+        runner = NeoTestRunner()
+        runner.call_contract(path, 'send_event_with_abort')
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.ABORTED_CONTRACT_MSG)
+        self.assertGreater(len(runner.notifications), 0)
 
-        with self.assertRaisesRegex(TestExecutionException, self.ABORTED_CONTRACT_MSG):
-            self.run_smart_contract(engine, path, 'send_event_with_abort')
-        self.assertEqual(0, len(engine.notifications))
-
-        result = self.run_smart_contract(engine, path, 'send_event')
-        self.assertIsVoid(result)
-        self.assertGreater(len(engine.notifications), 0)
-
-        previous_notification_count = len(engine.notifications)
-        with self.assertRaisesRegex(TestExecutionException, self.ABORTED_CONTRACT_MSG):
-            """
-            Notifications on a fault execution aren't logged into the blockchain
-            Even with rollback_on_fault set as False, TestEngine doesn't return it because that's the expected behavior
-            """
-            self.run_smart_contract(engine, path, 'send_event_with_abort', rollback_on_fault=False)
-
-        self.assertEqual(previous_notification_count, len(engine.notifications))
+        invoke = runner.call_contract(path, 'send_event')
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        self.assertIsNone(invoke.result)
+        self.assertGreater(len(runner.notifications), 0)
 
     def test_boa2_event_test(self):
-        path = self.get_contract_path('EventBoa2Test.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main')
+        path, _ = self.get_deploy_file_paths('EventBoa2Test.py')
+        runner = NeoTestRunner()
+        invoke = runner.call_contract(path, 'main')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        result = invoke.result
+        self.assertIsNotNone(result)
         self.assertEqual(7, result)
 
-        event_notifications1 = engine.get_events('transfer_test')
+        event_notifications1 = runner.get_events('transfer_test')
         self.assertEqual(1, len(event_notifications1))
         self.assertEqual(3, len(event_notifications1[0].arguments))
         from_address, to_address, amount = event_notifications1[0].arguments
@@ -311,7 +346,7 @@ class TestEvent(BoaTest):
         self.assertEqual(5, to_address)
         self.assertEqual(7, amount)
 
-        event_notifications2 = engine.get_events('refund')
+        event_notifications2 = runner.get_events('refund')
         self.assertEqual(1, len(event_notifications2))
         self.assertEqual(2, len(event_notifications2[0].arguments))
         to_address, amount = event_notifications2[0].arguments

--- a/boa3_test/tests/compiler_tests/test_import.py
+++ b/boa3_test/tests/compiler_tests/test_import.py
@@ -2,9 +2,9 @@ from boa3.boa3 import Boa3
 from boa3.exception import CompilerError
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
+from boa3.neo3.vm import VMState
+from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.boa_test import BoaTest
-from boa3_test.tests.test_classes.TestExecutionException import TestExecutionException
-from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestImport(BoaTest):
@@ -53,9 +53,20 @@ class TestImport(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual([], result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append([])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_import_user_module_with_alias(self):
         expected_output = (
@@ -74,9 +85,20 @@ class TestImport(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual([], result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append([])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_import_user_module_with_global_variables(self):
         expected_output = (
@@ -97,9 +119,20 @@ class TestImport(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual([], result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append([])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_import_variable(self):
         expected_output = (
@@ -117,29 +150,58 @@ class TestImport(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual([], result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append([])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_variable_from_imported_module(self):
-        path = self.get_contract_path('variable_import', 'VariableFromImportedModule.py')
+        path, _ = self.get_deploy_file_paths('variable_import', 'VariableFromImportedModule.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'get_foo', expected_result_type=bytes)
-        self.assertEqual(b'Foo', result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'get_bar')
-        self.assertEqual('bar', result)
+        invokes.append(runner.call_contract(path, 'get_foo', expected_result_type=bytes))
+        expected_results.append(b'Foo')
+
+        invokes.append(runner.call_contract(path, 'get_bar'))
+        expected_results.append('bar')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_variable_access_from_imported_module(self):
-        path = self.get_contract_path('variable_import', 'VariableAccessFromImportedModule.py')
+        path, _ = self.get_deploy_file_paths('variable_import', 'VariableAccessFromImportedModule.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'get_foo', expected_result_type=bytes)
-        self.assertEqual(b'Foo', result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'get_bar')
-        self.assertEqual('bar', result)
+        invokes.append(runner.call_contract(path, 'get_foo', expected_result_type=bytes))
+        expected_results.append(b'Foo')
+
+        invokes.append(runner.call_contract(path, 'get_bar'))
+        expected_results.append('bar')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_typing_python_library(self):
         path = self.get_contract_path('ImportPythonLib.py')
@@ -197,12 +259,23 @@ class TestImport(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'call_imported_method')
-        self.assertEqual([], result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'call_imported_variable')
-        self.assertEqual([], result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'call_imported_method'))
+        expected_results.append([])
+
+        invokes.append(runner.call_contract(path, 'call_imported_variable'))
+        expected_results.append([])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_from_import_user_module(self):
         expected_output = (
@@ -226,9 +299,20 @@ class TestImport(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual([], result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append([])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_from_import_user_module_with_alias(self):
         expected_output = (
@@ -252,20 +336,40 @@ class TestImport(BoaTest):
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual([], result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append([])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_import_non_existent_package(self):
         path = self.get_contract_path('ImportNonExistentPackage.py')
         self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
 
     def test_import_interop_with_alias(self):
-        path = self.get_contract_path('ImportInteropWithAlias.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ImportInteropWithAlias.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertIsVoid(result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append(None)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_import_user_module_recursive_import(self):
         path = self.get_contract_path('ImportUserModuleRecursiveImport.py')
@@ -276,34 +380,45 @@ class TestImport(BoaTest):
         self.assertCompilerLogs(CompilerError.CircularImport, path)
 
     def test_import_user_module_with_not_imported_symbols(self):
-        path = self.get_contract_path('ImportUserModuleWithNotImportedSymbols.py')
+        path, _ = self.get_deploy_file_paths('ImportUserModuleWithNotImportedSymbols.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        self.run_smart_contract(engine, path, 'main', [], b'00000000000000000000')
-        script = engine.executed_script_hash.to_array()
+        invokes = []
+        expected_results = []
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', [], script)
-        self.assertEqual([], result)
+        contract = runner.deploy_contract(path)
+        runner.update_contracts()
+        script = contract.script_hash
 
-        result = self.run_smart_contract(engine, path, 'main', [1, 2, 3], script)
+        invokes.append(runner.call_contract(path, 'main', [], script))
+        expected_results.append([])
+
+        invokes.append(runner.call_contract(path, 'main', [1, 2, 3], script))
         expected_result = []
         for x in [1, 2, 3]:
             expected_result.append([script,
                                     'notify',
                                     [x]])
-        self.assertEqual(expected_result, result)
+        expected_results.append(expected_result)
 
-        result = self.run_smart_contract(engine, path, 'main', [1, 2, 3], b'\x01' * 20)
-        self.assertEqual([], result)
+        invokes.append(runner.call_contract(path, 'main', [1, 2, 3], b'\x01' * 20))
+        expected_results.append([])
 
         # 'with_param' is a public method, so it should be included in the manifest when imported
-        result = self.run_smart_contract(engine, path, 'with_param', [1, 2, 3], b'\x01' * 20)
-        self.assertEqual([], result)
+        invokes.append(runner.call_contract(path, 'with_param', [1, 2, 3], b'\x01' * 20))
+        expected_results.append([])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
         # 'without_param' is a public method, but it isn't imported, so it shouldn't be included in the manifest
-        with self.assertRaisesRegex(TestExecutionException, f'{self.CANT_FIND_METHOD_MSG_PREFIX} : without_param'):
-            self.run_smart_contract(engine, path, 'without_param', [1, 2, 3])
+        runner.call_contract(path, 'without_param', [1, 2, 3])
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.FORMAT_METHOD_DOESNT_EXIST_IN_CONTRACT_MSG_REGEX_PREFIX.format('without_param'))
 
     def test_import_user_module_with_not_imported_variables(self):
         expected_output = (
@@ -328,9 +443,20 @@ class TestImport(BoaTest):
         output, manifest = self.compile_and_save(path)
         self.assertEqual(expected_output, output)
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(5, result)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(5)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_not_imported_builtin_public(self):
         path = self.get_contract_path('NotImportedBuiltinPublic.py')
@@ -350,43 +476,78 @@ class TestImport(BoaTest):
         self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
 
     def test_incorrect_circular_import(self):
-        path = self.get_contract_path('incorrect_circular_import', 'IncorrectCircularImportDetection.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('incorrect_circular_import', 'IncorrectCircularImportDetection.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(3, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(3)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_import_module_with_init(self):
-        path = self.get_contract_path('ImportModuleWithInit.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ImportModuleWithInit.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'call_imported_method')
-        self.assertEqual([], result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'call_imported_variable')
-        self.assertEqual(42, result)
+        invokes.append(runner.call_contract(path, 'call_imported_method'))
+        expected_results.append([])
+
+        invokes.append(runner.call_contract(path, 'call_imported_variable'))
+        expected_results.append(42)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_import_module_without_init(self):
-        path = self.get_contract_path('ImportModuleWithoutInit.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ImportModuleWithoutInit.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'call_imported_method')
-        self.assertEqual({}, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'call_imported_variable')
-        self.assertEqual([], result)
+        invokes.append(runner.call_contract(path, 'call_imported_method'))
+        expected_results.append({})
+
+        invokes.append(runner.call_contract(path, 'call_imported_variable'))
+        expected_results.append([])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_import_user_class_inner_files(self):
-        inner_path = self.get_contract_path('class_import', 'ImportUserClass.py')
-        path = self.get_contract_path('ImportUserClassInnerFiles.py')
+        inner_path, _ = self.get_deploy_file_paths('class_import', 'ImportUserClass.py')
+        path, _ = self.get_deploy_file_paths('ImportUserClassInnerFiles.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, inner_path, 'build_example_object')
-        self.assertEqual([42, '42'], result)
+        invokes.append(runner.call_contract(inner_path, 'build_example_object'))
+        expected_results.append([42, '42'])
 
-        result = self.run_smart_contract(engine, path, 'build_example_object')
-        self.assertEqual('42', result)
+        invokes.append(runner.call_contract(path, 'build_example_object'))
+        expected_results.append('42')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_from_import_not_existing_method(self):
         path = self.get_contract_path('FromImportNotExistingMethod.py')

--- a/boa3_test/tests/compiler_tests/test_neo_types.py
+++ b/boa3_test/tests/compiler_tests/test_neo_types.py
@@ -1,9 +1,9 @@
 from boa3.exception import CompilerError, CompilerWarning
 from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.String import String
+from boa3.neo3.vm import VMState
+from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.boa_test import BoaTest
-from boa3_test.tests.test_classes.TestExecutionException import TestExecutionException
-from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestNeoTypes(BoaTest):
@@ -12,89 +12,148 @@ class TestNeoTypes(BoaTest):
     # region UInt160
 
     def test_uint160_call_bytes(self):
-        path = self.get_contract_path('uint160', 'UInt160CallBytes.py')
+        path, _ = self.get_deploy_file_paths('uint160', 'UInt160CallBytes.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
+        invokes = []
+        expected_results = []
+
         value = bytes(20)
-        result = self.run_smart_contract(engine, path, 'uint160', value,
-                                         expected_result_type=bytes)
-        self.assertEqual(value, result)
+        invokes.append(runner.call_contract(path, 'uint160', value,
+                                            expected_result_type=bytes))
+        expected_results.append(value)
 
         value = bytes(range(20))
-        result = self.run_smart_contract(engine, path, 'uint160', value,
-                                         expected_result_type=bytes)
-        self.assertEqual(value, result)
+        invokes.append(runner.call_contract(path, 'uint160', value,
+                                            expected_result_type=bytes))
+        expected_results.append(value)
 
-        with self.assertRaisesRegex(TestExecutionException, self.ASSERT_RESULTED_FALSE_MSG):
-            self.run_smart_contract(engine, path, 'uint160', bytes(10),
-                                    expected_result_type=bytes)
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
-        with self.assertRaisesRegex(TestExecutionException, self.ASSERT_RESULTED_FALSE_MSG):
-            self.run_smart_contract(engine, path, 'uint160', bytes(30),
-                                    expected_result_type=bytes)
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        runner.call_contract(path, 'uint160', bytes(10),
+                             expected_result_type=bytes)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.ASSERT_RESULTED_FALSE_MSG)
+
+        runner.call_contract(path, 'uint160', bytes(30),
+                             expected_result_type=bytes)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.ASSERT_RESULTED_FALSE_MSG)
 
     def test_uint160_call_int(self):
-        path = self.get_contract_path('uint160', 'UInt160CallInt.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'uint160', 0,
-                                         expected_result_type=bytes)
-        self.assertEqual(bytes(20), result)
+        path, _ = self.get_deploy_file_paths('uint160', 'UInt160CallInt.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'uint160', 0,
+                                            expected_result_type=bytes))
+        expected_results.append(bytes(20))
 
         value = Integer(1_000_000_000).to_byte_array(min_length=20)
-        result = self.run_smart_contract(engine, path, 'uint160', 1_000_000_000,
-                                         expected_result_type=bytes)
-        self.assertEqual(value, result)
+        invokes.append(runner.call_contract(path, 'uint160', 1_000_000_000,
+                                            expected_result_type=bytes))
+        expected_results.append(value)
 
-        with self.assertRaisesRegex(TestExecutionException, self.ASSERT_RESULTED_FALSE_MSG):
-            self.run_smart_contract(engine, path, 'uint160', -50,
-                                    expected_result_type=bytes)
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
-        with self.assertRaisesRegex(TestExecutionException, self.ASSERT_RESULTED_FALSE_MSG):
-            self.run_smart_contract(engine, path, 'uint160', bytes(30),
-                                    expected_result_type=bytes)
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        runner.call_contract(path, 'uint160', -50,
+                             expected_result_type=bytes)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.ASSERT_RESULTED_FALSE_MSG)
+
+        runner.call_contract(path, 'uint160', bytes(30),
+                             expected_result_type=bytes)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.ASSERT_RESULTED_FALSE_MSG)
 
     def test_uint160_call_without_args(self):
-        path = self.get_contract_path('uint160', 'UInt160CallWithoutArgs.py')
+        path, _ = self.get_deploy_file_paths('uint160', 'UInt160CallWithoutArgs.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'uint160',
-                                         expected_result_type=bytes)
-        self.assertEqual(bytes(20), result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'uint160',
+                                            expected_result_type=bytes))
+        expected_results.append(bytes(20))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_uint160_return_bytes(self):
-        path = self.get_contract_path('uint160', 'UInt160ReturnBytes.py')
+        path, _ = self.get_deploy_file_paths('uint160', 'UInt160ReturnBytes.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
+        invokes = []
+        expected_results = []
+
         value = bytes(20)
-        result = self.run_smart_contract(engine, path, 'uint160', value,
-                                         expected_result_type=bytes)
-        self.assertEqual(value, result)
+        invokes.append(runner.call_contract(path, 'uint160', value,
+                                            expected_result_type=bytes))
+        expected_results.append(value)
 
         value = bytes(range(20))
-        result = self.run_smart_contract(engine, path, 'uint160', value,
-                                         expected_result_type=bytes)
-        self.assertEqual(value, result)
+        invokes.append(runner.call_contract(path, 'uint160', value,
+                                            expected_result_type=bytes))
+        expected_results.append(value)
 
-        with self.assertRaisesRegex(TestExecutionException, self.ASSERT_RESULTED_FALSE_MSG):
-            self.run_smart_contract(engine, path, 'uint160', bytes(10),
-                                    expected_result_type=bytes)
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
-        with self.assertRaisesRegex(TestExecutionException, self.ASSERT_RESULTED_FALSE_MSG):
-            self.run_smart_contract(engine, path, 'uint160', bytes(30),
-                                    expected_result_type=bytes)
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        runner.call_contract(path, 'uint160', bytes(10),
+                             expected_result_type=bytes)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.ASSERT_RESULTED_FALSE_MSG)
+
+        runner.call_contract(path, 'uint160', bytes(30),
+                             expected_result_type=bytes)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.ASSERT_RESULTED_FALSE_MSG)
 
     def test_uint160_concat_with_bytes(self):
-        path = self.get_contract_path('uint160', 'UInt160ConcatWithBytes.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('uint160', 'UInt160ConcatWithBytes.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         value = bytes(20)
-        result = self.run_smart_contract(engine, path, 'uint160_method', value,
-                                         expected_result_type=bytes)
-        self.assertEqual(value + b'123', result)
+        invokes.append(runner.call_contract(path, 'uint160_method', value,
+                                            expected_result_type=bytes))
+        expected_results.append(value + b'123')
 
         value = bytes(range(20))
-        result = self.run_smart_contract(engine, path, 'uint160_method', value,
-                                         expected_result_type=bytes)
-        self.assertEqual(value + b'123', result)
+        invokes.append(runner.call_contract(path, 'uint160_method', value,
+                                            expected_result_type=bytes))
+        expected_results.append(value + b'123')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_uint160_mismatched_type(self):
         path = self.get_contract_path('uint160', 'UInt160CallMismatchedType.py')
@@ -105,89 +164,148 @@ class TestNeoTypes(BoaTest):
     # region UInt256
 
     def test_uint256_call_bytes(self):
-        path = self.get_contract_path('uint256', 'UInt256CallBytes.py')
+        path, _ = self.get_deploy_file_paths('uint256', 'UInt256CallBytes.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
+        invokes = []
+        expected_results = []
+
         value = bytes(32)
-        result = self.run_smart_contract(engine, path, 'uint256', value,
-                                         expected_result_type=bytes)
-        self.assertEqual(value, result)
+        invokes.append(runner.call_contract(path, 'uint256', value,
+                                            expected_result_type=bytes))
+        expected_results.append(value)
 
         value = bytes(range(32))
-        result = self.run_smart_contract(engine, path, 'uint256', value,
-                                         expected_result_type=bytes)
-        self.assertEqual(value, result)
+        invokes.append(runner.call_contract(path, 'uint256', value,
+                                            expected_result_type=bytes))
+        expected_results.append(value)
 
-        with self.assertRaisesRegex(TestExecutionException, self.ASSERT_RESULTED_FALSE_MSG):
-            self.run_smart_contract(engine, path, 'uint256', bytes(20),
-                                    expected_result_type=bytes)
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
-        with self.assertRaisesRegex(TestExecutionException, self.ASSERT_RESULTED_FALSE_MSG):
-            self.run_smart_contract(engine, path, 'uint256', bytes(30),
-                                    expected_result_type=bytes)
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        runner.call_contract(path, 'uint256', bytes(20),
+                             expected_result_type=bytes)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.ASSERT_RESULTED_FALSE_MSG)
+
+        runner.call_contract(path, 'uint256', bytes(30),
+                             expected_result_type=bytes)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.ASSERT_RESULTED_FALSE_MSG)
 
     def test_uint256_call_int(self):
-        path = self.get_contract_path('uint256', 'UInt256CallInt.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'uint256', 0,
-                                         expected_result_type=bytes)
-        self.assertEqual(bytes(32), result)
+        path, _ = self.get_deploy_file_paths('uint256', 'UInt256CallInt.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'uint256', 0,
+                                            expected_result_type=bytes))
+        expected_results.append(bytes(32))
 
         value = Integer(1_000_000_000).to_byte_array(min_length=32)
-        result = self.run_smart_contract(engine, path, 'uint256', 1_000_000_000,
-                                         expected_result_type=bytes)
-        self.assertEqual(value, result)
+        invokes.append(runner.call_contract(path, 'uint256', 1_000_000_000,
+                                            expected_result_type=bytes))
+        expected_results.append(value)
 
-        with self.assertRaisesRegex(TestExecutionException, self.ASSERT_RESULTED_FALSE_MSG):
-            self.run_smart_contract(engine, path, 'uint256', -50,
-                                    expected_result_type=bytes)
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
-        with self.assertRaisesRegex(TestExecutionException, self.ASSERT_RESULTED_FALSE_MSG):
-            self.run_smart_contract(engine, path, 'uint256', bytes(30),
-                                    expected_result_type=bytes)
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        runner.call_contract(path, 'uint256', -50,
+                             expected_result_type=bytes)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.ASSERT_RESULTED_FALSE_MSG)
+
+        runner.call_contract(path, 'uint256', bytes(30),
+                             expected_result_type=bytes)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.ASSERT_RESULTED_FALSE_MSG)
 
     def test_uint256_call_without_args(self):
-        path = self.get_contract_path('uint256', 'UInt256CallWithoutArgs.py')
+        path, _ = self.get_deploy_file_paths('uint256', 'UInt256CallWithoutArgs.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'uint256',
-                                         expected_result_type=bytes)
-        self.assertEqual(bytes(32), result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'uint256',
+                                            expected_result_type=bytes))
+        expected_results.append(bytes(32))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_uint256_return_bytes(self):
-        path = self.get_contract_path('uint256', 'UInt256ReturnBytes.py')
+        path, _ = self.get_deploy_file_paths('uint256', 'UInt256ReturnBytes.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
+        invokes = []
+        expected_results = []
+
         value = bytes(32)
-        result = self.run_smart_contract(engine, path, 'uint256', value,
-                                         expected_result_type=bytes)
-        self.assertEqual(value, result)
+        invokes.append(runner.call_contract(path, 'uint256', value,
+                                            expected_result_type=bytes))
+        expected_results.append(value)
 
         value = bytes(range(32))
-        result = self.run_smart_contract(engine, path, 'uint256', value,
-                                         expected_result_type=bytes)
-        self.assertEqual(value, result)
+        invokes.append(runner.call_contract(path, 'uint256', value,
+                                            expected_result_type=bytes))
+        expected_results.append(value)
 
-        with self.assertRaisesRegex(TestExecutionException, self.ASSERT_RESULTED_FALSE_MSG):
-            self.run_smart_contract(engine, path, 'uint256', bytes(10),
-                                    expected_result_type=bytes)
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
-        with self.assertRaisesRegex(TestExecutionException, self.ASSERT_RESULTED_FALSE_MSG):
-            self.run_smart_contract(engine, path, 'uint256', bytes(30),
-                                    expected_result_type=bytes)
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        runner.call_contract(path, 'uint256', bytes(10),
+                             expected_result_type=bytes)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.ASSERT_RESULTED_FALSE_MSG)
+
+        runner.call_contract(path, 'uint256', bytes(30),
+                             expected_result_type=bytes)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.ASSERT_RESULTED_FALSE_MSG)
 
     def test_uint256_concat_with_bytes(self):
-        path = self.get_contract_path('uint256', 'UInt256ConcatWithBytes.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('uint256', 'UInt256ConcatWithBytes.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         value = bytes(32)
-        result = self.run_smart_contract(engine, path, 'uint256_method', value,
-                                         expected_result_type=bytes)
-        self.assertEqual(value + b'123', result)
+        invokes.append(runner.call_contract(path, 'uint256_method', value,
+                                            expected_result_type=bytes))
+        expected_results.append(value + b'123')
 
         value = bytes(range(32))
-        result = self.run_smart_contract(engine, path, 'uint256_method', value,
-                                         expected_result_type=bytes)
-        self.assertEqual(value + b'123', result)
+        invokes.append(runner.call_contract(path, 'uint256_method', value,
+                                            expected_result_type=bytes))
+        expected_results.append(value + b'123')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_uint256_mismatched_type(self):
         path = self.get_contract_path('uint256', 'UInt256CallMismatchedType.py')
@@ -198,92 +316,145 @@ class TestNeoTypes(BoaTest):
     # region ECPoint
 
     def test_ecpoint_call_bytes(self):
-        path = self.get_contract_path('ecpoint', 'ECPointCallBytes.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ecpoint', 'ECPointCallBytes.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         value = bytes(33)
-        result = self.run_smart_contract(engine, path, 'ecpoint', value,
-                                         expected_result_type=bytes)
-        self.assertEqual(value, result)
+        invokes.append(runner.call_contract(path, 'ecpoint', value,
+                                            expected_result_type=bytes))
+        expected_results.append(value)
 
         value = bytes(range(33))
-        result = self.run_smart_contract(engine, path, 'ecpoint', value,
-                                         expected_result_type=bytes)
-        self.assertEqual(value, result)
+        invokes.append(runner.call_contract(path, 'ecpoint', value,
+                                            expected_result_type=bytes))
+        expected_results.append(value)
 
-        with self.assertRaisesRegex(TestExecutionException, f'^{self.UNHANDLED_EXCEPTION_MSG_PREFIX}'):
-            self.run_smart_contract(engine, path, 'ecpoint', bytes(20),
-                                    expected_result_type=bytes)
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
-        with self.assertRaisesRegex(TestExecutionException, f'^{self.UNHANDLED_EXCEPTION_MSG_PREFIX}'):
-            self.run_smart_contract(engine, path, 'ecpoint', bytes(30),
-                                    expected_result_type=bytes)
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        runner.call_contract(path, 'ecpoint', bytes(20),
+                             expected_result_type=bytes)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'^{self.UNHANDLED_EXCEPTION_MSG_PREFIX}')
+
+        runner.call_contract(path, 'ecpoint', bytes(30),
+                             expected_result_type=bytes)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'^{self.UNHANDLED_EXCEPTION_MSG_PREFIX}')
 
     def test_ecpoint_call_without_args(self):
         path = self.get_contract_path('ecpoint', 'ECPointCallWithoutArgs.py')
         self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
 
     def test_ecpoint_return_bytes(self):
-        path = self.get_contract_path('ecpoint', 'ECPointReturnBytes.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ecpoint', 'ECPointReturnBytes.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         value = bytes(33)
-        result = self.run_smart_contract(engine, path, 'ecpoint', value,
-                                         expected_result_type=bytes)
-        self.assertEqual(value, result)
+        invokes.append(runner.call_contract(path, 'ecpoint', value,
+                                            expected_result_type=bytes))
+        expected_results.append(value)
 
         value = bytes(range(33))
-        result = self.run_smart_contract(engine, path, 'ecpoint', value,
-                                         expected_result_type=bytes)
-        self.assertEqual(value, result)
+        invokes.append(runner.call_contract(path, 'ecpoint', value,
+                                            expected_result_type=bytes))
+        expected_results.append(value)
 
-        with self.assertRaisesRegex(TestExecutionException, f'^{self.UNHANDLED_EXCEPTION_MSG_PREFIX}'):
-            self.run_smart_contract(engine, path, 'ecpoint', bytes(10),
-                                    expected_result_type=bytes)
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
-        with self.assertRaisesRegex(TestExecutionException, f'^{self.UNHANDLED_EXCEPTION_MSG_PREFIX}'):
-            self.run_smart_contract(engine, path, 'ecpoint', bytes(30),
-                                    expected_result_type=bytes)
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        runner.call_contract(path, 'ecpoint', bytes(10),
+                             expected_result_type=bytes)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'^{self.UNHANDLED_EXCEPTION_MSG_PREFIX}')
+
+        runner.call_contract(path, 'ecpoint', bytes(30),
+                             expected_result_type=bytes)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'^{self.UNHANDLED_EXCEPTION_MSG_PREFIX}')
 
     def test_ecpoint_concat_with_bytes(self):
-        path = self.get_contract_path('ecpoint', 'ECPointConcatWithBytes.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ecpoint', 'ECPointConcatWithBytes.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         value = bytes(33)
-        result = self.run_smart_contract(engine, path, 'ecpoint_method', value,
-                                         expected_result_type=bytes)
-        self.assertEqual(value + b'123', result)
+        invokes.append(runner.call_contract(path, 'ecpoint_method', value,
+                                            expected_result_type=bytes))
+        expected_results.append(value + b'123')
 
         value = bytes(range(33))
-        result = self.run_smart_contract(engine, path, 'ecpoint_method', value,
-                                         expected_result_type=bytes)
-        self.assertEqual(value + b'123', result)
+        invokes.append(runner.call_contract(path, 'ecpoint_method', value,
+                                            expected_result_type=bytes))
+        expected_results.append(value + b'123')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_ecpoint_mismatched_type(self):
         path = self.get_contract_path('ecpoint', 'ECPointCallMismatchedType.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_ecpoint_script_hash(self):
-        path = self.get_contract_path('ecpoint', 'ECPointScriptHash.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ecpoint', 'ECPointScriptHash.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         from boa3.neo import public_key_to_script_hash
         value = bytes(range(33))
         script_hash = public_key_to_script_hash(value)
 
-        result = self.run_smart_contract(engine, path, 'Main', value)
-        self.assertEqual(script_hash, result)
+        invokes.append(runner.call_contract(path, 'Main', value))
+        expected_results.append(script_hash)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_ecpoint_script_hash_from_builtin(self):
-        path = self.get_contract_path('ecpoint', 'ECPointScriptHashBuiltinCall.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ecpoint', 'ECPointScriptHashBuiltinCall.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         from boa3.neo import public_key_to_script_hash
         value = bytes(range(33))
         script_hash = public_key_to_script_hash(value)
 
-        result = self.run_smart_contract(engine, path, 'Main', value)
-        self.assertEqual(script_hash, result)
+        invokes.append(runner.call_contract(path, 'Main', value))
+        expected_results.append(script_hash)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     # endregion
 
@@ -312,166 +483,274 @@ class TestNeoTypes(BoaTest):
         self.assertEqual(AbiType.ByteArray, method['parameters'][0]['type'])
 
     def test_byte_string_to_bool(self):
-        path = self.get_contract_path('bytestring', 'ByteStringToBool.py')
+        path, _ = self.get_deploy_file_paths('bytestring', 'ByteStringToBool.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'to_bool', b'\x00')
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'to_bool', '\x00')
-        self.assertEqual(False, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'to_bool', b'\x01')
-        self.assertEqual(True, result)
-        result = self.run_smart_contract(engine, path, 'to_bool', '\x01')
-        self.assertEqual(True, result)
+        invokes.append(runner.call_contract(path, 'to_bool', b'\x00'))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'to_bool', '\x00'))
+        expected_results.append(False)
 
-        result = self.run_smart_contract(engine, path, 'to_bool', b'\x02')
-        self.assertEqual(True, result)
-        result = self.run_smart_contract(engine, path, 'to_bool', '\x02')
-        self.assertEqual(True, result)
+        invokes.append(runner.call_contract(path, 'to_bool', b'\x01'))
+        expected_results.append(True)
+        invokes.append(runner.call_contract(path, 'to_bool', '\x01'))
+        expected_results.append(True)
+
+        invokes.append(runner.call_contract(path, 'to_bool', b'\x02'))
+        expected_results.append(True)
+        invokes.append(runner.call_contract(path, 'to_bool', '\x02'))
+        expected_results.append(True)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_byte_string_to_bool_with_builtin(self):
-        path = self.get_contract_path('bytestring', 'ByteStringToBoolWithBuiltin.py')
+        path, _ = self.get_deploy_file_paths('bytestring', 'ByteStringToBoolWithBuiltin.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'to_bool', b'\x00')
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'to_bool', '\x00')
-        self.assertEqual(False, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'to_bool', b'\x01')
-        self.assertEqual(True, result)
-        result = self.run_smart_contract(engine, path, 'to_bool', '\x01')
-        self.assertEqual(True, result)
+        invokes.append(runner.call_contract(path, 'to_bool', b'\x00'))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'to_bool', '\x00'))
+        expected_results.append(False)
 
-        result = self.run_smart_contract(engine, path, 'to_bool', b'\x02')
-        self.assertEqual(True, result)
-        result = self.run_smart_contract(engine, path, 'to_bool', '\x02')
-        self.assertEqual(True, result)
+        invokes.append(runner.call_contract(path, 'to_bool', b'\x01'))
+        expected_results.append(True)
+        invokes.append(runner.call_contract(path, 'to_bool', '\x01'))
+        expected_results.append(True)
+
+        invokes.append(runner.call_contract(path, 'to_bool', b'\x02'))
+        expected_results.append(True)
+        invokes.append(runner.call_contract(path, 'to_bool', '\x02'))
+        expected_results.append(True)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_byte_string_to_int(self):
-        path = self.get_contract_path('bytestring', 'ByteStringToInt.py')
+        path, _ = self.get_deploy_file_paths('bytestring', 'ByteStringToInt.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'to_int', b'\x01\x02')
-        self.assertEqual(513, result)
-        result = self.run_smart_contract(engine, path, 'to_int', '\x01\x02')
-        self.assertEqual(513, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'to_int', b'\x01\x02'))
+        expected_results.append(513)
+        invokes.append(runner.call_contract(path, 'to_int', '\x01\x02'))
+        expected_results.append(513)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_byte_string_to_int_with_builtin(self):
-        path = self.get_contract_path('bytestring', 'ByteStringToIntWithBuiltin.py')
+        path, _ = self.get_deploy_file_paths('bytestring', 'ByteStringToIntWithBuiltin.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'to_int', b'\x01\x02')
-        self.assertEqual(513, result)
-        result = self.run_smart_contract(engine, path, 'to_int', '\x01\x02')
-        self.assertEqual(513, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'to_int', b'\x01\x02'))
+        expected_results.append(513)
+        invokes.append(runner.call_contract(path, 'to_int', '\x01\x02'))
+        expected_results.append(513)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_byte_string_to_str(self):
-        path = self.get_contract_path('bytestring', 'ByteStringToStr.py')
+        path, _ = self.get_deploy_file_paths('bytestring', 'ByteStringToStr.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'to_str', b'abc')
-        self.assertEqual('abc', result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'to_str', b'123')
-        self.assertEqual('123', result)
+        invokes.append(runner.call_contract(path, 'to_str', b'abc'))
+        expected_results.append('abc')
+
+        invokes.append(runner.call_contract(path, 'to_str', b'123'))
+        expected_results.append('123')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_byte_string_to_str_with_builtin(self):
-        path = self.get_contract_path('bytestring', 'ByteStringToStrWithBuiltin.py')
+        path, _ = self.get_deploy_file_paths('bytestring', 'ByteStringToStrWithBuiltin.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'to_str', b'abc')
-        self.assertEqual('abc', result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'to_str', b'123')
-        self.assertEqual('123', result)
+        invokes.append(runner.call_contract(path, 'to_str', b'abc'))
+        expected_results.append('abc')
+
+        invokes.append(runner.call_contract(path, 'to_str', b'123'))
+        expected_results.append('123')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_byte_string_to_bytes(self):
-        path = self.get_contract_path('bytestring', 'ByteStringToBytes.py')
+        path, _ = self.get_deploy_file_paths('bytestring', 'ByteStringToBytes.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'to_bytes', 'abc',
-                                         expected_result_type=bytes)
-        self.assertEqual(b'abc', result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'to_bytes', '123',
-                                         expected_result_type=bytes)
-        self.assertEqual(b'123', result)
+        invokes.append(runner.call_contract(path, 'to_bytes', 'abc',
+                                            expected_result_type=bytes))
+        expected_results.append(b'abc')
+
+        invokes.append(runner.call_contract(path, 'to_bytes', '123',
+                                            expected_result_type=bytes))
+        expected_results.append(b'123')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_byte_string_to_bytes_with_builtin(self):
-        path = self.get_contract_path('bytestring', 'ByteStringToBytesWithBuiltin.py')
+        path, _ = self.get_deploy_file_paths('bytestring', 'ByteStringToBytesWithBuiltin.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'to_bytes', 'abc',
-                                         expected_result_type=bytes)
-        self.assertEqual(b'abc', result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'to_bytes', '123',
-                                         expected_result_type=bytes)
-        self.assertEqual(b'123', result)
+        invokes.append(runner.call_contract(path, 'to_bytes', 'abc',
+                                            expected_result_type=bytes))
+        expected_results.append(b'abc')
+
+        invokes.append(runner.call_contract(path, 'to_bytes', '123',
+                                            expected_result_type=bytes))
+        expected_results.append(b'123')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_concat_with_bytes(self):
-        path = self.get_contract_path('bytestring', 'ConcatWithBytes.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('bytestring', 'ConcatWithBytes.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         prefix = b'12345'
         arg = b'a'
-        result = self.run_smart_contract(engine, path, 'concat', arg,
-                                         expected_result_type=bytes)
-        self.assertEqual(prefix + arg, result)
+        invokes.append(runner.call_contract(path, 'concat', arg,
+                                            expected_result_type=bytes))
+        expected_results.append(prefix + arg)
 
         arg = '6789'
-        result = self.run_smart_contract(engine, path, 'concat', arg,
-                                         expected_result_type=bytes)
-        self.assertEqual(prefix + String(arg).to_bytes(), result)
+        invokes.append(runner.call_contract(path, 'concat', arg,
+                                            expected_result_type=bytes))
+        expected_results.append(prefix + String(arg).to_bytes())
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_concat_with_str(self):
-        path = self.get_contract_path('bytestring', 'ConcatWithStr.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('bytestring', 'ConcatWithStr.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         prefix = '12345'
         arg = 'a'
-        result = self.run_smart_contract(engine, path, 'concat', arg)
-        self.assertEqual(prefix + arg, result)
+        invokes.append(runner.call_contract(path, 'concat', arg))
+        expected_results.append(prefix + arg)
 
         arg = b'6789'
-        result = self.run_smart_contract(engine, path, 'concat', arg)
-        self.assertEqual(prefix + String.from_bytes(arg), result)
+        invokes.append(runner.call_contract(path, 'concat', arg))
+        expected_results.append(prefix + String.from_bytes(arg))
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_concat_with_bytestring(self):
-        path = self.get_contract_path('bytestring', 'ConcatWithByteString.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('bytestring', 'ConcatWithByteString.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         prefix = '12345'
         arg = 'a'
-        result = self.run_smart_contract(engine, path, 'concat', prefix, arg)
-        self.assertEqual(prefix + arg, result)
+        invokes.append(runner.call_contract(path, 'concat', prefix, arg))
+        expected_results.append(prefix + arg)
 
         arg = b'a'
-        result = self.run_smart_contract(engine, path, 'concat', prefix, arg)
-        self.assertEqual(prefix + String.from_bytes(arg), result)
+        invokes.append(runner.call_contract(path, 'concat', prefix, arg))
+        expected_results.append(prefix + String.from_bytes(arg))
 
         prefix = b'12345'
         arg = b'6789'
-        result = self.run_smart_contract(engine, path, 'concat', prefix, arg,
-                                         expected_result_type=bytes)
-        self.assertEqual(prefix + arg, result)
+        invokes.append(runner.call_contract(path, 'concat', prefix, arg,
+                                            expected_result_type=bytes))
+        expected_results.append(prefix + arg)
 
         arg = '6789'
-        result = self.run_smart_contract(engine, path, 'concat', prefix, arg,
-                                         expected_result_type=bytes)
-        self.assertEqual(prefix + String(arg).to_bytes(), result)
+        invokes.append(runner.call_contract(path, 'concat', prefix, arg,
+                                            expected_result_type=bytes))
+        expected_results.append(prefix + String(arg).to_bytes())
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_bytestring_multiplication(self):
-        path = self.get_contract_path('bytestring', 'ByteStringMultiplication.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('bytestring', 'ByteStringMultiplication.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'bytestring_mult', b'a', 4,
-                                         expected_result_type=bytes)
-        self.assertEqual(b'aaaa', result)
-        result = self.run_smart_contract(engine, path, 'bytestring_mult', 'unit', 50)
-        self.assertEqual('unit' * 50, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'bytestring_mult', b'a', 4,
+                                            expected_result_type=bytes))
+        expected_results.append(b'aaaa')
+        invokes.append(runner.call_contract(path, 'bytestring_mult', 'unit', 50))
+        expected_results.append('unit' * 50)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     # endregion
 
@@ -501,33 +780,51 @@ class TestNeoTypes(BoaTest):
 
     def test_opcode_concat(self):
         from boa3.neo.vm.opcode.Opcode import Opcode
-        path = self.get_contract_path('opcode', 'ConcatWithOpcode.py')
+        path, _ = self.get_deploy_file_paths('opcode', 'ConcatWithOpcode.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
+        invokes = []
+        expected_results = []
+
         expected_result = Opcode.LDARG0 + Opcode.LDARG1 + Opcode.ADD
-        result = self.run_smart_contract(engine, path, 'concat')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'concat'))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_opcode_concat_with_bytes(self):
         from boa3.neo.vm.opcode.Opcode import Opcode
-        path = self.get_contract_path('opcode', 'ConcatWithBytes.py')
+        path, _ = self.get_deploy_file_paths('opcode', 'ConcatWithBytes.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
+        invokes = []
+        expected_results = []
+
         concat_bytes = b'12345'
         arg = Opcode.LDARG0
-        result = self.run_smart_contract(engine, path, 'concat', arg,
-                                         expected_result_type=bytes)
-        self.assertEqual(concat_bytes + arg, result)
+        invokes.append(runner.call_contract(path, 'concat', arg,
+                                            expected_result_type=bytes))
+        expected_results.append(concat_bytes + arg)
 
         arg = Opcode.LDLOC1
-        result = self.run_smart_contract(engine, path, 'concat', arg,
-                                         expected_result_type=bytes)
-        self.assertEqual(concat_bytes + arg, result)
+        invokes.append(runner.call_contract(path, 'concat', arg,
+                                            expected_result_type=bytes))
+        expected_results.append(concat_bytes + arg)
 
         arg = Opcode.NOP
-        result = self.run_smart_contract(engine, path, 'concat', arg,
-                                         expected_result_type=bytes)
-        self.assertEqual(concat_bytes + arg, result)
+        invokes.append(runner.call_contract(path, 'concat', arg,
+                                            expected_result_type=bytes))
+        expected_results.append(concat_bytes + arg)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_opcode_concat_mismatched_type(self):
         path = self.get_contract_path('opcode', 'ConcatMismatchedType.py')
@@ -535,54 +832,81 @@ class TestNeoTypes(BoaTest):
 
     def test_opcode_multiplication(self):
         from boa3.neo.vm.opcode.Opcode import Opcode
-        path = self.get_contract_path('opcode', 'OpcodeMultiplication.py')
+        path, _ = self.get_deploy_file_paths('opcode', 'OpcodeMultiplication.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
+        invokes = []
+        expected_results = []
 
         multiplier = 4
-        result = self.run_smart_contract(engine, path, 'opcode_mult', multiplier,
-                                         expected_result_type=bytes)
-        self.assertEqual(Opcode.NOP * multiplier, result)
+        invokes.append(runner.call_contract(path, 'opcode_mult', multiplier,
+                                            expected_result_type=bytes))
+        expected_results.append(Opcode.NOP * multiplier)
 
         multiplier = 50
-        result = self.run_smart_contract(engine, path, 'opcode_mult', multiplier,
-                                         expected_result_type=bytes)
-        self.assertEqual(Opcode.NOP * multiplier, result)
+        invokes.append(runner.call_contract(path, 'opcode_mult', multiplier,
+                                            expected_result_type=bytes))
+        expected_results.append(Opcode.NOP * multiplier)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     # endregion
 
     # region IsInstance Neo Types
 
     def test_isinstance_contract(self):
-        path = self.get_contract_path('IsInstanceContract.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'is_contract', bytes(10))
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_contract', [1, 2, 3])
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_contract', "test_with_string")
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_contract', 42)
-        self.assertEqual(False, result)
+        path, _ = self.get_deploy_file_paths('IsInstanceContract.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'is_get_contract_a_contract')
-        self.assertEqual(True, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'is_contract', bytes(10)))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'is_contract', [1, 2, 3]))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'is_contract', "test_with_string"))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'is_contract', 42))
+        expected_results.append(False)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        invokes.append(runner.call_contract(path, 'is_get_contract_a_contract'))
+        expected_results.append(True)
 
     def test_isinstance_block(self):
-        path = self.get_contract_path('IsInstanceBlock.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'is_block', bytes(10))
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_block', [1, 2, 3])
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_block', "test_with_string")
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_block', 42)
-        self.assertEqual(False, result)
+        path, _ = self.get_deploy_file_paths('IsInstanceBlock.py')
+        runner = NeoTestRunner()
 
-        engine.increase_block(10)
-        result = self.run_smart_contract(engine, path, 'get_block_is_block', 5)
-        self.assertEqual(True, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'is_block', bytes(10)))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'is_block', [1, 2, 3]))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'is_block', "test_with_string"))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'is_block', 42))
+        expected_results.append(False)
+
+        invokes.append(runner.call_contract(path, 'get_block_is_block', 0))
+        expected_results.append(True)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_transaction_cast_and_get_hash(self):
         path = self.get_contract_path('CastTransactionGetHash.py')
@@ -597,95 +921,151 @@ class TestNeoTypes(BoaTest):
         self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
 
     def test_isinstance_transaction(self):
-        path = self.get_contract_path('IsInstanceTransaction.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'is_tx', bytes(10))
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_tx', [1, 2, 3])
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_tx', "test_with_string")
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_tx', 42)
-        self.assertEqual(False, result)
+        path, _ = self.get_deploy_file_paths('IsInstanceTransaction.py')
+        runner = NeoTestRunner()
 
-        txs = engine.current_block.get_transactions()
-        self.assertGreater(len(txs), 0)
-        tx_hash = txs[-1].hash
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'get_transaction_is_tx', tx_hash)
-        self.assertEqual(True, result)
+        invokes.append(runner.call_contract(path, 'is_tx', bytes(10)))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'is_tx', [1, 2, 3]))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'is_tx', "test_with_string"))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'is_tx', 42))
+        expected_results.append(False)
+
+        # TODO: refactor on #864dzuvjt to test with tx hash
+        # txs = engine.current_block.get_transactions()
+        # self.assertGreater(len(txs), 0)
+        # tx_hash = txs[-1].hash
+
+        # invokes.append(runner.call_contract(path, 'get_transaction_is_tx', tx_hash))
+        # expected_results.append(True)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_isinstance_notification(self):
-        path = self.get_contract_path('IsInstanceNotification.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'is_notification', bytes(10))
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_notification', [1, 2, 3])
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_notification', "test_with_string")
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_notification', 42)
-        self.assertEqual(False, result)
+        path, _ = self.get_deploy_file_paths('IsInstanceNotification.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'get_notifications_is_notification')
-        self.assertEqual(True, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'is_notification', bytes(10)))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'is_notification', [1, 2, 3]))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'is_notification', "test_with_string"))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'is_notification', 42))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'get_notifications_is_notification'))
+        expected_results.append(True)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_isinstance_storage_context(self):
-        path = self.get_contract_path('IsInstanceStorageContext.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'is_context', bytes(10))
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_context', [1, 2, 3])
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_context', "test_with_string")
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_context', 42)
-        self.assertEqual(False, result)
+        path, _ = self.get_deploy_file_paths('IsInstanceStorageContext.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'get_context_is_context')
-        self.assertEqual(True, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'is_context', bytes(10)))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'is_context', [1, 2, 3]))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'is_context', "test_with_string"))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'is_context', 42))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'get_context_is_context'))
+        expected_results.append(True)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_isinstance_storage_map(self):
-        path = self.get_contract_path('IsInstanceStorageMap.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'is_storage_map', bytes(10))
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_storage_map', [1, 2, 3])
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_storage_map', "test_with_string")
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_storage_map', 42)
-        self.assertEqual(False, result)
+        path, _ = self.get_deploy_file_paths('IsInstanceStorageMap.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'create_map_is_storage_map')
-        self.assertEqual(True, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'is_storage_map', bytes(10)))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'is_storage_map', [1, 2, 3]))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'is_storage_map', "test_with_string"))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'is_storage_map', 42))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'create_map_is_storage_map'))
+        expected_results.append(True)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_isinstance_iterator(self):
-        path = self.get_contract_path('IsInstanceIterator.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'is_iterator', bytes(10))
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_iterator', [1, 2, 3])
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_iterator', "test_with_string")
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_iterator', 42)
-        self.assertEqual(False, result)
+        path, _ = self.get_deploy_file_paths('IsInstanceIterator.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'storage_find_is_context')
-        self.assertEqual(True, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'is_iterator', bytes(10)))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'is_iterator', [1, 2, 3]))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'is_iterator', "test_with_string"))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'is_iterator', 42))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'storage_find_is_context'))
+        expected_results.append(True)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_isinstance_ecpoint(self):
-        path = self.get_contract_path('IsInstanceECPoint.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('IsInstanceECPoint.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'is_ecpoint', bytes(10))
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_ecpoint', bytes(33))
-        self.assertEqual(True, result)
-        result = self.run_smart_contract(engine, path, 'is_ecpoint', bytes(30))
-        self.assertEqual(False, result)
-        result = self.run_smart_contract(engine, path, 'is_ecpoint', 42)
-        self.assertEqual(False, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'is_ecpoint', bytes(10)))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'is_ecpoint', bytes(33)))
+        expected_results.append(True)
+        invokes.append(runner.call_contract(path, 'is_ecpoint', bytes(30)))
+        expected_results.append(False)
+        invokes.append(runner.call_contract(path, 'is_ecpoint', 42))
+        expected_results.append(False)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     # endregion


### PR DESCRIPTION
**Summary or solution description**
Part of an overall refactoring. 
Changed the execution tests of the compiled smart contracts related to Boa built-in types to use TestRunner instead of TestEngine

**Tests**
Rerun the modified unit tests
