### PR TITLE
Refactor native contract unit tests to use test runner

### DIFF
--- a/boa3/constants.py
+++ b/boa3/constants.py
@@ -1,3 +1,4 @@
+import locale
 import os
 import platform
 import sys
@@ -18,6 +19,10 @@ SYS_VERSION = platform.python_version()
 BOA_VERSION = _actual_boa_version  # for logging only
 COMPILER_VERSION = BOA_VERSION
 BOA_PACKAGE_PATH = os.path.abspath(f'{__file__}/..')
+
+locale.setlocale(locale.LC_ALL, '')
+SYS_LOCALE = locale.localeconv()
+SYS_LOCALE_DECIMAL_POINT = SYS_LOCALE['decimal_point'] if 'decimal_point' in SYS_LOCALE else '.'
 
 ONE_BYTE_MAX_VALUE = 255
 TWO_BYTES_MAX_VALUE = 256 ** 2 - 1

--- a/boa3_test/test_drive/model/invoker/invokeresult.py
+++ b/boa3_test/test_drive/model/invoker/invokeresult.py
@@ -1,0 +1,12 @@
+class _NotExecuted:
+    def __repr__(self) -> str:
+        return 'Invoke not executed yet'
+
+
+class _Canceled:
+    def __repr__(self) -> str:
+        return 'Invoke was canceled before being executed'
+
+
+NOT_EXECUTED = _NotExecuted()
+CANCELED = _Canceled()

--- a/boa3_test/test_drive/model/invoker/neobatchinvoke.py
+++ b/boa3_test/test_drive/model/invoker/neobatchinvoke.py
@@ -1,12 +1,16 @@
 from typing import Type, Iterable
 
+from boa3.neo3.core.types import UInt256
 from boa3_test.test_drive.model.invoker import invokeresult
 from boa3_test.test_drive.model.invoker.neoinvoke import NeoInvoke
 
 
-class NeoInvokeResult:
-    def __init__(self, invoke: NeoInvoke, expected_result_type: Type = None):
+class NeoBatchInvoke:
+    def __init__(self, invoke: NeoInvoke, tx_pos: int, expected_result_type: Type = None):
         self._invoke: NeoInvoke = invoke
+        self._tx_pos: int = tx_pos
+        self._log: str = ''
+        self._tx_id: UInt256 = None
         self._result = invokeresult.NOT_EXECUTED
 
         if not isinstance(expected_result_type, type):
@@ -44,5 +48,18 @@ class NeoInvokeResult:
 
         return result
 
+    @property
+    def tx_id(self) -> UInt256:
+        if not isinstance(self._tx_id, UInt256) and not self._log.isspace():
+            try:
+                import re
+                groups = re.match(r'.*?(?P<txhash>0x\w+) submitted$', self._log).groupdict()
+                tx_hash = groups['txhash']
+                self._tx_id = UInt256.from_string(tx_hash)
+            except:
+                pass
+
+        return self._tx_id
+
     def __repr__(self):
-        return f'{self._invoke.__repr__()} -> {self._result.__repr__()}'
+        return f'{self._invoke.__repr__()} -> {self.tx_id.__repr__()}'

--- a/boa3_test/test_drive/model/invoker/neoinvokecollection.py
+++ b/boa3_test/test_drive/model/invoker/neoinvokecollection.py
@@ -12,6 +12,11 @@ class NeoInvokeCollection:
         self._invoke_results: List[NeoInvokeResult] = []
         self._pending_results: List[NeoInvokeResult] = []
 
+    def create_contract_invoke(self, contract: TestContract, operation: str, *args: Any) -> NeoInvoke:
+        invoker = NeoInvoke(contract.name, operation, *args)
+        invoker._contract = contract
+        return invoker
+
     def append_contract_invoke(self, contract: TestContract, operation: str, *args: Any,
                                expected_result_type: Type = None) -> NeoInvokeResult:
         invoker = NeoInvoke(contract.name, operation, *args)

--- a/boa3_test/test_drive/neoxp/batch.py
+++ b/boa3_test/test_drive/neoxp/batch.py
@@ -1,7 +1,8 @@
-from typing import List, Union, Any
+from typing import List, Union, Any, Type
 
 from boa3.neo.vm.type.String import String
 from boa3.neo3.core.types import UInt160
+from boa3_test.test_drive.model.invoker.neobatchinvoke import NeoBatchInvoke
 from boa3_test.test_drive.model.invoker.neoinvoke import NeoInvoke
 from boa3_test.test_drive.model.smart_contract.testcontract import TestContract
 from boa3_test.test_drive.model.wallet.account import Account
@@ -13,6 +14,11 @@ from boa3_test.test_drive.neoxp.command.neoexpresscommand import NeoExpressComma
 class NeoExpressBatch:
     def __init__(self):
         self._instructions: List[NeoExpressCommand] = []
+        self._transaction_submissions: List[int] = []
+        self._transaction_logs: List[str] = []
+
+        self._contract_invokes: List[NeoBatchInvoke] = []
+        self._contract_invokes_pos: List[int] = []
 
     def is_empty(self) -> bool:
         return len(self._instructions) == 0
@@ -29,20 +35,33 @@ class NeoExpressBatch:
         else:
             deployer_id = 'genesis'  # neo express default account
 
+        tx_pos = len(self._instructions)
         self._instructions.append(neoxp_contract.deploy(nef_path, deployer_id))
+        self._transaction_submissions.append(tx_pos)
+
         return TestContract(nef_path, nef_path.replace('.nef', '.manifest.json'))
 
-    def run_contract(self, invoke: NeoInvoke):
+    def run_contract(self, invoke: NeoInvoke,
+                     expected_result_type: Type = None) -> NeoBatchInvoke:
         if hasattr(invoke.invoker, 'name') and isinstance(invoke.invoker.name, str):
             invoker_id = invoke.invoker.name
         else:
             invoker_id = 'genesis'  # neo express default account
 
+        tx_pos = len(self._instructions)
+        batch_invoke = NeoBatchInvoke(invoke, tx_pos, expected_result_type=expected_result_type)
+
         self._instructions.append(neoxp_contract.run(invoke.contract_id, invoke.operation, *invoke.args,
                                                      account=invoker_id))
+        self._transaction_submissions.append(tx_pos)
+
+        self._contract_invokes.append(batch_invoke)
+        self._contract_invokes_pos.append(tx_pos)
+
+        return batch_invoke
 
     def transfer_assets(self, sender: str, receiver: str,
-                        quantity: int, asset: Union[str, UInt160], data: Any = None):
+                        quantity: Union[int, str], asset: Union[str, UInt160], data: Any = None):
         if isinstance(asset, UInt160):
             asset = asset.__str__()
 
@@ -57,9 +76,20 @@ class NeoExpressBatch:
 
     def clear(self):
         self._instructions.clear()
+        self._transaction_submissions.clear()
+        self._transaction_logs.clear()
 
     def pop(self):
-        return self._instructions.pop()
+        result = self._instructions.pop()
+
+        pop_index = len(self._instructions)
+        if pop_index in self._transaction_submissions:
+            index = self._transaction_submissions.index(len(self._instructions))
+            self._transaction_submissions.pop(index)
+            if len(self._transaction_logs) > index:
+                self._transaction_logs.pop(index)
+
+        return result
 
     def write(self, path: str) -> bool:
         try:
@@ -73,7 +103,21 @@ class NeoExpressBatch:
 
     def execute(self, neoxp_path: str, batch_file_path: str, reset: bool = False) -> str:
         self.write(batch_file_path)
-        return utils.run_batch(neoxp_path, batch_file_path, reset=reset)
+        self._transaction_logs.clear()
+        log = utils.run_batch(neoxp_path, batch_file_path, reset=reset)
+
+        self._update_logs(log)
+        return log
+
+    def _update_logs(self, log: str):
+        tx_logs = []
+        for lineno, line in enumerate(log.splitlines()[-len(self._instructions):]):
+            if lineno in self._transaction_submissions:
+                tx_logs.append(line)
+            if lineno in self._contract_invokes_pos:
+                index = self._contract_invokes_pos.index(lineno)
+                self._contract_invokes[index]._log = line
+        self._transaction_logs = tx_logs
 
     def has_new_deploys_since(self, last_verified_command: int = -1):
         if not isinstance(last_verified_command, int):

--- a/boa3_test/test_drive/testrunner/neo_test_runner.py
+++ b/boa3_test/test_drive/testrunner/neo_test_runner.py
@@ -145,7 +145,7 @@ class NeoTestRunner:
     def add_gas(self, script_hash_or_address: Union[bytes, str], amount: int):
         address = neoxp_utils.get_account_identifier_from_script_hash_or_name(script_hash_or_address)
         self._batch.transfer_assets(sender=self._DEFAULT_ACCOUNT.name, receiver=address,
-                                    quantity=f'{(amount / (10 ** 8)):.8f}'.replace('.', ','),
+                                    quantity=f'{(amount / (10 ** 8)):.8f}'.replace('.', constants.SYS_LOCALE_DECIMAL_POINT),
                                     asset='GAS')
 
     def deploy_contract(self, nef_path: str, account: Account = None) -> TestContract:

--- a/boa3_test/tests/boa_test.py
+++ b/boa3_test/tests/boa_test.py
@@ -28,6 +28,7 @@ class BoaTest(TestCase):
     CALLED_CONTRACT_DOES_NOT_EXIST_MSG = 'Called Contract Does Not Exist'
     GAS_MUST_BE_POSITIVE_MSG = 'GAS must be positive.'
     GIVEN_KEY_NOT_PRESENT_IN_DICT_MSG_REGEX = "The given key '\\S+' was not present in the dictionary."
+    INSUFFICIENT_GAS = 'Insufficient GAS.'
     MAP_KEY_NOT_FOUND_ERROR_MSG = 'Key not found in Map'
     MAX_ITEM_SIZE_EXCEED_MSG_PREFIX = 'MaxItemSize exceed'
     FORMAT_METHOD_DOESNT_EXIST_IN_CONTRACT_MSG_REGEX_PREFIX = r'^Method "{0}" with \d+ parameter\(s\) ' \

--- a/boa3_test/tests/compiler_tests/test_interop/test_blockchain.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_blockchain.py
@@ -38,7 +38,7 @@ class TestBlockchainInterop(BoaTest):
         self.assertEqual(0, result[9])  # transaction_count
 
     def test_get_contract(self):
-        path = self.get_contract_path('GetContract.py')
+        path, _ = self.get_deploy_file_paths('GetContract.py')
         runner = NeoTestRunner()
 
         invokes = []

--- a/boa3_test/tests/compiler_tests/test_interop/test_blockchain.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_blockchain.py
@@ -6,6 +6,8 @@ from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.String import String
 from boa3.neo3.contracts import CallFlags
 from boa3.neo3.core.types import UInt160, UInt256
+from boa3.neo3.vm import VMState
+from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.boa_test import BoaTest
 from boa3_test.tests.test_classes.contract.neomanifeststruct import NeoManifestStruct
 from boa3_test.tests.test_classes.testengine import TestEngine
@@ -37,21 +39,30 @@ class TestBlockchainInterop(BoaTest):
 
     def test_get_contract(self):
         path = self.get_contract_path('GetContract.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', bytes(20))
-        self.assertIsNone(result)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', bytes(20)))
+        expected_results.append(None)
 
         call_contract_path = self.get_contract_path('test_sc/arithmetic_test', 'Addition.py')
-        self.run_smart_contract(engine, call_contract_path, 'add', 1, 2)
-        call_hash = engine.executed_script_hash.to_array()
-
         nef, manifest = self.get_bytes_output(call_contract_path)
-        call_contract_path = call_contract_path.replace('.py', '.nef')
 
-        engine.reset_engine()
-        engine.add_contract(call_contract_path)
+        call_contract_path, _ = self.get_deploy_file_paths(call_contract_path)
+        contract = runner.deploy_contract(call_contract_path)
+        runner.update_contracts()
+        call_hash = contract.script_hash
 
-        result = self.run_smart_contract(engine, path, 'main', call_hash)
+        invoke = runner.call_contract(path, 'main', call_hash)
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        result = invoke.result
         self.assertEqual(5, len(result))
         self.assertEqual(call_hash, result[2])
         self.assertEqual(nef, result[3])

--- a/boa3_test/tests/compiler_tests/test_interop/test_runtime.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_runtime.py
@@ -7,7 +7,7 @@ from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.String import String
 from boa3.neo3.contracts import TriggerType
 from boa3.neo3.vm import VMState
