### PR TITLE
Don't compile where there are internal errors during code generation

### DIFF
--- a/boa3/analyser/analyser.py
+++ b/boa3/analyser/analyser.py
@@ -127,7 +127,7 @@ class Analyser:
         :return: a boolean value that represents if the analysis was successful
         """
         type_analyser = TypeAnalyser(self, self.symbol_table, log=self._log)
-        self.__update_logs(type_analyser)
+        self._update_logs(type_analyser)
         return not type_analyser.has_errors
 
     def __analyse_modules(self,
@@ -147,7 +147,7 @@ class Analyser:
                                          import_stack=import_stack)
         self.symbol_table.update(module_analyser.global_symbols)
         self.ast_tree.body.extend(module_analyser.imported_nodes)
-        self.__update_logs(module_analyser)
+        self._update_logs(module_analyser)
         self._imported_files = module_analyser.analysed_files.copy()
 
         if self.metadata != current_metadata:
@@ -162,10 +162,10 @@ class Analyser:
         :return: a boolean value that represents if the analysis was successful
         """
         standards_analyser = StandardAnalyser(self, self.symbol_table, log=self._log)
-        self.__update_logs(standards_analyser)
+        self._update_logs(standards_analyser)
         return not standards_analyser.has_errors
 
-    def __update_logs(self, analyser: IAstAnalyser):
+    def _update_logs(self, analyser: IAstAnalyser):
         self._errors.extend(analyser.errors)
         self._warnings.extend(analyser.warnings)
 
@@ -180,7 +180,7 @@ class Analyser:
         Tries to optimize the ast after validations
         """
         optimizer = AstOptimizer(self, log=self._log)
-        self.__update_logs(optimizer)
+        self._update_logs(optimizer)
 
     def update_symbol_table(self, symbol_table: Dict[str, ISymbol]):
         for symbol_id, symbol in symbol_table.items():

--- a/boa3/compiler/codegenerator/codegenerator.py
+++ b/boa3/compiler/codegenerator/codegenerator.py
@@ -73,7 +73,7 @@ class CodeGenerator:
 
         visitor = VisitorCodeGenerator(generator, analyser.filename)
         visitor._root_module = analyser.ast_tree
-        visitor.visit(analyser.ast_tree)
+        visitor.visit_and_update_analyser(analyser.ast_tree, analyser)
 
         analyser.update_symbol_table(generator.symbol_table)
         generator.symbol_table.clear()
@@ -87,7 +87,7 @@ class CodeGenerator:
                 deploy_origin_module = symbol.ast
 
             visitor.set_filename(symbol.origin)
-            visitor.visit(symbol.ast)
+            visitor.visit_and_update_analyser(symbol.ast, analyser)
 
             analyser.update_symbol_table(symbol.all_symbols)
             generator.symbol_table.clear()
@@ -115,7 +115,7 @@ class CodeGenerator:
             generator.symbol_table[constants.DEPLOY_METHOD_ID] = deploy_method
             analyser.symbol_table[constants.DEPLOY_METHOD_ID] = deploy_method
             visitor._tree = deploy_origin_module
-            visitor.visit(deploy_ast)
+            visitor.visit_and_update_analyser(deploy_ast, analyser)
 
             generator.symbol_table.clear()
             generator.symbol_table.update(analyser.symbol_table.copy())
@@ -125,7 +125,7 @@ class CodeGenerator:
         if len(visitor.global_stmts) > 0:
             global_ast = ast.parse("")
             global_ast.body = visitor.global_stmts
-            visitor.visit(global_ast)
+            visitor.visit_and_update_analyser(global_ast, analyser)
             generator.initialized_static_fields = True
 
         analyser.update_symbol_table(generator.symbol_table)

--- a/boa3/compiler/codegenerator/codegeneratorvisitor.py
+++ b/boa3/compiler/codegenerator/codegeneratorvisitor.py
@@ -92,6 +92,12 @@ class VisitorCodeGenerator(IAstAnalyser):
 
         return GeneratorData(origin_node, symbol_id, symbol, result_type, index, origin_object_type, already_generated)
 
+    def visit_and_update_analyser(self, node: ast.AST, target_analyser) -> GeneratorData:
+        result = self.visit(node)
+        if hasattr(target_analyser, '_update_logs'):
+            target_analyser._update_logs(self)
+        return result
+
     def visit(self, node: ast.AST) -> GeneratorData:
         result = super().visit(node)
         if not isinstance(result, GeneratorData):

--- a/boa3/compiler/compiler.py
+++ b/boa3/compiler/compiler.py
@@ -82,6 +82,10 @@ class Compiler:
             raise NotLoadedException
         analyser = self._analyser.copy()
         result = CodeGenerator.generate_code(analyser)
+
+        if len(analyser.errors) > 0:
+            # should not succeed if there are unexpected internal errors during code generation
+            raise NotLoadedException
         if len(result.bytecode) == 0:
             raise NotLoadedException(empty_script=True)
 


### PR DESCRIPTION
**Summary or solution description**
When there were unexpected errors during the code generator, the compilation process wouldn't stop. This caused incorrectly generated code that could fail during execution after the contract is compiled.
Changed the code generator specialized class to check if there are new errors logged before generating the output files