### PR TITLE
Update Neo enum values in boa builtin package

### DIFF
--- a/boa3/internal/neo3/contracts/findoptions.py
+++ b/boa3/internal/neo3/contracts/findoptions.py
@@ -10,3 +10,4 @@ class FindOptions(IntFlag):
     DESERIALIZE_VALUES = 1 << 3
     PICK_FIELD_0 = 1 << 4
     PICK_FIELD_1 = 1 << 5
+    BACKWARDS = 1 << 7

--- a/boa3_test/test_sc/interop_test/storage/FindOptionsMismatchedType.py
+++ b/boa3_test/test_sc/interop_test/storage/FindOptionsMismatchedType.py
@@ -1,0 +1,9 @@
+from boa3.builtin.interop.storage.findoptions import FindOptions
+
+
+def main(option: FindOptions) -> FindOptions:
+    return option
+
+
+def call_main():
+    main(12)

--- a/boa3_test/test_sc/interop_test/storage/FindOptionsValues.py
+++ b/boa3_test/test_sc/interop_test/storage/FindOptionsValues.py
@@ -1,0 +1,42 @@
+from boa3.builtin.compile_time import public
+from boa3.builtin.interop.storage.findoptions import FindOptions
+
+
+@public
+def main(option: FindOptions) -> FindOptions:
+    return option
+
+
+@public
+def option_keys_only() -> FindOptions:
+    return FindOptions.KEYS_ONLY
+
+
+@public
+def option_remove_prefix() -> FindOptions:
+    return FindOptions.REMOVE_PREFIX
+
+
+@public
+def option_values_only() -> FindOptions:
+    return FindOptions.VALUES_ONLY
+
+
+@public
+def option_deserialize_values() -> FindOptions:
+    return FindOptions.DESERIALIZE_VALUES
+
+
+@public
+def option_pick_field_0() -> FindOptions:
+    return FindOptions.PICK_FIELD_0
+
+
+@public
+def option_pick_field_1() -> FindOptions:
+    return FindOptions.PICK_FIELD_1
+
+
+@public
+def option_backwards() -> FindOptions:
+    return FindOptions.BACKWARDS

--- a/boa3_test/tests/compiler_tests/test_interop/test_storage.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_storage.py
@@ -6,6 +6,7 @@ from boa3.internal.neo.core.types.InteropInterface import InteropInterface
 from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo.vm.type.String import String
+from boa3.internal.neo3.contracts import FindOptions
 from boa3.internal.neo3.vm import VMState
 from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.boa_test import BoaTest
@@ -995,3 +996,44 @@ class TestStorageInterop(BoaTest):
         runner.execute()
         self.assertEqual(VMState.FAULT, runner.vm_state)
         self.assertRegex(runner.error, self.VALUE_DOES_NOT_FALL_WITHIN_EXPECTED_RANGE_MSG)
+
+    def test_find_options_values(self):
+        path, _ = self.get_deploy_file_paths('FindOptionsValues.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', FindOptions.KEYS_ONLY))
+        expected_results.append(FindOptions.KEYS_ONLY)
+
+        invokes.append(runner.call_contract(path, 'option_keys_only'))
+        expected_results.append(FindOptions.KEYS_ONLY)
+
+        invokes.append(runner.call_contract(path, 'option_remove_prefix'))
+        expected_results.append(FindOptions.REMOVE_PREFIX)
+
+        invokes.append(runner.call_contract(path, 'option_values_only'))
+        expected_results.append(FindOptions.VALUES_ONLY)
+
+        invokes.append(runner.call_contract(path, 'option_deserialize_values'))
+        expected_results.append(FindOptions.DESERIALIZE_VALUES)
+
+        invokes.append(runner.call_contract(path, 'option_pick_field_0'))
+        expected_results.append(FindOptions.PICK_FIELD_0)
+
+        invokes.append(runner.call_contract(path, 'option_pick_field_1'))
+        expected_results.append(FindOptions.PICK_FIELD_1)
+
+        invokes.append(runner.call_contract(path, 'option_backwards'))
+        expected_results.append(FindOptions.BACKWARDS)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+    def test_find_options_mismatched_type(self):
+        path = self.get_contract_path('FindOptionsMismatchedType.py')
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)


### PR DESCRIPTION
**Summary or solution description**
Neo will add a new value for FindOptions (BACKWARDS), so it will also be added to neo3-boa.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/3d8cf826ca528d76e26d48201c600bb6c7b1fa49/boa3_test/test_sc/interop_test/storage/FindOptionsValues.py#L40-L42

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/3d8cf826ca528d76e26d48201c600bb6c7b1fa49/boa3_test/tests/compiler_tests/test_interop/test_storage.py#L1000-L1035

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8

**(Optional) Additional context**
Since the functionality was not merged on Neo yet, testing the storage won't be possible now