-from boa3_test.test_drive.neoxp import utils as neoxp_utils
+from boa3_test.test_drive import neoxp
 from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.boa_test import BoaTest
 
@@ -17,7 +17,7 @@ class TestRuntimeInterop(BoaTest):
 
     def test_check_witness(self):
         path, _ = self.get_deploy_file_paths('CheckWitness.py')
-        account = neoxp_utils.get_account_by_name('testAccount1')
+        account = neoxp.utils.get_account_by_name('testAccount1')
         account_hash = account.script_hash.to_array()
         runner = NeoTestRunner()
 
@@ -42,7 +42,7 @@ class TestRuntimeInterop(BoaTest):
     def test_contract_with_check_witness(self):
         path, _ = self.get_deploy_file_paths('test_sc/interop_test/contract', 'CallScriptHash.py')
         call_contract_path, _ = self.get_deploy_file_paths('CheckWitness.py')
-        account = neoxp_utils.get_account_by_name('testAccount1')
+        account = neoxp.utils.get_account_by_name('testAccount1')
         account_hash = account.script_hash.to_array()
         runner = NeoTestRunner()
 
@@ -74,7 +74,7 @@ class TestRuntimeInterop(BoaTest):
 
     def test_check_witness_imported_as(self):
         path, _ = self.get_deploy_file_paths('CheckWitnessImportedAs.py')
-        account = neoxp_utils.get_account_by_name('testAccount1')
+        account = neoxp.utils.get_account_by_name('testAccount1')
         account_hash = account.script_hash.to_array()
         runner = NeoTestRunner()
 
@@ -760,7 +760,7 @@ class TestRuntimeInterop(BoaTest):
 
     def test_boa2_runtime_test(self):
         path, _ = self.get_deploy_file_paths('RuntimeBoa2Test.py')
-        account = neoxp_utils.get_account_by_name('testAccount1').script_hash.to_array()
+        account = neoxp.utils.get_account_by_name('testAccount1').script_hash.to_array()
         runner = NeoTestRunner()
 
         invokes = []
@@ -863,7 +863,7 @@ class TestRuntimeInterop(BoaTest):
         expected_results = []
 
         invokes.append(runner.call_contract(path, 'main'))
-        expected_results.append(neoxp_utils.get_magic())
+        expected_results.append(neoxp.utils.get_magic())
 
         runner.execute()
         self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)

--- a/boa3_test/tests/compiler_tests/test_native/test_contract_management.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_contract_management.py
@@ -1,53 +1,80 @@
 import json
 
 from boa3 import constants
-from boa3.boa3 import Boa3
 from boa3.exception import CompilerError
 from boa3.neo.vm.type.String import String
+from boa3.neo3.vm import VMState
+from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.boa_test import BoaTest
-from boa3_test.tests.test_classes.TestExecutionException import TestExecutionException
 from boa3_test.tests.test_classes.contract.neomanifeststruct import NeoManifestStruct
-from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestContractManagementContract(BoaTest):
     default_folder: str = 'test_sc/native_test/contractmanagement'
 
     def test_get_hash(self):
