### PR TITLE
Using variables with the same name on different scopes is bugged

### DIFF
--- a/boa3/compiler/codegenerator/variablegenerationdata.py
+++ b/boa3/compiler/codegenerator/variablegenerationdata.py
@@ -1,0 +1,14 @@
+import ast
+from typing import Optional
+
+
+class VariableGenerationData:
+    def __init__(self, var_id: str, index: Optional[ast.AST], address: int):
+        self.var_id: str = var_id
+        self.index: Optional[ast.AST] = index
+        self.address: int = address
+
+    def __iter__(self):
+        yield self.var_id
+        yield self.index
+        yield self.address

--- a/boa3/internal/compiler/codegenerator/codegenerator.py
+++ b/boa3/internal/compiler/codegenerator/codegenerator.py
@@ -1899,7 +1899,7 @@ class CodeGenerator:
 
             if load:
                 self.convert_literal(index)
-                self.convert_get_item()
+                self.convert_get_item(index_inserted_internally=True)
 
             return index
 

--- a/boa3/internal/compiler/codegenerator/codegeneratorvisitor.py
+++ b/boa3/internal/compiler/codegenerator/codegeneratorvisitor.py
@@ -1025,9 +1025,11 @@ class VisitorCodeGenerator(IAstAnalyser):
                 symbol = None
                 result_type = None
                 symbol_index = None
-                is_load_context_instance_variable = isinstance(attribute.ctx, ast.Load) and isinstance(attr, Variable) and value_data.symbol_id == 'self'
+                is_load_context_variable_from_class = (isinstance(attribute.ctx, ast.Load) and
+                                                       isinstance(attr, Variable) and
+                                                       isinstance(result, UserClass))
 
-                if self.generator.bytecode_size > current_bytecode_size and isinstance(result, UserClass) and not is_load_context_instance_variable:
+                if self.generator.bytecode_size > current_bytecode_size and isinstance(result, UserClass) and not is_load_context_variable_from_class:
                     # it was generated already, don't convert again
                     generated = False
                     symbol_id = attribute.attr if isinstance(generation_result, Variable) else class_attr_id

--- a/boa3_test/test_sc/variable_test/VariablesWithSameName.py
+++ b/boa3_test/test_sc/variable_test/VariablesWithSameName.py
@@ -1,0 +1,19 @@
+from boa3.builtin.compile_time import public
+
+
+class Example:
+    def __init__(self):
+        self.var_1 = 'example'
+
+    def test(self) -> str:
+        var_1 = 'example 2'
+        if len(self.var_1) > 0:
+            return self.var_1
+        return var_1
+
+
+@public
+def main() -> str:
+    var_1 = Example()
+
+    return var_1.test()

--- a/boa3_test/test_sc/variable_test/VariablesWithSameNameClassVariableAndLocal.py
+++ b/boa3_test/test_sc/variable_test/VariablesWithSameNameClassVariableAndLocal.py
@@ -1,0 +1,19 @@
+from boa3.builtin.compile_time import public
+
+
+class Example:
+    var_1 = 'example'
+
+    @classmethod
+    def test(cls) -> str:
+        var_1 = 'example 2'
+        if len(cls.var_1) > 0:
+            return cls.var_1
+        return var_1
+
+
+@public
+def main() -> str:
+    a = Example()
+
+    return a.test()

--- a/boa3_test/test_sc/variable_test/VariablesWithSameNameInstanceAndLocal.py
+++ b/boa3_test/test_sc/variable_test/VariablesWithSameNameInstanceAndLocal.py
@@ -1,0 +1,18 @@
+from boa3.builtin.compile_time import public
+
+
+class Example:
+    def __init__(self):
+        self.var_1 = 'example'
+
+    def test(self) -> str:
+        var_1 = 'example 2'
+        if len(self.var_1) > 0:
+            return self.var_1
+        return var_1
+
+
+@public
+def main() -> str:
+    a = Example()
+    return a.test()

--- a/boa3_test/tests/compiler_tests/test_variable.py
+++ b/boa3_test/tests/compiler_tests/test_variable.py
@@ -908,6 +908,23 @@ class TestVariable(BoaTest):
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
 
+    def test_variables_with_same_name_class_variable_and_local(self):
+        path, _ = self.get_deploy_file_paths('VariablesWithSameNameClassVariableAndLocal.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        expected_return = 'example'
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(expected_return)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
     def test_variables_with_same_name_instance_and_local(self):
         path, _ = self.get_deploy_file_paths('VariablesWithSameNameInstanceAndLocal.py')
         runner = NeoTestRunner()

--- a/boa3_test/tests/compiler_tests/test_variable.py
+++ b/boa3_test/tests/compiler_tests/test_variable.py
@@ -907,3 +907,37 @@ class TestVariable(BoaTest):
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
+
+    def test_variables_with_same_name_instance_and_local(self):
+        path, _ = self.get_deploy_file_paths('VariablesWithSameNameInstanceAndLocal.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        expected_return = 'example'
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(expected_return)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+    def test_variables_with_same_name(self):
+        path, _ = self.get_deploy_file_paths('VariablesWithSameName.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        expected_return = 'example'
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append(expected_return)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)


### PR DESCRIPTION
**Summary or solution description**
Now `user_class` will only be sent if it's not a method, so it won't try to check if `symbol` is in class when not needed.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/d9ac69155bb588b89d5239e1fb436af49b2dfa8e/boa3_test/test_sc/variable_test/VariablesWithSameName.py#L1-L19

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/d9ac69155bb588b89d5239e1fb436af49b2dfa8e/boa3_test/tests/compiler_tests/test_variable.py#L928-L943

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8