-        path = self.get_contract_path('GetHash.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('GetHash.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(constants.MANAGEMENT_SCRIPT, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(constants.MANAGEMENT_SCRIPT)
+        
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_get_minimum_deployment_fee(self):
-        path = self.get_contract_path('GetMinimumDeploymentFee.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('GetMinimumDeploymentFee.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         minimum_cost = 10 * 10 ** 8  # minimum deployment cost is 10 GAS right now
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(minimum_cost, result)
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(minimum_cost)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_get_minimum_deployment_fee_too_many_parameters(self):
         path = self.get_contract_path('GetMinimumDeploymentFeeTooManyArguments.py')
         self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
 
     def test_get_contract(self):
-        path = self.get_contract_path('GetContract.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', bytes(20))
-        self.assertIsNone(result)
+        path, _ = self.get_deploy_file_paths('GetContract.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', bytes(20)))
+        expected_results.append(None)
 
         call_contract_path = self.get_contract_path('test_sc/arithmetic_test', 'Addition.py')
         nef, manifest = self.get_bytes_output(call_contract_path)
-        self.run_smart_contract(engine, call_contract_path, 'add', 1, 2)
-        call_hash = engine.executed_script_hash.to_array()
-        call_contract_path = call_contract_path.replace('.py', '.nef')
 
-        engine = TestEngine()
-        engine.add_contract(call_contract_path)
+        call_contract_path, _ = self.get_deploy_file_paths(call_contract_path)
+        contract = runner.deploy_contract(call_contract_path)
+        runner.update_contracts()
+        call_hash = contract.script_hash
 
-        result = self.run_smart_contract(engine, path, 'main', call_hash)
+        invoke = runner.call_contract(path, 'main', call_hash)
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        result = invoke.result
         self.assertEqual(5, len(result))
         self.assertEqual(call_hash, result[2])
         self.assertEqual(nef, result[3])
@@ -55,61 +82,78 @@ class TestContractManagementContract(BoaTest):
         self.assertEqual(manifest_struct, result[4])
 
     def test_has_method(self):
-        path = self.get_contract_path('HasMethod.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('HasMethod.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        call_contract_path, _ = self.get_deploy_file_paths('test_sc/arithmetic_test', 'Addition.py')
+        contract = runner.deploy_contract(call_contract_path)
+        runner.update_contracts()
+        call_hash = contract.script_hash
 
         test_method = 'add'
         test_parameter_count = 2
-        result = self.run_smart_contract(engine, path, 'main', bytes(20), test_method, test_parameter_count)
-        self.assertEqual(False, result)
+        invokes.append(runner.call_contract(path, 'main', bytes(20), test_method, test_parameter_count))
+        expected_results.append(False)
 
-        call_contract_path = self.get_contract_path('test_sc/arithmetic_test', 'Addition.py')
-        self.run_smart_contract(engine, call_contract_path, 'add', 1, 2)
-        call_hash = engine.executed_script_hash.to_array()
+        invokes.append(runner.call_contract(path, 'main', call_hash, test_method, test_parameter_count))
+        expected_results.append(True)
 
-        result = self.run_smart_contract(engine, path, 'main', call_hash, test_method, test_parameter_count)
-        self.assertEqual(True, result)
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_deploy_contract(self):
-        path = self.get_contract_path('DeployContract.py')
+        path, _ = self.get_deploy_file_paths('DeployContract.py')
         call_contract_path = self.get_contract_path('test_sc/arithmetic_test', 'Addition.py')
-        Boa3.compile_and_save(call_contract_path)
-        self.compile_and_save(path)
 
+        self.compile_and_save(call_contract_path)
         nef_file, manifest = self.get_bytes_output(call_contract_path)
         arg_manifest = String(json.dumps(manifest, separators=(',', ':'))).to_bytes()
 
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main', nef_file, arg_manifest, None)
+        runner = NeoTestRunner()
+        invoke = runner.call_contract(path, 'Main', nef_file, arg_manifest, None)
 
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        result = invoke.result
         self.assertEqual(5, len(result))
         self.assertEqual(nef_file, result[3])
         manifest_struct = NeoManifestStruct.from_json(manifest)
         self.assertEqual(manifest_struct, result[4])
 
     def test_deploy_contract_data_deploy(self):
-        path = self.get_contract_path('DeployContract.py')
+        path, _ = self.get_deploy_file_paths('DeployContract.py')
         call_contract_path = self.get_contract_path('boa3_test/test_sc/interop_test/contract', 'NewContract.py')
-        self.compile_and_save(call_contract_path)
 
+        self.compile_and_save(call_contract_path)
         nef_file, manifest = self.get_bytes_output(call_contract_path)
         arg_manifest = String(json.dumps(manifest, separators=(',', ':'))).to_bytes()
 
-        engine = TestEngine()
-        data = 'some sort of data'
-        result = self.run_smart_contract(engine, path, 'Main', nef_file, arg_manifest, data)
+        runner = NeoTestRunner()
+        runner.file_name = 'test_create_contract'
 
+        data = 'some sort of data'
+        invoke = runner.call_contract(path, 'Main', nef_file, arg_manifest, data)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        result = invoke.result
         self.assertEqual(5, len(result))
         self.assertEqual(nef_file, result[3])
         manifest_struct = NeoManifestStruct.from_json(manifest)
         self.assertEqual(manifest_struct, result[4])
 
-        notifies = engine.get_events('notify')
+        notifies = runner.get_events('notify')
         self.assertEqual(2, len(notifies))
         self.assertEqual(False, notifies[0].arguments[0])  # not updated
-        self.assertEqual(data, notifies[1].arguments[0])   # data
-        result = self.run_smart_contract(engine, call_contract_path, 'main')
-        self.assertEqual(data, result)
+        self.assertEqual(data, notifies[1].arguments[0])  # data
 
     def test_deploy_contract_too_many_parameters(self):
         path = self.get_contract_path('DeployContractTooManyArguments.py')
@@ -120,37 +164,61 @@ class TestContractManagementContract(BoaTest):
         self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
 
     def test_update_contract(self):
-        path = self.get_contract_path('UpdateContract.py')
-        engine = TestEngine()
-        with self.assertRaisesRegex(TestExecutionException, f'{self.CANT_FIND_METHOD_MSG_PREFIX} : new_method'):
-            self.run_smart_contract(engine, path, 'new_method')
+        path, _ = self.get_deploy_file_paths('UpdateContract.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        runner.call_contract(path, 'new_method')
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.FORMAT_METHOD_DOESNT_EXIST_IN_CONTRACT_MSG_REGEX_PREFIX.format('new_method'))
 
         new_path = self.get_contract_path('test_sc/interop_test', 'UpdateContract.py')
         self.compile_and_save(new_path)
         new_nef, new_manifest = self.get_bytes_output(new_path)
         arg_manifest = String(json.dumps(new_manifest, separators=(',', ':'))).to_bytes()
 
-        result = self.run_smart_contract(engine, path, 'update', new_nef, arg_manifest, None)
-        self.assertIsVoid(result)
+        invokes.append(runner.call_contract(path, 'update', new_nef, arg_manifest, None))
+        expected_results.append(None)
 
-        result = self.run_smart_contract(engine, path, 'new_method')
-        self.assertEqual(42, result)
+        invokes.append(runner.call_contract(path, 'new_method'))
+        expected_results.append(42)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_update_contract_data_deploy(self):
-        path = self.get_contract_path('UpdateContract.py')
-        engine = TestEngine()
-        with self.assertRaisesRegex(TestExecutionException, f'{self.CANT_FIND_METHOD_MSG_PREFIX} : new_method'):
-            self.run_smart_contract(engine, path, 'new_method')
+        path, _ = self.get_deploy_file_paths('UpdateContract.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        runner.call_contract(path, 'new_method')
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.FORMAT_METHOD_DOESNT_EXIST_IN_CONTRACT_MSG_REGEX_PREFIX.format('new_method'))
 
         new_path = self.get_contract_path('test_sc/interop_test', 'UpdateContract.py')
-        self.compile_and_save(new_path)
         new_nef, new_manifest = self.get_bytes_output(new_path)
         arg_manifest = String(json.dumps(new_manifest, separators=(',', ':'))).to_bytes()
 
         data = 'this function was deployed'
-        result = self.run_smart_contract(engine, path, 'update', new_nef, arg_manifest, data)
-        self.assertIsVoid(result)
-        notifies = engine.get_events('notify')
+        invokes.append(runner.call_contract(path, 'update', new_nef, arg_manifest, data))
+        expected_results.append(None)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        notifies = runner.get_events('notify')
         self.assertEqual(2, len(notifies))
         self.assertEqual(True, notifies[0].arguments[0])
         self.assertEqual(data, notifies[1].arguments[0])
@@ -164,16 +232,29 @@ class TestContractManagementContract(BoaTest):
         self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
 
     def test_destroy_contract(self):
-        path = self.get_contract_path('DestroyContract.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertIsVoid(result)
+        path, _ = self.get_deploy_file_paths('DestroyContract.py')
+        runner = NeoTestRunner()
 
-        script_hash = engine.executed_script_hash.to_array()
-        call_contract_path = self.get_contract_path('boa3_test/test_sc/interop_test/contract', 'CallScriptHash.py')
-        with self.assertRaisesRegex(TestExecutionException, f'^{self.CALLED_CONTRACT_DOES_NOT_EXIST_MSG}'):
-            self.run_smart_contract(engine, call_contract_path, 'Main',
-                                    script_hash, 'Main', [])
+        invokes = []
+        expected_results = []
+
+        call = runner.call_contract(path, 'Main')
+        invokes.append(call)
+        expected_results.append(None)
+
+        runner.execute(clear_invokes=False)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        script_hash = call.invoke.contract.script_hash
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        call_contract_path, _ = self.get_deploy_file_paths('boa3_test/test_sc/interop_test/contract', 'CallScriptHash.py')
+        runner.call_contract(call_contract_path, 'Main',
+                             script_hash, 'Main', [])
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'^{self.CALLED_CONTRACT_DOES_NOT_EXIST_MSG}')
 
     def test_destroy_contract_too_many_parameters(self):
         path = self.get_contract_path('DestroyContractTooManyArguments.py')

--- a/boa3_test/tests/compiler_tests/test_native/test_cryptolib.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_cryptolib.py
@@ -7,8 +7,9 @@ from boa3.model.type.type import Type
 from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3.neo3.contracts.namedcurve import NamedCurve
+from boa3.neo3.vm import VMState
+from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.boa_test import BoaTest
-from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestCryptoLibClass(BoaTest):
@@ -26,43 +27,92 @@ class TestCryptoLibClass(BoaTest):
     )
 
     def test_get_hash(self):
-        path = self.get_contract_path('GetHash.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('GetHash.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(constants.CRYPTO_SCRIPT, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(constants.CRYPTO_SCRIPT)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_ripemd160_str(self):
-        path = self.get_contract_path('Ripemd160Str.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Ripemd160Str.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         expected_result = hashlib.new('ripemd160', b'unit test')
-        result = self.run_smart_contract(engine, path, 'Main', 'unit test')
-        self.assertEqual(expected_result.digest(), result)
+        invokes.append(runner.call_contract(path, 'Main', 'unit test'))
+        expected_results.append(expected_result.digest())
 
         expected_result = hashlib.new('ripemd160', b'')
-        result = self.run_smart_contract(engine, path, 'Main', '')
-        self.assertEqual(expected_result.digest(), result)
+        invokes.append(runner.call_contract(path, 'Main', ''))
+        expected_results.append(expected_result.digest())
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_ripemd160_int(self):
-        path = self.get_contract_path('Ripemd160Int.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Ripemd160Int.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         expected_result = hashlib.new('ripemd160', Integer(10).to_byte_array())
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(expected_result.digest(), result)
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append(expected_result.digest())
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_ripemd160_bool(self):
-        path = self.get_contract_path('Ripemd160Bool.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Ripemd160Bool.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         expected_result = hashlib.new('ripemd160', Integer(1).to_byte_array())
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(expected_result.digest(), result)
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append(expected_result.digest())
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_ripemd160_bytes(self):
-        path = self.get_contract_path('Ripemd160Bytes.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Ripemd160Bytes.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         expected_result = hashlib.new('ripemd160', b'unit test')
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(expected_result.digest(), result)
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append(expected_result.digest())
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_ripemd160_too_many_parameters(self):
         path = self.get_contract_path('Ripemd160TooManyArguments.py')
@@ -73,36 +123,76 @@ class TestCryptoLibClass(BoaTest):
         self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
 
     def test_sha256_str(self):
-        path = self.get_contract_path('Sha256Str.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Sha256Str.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         expected_result = hashlib.sha256(b'unit test')
-        result = self.run_smart_contract(engine, path, 'Main', 'unit test')
-        self.assertEqual(expected_result.digest(), result)
+        invokes.append(runner.call_contract(path, 'Main', 'unit test'))
+        expected_results.append(expected_result.digest())
 
         expected_result = hashlib.sha256(b'')
-        result = self.run_smart_contract(engine, path, 'Main', '')
-        self.assertEqual(expected_result.digest(), result)
+        invokes.append(runner.call_contract(path, 'Main', ''))
+        expected_results.append(expected_result.digest())
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_sha256_int(self):
-        path = self.get_contract_path('Sha256Int.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Sha256Int.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         expected_result = hashlib.sha256(Integer(10).to_byte_array())
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(expected_result.digest(), result)
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append(expected_result.digest())
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_sha256_bool(self):
-        path = self.get_contract_path('Sha256Bool.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Sha256Bool.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         expected_result = hashlib.sha256(Integer(1).to_byte_array())
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(expected_result.digest(), result)
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append(expected_result.digest())
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_sha256_bytes(self):
-        path = self.get_contract_path('Sha256Bytes.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Sha256Bytes.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         expected_result = hashlib.sha256(b'unit test')
-        result = self.run_smart_contract(engine, path, 'Main')
-        self.assertEqual(expected_result.digest(), result)
+        invokes.append(runner.call_contract(path, 'Main'))
+        expected_results.append(expected_result.digest())
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_sha256_too_many_parameters(self):
         path = self.get_contract_path('Sha256TooManyArguments.py')

--- a/boa3_test/tests/compiler_tests/test_native/test_gas.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_gas.py
@@ -1,102 +1,178 @@
 from boa3 import constants
 from boa3.exception import CompilerError
+from boa3.neo3.vm import VMState
+from boa3_test.test_drive import neoxp
+from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.boa_test import BoaTest
-from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestGasClass(BoaTest):
     default_folder: str = 'test_sc/native_test/gas'
+    GAS_CONTRACT_NAME = 'GasToken'
 
     def test_get_hash(self):
-        path = self.get_contract_path('GetHash.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('GetHash.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(constants.GAS_SCRIPT, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(constants.GAS_SCRIPT)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_symbol(self):
-        path = self.get_contract_path('Symbol.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Symbol.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual('GAS', result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append('GAS')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_symbol_too_many_parameters(self):
         path = self.get_contract_path('SymbolTooManyArguments.py')
         self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
 
     def test_decimals(self):
-        path = self.get_contract_path('Decimals.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Decimals.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(8, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(8)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_decimals_too_many_parameters(self):
         path = self.get_contract_path('DecimalsTooManyArguments.py')
         self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
 
     def test_total_supply(self):
-        path = self.get_contract_path('TotalSupply.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('TotalSupply.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertIsInstance(result, int)
+        contract_call = runner.call_contract(path, 'main')
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        self.assertIsInstance(contract_call.result, int)
 
     def test_total_supply_too_many_parameters(self):
         path = self.get_contract_path('TotalSupplyTooManyArguments.py')
         self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
 
     def test_balance_of(self):
-        path = self.get_contract_path('BalanceOf.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('BalanceOf.py')
+        test_account_1 = neoxp.utils.get_account_by_name('testAccount1').script_hash.to_array()
+        test_account_2 = neoxp.utils.get_account_by_name('testAccount2').script_hash.to_array()
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', bytes(range(20)))
-        self.assertEqual(0, result)
+        invokes = []
+        expected_results = []
 
-        engine.add_gas(bytes(range(20)), 10)
-        result = self.run_smart_contract(engine, path, 'main', bytes(range(20)))
-        self.assertEqual(10, result)
+        invokes.append(runner.call_contract(path, 'main', test_account_2))
+        expected_results.append(0)
+
+        runner.add_gas(test_account_1, 10)
+        invokes.append(runner.call_contract(path, 'main', test_account_1))
+        expected_results.append(10)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_balance_of_too_many_parameters(self):
         path = self.get_contract_path('BalanceOfTooManyArguments.py')
         self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
 
     def test_transfer(self):
-        path = self.get_contract_path('Transfer.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Transfer.py')
+        runner = NeoTestRunner()
 
-        account_1 = bytes(range(20))
-        account_2 = bytes(range(20)[::-1])
+        invokes = []
+        expected_results = []
+
+        account = neoxp.utils.get_account_by_name('testAccount1')
+        account_1 = account.script_hash.to_array()
+        account_2 = neoxp.utils.get_account_by_name('testAccount2').script_hash.to_array()
         amount = 10000
 
-        result = self.run_smart_contract(engine, path, 'main', account_1, account_2, amount, ['value', 123, False])
-        self.assertEqual(False, result)
+        runner.add_gas(account_1, amount)
+        invokes.append(runner.call_contract(path, 'main', account_2, account_1, amount, ['value', 123, False]))
+        expected_results.append(False)
 
-        engine.add_gas(account_1, amount)
         # can't transfer if there is no signature, even with enough GAS
-        result = self.run_smart_contract(engine, path, 'main', account_1, account_2, amount, ['value', 123, False])
-        self.assertEqual(False, result)
+        invokes.append(runner.call_contract(path, 'main', account_1, account_2, amount, ['value', 123, False]))
+        expected_results.append(False)
 
-        result = self.run_smart_contract(engine, path, 'main', account_1, account_2, amount, ['value', 123, False],
-                                         signer_accounts=[account_1])
-        self.assertEqual(True, result)
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        # TestRunner doesn't have WitnessScope modifier
+        # signing is not enough to pass check witness calling from test contract
+        invokes.append(runner.call_contract(path, 'main', account_1, account_2, amount, ['value', 123, False]))
+        expected_results.append(False)
+
+        invokes.append(runner.call_contract(self.GAS_CONTRACT_NAME, 'transfer',
+                                            account_1, account_2, amount, ['value', 123, False]))
+        expected_results.append(True)
+
+        runner.execute(account=account)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_transfer_data_default(self):
-        path = self.get_contract_path('TransferDataDefault.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('TransferDataDefault.py')
+        runner = NeoTestRunner()
 
-        account_1 = bytes(range(20))
-        account_2 = bytes(range(20)[::-1])
+        invokes = []
+        expected_results = []
+
+        account = neoxp.utils.get_account_by_name('testAccount1')
+        account_1 = account.script_hash.to_array()
+        account_2 = neoxp.utils.get_account_by_name('testAccount2').script_hash.to_array()
         amount = 100
 
-        result = self.run_smart_contract(engine, path, 'main', account_1, account_2, amount)
-        self.assertEqual(False, result)
+        runner.add_gas(account_1, amount)
+        invokes.append(runner.call_contract(path, 'main', account_2, account_1, amount))
+        expected_results.append(False)
+        runner.update_contracts()
 
-        engine.add_gas(account_1, amount)
-        result = self.run_smart_contract(engine, path, 'main', account_1, account_2, amount,
-                                         signer_accounts=[account_1])
-        self.assertEqual(True, result)
+        # TestRunner doesn't have WitnessScope modifier
+        # signing is not enough to pass check witness calling from test contract
+        invokes.append(runner.call_contract(path, 'main', account_1, account_2, amount))
+        expected_results.append(False)
+
+        invokes.append(runner.call_contract(self.GAS_CONTRACT_NAME, 'transfer', account_1, account_2, amount, None))
+        expected_results.append(True)
+
+        runner.execute(account=account)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_transfer_too_many_parameters(self):
         path = self.get_contract_path('TransferTooManyArguments.py')
@@ -107,8 +183,17 @@ class TestGasClass(BoaTest):
         self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
 
     def test_import_with_alias(self):
-        path = self.get_contract_path('ImportWithAlias.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ImportWithAlias.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', bytes(20))
-        self.assertEqual(0, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', bytes(20)))
+        expected_results.append(0)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)

--- a/boa3_test/tests/compiler_tests/test_native/test_ledger.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_ledger.py
@@ -7,6 +7,8 @@ from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.String import String
 from boa3.neo3.contracts import CallFlags
 from boa3.neo3.core.types import UInt160, UInt256
+from boa3.neo3.vm import VMState
+from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.boa_test import BoaTest
 from boa3_test.tests.test_classes.testengine import TestEngine
 
@@ -15,11 +17,20 @@ class TestLedgerContract(BoaTest):
     default_folder: str = 'test_sc/native_test/ledger'
 
     def test_get_hash(self):
-        path = self.get_contract_path('GetHash.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('GetHash.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(constants.LEDGER_SCRIPT, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(constants.LEDGER_SCRIPT)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_get_block_by_hash(self):
         path = self.get_contract_path('GetBlockByHash.py')
@@ -318,8 +329,17 @@ class TestLedgerContract(BoaTest):
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_get_current_index(self):
-        path = self.get_contract_path('GetCurrentIndex.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('GetCurrentIndex.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(engine.height, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(1)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)

--- a/boa3_test/tests/compiler_tests/test_native/test_neo.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_neo.py
@@ -1,103 +1,187 @@
 from boa3 import constants
 from boa3.exception import CompilerError
 from boa3.neo import from_hex_str
+from boa3.neo3.vm import VMState
+from boa3_test.test_drive import neoxp
+from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.boa_test import BoaTest
 from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestNeoClass(BoaTest):
     default_folder: str = 'test_sc/native_test/neo'
+    NEO_CONTRACT_NAME = 'NeoToken'
 
     def test_get_hash(self):
-        path = self.get_contract_path('GetHash.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('GetHash.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(constants.NEO_SCRIPT, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(constants.NEO_SCRIPT)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_symbol(self):
-        path = self.get_contract_path('Symbol.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Symbol.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual('NEO', result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append('NEO')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_symbol_too_many_parameters(self):
         path = self.get_contract_path('SymbolTooManyArguments.py')
         self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
 
     def test_decimals(self):
-        path = self.get_contract_path('Decimals.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Decimals.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(0, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(0)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_decimals_too_many_parameters(self):
         path = self.get_contract_path('DecimalsTooManyArguments.py')
         self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
 
     def test_total_supply(self):
-        path = self.get_contract_path('TotalSupply.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('TotalSupply.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(100_000_000, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(100_000_000)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_total_supply_too_many_parameters(self):
         path = self.get_contract_path('TotalSupplyTooManyArguments.py')
         self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
 
     def test_balance_of(self):
-        path = self.get_contract_path('BalanceOf.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('BalanceOf.py')
+        test_account_1 = neoxp.utils.get_account_by_name('testAccount1').script_hash.to_array()
+        test_account_2 = neoxp.utils.get_account_by_name('testAccount2').script_hash.to_array()
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', bytes(range(20)))
-        self.assertEqual(0, result)
+        invokes = []
+        expected_results = []
 
-        engine.add_neo(bytes(range(20)), 10)
-        result = self.run_smart_contract(engine, path, 'main', bytes(range(20)))
-        self.assertEqual(10, result)
+        invokes.append(runner.call_contract(path, 'main', test_account_2))
+        expected_results.append(0)
+
+        runner.add_neo(test_account_1, 10)
+        invokes.append(runner.call_contract(path, 'main', test_account_1))
+        expected_results.append(10)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_balance_of_too_many_parameters(self):
         path = self.get_contract_path('BalanceOfTooManyArguments.py')
         self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
 
     def test_transfer(self):
-        path = self.get_contract_path('Transfer.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Transfer.py')
+        runner = NeoTestRunner()
 
-        account_1 = bytes(range(20))
-        account_2 = bytes(range(20)[::-1])
+        invokes = []
+        expected_results = []
+
+        account = neoxp.utils.get_account_by_name('testAccount1')
+        account_1 = account.script_hash.to_array()
+        account_2 = neoxp.utils.get_account_by_name('testAccount2').script_hash.to_array()
         amount = 10000
 
-        result = self.run_smart_contract(engine, path, 'main', account_1, account_2, amount, ['value', 123, False])
-        self.assertEqual(False, result)
+        runner.add_neo(account_1, amount)
+        invokes.append(runner.call_contract(path, 'main', account_2, account_1, amount, ['value', 123, False]))
+        expected_results.append(False)
 
-        engine.add_neo(account_1, amount)
         # can't transfer if there is no signature, even with enough GAS
-        result = self.run_smart_contract(engine, path, 'main', account_1, account_2, amount, ['value', 123, False])
-        self.assertEqual(False, result)
+        invokes.append(runner.call_contract(path, 'main', account_1, account_2, amount, ['value', 123, False]))
+        expected_results.append(False)
 
-        result = self.run_smart_contract(engine, path, 'main', account_1, account_2, amount, ['value', 123, False],
-                                         signer_accounts=[account_1])
-        self.assertEqual(True, result)
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        # TestRunner doesn't have WitnessScope modifier
+        # signing is not enough to pass check witness calling from test contract
+        invokes.append(runner.call_contract(path, 'main', account_1, account_2, amount, ['value', 123, False]))
+        expected_results.append(False)
+
+        invokes.append(runner.call_contract(self.NEO_CONTRACT_NAME, 'transfer',
+                                            account_1, account_2, amount, ['value', 123, False]))
+        expected_results.append(True)
+
+        runner.execute(account=account)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_transfer_data_default(self):
-        path = self.get_contract_path('TransferDataDefault.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('TransferDataDefault.py')
+        runner = NeoTestRunner()
 
-        account_1 = bytes(range(20))
-        account_2 = bytes(range(20)[::-1])
+        invokes = []
+        expected_results = []
+
+        account = neoxp.utils.get_account_by_name('testAccount1')
+        account_1 = account.script_hash.to_array()
+        account_2 = neoxp.utils.get_account_by_name('testAccount2').script_hash.to_array()
         amount = 100
 
-        result = self.run_smart_contract(engine, path, 'main', account_1, account_2, amount)
-        self.assertEqual(False, result)
+        runner.add_neo(account_1, amount)
+        invokes.append(runner.call_contract(path, 'main', account_2, account_1, amount))
+        expected_results.append(False)
+        runner.update_contracts()
 
-        engine.add_neo(account_1, amount)
-        result = self.run_smart_contract(engine, path, 'main', account_1, account_2, amount,
-                                         signer_accounts=[account_1])
-        self.assertEqual(True, result)
+        # TestRunner doesn't have WitnessScope modifier
+        # signing is not enough to pass check witness calling from test contract
+        invokes.append(runner.call_contract(path, 'main', account_1, account_2, amount))
+        expected_results.append(False)
+
+        invokes.append(runner.call_contract(self.NEO_CONTRACT_NAME, 'transfer', account_1, account_2, amount, None))
+        expected_results.append(True)
+
+        runner.execute(account=account)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_transfer_too_many_parameters(self):
         path = self.get_contract_path('TransferTooManyArguments.py')
@@ -108,103 +192,189 @@ class TestNeoClass(BoaTest):
         self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
 
     def test_get_gas_per_block(self):
-        path = self.get_contract_path('GetGasPerBlock.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('GetGasPerBlock.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(5 * 10 ** 8, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(5 * 10 ** 8)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_unclaimed_gas(self):
-        path = self.get_contract_path('UnclaimedGas.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('UnclaimedGas.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', bytes(20), 0)
-        self.assertIsInstance(result, int)
+        contract_call = runner.call_contract(path, 'main', bytes(20), 0)
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        self.assertIsInstance(contract_call.result, int)
 
     def test_register_candidate(self):
-        path = self.get_contract_path('RegisterCandidate.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('RegisterCandidate.py')
+        runner = NeoTestRunner()
 
-        candidate_pubkey = bytes.fromhex('0296852e74830f48185caec9980d21dee5e8bee3da97d712123c19ee01c2d3f3ae')
-        candidate_scripthash = from_hex_str('a8de26eb4931c674d31885acf722bd82e6bcd06d')
-        result = self.run_smart_contract(engine, path, 'main', candidate_pubkey)
-        self.assertEqual(False, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', candidate_pubkey,
-                                         signer_accounts=[candidate_scripthash])
-        self.assertEqual(True, result)
+        candidate = neoxp.utils.get_account_by_name('testAccount1')
+        candidate_pubkey = bytes.fromhex('035F34EF4B4704C68617C427B3A3059BF0AF86E9AF46992588C6605C2B87366F16')
+        candidate_script_hash = candidate.script_hash.to_array()
+        register_gas_price = 1_000
+        runner.add_gas(candidate_script_hash, (register_gas_price + 1) * 10 ** 8)  # +1 to make sure it has enough gas
+
+        invokes.append(runner.call_contract(path, 'main', candidate_pubkey))
+        expected_results.append(False)
+        runner.update_contracts()
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        # TestRunner doesn't have WitnessScope modifier
+        # signing is not enough to pass check witness calling from test contract
+        invokes.append(runner.call_contract(path, 'main', candidate_pubkey))
+        expected_results.append(False)
+
+        runner.execute(account=candidate)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        # cannot test it with a Test Invoke
+        runner.call_contract(self.NEO_CONTRACT_NAME, 'registerCandidate', candidate_pubkey)
+        # expected_results.append(True)
+
+        # TODO: check tx result on #864dzuvjt
+        runner.run_contract(self.NEO_CONTRACT_NAME, 'registerCandidate', candidate_pubkey)
+
+        runner.execute(account=candidate)
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.INSUFFICIENT_GAS)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_unregister_candidate(self):
-        path = self.get_contract_path('UnregisterCandidate.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('UnregisterCandidate.py')
+        runner = NeoTestRunner()
 
-        candidate_pubkey = bytes.fromhex('0296852e74830f48185caec9980d21dee5e8bee3da97d712123c19ee01c2d3f3ae')
-        candidate_scripthash = from_hex_str('a8de26eb4931c674d31885acf722bd82e6bcd06d')
-        result = self.run_smart_contract(engine, path, 'main', candidate_pubkey)
-        self.assertEqual(False, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', candidate_pubkey, signer_accounts=[candidate_scripthash])
-        self.assertEqual(True, result)
+        candidate = neoxp.utils.get_account_by_name('testAccount1')
+        candidate_pubkey = bytes.fromhex('035F34EF4B4704C68617C427B3A3059BF0AF86E9AF46992588C6605C2B87366F16')
+        candidate_script_hash = candidate.script_hash.to_array()
+        unregister_gas_price = 1_000
+        runner.add_gas(candidate_script_hash, (unregister_gas_price + 1) * 10 ** 8)  # +1 to make sure it has enough gas
+
+        invokes.append(runner.call_contract(path, 'main', candidate_pubkey))
+        expected_results.append(False)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        # TestRunner doesn't have WitnessScope modifier
+        # signing is not enough to pass check witness calling from test contract
+        invokes.append(runner.call_contract(path, 'main', candidate_pubkey))
+        expected_results.append(False)
+
+        invokes.append(runner.call_contract(self.NEO_CONTRACT_NAME, 'unregisterCandidate', candidate_pubkey))
+        expected_results.append(True)
+
+        runner.execute(account=candidate)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_vote(self):
-        path = self.get_contract_path('Vote.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Vote.py')
+        path_get, _ = self.get_deploy_file_paths('GetCandidates.py')
 
-        account = bytes(range(20))
+        runner = NeoTestRunner()
+        runner.deploy_contract(path_get)
+
+        invokes = []
+        expected_results = []
+
+        candidate = neoxp.utils.get_account_by_name('testAccount1')
+        candidate_pubkey = bytes.fromhex('035F34EF4B4704C68617C427B3A3059BF0AF86E9AF46992588C6605C2B87366F16')
+        candidate_script_hash = candidate.script_hash.to_array()
+
         n_votes = 100
-        candidate_pubkey = bytes.fromhex('0296852e74830f48185caec9980d21dee5e8bee3da97d712123c19ee01c2d3f3ae')
+        account = neoxp.utils.get_account_by_name('testAccount2')
+        account_script_hash = account.script_hash.to_array()
+
+        register_gas_price = 1_000
+        runner.add_gas(candidate_script_hash, (register_gas_price + 1) * 10 ** 8)  # +1 to make sure it has enough gas
+
         # will fail check_witness
-        result = self.run_smart_contract(engine, path, 'main', account, candidate_pubkey)
-        self.assertEqual(False, result)
+        invokes.append(runner.call_contract(path, 'main', account_script_hash, candidate_pubkey))
+        expected_results.append(False)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         # NeoAccountState is None and will return false
-        result = self.run_smart_contract(engine, path, 'main', account, candidate_pubkey, signer_accounts=[account])
-        self.assertEqual(False, result)
+        invokes.append(runner.call_contract(path, 'main', account_script_hash, candidate_pubkey))
+        expected_results.append(False)
+
+        runner.execute(account=account)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         # adding NEO to the account will make NeoAccountState not None
-        engine.add_neo(account, n_votes)
+        runner.add_neo(account_script_hash, n_votes)
 
         # candidate is not registered yet
-        result = self.run_smart_contract(engine, path, 'main', account, candidate_pubkey, signer_accounts=[account])
-        self.assertEqual(False, result)
+        invokes.append(runner.call_contract(path, 'main', account_script_hash, candidate_pubkey))
+        expected_results.append(False)
 
-        path_register = self.get_contract_path('RegisterCandidate.py')
-        candidate_pubkey = bytes.fromhex('0296852e74830f48185caec9980d21dee5e8bee3da97d712123c19ee01c2d3f3ae')
-        candidate_scripthash = from_hex_str('a8de26eb4931c674d31885acf722bd82e6bcd06d')
-        self.run_smart_contract(engine, path_register, 'main', candidate_pubkey,
-                                signer_accounts=[candidate_scripthash])
+        runner.execute(account=account)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        # TODO: check tx result on #864dzuvjt
+        runner.run_contract(self.NEO_CONTRACT_NAME, 'registerCandidate', candidate_pubkey,
+                            account=candidate)
 
         # candidate was registered
-        result = self.run_smart_contract(engine, path, 'main', account, candidate_pubkey, signer_accounts=[account])
-        self.assertEqual(True, result)
+        # TestRunner doesn't have WitnessScope modifier
+        # signing is not enough to pass check witness calling from test contract
+        invokes.append(runner.call_contract(path, 'main', account_script_hash, candidate_pubkey))
+        expected_results.append(False)
 
-        path_get = self.get_contract_path('GetCandidates.py')
-        result = self.run_smart_contract(engine, path_get, 'main')
-        self.assertEqual(1, len(result))
-        self.assertEqual(candidate_pubkey, result[0][0])
-        self.assertEqual(n_votes, result[0][1])
+        invokes.append(runner.call_contract(self.NEO_CONTRACT_NAME, 'vote', account_script_hash, candidate_pubkey))
+        expected_results.append(True)
+
+        get_candidates_call_1 = runner.call_contract(path_get, 'main')
 
         # remove votes from candidate
-        result = self.run_smart_contract(engine, path, 'un_vote', account, signer_accounts=[account])
-        self.assertEqual(True, result)
+        # TestRunner doesn't have WitnessScope modifier
+        # signing is not enough to pass check witness calling from test contract
+        invokes.append(runner.call_contract(path, 'un_vote', account_script_hash))
+        expected_results.append(False)
+
+        invokes.append(runner.call_contract(self.NEO_CONTRACT_NAME, 'vote', account_script_hash, None))
+        expected_results.append(True)
 
         # candidate has no votes now
-        result = self.run_smart_contract(engine, path_get, 'main')
+        get_candidates_call_2 = runner.call_contract(path_get, 'main')
+
+        runner.execute(account=account)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        result = get_candidates_call_1.result
         self.assertEqual(1, len(result))
         self.assertEqual(candidate_pubkey, result[0][0])
-        self.assertEqual(0, result[0][1])
-
-        # voting for candidate again
-        self.run_smart_contract(engine, path, 'main', account, candidate_pubkey, signer_accounts=[account])
-        result = self.run_smart_contract(engine, path_get, 'main')
         self.assertEqual(n_votes, result[0][1])
 
-        # it's also possible to remove votes by voting for None instead of using un_vote
-        result = self.run_smart_contract(engine, path, 'main', account, None, signer_accounts=[account])
-        self.assertEqual(True, result)
-
-        # candidate has no votes now again
-        result = self.run_smart_contract(engine, path_get, 'main')
+        result = get_candidates_call_2.result
         self.assertEqual(1, len(result))
         self.assertEqual(candidate_pubkey, result[0][0])
         self.assertEqual(0, result[0][1])
@@ -240,80 +410,102 @@ class TestNeoClass(BoaTest):
         self.assertEqual(0, result[0][1])
 
     def test_get_candidates(self):
-        path = self.get_contract_path('GetCandidates.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('GetCandidates.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         # no candidate was registered
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(0, len(result))
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append([])
 
-        path_register = self.get_contract_path('RegisterCandidate.py')
-        candidate_pubkey = bytes.fromhex('0296852e74830f48185caec9980d21dee5e8bee3da97d712123c19ee01c2d3f3ae')
-        candidate_scripthash = from_hex_str('a8de26eb4931c674d31885acf722bd82e6bcd06d')
-        self.run_smart_contract(engine, path_register, 'main', candidate_pubkey,
-                                signer_accounts=[candidate_scripthash])
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        candidate = neoxp.utils.get_account_by_name('testAccount1')
+        candidate_pubkey = bytes.fromhex('035F34EF4B4704C68617C427B3A3059BF0AF86E9AF46992588C6605C2B87366F16')
+        candidate_script_hash = candidate.script_hash.to_array()
+        register_gas_price = 1_000
+        runner.add_gas(candidate_script_hash, (register_gas_price + 1) * 10 ** 8)  # +1 to make sure it has enough gas
+
+        # TODO: check tx result on #864dzuvjt
+        runner.run_contract(self.NEO_CONTRACT_NAME, 'registerCandidate', candidate_pubkey,
+                            account=candidate)
 
         # after registering one
-        result = self.run_smart_contract(engine, path, 'main')
+        invoke = runner.call_contract(path, 'main')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        result = invoke.result
         self.assertEqual(1, len(result))
         self.assertEqual(candidate_pubkey, result[0][0])
         self.assertEqual(0, result[0][1])
 
     def test_get_candidate_vote(self):
-        path = self.get_contract_path('GetCandidateVote.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('GetCandidateVote.py')
+        runner = NeoTestRunner()
 
-        account = bytes(range(20))
+        invokes = []
+        expected_results = []
+
+        candidate = neoxp.utils.get_account_by_name('testAccount1')
+        candidate_pubkey = bytes.fromhex('035F34EF4B4704C68617C427B3A3059BF0AF86E9AF46992588C6605C2B87366F16')
+        candidate_script_hash = candidate.script_hash.to_array()
+
         n_votes = 100
-        candidate_pubkey = bytes.fromhex('0296852e74830f48185caec9980d21dee5e8bee3da97d712123c19ee01c2d3f3ae')
-        candidate_scripthash = from_hex_str('a8de26eb4931c674d31885acf722bd82e6bcd06d')
-        # will fail check_witness
-        result = self.run_smart_contract(engine, path, 'main', candidate_pubkey)
-        self.assertEqual(-1, result)
+        account = neoxp.utils.get_account_by_name('testAccount2')
+        account_script_hash = account.script_hash.to_array()
 
-        engine.add_neo(account, n_votes)
-        path_register = self.get_contract_path('RegisterCandidate.py')
-        result = self.run_smart_contract(engine, path_register, 'main', candidate_pubkey,
-                                         signer_accounts=[candidate_scripthash])
-        self.assertTrue(result)
+        register_gas_price = 1_000
+        runner.add_gas(candidate_script_hash, (register_gas_price + 1) * 10 ** 8)  # +1 to make sure it has enough gas
+
+        # will fail check_witness
+        invokes.append(runner.call_contract(path, 'main', candidate_pubkey))
+        expected_results.append(-1)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        runner.add_neo(account_script_hash, n_votes)
+
+        # TODO: check tx result on #864dzuvjt
+        runner.run_contract(self.NEO_CONTRACT_NAME, 'registerCandidate', candidate_pubkey,
+                            account=candidate)
 
         # candidate was registered
-        path_vote = self.get_contract_path('Vote.py')
-        result = self.run_smart_contract(engine, path_vote, 'main', account, candidate_pubkey,
-                                         signer_accounts=[account])
-        self.assertTrue(result)
+        invokes.append(runner.call_contract(self.NEO_CONTRACT_NAME, 'vote', account_script_hash, candidate_pubkey))
+        expected_results.append(True)
 
-        result = self.run_smart_contract(engine, path, 'main', candidate_pubkey)
-        self.assertEqual(n_votes, result)
+        invokes.append(runner.call_contract(path, 'main', candidate_pubkey))
+        expected_results.append(n_votes)
+
+        runner.execute(account=account)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_get_committee(self):
-        path = self.get_contract_path('GetCommittee.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('GetCommittee.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main')
+        default_committee = neoxp.utils.get_account_by_name('node1')
         default_council = [
-            bytes.fromhex('03b209fd4f53a7170ea4444e0cb0a6bb6a53c2bd016926989cf85f9b0fba17a70c'),
-            bytes.fromhex('02486fd15702c4490a26703112a5cc1d0923fd697a33406bd5a1c00e0013b09a70'),
-            bytes.fromhex('02ca0e27697b9c248f6f16e085fd0061e26f44da85b58ee835c110caa5ec3ba554'),
-            bytes.fromhex('024c7b7fb6c310fccf1ba33b082519d82964ea93868d676662d4a59ad548df0e7d'),
-            bytes.fromhex('03b8d9d5771d8f513aa0869b9cc8d50986403b78c6da36890638c3d46a5adce04a'),
-            bytes.fromhex('02df48f60e8f3e01c48ff40b9b7f1310d7a8b2a193188befe1c2e3df740e895093'),
-            bytes.fromhex('02aaec38470f6aad0042c6e877cfd8087d2676b0f516fddd362801b9bd3936399e'),
-            bytes.fromhex('023a36c72844610b4d34d1968662424011bf783ca9d984efa19a20babf5582f3fe'),
-            bytes.fromhex('03708b860c1de5d87f5b151a12c2a99feebd2e8b315ee8e7cf8aa19692a9e18379'),
-            bytes.fromhex('03c6aa6e12638b36e88adc1ccdceac4db9929575c3e03576c617c49cce7114a050'),
-            bytes.fromhex('03204223f8c86b8cd5c89ef12e4f0dbb314172e9241e30c9ef2293790793537cf0'),
-            bytes.fromhex('02a62c915cf19c7f19a50ec217e79fac2439bbaad658493de0c7d8ffa92ab0aa62'),
-            bytes.fromhex('03409f31f0d66bdc2f70a9730b66fe186658f84a8018204db01c106edc36553cd0'),
-            bytes.fromhex('0288342b141c30dc8ffcde0204929bb46aed5756b41ef4a56778d15ada8f0c6654'),
-            bytes.fromhex('020f2887f41474cfeb11fd262e982051c1541418137c02a0f4961af911045de639'),
-            bytes.fromhex('0222038884bbd1d8ff109ed3bdef3542e768eef76c1247aea8bc8171f532928c30'),
-            bytes.fromhex('03d281b42002647f0113f36c7b8efb30db66078dfaaa9ab3ff76d043a98d512fde'),
-            bytes.fromhex('02504acbc1f4b3bdad1d86d6e1a08603771db135a73e61c9d565ae06a1938cd2ad'),
-            bytes.fromhex('0226933336f1b75baa42d42b71d9091508b638046d19abd67f4e119bf64a7cfb4d'),
-            bytes.fromhex('03cdcea66032b82f5c30450e381e5295cae85c5e6943af716cc6b646352a6067dc'),
-            bytes.fromhex('02cd5a5547119e24feaa7c2a0f37b8c9366216bab7054de0065c9be42084003c8a'),
+            # default_committee.public_key,  # not implemented
+            bytes.fromhex('027C84B056C26A7B2458471E6DCF6752EDD96B96887D783334E351DDFE13C4BCA2'),
         ]
+
+        invoke = runner.call_contract(path, 'main')
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        result = invoke.result
         is_committee_member = True
         for pubkey in default_council:
             if pubkey not in result:
@@ -321,19 +513,20 @@ class TestNeoClass(BoaTest):
         self.assertEqual(True, is_committee_member)
 
     def test_get_next_block_validators(self):
-        path = self.get_contract_path('GetNextBlockValidators.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('GetNextBlockValidators.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main')
+        default_committee = neoxp.utils.get_account_by_name('node1')
         consensus_nodes = [
-            bytes.fromhex('03b209fd4f53a7170ea4444e0cb0a6bb6a53c2bd016926989cf85f9b0fba17a70c'),
-            bytes.fromhex('02486fd15702c4490a26703112a5cc1d0923fd697a33406bd5a1c00e0013b09a70'),
-            bytes.fromhex('02ca0e27697b9c248f6f16e085fd0061e26f44da85b58ee835c110caa5ec3ba554'),
-            bytes.fromhex('024c7b7fb6c310fccf1ba33b082519d82964ea93868d676662d4a59ad548df0e7d'),
-            bytes.fromhex('03b8d9d5771d8f513aa0869b9cc8d50986403b78c6da36890638c3d46a5adce04a'),
-            bytes.fromhex('02df48f60e8f3e01c48ff40b9b7f1310d7a8b2a193188befe1c2e3df740e895093'),
-            bytes.fromhex('02aaec38470f6aad0042c6e877cfd8087d2676b0f516fddd362801b9bd3936399e'),
+            # default_committee.public_key,  # not implemented
+            bytes.fromhex('027C84B056C26A7B2458471E6DCF6752EDD96B96887D783334E351DDFE13C4BCA2'),
         ]
+
+        invoke = runner.call_contract(path, 'main')
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        result = invoke.result
         is_consensus_node = True
         for pubkey in consensus_nodes:
             if pubkey not in result:
@@ -341,36 +534,50 @@ class TestNeoClass(BoaTest):
         self.assertEqual(True, is_consensus_node)
 
     def test_get_account_state(self):
-        path = self.get_contract_path('GetAccountState.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('GetAccountState.py')
+        runner = NeoTestRunner()
 
-        account = bytes(range(20))
-        result = self.run_smart_contract(engine, path, 'main', account)
-        self.assertIsNone(result)
+        invokes = []
+        expected_results = []
+
+        account = neoxp.utils.get_account_by_name('testAccount1')
+        account_script_hash = account.script_hash.to_array()
+
+        invokes.append(runner.call_contract(path, 'main', account_script_hash))
+        expected_results.append(None)
 
         # adding votes
         votes = 10000
-        engine.add_neo(account, votes)
-        result = self.run_smart_contract(engine, path, 'main', account)
+        runner.add_neo(account_script_hash, votes)
+        invoke = runner.call_contract(path, 'main', account_script_hash)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        result = invoke.result
         self.assertEqual(3, len(result))
         # number of votes in the account
         self.assertEqual(votes, result[0])
         # balance was changed at height 0
-        self.assertEqual(0, result[1])
+        self.assertEqual(2, result[1])
         # who the account is voting for
         self.assertIsNone(result[2])
 
-        engine.increase_block(10)
-        other_account = bytes(20)
+        runner.increase_block(10)
+        other_account = neoxp.utils.get_account_by_name('testAccount2')
+        other_account_script_hash = other_account.script_hash.to_array()
 
-        path_transfer = self.get_contract_path('Transfer.py')
-
-        self.run_smart_contract(engine, path_transfer, 'main', account, other_account, 1, None,
-                                signer_accounts=[account])
+        runner.call_contract(self.NEO_CONTRACT_NAME, 'transfer',
+                             account_script_hash, other_account_script_hash, 1, None)
         votes = votes - 1
 
-        result = self.run_smart_contract(engine, path, 'main', account)
+        invoke = runner.call_contract(path, 'main', account_script_hash)
+
+        runner.execute(account=account)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        result = invoke.result
         self.assertEqual(3, len(result))
         self.assertEqual(votes, result[0])
-        self.assertEqual(10, result[1])
+        self.assertEqual(2, result[1])
         self.assertIsNone(result[2])

--- a/boa3_test/tests/compiler_tests/test_native/test_policy.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_policy.py
@@ -1,58 +1,83 @@
 from boa3 import constants
 from boa3.exception import CompilerError
+from boa3.neo3.vm import VMState
+from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.boa_test import BoaTest
-from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestPolicyContract(BoaTest):
     default_folder: str = 'test_sc/native_test/policy'
 
     def test_get_hash(self):
-        path = self.get_contract_path('GetHash.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('GetHash.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(constants.POLICY_SCRIPT, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(constants.POLICY_SCRIPT)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_get_exec_fee_factor(self):
-        path = self.get_contract_path('GetExecFeeFactor.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('GetExecFeeFactor.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertIsInstance(result, int)
+        invoke = runner.call_contract(path, 'main')
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        self.assertIsInstance(invoke.result, int)
 
     def test_get_exec_fee_too_many_parameters(self):
         path = self.get_contract_path('GetExecFeeFactorTooManyArguments.py')
         self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
 
     def test_get_fee_per_byte(self):
-        path = self.get_contract_path('GetFeePerByte.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('GetFeePerByte.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertIsInstance(result, int)
+        invoke = runner.call_contract(path, 'main')
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        self.assertIsInstance(invoke.result, int)
 
     def test_get_fee_per_byte_too_many_parameters(self):
         path = self.get_contract_path('GetFeePerByteTooManyArguments.py')
         self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
 
     def test_get_storage_price(self):
-        path = self.get_contract_path('GetStoragePrice.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('GetStoragePrice.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertIsInstance(result, int)
+        invoke = runner.call_contract(path, 'main')
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        self.assertIsInstance(invoke.result, int)
 
     def test_get_storage_price_too_many_parameters(self):
         path = self.get_contract_path('GetStoragePriceTooManyArguments.py')
         self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
 
     def test_is_blocked(self):
-        path = self.get_contract_path('IsBlocked.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('IsBlocked.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', bytes(20))
-        self.assertEqual(False, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', bytes(20)))
+        expected_results.append(False)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_is_blocked_mismatched_type(self):
         path = self.get_contract_path('IsBlockedMismatchedTypeInt.py')

--- a/boa3_test/tests/compiler_tests/test_native/test_rolemanagement.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_rolemanagement.py
@@ -6,19 +6,29 @@ from boa3.neo.vm.opcode.Opcode import Opcode
 from boa3.neo.vm.type.Integer import Integer
 from boa3.neo.vm.type.String import String
 from boa3.neo3.contracts import CallFlags
+from boa3.neo3.vm import VMState
+from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.boa_test import BoaTest
-from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestRoleManagementClass(BoaTest):
     default_folder: str = 'test_sc/native_test/rolemanagement'
 
     def test_get_hash(self):
-        path = self.get_contract_path('GetHash.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('GetHash.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(constants.ROLE_MANAGEMENT, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(constants.ROLE_MANAGEMENT)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_get_designated_by_role(self):
         call_flags = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)

--- a/boa3_test/tests/compiler_tests/test_native/test_stdlib.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_stdlib.py
@@ -4,34 +4,47 @@ from boa3 import constants
 from boa3.exception import CompilerError
 from boa3.neo.vm.type.StackItem import StackItemType, serialize
 from boa3.neo.vm.type.String import String
+from boa3.neo3.vm import VMState
+from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.boa_test import BoaTest
-from boa3_test.tests.test_classes.TestExecutionException import TestExecutionException
-from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestStdlibClass(BoaTest):
     default_folder: str = 'test_sc/native_test/stdlib'
 
     def test_get_hash(self):
-        path = self.get_contract_path('GetHash.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('GetHash.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(constants.STD_LIB_SCRIPT, result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(constants.STD_LIB_SCRIPT)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_base64_encode(self):
         import base64
-        path = self.get_contract_path('Base64Encode.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Base64Encode.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         expected_result = base64.b64encode(b'unit test')
-        result = self.run_smart_contract(engine, path, 'Main', b'unit test',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'Main', b'unit test',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         expected_result = base64.b64encode(b'')
-        result = self.run_smart_contract(engine, path, 'Main', b'',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'Main', b'',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         long_byte_string = (b'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam accumsan magna eu massa '
                             b'vulputate bibendum. Aliquam commodo euismod tristique. Sed purus erat, pretium ut interdum '
@@ -42,9 +55,15 @@ class TestStdlibClass(BoaTest):
                             b'dolor sit amet, consectetur adipiscing elit. Ut tincidunt, nisi in ullamcorper ornare, '
                             b'est enim dictum massa, id aliquet justo magna in purus.')
         expected_result = base64.b64encode(long_byte_string)
-        result = self.run_smart_contract(engine, path, 'Main', long_byte_string,
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'Main', long_byte_string,
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_base64_encode_mismatched_type(self):
         path = self.get_contract_path('Base64EncodeMismatchedType.py')
@@ -52,17 +71,21 @@ class TestStdlibClass(BoaTest):
 
     def test_base64_decode(self):
         import base64
-        path = self.get_contract_path('Base64Decode.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Base64Decode.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         arg = String.from_bytes(base64.b64encode(b'unit test'))
-        result = self.run_smart_contract(engine, path, 'Main', arg,
-                                         expected_result_type=bytes)
-        self.assertEqual(b'unit test', result)
+        invokes.append(runner.call_contract(path, 'Main', arg,
+                                            expected_result_type=bytes))
+        expected_results.append(b'unit test')
 
         arg = String.from_bytes(base64.b64encode(b''))
-        result = self.run_smart_contract(engine, path, 'Main', arg,
-                                         expected_result_type=bytes)
-        self.assertEqual(b'', result)
+        invokes.append(runner.call_contract(path, 'Main', arg,
+                                            expected_result_type=bytes))
+        expected_results.append(b'')
 
         long_string = ('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam accumsan magna eu massa '
                        'vulputate bibendum. Aliquam commodo euismod tristique. Sed purus erat, pretium ut interdum '
@@ -73,9 +96,15 @@ class TestStdlibClass(BoaTest):
                        'dolor sit amet, consectetur adipiscing elit. Ut tincidunt, nisi in ullamcorper ornare, '
                        'est enim dictum massa, id aliquet justo magna in purus.')
         arg = String.from_bytes(base64.b64encode(String(long_string).to_bytes()))
-        result = self.run_smart_contract(engine, path, 'Main', arg,
-                                         expected_result_type=bytes)
-        self.assertEqual(String(long_string).to_bytes(), result)
+        invokes.append(runner.call_contract(path, 'Main', arg,
+                                            expected_result_type=bytes))
+        expected_results.append(String(long_string).to_bytes())
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_base64_decode_mismatched_type(self):
         path = self.get_contract_path('Base64DecodeMismatchedType.py')
@@ -83,17 +112,21 @@ class TestStdlibClass(BoaTest):
 
     def test_base58_encode(self):
         import base58
-        path = self.get_contract_path('Base58Encode.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Base58Encode.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         expected_result = base58.b58encode('unit test')
-        result = self.run_smart_contract(engine, path, 'Main', 'unit test',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'Main', 'unit test',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         expected_result = base58.b58encode('')
-        result = self.run_smart_contract(engine, path, 'Main', '',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'Main', '',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         long_string = ('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam accumsan magna eu massa '
                        'vulputate bibendum. Aliquam commodo euismod tristique. Sed purus erat, pretium ut interdum '
@@ -104,9 +137,15 @@ class TestStdlibClass(BoaTest):
                        'dolor sit amet, consectetur adipiscing elit. Ut tincidunt, nisi in ullamcorper ornare, '
                        'est enim dictum massa, id aliquet justo magna in purus.')
         expected_result = base58.b58encode(long_string)
-        result = self.run_smart_contract(engine, path, 'Main', long_string,
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'Main', long_string,
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_base58_encode_mismatched_type(self):
         path = self.get_contract_path('Base58EncodeMismatchedType.py')
@@ -114,15 +153,19 @@ class TestStdlibClass(BoaTest):
 
     def test_base58_decode(self):
         import base58
-        path = self.get_contract_path('Base58Decode.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Base58Decode.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         arg = base58.b58encode('unit test')
-        result = self.run_smart_contract(engine, path, 'Main', arg)
-        self.assertEqual('unit test', result)
+        invokes.append(runner.call_contract(path, 'Main', arg))
+        expected_results.append('unit test')
 
         arg = base58.b58encode('')
-        result = self.run_smart_contract(engine, path, 'Main', arg)
-        self.assertEqual('', result)
+        invokes.append(runner.call_contract(path, 'Main', arg))
+        expected_results.append('')
 
         long_string = ('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam accumsan magna eu massa '
                        'vulputate bibendum. Aliquam commodo euismod tristique. Sed purus erat, pretium ut interdum '
@@ -133,8 +176,14 @@ class TestStdlibClass(BoaTest):
                        'dolor sit amet, consectetur adipiscing elit. Ut tincidunt, nisi in ullamcorper ornare, '
                        'est enim dictum massa, id aliquet justo magna in purus.')
         arg = base58.b58encode(long_string)
-        result = self.run_smart_contract(engine, path, 'Main', arg)
-        self.assertEqual(long_string, result)
+        invokes.append(runner.call_contract(path, 'Main', arg))
+        expected_results.append(long_string)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_base58_decode_mismatched_type(self):
         path = self.get_contract_path('Base58DecodeMismatchedType.py')
@@ -142,15 +191,19 @@ class TestStdlibClass(BoaTest):
 
     def test_base58_check_decode(self):
         import base58
-        path = self.get_contract_path('Base58CheckDecode.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Base58CheckDecode.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         arg = base58.b58encode_check('unit test'.encode('utf-8'))
-        result = self.run_smart_contract(engine, path, 'main', arg)
-        self.assertEqual('unit test', result)
+        invokes.append(runner.call_contract(path, 'main', arg))
+        expected_results.append('unit test')
 
         arg = base58.b58encode_check(''.encode('utf-8'))
-        result = self.run_smart_contract(engine, path, 'main', arg)
-        self.assertEqual('', result)
+        invokes.append(runner.call_contract(path, 'main', arg))
+        expected_results.append('')
 
         long_string = ('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam accumsan magna eu massa '
                        'vulputate bibendum. Aliquam commodo euismod tristique. Sed purus erat, pretium ut interdum '
@@ -161,8 +214,14 @@ class TestStdlibClass(BoaTest):
                        'dolor sit amet, consectetur adipiscing elit. Ut tincidunt, nisi in ullamcorper ornare, '
                        'est enim dictum massa, id aliquet justo magna in purus.')
         arg = base58.b58encode_check(long_string.encode('utf-8'))
-        result = self.run_smart_contract(engine, path, 'main', arg)
-        self.assertEqual(long_string, result)
+        invokes.append(runner.call_contract(path, 'main', arg))
+        expected_results.append(long_string)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_base58_check_decode_mismatched_type(self):
         path = self.get_contract_path('Base58CheckDecodeMismatchedType.py')
@@ -170,17 +229,21 @@ class TestStdlibClass(BoaTest):
 
     def test_base58_check_encode(self):
         import base58
-        path = self.get_contract_path('Base58CheckEncode.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Base58CheckEncode.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
         expected_result = base58.b58encode_check('unit test'.encode('utf-8'))
-        result = self.run_smart_contract(engine, path, 'main', 'unit test',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'main', 'unit test',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         expected_result = base58.b58encode_check(''.encode('utf-8'))
-        result = self.run_smart_contract(engine, path, 'main', '',
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'main', '',
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         long_string = ('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam accumsan magna eu massa '
                        'vulputate bibendum. Aliquam commodo euismod tristique. Sed purus erat, pretium ut interdum '
@@ -191,234 +254,421 @@ class TestStdlibClass(BoaTest):
                        'dolor sit amet, consectetur adipiscing elit. Ut tincidunt, nisi in ullamcorper ornare, '
                        'est enim dictum massa, id aliquet justo magna in purus.')
         expected_result = base58.b58encode_check(long_string.encode('utf-8'))
-        result = self.run_smart_contract(engine, path, 'main', long_string,
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'main', long_string,
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_base58_check_encode_mismatched_type(self):
         path = self.get_contract_path('Base58CheckEncodeMismatchedType.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_serialize_int(self):
-        path = self.get_contract_path('SerializeInt.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'serialize_int',
-                                         expected_result_type=bytes)
+        path, _ = self.get_deploy_file_paths('SerializeInt.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'serialize_int',
+                                            expected_result_type=bytes))
         expected_result = serialize(42)
-        self.assertEqual(expected_result, result)
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_serialize_bool(self):
-        path = self.get_contract_path('SerializeBool.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'serialize_bool',
-                                         expected_result_type=bytes)
+        path, _ = self.get_deploy_file_paths('SerializeBool.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'serialize_bool',
+                                            expected_result_type=bytes))
         expected_result = serialize(True)
-        self.assertEqual(expected_result, result)
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_serialize_str(self):
-        path = self.get_contract_path('SerializeStr.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'serialize_str',
-                                         expected_result_type=bytes)
+        path, _ = self.get_deploy_file_paths('SerializeStr.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'serialize_str',
+                                            expected_result_type=bytes))
         expected_result = serialize('42')
-        self.assertEqual(expected_result, result)
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_serialize_sequence(self):
-        path = self.get_contract_path('SerializeSequence.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'serialize_sequence',
-                                         expected_result_type=bytes)
+        path, _ = self.get_deploy_file_paths('SerializeSequence.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'serialize_sequence',
+                                            expected_result_type=bytes))
         expected_result = serialize([2, 3, 5, 7])
-        self.assertEqual(expected_result, result)
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_serialize_dict(self):
-        path = self.get_contract_path('SerializeDict.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'serialize_dict',
-                                         expected_result_type=bytes)
+        path, _ = self.get_deploy_file_paths('SerializeDict.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'serialize_dict',
+                                            expected_result_type=bytes))
         expected_result = serialize({1: 1, 2: 1, 3: 2})
-        self.assertEqual(expected_result, result)
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_deserialize(self):
-        path = self.get_contract_path('Deserialize.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Deserialize.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         expected_result = 42
         value = serialize(expected_result)
-        result = self.run_smart_contract(engine, path, 'deserialize_arg', value,
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'deserialize_arg', value,
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         expected_result = True
         value = serialize(expected_result)
-        result = self.run_smart_contract(engine, path, 'deserialize_arg', value)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'deserialize_arg', value))
+        expected_results.append(expected_result)
 
         value = StackItemType.Boolean + value[1:]
-        result = self.run_smart_contract(engine, path, 'deserialize_arg', value)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'deserialize_arg', value))
+        expected_results.append(expected_result)
 
         expected_result = '42'
         value = serialize(expected_result)
-        result = self.run_smart_contract(engine, path, 'deserialize_arg', value)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'deserialize_arg', value))
+        expected_results.append(expected_result)
 
         expected_result = b'42'
         value = serialize(expected_result)
-        result = self.run_smart_contract(engine, path, 'deserialize_arg', value,
-                                         expected_result_type=bytes)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'deserialize_arg', value,
+                                            expected_result_type=bytes))
+        expected_results.append(expected_result)
 
         expected_result = [1, '2', b'3']
         value = serialize(expected_result)
-        result = self.run_smart_contract(engine, path, 'deserialize_arg', value)
+        invokes.append(runner.call_contract(path, 'deserialize_arg', value))
         expected_result[2] = String.from_bytes(expected_result[2])
-        self.assertEqual(expected_result, result)
+        expected_results.append(expected_result)
 
         expected_result = {'int': 1, 'str': '2', 'bytes': b'3'}
         value = serialize(expected_result)
-        result = self.run_smart_contract(engine, path, 'deserialize_arg', value)
+        invokes.append(runner.call_contract(path, 'deserialize_arg', value))
         expected_result['bytes'] = String.from_bytes(expected_result['bytes'])
-        self.assertEqual(expected_result, result)
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_deserialize_mismatched_type(self):
         path = self.get_contract_path('DeserializeMismatchedType.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_json_serialize(self):
-        path = self.get_contract_path('JsonSerialize.py')
+        path, _ = self.get_deploy_file_paths('JsonSerialize.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
+        invokes = []
+        expected_results = []
+
         test_input = {"one": 1, "two": 2, "three": 3}
         expected_result = json.dumps(test_input, separators=(',', ':'))
-        result = self.run_smart_contract(engine, path, 'main', test_input)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'main', test_input))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_json_serialize_int(self):
-        path = self.get_contract_path('JsonSerializeInt.py')
+        path, _ = self.get_deploy_file_paths('JsonSerializeInt.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
+        invokes = []
+        expected_results = []
+
         expected_result = json.dumps(10)
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_json_serialize_bool(self):
-        path = self.get_contract_path('JsonSerializeBool.py')
+        path, _ = self.get_deploy_file_paths('JsonSerializeBool.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
+        invokes = []
+        expected_results = []
+
         expected_result = json.dumps(True)
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_json_serialize_str(self):
-        path = self.get_contract_path('JsonSerializeStr.py')
+        path, _ = self.get_deploy_file_paths('JsonSerializeStr.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
+        invokes = []
+        expected_results = []
+
         expected_result = json.dumps('unit test')
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_json_serialize_bytes(self):
-        path = self.get_contract_path('JsonSerializeBytes.py')
+        path, _ = self.get_deploy_file_paths('JsonSerializeBytes.py')
+        runner = NeoTestRunner()
 
-        engine = TestEngine()
+        invokes = []
+        expected_results = []
+
         # Python does not accept bytes as parameter for json.dumps() method, since string and bytes ends up being the
         # same on Neo, it's being converted to string, before using dumps
         expected_result = json.dumps(String().from_bytes(b'unit test'))
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_json_deserialize(self):
-        path = self.get_contract_path('JsonDeserialize.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('JsonDeserialize.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         test_input = json.dumps(12345)
         expected_result = json.loads(test_input)
-        result = self.run_smart_contract(engine, path, 'main', test_input)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'main', test_input))
+        expected_results.append(expected_result)
 
         test_input = json.dumps('unit test')
         expected_result = json.loads(test_input)
-        result = self.run_smart_contract(engine, path, 'main', test_input)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'main', test_input))
+        expected_results.append(expected_result)
 
         test_input = json.dumps(True)
         expected_result = json.loads(test_input)
-        result = self.run_smart_contract(engine, path, 'main', test_input)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'main', test_input))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_boa2_serialization_test1(self):
-        path = self.get_contract_path('SerializationBoa2Test.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', 1, expected_result_type=bytes)
+        path, _ = self.get_deploy_file_paths('SerializationBoa2Test.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', 1, expected_result_type=bytes))
         expected_result = serialize(['a', 3, ['j', 3, 5], 'jk', 'lmnopqr'])
-        self.assertEqual(expected_result, result)
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_boa2_serialization_test2(self):
-        path = self.get_contract_path('SerializationBoa2Test.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', 2, expected_result_type=bytes)
+        path, _ = self.get_deploy_file_paths('SerializationBoa2Test.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', 2, expected_result_type=bytes))
         expected_result = serialize(['a', 3, ['j', 3, 5], 'jk', 'lmnopqr'])
-        self.assertEqual(expected_result, result)
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_boa2_serialization_test3(self):
-        path = self.get_contract_path('SerializationBoa2Test.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', 3)
-        self.assertEqual(['a', 3, ['j', 3, 5], 'jk', 'lmnopqr'], result)
+        path, _ = self.get_deploy_file_paths('SerializationBoa2Test.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', 3))
+        expected_results.append(['a', 3, ['j', 3, 5], 'jk', 'lmnopqr'])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_boa2_serialization_test4(self):
-        path = self.get_contract_path('SerializationBoa2Test.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'main', 4)
-        self.assertEqual(['j', 3, 5], result)
+        path, _ = self.get_deploy_file_paths('SerializationBoa2Test.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', 4))
+        expected_results.append(['j', 3, 5])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_atoi(self):
-        path = self.get_contract_path('Atoi.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Atoi.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', '10', 10)
-        self.assertEqual(10, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', '10', 16)
-        self.assertEqual(16, result)
+        invokes.append(runner.call_contract(path, 'main', '10', 10))
+        expected_results.append(10)
 
-        result = self.run_smart_contract(engine, path, 'main', '123', 10)
-        self.assertEqual(123, result)
+        invokes.append(runner.call_contract(path, 'main', '10', 16))
+        expected_results.append(16)
 
-        result = self.run_smart_contract(engine, path, 'main', '123', 16)
-        self.assertEqual(291, result)
+        invokes.append(runner.call_contract(path, 'main', '123', 10))
+        expected_results.append(123)
 
-        result = self.run_smart_contract(engine, path, 'main', '1f', 16)
-        self.assertEqual(31, result)
+        invokes.append(runner.call_contract(path, 'main', '123', 16))
+        expected_results.append(291)
 
-        result = self.run_smart_contract(engine, path, 'main', 'ff', 16)
-        self.assertEqual(-1, result)
+        invokes.append(runner.call_contract(path, 'main', '1f', 16))
+        expected_results.append(31)
 
-        with self.assertRaisesRegex(TestExecutionException, self.CANT_PARSE_VALUE_MSG):
-            self.run_smart_contract(engine, path, 'main', 'string', 10)
+        invokes.append(runner.call_contract(path, 'main', 'ff', 16))
+        expected_results.append(-1)
 
-        with self.assertRaisesRegex(TestExecutionException, self.CANT_PARSE_VALUE_MSG):
-            self.run_smart_contract(engine, path, 'main', 'string', 16)
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
-        with self.assertRaisesRegex(TestExecutionException, self.CANT_PARSE_VALUE_MSG):
-            self.run_smart_contract(engine, path, 'main', 'abc', 10)
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
-        with self.assertRaisesRegex(TestExecutionException, f'^{self.ARGUMENT_OUT_OF_RANGE_MSG_PREFIX}'):
-            self.run_smart_contract(engine, path, 'main', '10', 2)
+        runner.call_contract(path, 'main', 'string', 10)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.CANT_PARSE_VALUE_MSG)
+
+        runner.call_contract(path, 'main', 'string', 16)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.CANT_PARSE_VALUE_MSG)
+
+        runner.call_contract(path, 'main', 'abc', 10)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.CANT_PARSE_VALUE_MSG)
+
+        runner.call_contract(path, 'main', '10', 2)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'^{self.ARGUMENT_OUT_OF_RANGE_MSG_PREFIX}')
 
     def test_atoi_default(self):
-        path = self.get_contract_path('AtoiDefault.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('AtoiDefault.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', '10')
-        self.assertEqual(10, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', '123')
-        self.assertEqual(123, result)
+        invokes.append(runner.call_contract(path, 'main', '10'))
+        expected_results.append(10)
 
-        with self.assertRaisesRegex(TestExecutionException, self.CANT_PARSE_VALUE_MSG):
-            self.run_smart_contract(engine, path, 'main', 'string')
+        invokes.append(runner.call_contract(path, 'main', '123'))
+        expected_results.append(123)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        runner.call_contract(path, 'main', 'string')
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, self.CANT_PARSE_VALUE_MSG)
 
     def test_atoi_too_few_parameters(self):
         path = self.get_contract_path('AtoiTooFewArguments.py')
@@ -433,31 +683,51 @@ class TestStdlibClass(BoaTest):
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_itoa(self):
-        path = self.get_contract_path('Itoa')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('Itoa')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', 10, 10)
-        self.assertEqual('10', result)
-        result = self.run_smart_contract(engine, path, 'main', 16, 16)
-        self.assertEqual('10', result)
-        result = self.run_smart_contract(engine, path, 'main', -1, 10)
-        self.assertEqual('-1', result)
-        result = self.run_smart_contract(engine, path, 'main', -1, 16)
-        self.assertEqual('f', result)
-        result = self.run_smart_contract(engine, path, 'main', 15, 16)
-        self.assertEqual('0f', result)
+        invokes = []
+        expected_results = []
 
-        with self.assertRaisesRegex(TestExecutionException, f'^{self.ARGUMENT_OUT_OF_RANGE_MSG_PREFIX}'):
-            self.run_smart_contract(engine, path, 'main', 10, 2)
+        invokes.append(runner.call_contract(path, 'main', 10, 10))
+        expected_results.append('10')
+        invokes.append(runner.call_contract(path, 'main', 16, 16))
+        expected_results.append('10')
+        invokes.append(runner.call_contract(path, 'main', -1, 10))
+        expected_results.append('-1')
+        invokes.append(runner.call_contract(path, 'main', -1, 16))
+        expected_results.append('f')
+        invokes.append(runner.call_contract(path, 'main', 15, 16))
+        expected_results.append('0f')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        runner.call_contract(path, 'main', 10, 2)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'^{self.ARGUMENT_OUT_OF_RANGE_MSG_PREFIX}')
 
     def test_itoa_default(self):
-        path = self.get_contract_path('ItoaDefault')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ItoaDefault')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', 10)
-        self.assertEqual('10', result)
-        result = self.run_smart_contract(engine, path, 'main', -1)
-        self.assertEqual('-1', result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', 10))
+        expected_results.append('10')
+        invokes.append(runner.call_contract(path, 'main', -1))
+        expected_results.append('-1')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_itoa_too_few_arguments(self):
         path = self.get_contract_path('ItoaTooFewArguments')
@@ -472,134 +742,176 @@ class TestStdlibClass(BoaTest):
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_memory_search(self):
-        path = self.get_contract_path('MemorySearch')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('MemorySearch')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', 'abcde', 'a', 0, False)
-        self.assertEqual(0, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'a', 0, False)
-        self.assertEqual(0, result)
+        invokes.append(runner.call_contract(path, 'main', 'abcde', 'a', 0, False))
+        expected_results.append(0)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'b', 0, False)
-        self.assertEqual(1, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'a', 0, False))
+        expected_results.append(0)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'c', 0, False)
-        self.assertEqual(2, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'b', 0, False))
+        expected_results.append(1)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'd', 0, False)
-        self.assertEqual(3, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'c', 0, False))
+        expected_results.append(2)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'e', 0, False)
-        self.assertEqual(4, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'd', 0, False))
+        expected_results.append(3)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'a', 1, False)
-        self.assertEqual(-1, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'e', 0, False))
+        expected_results.append(4)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'cd', 0, False)
-        self.assertEqual(2, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'a', 1, False))
+        expected_results.append(-1)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'abe', 0, False)
-        self.assertEqual(-1, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'cd', 0, False))
+        expected_results.append(2)
 
-        result = self.run_smart_contract(engine, path, 'main', b'aaaaa', b'a', 0, False)
-        self.assertEqual(0, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'abe', 0, False))
+        expected_results.append(-1)
 
-        with self.assertRaisesRegex(TestExecutionException, f'^{self.ARGUMENT_OUT_OF_RANGE_MSG_PREFIX}'):
-            self.run_smart_contract(engine, path, 'main', b'abcde', b'a', 20, False)
+        invokes.append(runner.call_contract(path, 'main', b'aaaaa', b'a', 0, False))
+        expected_results.append(0)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        runner.call_contract(path, 'main', b'abcde', b'a', 20, False)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'^{self.ARGUMENT_OUT_OF_RANGE_MSG_PREFIX}')
 
     def test_memory_search_backward(self):
-        path = self.get_contract_path('MemorySearch')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('MemorySearch')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', 'abcde', 'a', 5, True)
-        self.assertEqual(0, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'a', 5, True)
-        self.assertEqual(0, result)
+        invokes.append(runner.call_contract(path, 'main', 'abcde', 'a', 5, True))
+        expected_results.append(0)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'b', 5, True)
-        self.assertEqual(1, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'a', 5, True))
+        expected_results.append(0)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'c', 5, True)
-        self.assertEqual(2, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'b', 5, True))
+        expected_results.append(1)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'd', 5, True)
-        self.assertEqual(3, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'c', 5, True))
+        expected_results.append(2)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'e', 5, True)
-        self.assertEqual(4, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'd', 5, True))
+        expected_results.append(3)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'a', 0, True)
-        self.assertEqual(-1, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'e', 5, True))
+        expected_results.append(4)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'cd', 5, True)
-        self.assertEqual(2, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'a', 0, True))
+        expected_results.append(-1)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'abe', 5, True)
-        self.assertEqual(-1, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'cd', 5, True))
+        expected_results.append(2)
 
-        result = self.run_smart_contract(engine, path, 'main', b'aaaaa', b'a', 5, True)
-        self.assertEqual(4, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'abe', 5, True))
+        expected_results.append(-1)
 
-        with self.assertRaisesRegex(TestExecutionException, f'^{self.ARGUMENT_OUT_OF_RANGE_MSG_PREFIX}'):
-            self.run_smart_contract(engine, path, 'main', b'abcde', b'a', 20, True)
+        invokes.append(runner.call_contract(path, 'main', b'aaaaa', b'a', 5, True))
+        expected_results.append(4)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        runner.call_contract(path, 'main', b'abcde', b'a', 20, True)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'^{self.ARGUMENT_OUT_OF_RANGE_MSG_PREFIX}')
 
     def test_memory_search_start(self):
-        path = self.get_contract_path('MemorySearchStart')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('MemorySearchStart')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', 'abcde', 'a', 0)
-        self.assertEqual(0, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'a', 0)
-        self.assertEqual(0, result)
+        invokes.append(runner.call_contract(path, 'main', 'abcde', 'a', 0))
+        expected_results.append(0)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'e', 0)
-        self.assertEqual(4, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'a', 0))
+        expected_results.append(0)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'a', 1)
-        self.assertEqual(-1, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'e', 0))
+        expected_results.append(4)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'cd', 0)
-        self.assertEqual(2, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'a', 1))
+        expected_results.append(-1)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'abe', 0)
-        self.assertEqual(-1, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'cd', 0))
+        expected_results.append(2)
 
-        result = self.run_smart_contract(engine, path, 'main', b'aaaaa', b'a', 0)
-        self.assertEqual(0, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'abe', 0))
+        expected_results.append(-1)
 
-        with self.assertRaisesRegex(TestExecutionException, f'^{self.ARGUMENT_OUT_OF_RANGE_MSG_PREFIX}'):
-            self.run_smart_contract(engine, path, 'main', b'abcde', b'a', 20)
+        invokes.append(runner.call_contract(path, 'main', b'aaaaa', b'a', 0))
+        expected_results.append(0)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        runner.call_contract(path, 'main', b'abcde', b'a', 20)
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state)
+        self.assertRegex(runner.error, f'^{self.ARGUMENT_OUT_OF_RANGE_MSG_PREFIX}')
 
     def test_memory_search_default_values(self):
-        path = self.get_contract_path('MemorySearchDefault')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('MemorySearchDefault')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', 'abcde', 'a')
-        self.assertEqual(0, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'a')
-        self.assertEqual(0, result)
+        invokes.append(runner.call_contract(path, 'main', 'abcde', 'a'))
+        expected_results.append(0)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'b')
-        self.assertEqual(1, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'a'))
+        expected_results.append(0)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'c')
-        self.assertEqual(2, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'b'))
+        expected_results.append(1)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'd')
-        self.assertEqual(3, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'c'))
+        expected_results.append(2)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'e')
-        self.assertEqual(4, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'd'))
+        expected_results.append(3)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'cd')
-        self.assertEqual(2, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'e'))
+        expected_results.append(4)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abcde', b'aa')
-        self.assertEqual(-1, result)
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'cd'))
+        expected_results.append(2)
+
+        invokes.append(runner.call_contract(path, 'main', b'abcde', b'aa'))
+        expected_results.append(-1)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_memory_search_mismatched_type(self):
         path = self.get_contract_path('MemorySearchMismatchedType.py')
@@ -614,26 +926,35 @@ class TestStdlibClass(BoaTest):
         self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
 
     def test_memory_compare(self):
-        path = self.get_contract_path('MemoryCompare')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('MemoryCompare')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'main', 'abc', 'abc')
-        self.assertEqual(0, result)
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'main', 'abc', 'ABC')
-        self.assertEqual(1, result)
+        invokes.append(runner.call_contract(path, 'main', 'abc', 'abc'))
+        expected_results.append(0)
 
-        result = self.run_smart_contract(engine, path, 'main', 'ABC', 'abc')
-        self.assertEqual(-1, result)
+        invokes.append(runner.call_contract(path, 'main', 'abc', 'ABC'))
+        expected_results.append(1)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abc', b'abc')
-        self.assertEqual(0, result)
+        invokes.append(runner.call_contract(path, 'main', 'ABC', 'abc'))
+        expected_results.append(-1)
 
-        result = self.run_smart_contract(engine, path, 'main', b'abc', b'ABC')
-        self.assertEqual(1, result)
+        invokes.append(runner.call_contract(path, 'main', b'abc', b'abc'))
+        expected_results.append(0)
 
-        result = self.run_smart_contract(engine, path, 'main', b'ABC', b'abc')
-        self.assertEqual(-1, result)
+        invokes.append(runner.call_contract(path, 'main', b'abc', b'ABC'))
+        expected_results.append(1)
+
+        invokes.append(runner.call_contract(path, 'main', b'ABC', b'abc'))
+        expected_results.append(-1)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_memory_compare_too_few_parameters(self):
         path = self.get_contract_path('MemoryCompareTooFewArguments.py')

--- a/boa3_test/tests/test_app_tests/test_test_runner.py
+++ b/boa3_test/tests/test_app_tests/test_test_runner.py
@@ -1,7 +1,7 @@
 from boa3.neo.vm.type.AbiType import AbiType
 from boa3.neo.vm.type.String import String
 from boa3.neo3.vm import VMState
-from boa3_test.test_drive.model.invoker import neoinvokeresult
+from boa3_test.test_drive.model.invoker import invokeresult
 from boa3_test.test_drive.testrunner import utils
 from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.boa_test import BoaTest
@@ -14,7 +14,7 @@ class TestTestRunner(BoaTest):
         runner = NeoTestRunner()
 
         invoke_result = runner.call_contract(path, 'Sub', 50, 20)
-        self.assertEqual(neoinvokeresult.NOT_EXECUTED, invoke_result.result)
+        self.assertEqual(invokeresult.NOT_EXECUTED, invoke_result.result)
 
         runner.execute()
         self.assertEqual(VMState.HALT, runner.vm_state)


### PR DESCRIPTION
**Summary or solution description**
Part of an overall refactoring. 
Changed the execution tests of the compiled smart contracts related to Neo Native Contracts to use TestRunner instead of TestEngine

**Tests**
Rerun the modified unit tests
