### PR TITLE
Refactor Iterator unit tests to use test runner

### DIFF
--- a/boa3_test/test_drive/testrunner/neo_test_runner.py
+++ b/boa3_test/test_drive/testrunner/neo_test_runner.py
@@ -16,6 +16,7 @@ from boa3_test.test_drive.model.smart_contract.testcontract import TestContract
 from boa3_test.test_drive.model.wallet.account import Account
 from boa3_test.test_drive.neoxp import utils as neoxp_utils
 from boa3_test.test_drive.neoxp.batch import NeoExpressBatch
+from boa3_test.test_drive.testrunner import utils
 from boa3_test.test_drive.testrunner.blockchain.block import TestRunnerBlock as Block
 from boa3_test.test_drive.testrunner.blockchain.log import TestRunnerLog as Log
 from boa3_test.test_drive.testrunner.blockchain.notification import TestRunnerNotification as Notification
@@ -272,6 +273,10 @@ class NeoTestRunner:
 
         try:
             result = json.loads(stdout)
+        except json.JSONDecodeError:
+            result = utils.handle_return_error(stdout)
+
+        try:
             self._update_runner(result)
             if clear_invokes:
                 self._invokes.clear()

--- a/boa3_test/test_drive/testrunner/utils.py
+++ b/boa3_test/test_drive/testrunner/utils.py
@@ -30,3 +30,51 @@ def value_to_parameter(value: Any) -> Any:
 
 def bytes_to_hex(data: bytes) -> str:
     return '0x' + data.hex()
+
+
+def handle_return_error(json_result: str) -> dict:
+    import json
+
+    index = _get_first_json_closure(json_result)
+    result = json.loads(json_result[:index])
+    if 'stack' not in result:
+        return result
+
+    while index < len(json_result):
+        next_index = _get_first_json_closure(json_result, starting_index=index)
+        if next_index > index:
+            new_object = json.loads(json_result[index:next_index])
+            result['stack'].append(new_object)
+        else:
+            break
+        index = next_index
+
+    return result
+
+
+def _get_first_json_closure(json_result: str, starting_index: int = 0):
+    if starting_index < 0:
+        starting_index = 0
+
+    open_object = []
+    open_array = []
+
+    if len(json_result) == starting_index or json_result[starting_index] != '{':
+        return starting_index
+
+    open_object.append(starting_index)
+    index = starting_index + 1
+    while index < len(json_result) and len(open_object):
+        char = json_result[index]
+        if char == '{':
+            open_object.append(index)
+        elif char == '}':
+            open_object.pop()
+        elif char == '[':
+            open_array.append(index)
+        elif char == ']':
+            open_array.pop()
+
+        index += 1
+
+    return index

--- a/boa3_test/test_sc/interop_test/iterator/IteratorNext.py
+++ b/boa3_test/test_sc/interop_test/iterator/IteratorNext.py
@@ -1,7 +1,12 @@
 from boa3.builtin.compile_time import public
-from boa3.builtin.interop.storage import find
+from boa3.builtin.interop import storage
 
 
 @public
 def has_next(prefix: str) -> bool:
-    return find(prefix).next()
+    return storage.find(prefix).next()
+
+
+@public
+def store_data(key: str, value: int):
+    storage.put(key, value)

--- a/boa3_test/test_sc/interop_test/iterator/IteratorValue.py
+++ b/boa3_test/test_sc/interop_test/iterator/IteratorValue.py
@@ -1,12 +1,17 @@
 from typing import Union
 
 from boa3.builtin.compile_time import public
-from boa3.builtin.interop.storage import find
+from boa3.builtin.interop import storage
 
 
 @public
 def test_iterator(prefix: str) -> Union[tuple, None]:
-    it = find(prefix)
+    it = storage.find(prefix)
     if it.next():
         return it.value
     return None
+
+
+@public
+def store_data(key: str, value: int):
+    storage.put(key, value)

--- a/boa3_test/tests/compiler_tests/test_interop/test_iterator.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_iterator.py
@@ -1,6 +1,7 @@
 from boa3.internal.exception import CompilerError
+from boa3.internal.neo3.vm import VMState
+from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.boa_test import BoaTest
-from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestIteratorInterop(BoaTest):
@@ -11,78 +12,133 @@ class TestIteratorInterop(BoaTest):
         self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
 
     def test_iterator_next(self):
-        path = self.get_contract_path('IteratorNext.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('IteratorNext.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         prefix = 'test_iterator_next'
-        result = self.run_smart_contract(engine, path, 'has_next', prefix)
-        self.assertEqual(False, result)
-
-        engine.storage_put(prefix + 'example1', 1, contract_path=path)
-        result = self.run_smart_contract(engine, path, 'has_next', prefix)
-        self.assertEqual(True, result)
-
-    def test_iterator_value(self):
-        path = self.get_contract_path('IteratorValue.py')
-        engine = TestEngine()
-
-        prefix = 'test_iterator_value'
-        result = self.run_smart_contract(engine, path, 'test_iterator', prefix)
-        self.assertIsNone(result)
+        invokes.append(runner.call_contract(path, 'has_next', prefix))
+        expected_results.append(False)
 
         key = prefix + 'example1'
-        engine.storage_put(key, 1, contract_path=path)
-        result = self.run_smart_contract(engine, path, 'test_iterator', prefix)
-        self.assertEqual([key, '\x01'], result)
+        runner.call_contract(path, 'store_data', key, 1)
+        invokes.append(runner.call_contract(path, 'has_next', prefix))
+        expected_results.append(True)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+    def test_iterator_value(self):
+        path, _ = self.get_deploy_file_paths('IteratorValue.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        prefix = 'test_iterator_value'
+        invokes.append(runner.call_contract(path, 'test_iterator', prefix))
+        expected_results.append(None)
+
+        key = prefix + 'example1'
+        runner.call_contract(path, 'store_data', key, 1)
+        invokes.append(runner.call_contract(path, 'test_iterator', prefix))
+        expected_results.append([key, '\x01'])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_iterator_value_dict_mismatched_type(self):
         path = self.get_contract_path('IteratorValueMismatchedType.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_import_iterator(self):
-        path = self.get_contract_path('ImportIterator.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ImportIterator.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'return_iterator')
-        self.assertEqual([], result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'return_iterator'))
+        expected_results.append([])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_import_interop_iterator(self):
-        path = self.get_contract_path('ImportInteropIterator.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ImportInteropIterator.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'return_iterator')
-        self.assertEqual([], result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'return_iterator'))
+        expected_results.append([])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_iterator_implicit_typing(self):
-        path = self.get_contract_path('IteratorImplicitTyping.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('IteratorImplicitTyping.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         prefix = 'test_iterator_'
-        result = self.run_smart_contract(engine, path, 'search_storage', prefix)
-        self.assertEqual({}, result)
+        invokes.append(runner.call_contract(path, 'search_storage', prefix))
+        expected_results.append({})
 
-        result = self.run_smart_contract(engine, path, 'store', f'{prefix}1', 1)
-        self.assertIsVoid(result)
+        invokes.append(runner.call_contract(path, 'store', f'{prefix}1', 1))
+        expected_results.append(None)
 
-        result = self.run_smart_contract(engine, path, 'store', f'{prefix}2', 2)
-        self.assertIsVoid(result)
+        invokes.append(runner.call_contract(path, 'store', f'{prefix}2', 2))
+        expected_results.append(None)
 
-        result = self.run_smart_contract(engine, path, 'search_storage', prefix)
-        self.assertEqual({f'{prefix}1': 1, f'{prefix}2': 2}, result)
+        invokes.append(runner.call_contract(path, 'search_storage', prefix))
+        expected_results.append({f'{prefix}1': 1, f'{prefix}2': 2})
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_iterator_value_access(self):
-        path = self.get_contract_path('IteratorValueAccess.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('IteratorValueAccess.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         prefix = 'test_iterator_'
-        result = self.run_smart_contract(engine, path, 'search_storage', prefix)
-        self.assertEqual({}, result)
+        invokes.append(runner.call_contract(path, 'search_storage', prefix))
+        expected_results.append({})
 
-        result = self.run_smart_contract(engine, path, 'store', f'{prefix}1', 1)
-        self.assertIsVoid(result)
+        invokes.append(runner.call_contract(path, 'store', f'{prefix}1', 1))
+        expected_results.append(None)
 
-        result = self.run_smart_contract(engine, path, 'store', f'{prefix}2', 2)
-        self.assertIsVoid(result)
+        invokes.append(runner.call_contract(path, 'store', f'{prefix}2', 2))
+        expected_results.append(None)
 
-        result = self.run_smart_contract(engine, path, 'search_storage', prefix)
-        self.assertEqual({f'{prefix}1': 1, f'{prefix}2': 2}, result)
+        invokes.append(runner.call_contract(path, 'search_storage', prefix))
+        expected_results.append({f'{prefix}1': 1, f'{prefix}2': 2})
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)

--- a/boa3_test/tests/compiler_tests/test_interop/test_storage.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_storage.py
@@ -10,7 +10,6 @@ from boa3.internal.neo3.contracts import FindOptions
 from boa3.internal.neo3.vm import VMState
 from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.boa_test import BoaTest
-from boa3_test.tests.test_classes.testengine import TestEngine
 
 
 class TestStorageInterop(BoaTest):
@@ -509,32 +508,64 @@ class TestStorageInterop(BoaTest):
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_storage_find_bytes_prefix(self):
-        path = self.get_contract_path('StorageFindBytesPrefix.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'find_by_prefix', b'example')
-        self.assertEqual([], result)
+        path, _ = self.get_deploy_file_paths('StorageFindBytesPrefix.py')
+        runner = NeoTestRunner()
 
-        storage = {('example_0', path): '0',
-                   ('example_1', path): '1',
-                   ('example_2', path): '3'}
-        expected_result = [[key, value] for (key, sc), value in storage.items()]
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'find_by_prefix', 'example', fake_storage=storage)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'find_by_prefix', b'example'))
+        expected_results.append([])
+
+        runner.execute()  # getting result of multiple iterators is failing
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        storage = {'example_0': '0',
+                   'example_1': '1',
+                   'example_2': '3'}
+        expected_result = [[key, value] for key, value in storage.items()]
+
+        for (key, value) in expected_result:
+            runner.call_contract(path, 'put_on_storage', key, value)
+
+        invokes.append(runner.call_contract(path, 'find_by_prefix', b'example'))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_storage_find_str_prefix(self):
-        path = self.get_contract_path('StorageFindStrPrefix.py')
-        engine = TestEngine()
-        result = self.run_smart_contract(engine, path, 'find_by_prefix', 'example')
-        self.assertEqual([], result)
+        path, _ = self.get_deploy_file_paths('StorageFindStrPrefix.py')
+        runner = NeoTestRunner()
 
-        storage = {('example_0', path): '0',
-                   ('example_1', path): '1',
-                   ('example_2', path): '3'}
-        expected_result = [[key, value] for (key, sc), value in storage.items()]
+        invokes = []
+        expected_results = []
 
-        result = self.run_smart_contract(engine, path, 'find_by_prefix', 'example', fake_storage=storage)
-        self.assertEqual(expected_result, result)
+        invokes.append(runner.call_contract(path, 'find_by_prefix', 'example'))
+        expected_results.append([])
+
+        runner.execute()  # getting result of multiple iterators is failing
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        storage = {'example_0': '0',
+                   'example_1': '1',
+                   'example_2': '3'}
+        expected_result = [[key, value] for key, value in storage.items()]
+
+        for (key, value) in expected_result:
+            runner.call_contract(path, 'put_on_storage', key, value)
+
+        invokes.append(runner.call_contract(path, 'find_by_prefix', 'example'))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_storage_find_mismatched_type(self):
         path = self.get_contract_path('StorageFindMismatchedType.py')
@@ -714,36 +745,65 @@ class TestStorageInterop(BoaTest):
         self.assertIsNone(runner.storages.get(storage_contract, storage_key))
 
     def test_storage_find_with_context(self):
-        path = self.get_contract_path('StorageFindWithContext.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('StorageFindWithContext.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'find_by_prefix', 'example')
-        self.assertEqual([], result)
+        invokes = []
+        expected_results = []
 
-        storage = {('example_0', path): '0',
-                   ('example_1', path): '1',
-                   ('example_2', path): '3'}
-        expected_result = [[key, value] for (key, sc), value in storage.items()]
+        invokes.append(runner.call_contract(path, 'find_by_prefix', 'example'))
+        expected_results.append([])
 
-        result = self.run_smart_contract(engine, path, 'find_by_prefix', 'example', fake_storage=storage)
-        self.assertEqual(expected_result, result)
+        runner.execute()  # getting result of multiple iterators is failing
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        storage = {'example_0': '0',
+                   'example_1': '1',
+                   'example_2': '3'}
+        expected_result = [[key, value] for key, value in storage.items()]
+
+        for (key, value) in expected_result:
+            runner.call_contract(path, 'put_on_storage', key, value)
+
+        invokes.append(runner.call_contract(path, 'find_by_prefix', b'example'))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_storage_find_with_options(self):
-        path = self.get_contract_path('StorageFindWithOptions.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('StorageFindWithOptions.py')
+        runner = NeoTestRunner()
 
-        result = self.run_smart_contract(engine, path, 'find_by_prefix', 'example')
-        self.assertEqual([], result)
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'find_by_prefix', 'example'))
+        expected_results.append([])
+
+        runner.execute()  # getting result of multiple iterators is failing
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         prefix = 'example'
         expected_result = [['_0', '0'],
                            ['_1', '1'],
                            ['_2', '2']
                            ]
-        storage = {(prefix + key, path): value for (key, value) in expected_result}
 
-        result = self.run_smart_contract(engine, path, 'find_by_prefix', prefix, fake_storage=storage)
-        self.assertEqual(expected_result, result)
+        for (key, value) in expected_result:
+            runner.call_contract(path, 'put_on_storage', (prefix + key), value)
+
+        invokes.append(runner.call_contract(path, 'find_by_prefix', 'example'))
+        expected_results.append(expected_result)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_boa2_storage_test(self):
         path, _ = self.get_deploy_file_paths('StorageBoa2Test.py')
@@ -889,74 +949,104 @@ class TestStorageInterop(BoaTest):
             self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_import_storage(self):
-        path = self.get_contract_path('ImportStorage.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ImportStorage.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         prefix = 'unit'
         key = f'{prefix}_test'
         value = 1234
 
-        result = self.run_smart_contract(engine, path, 'get_value', key)
-        self.assertEqual(0, result)
+        invokes.append(runner.call_contract(path, 'get_value', key))
+        expected_results.append(0)
 
-        result = self.run_smart_contract(engine, path, 'find_by_prefix', prefix)
-        self.assertEqual([], result)
+        invokes.append(runner.call_contract(path, 'find_by_prefix', prefix))
+        expected_results.append([])
 
-        result = self.run_smart_contract(engine, path, 'put_value', key, value)
-        self.assertIsVoid(result)
+        runner.execute()  # getting result of multiple iterators is failing
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
-        result = self.run_smart_contract(engine, path, 'get_value', key)
-        self.assertEqual(value, result)
+        invokes.append(runner.call_contract(path, 'put_value', key, value))
+        expected_results.append(None)
 
-        result = self.run_smart_contract(engine, path, 'find_by_prefix', prefix)
-        self.assertEqual([[key, Integer(value).to_byte_array()]], result)
+        invokes.append(runner.call_contract(path, 'get_value', key))
+        expected_results.append(value)
 
-        result = self.run_smart_contract(engine, path, 'delete_value', key)
-        self.assertIsVoid(result)
+        invokes.append(runner.call_contract(path, 'find_by_prefix', prefix))
+        expected_results.append([[key, Integer(value).to_byte_array()]])
 
-        result = self.run_smart_contract(engine, path, 'get_value', key)
-        self.assertEqual(0, result)
+        runner.execute()  # getting result of multiple iterators is failing
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
-        result = self.run_smart_contract(engine, path, 'find_by_prefix', 'prefix')
-        self.assertEqual([], result)
+        runner.call_contract(path, 'put_value', key, value)
+        runner.call_contract(path, 'get_value', key)
 
-        result = self.run_smart_contract(engine, path, 'find_by_prefix', prefix)
-        self.assertEqual([], result)
+        invokes.append(runner.call_contract(path, 'delete_value', key))
+        expected_results.append(None)
+
+        invokes.append(runner.call_contract(path, 'get_value', key))
+        expected_results.append(0)
+
+        invokes.append(runner.call_contract(path, 'find_by_prefix', prefix))
+        expected_results.append([])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_import_interop_storage(self):
-        path = self.get_contract_path('ImportInteropStorage.py')
-        engine = TestEngine()
+        path, _ = self.get_deploy_file_paths('ImportInteropStorage.py')
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
 
         prefix = 'unit'
         key = f'{prefix}_test'
         value = 1234
 
-        result = self.run_smart_contract(engine, path, 'get_value', key)
-        self.assertEqual(0, result)
+        invokes.append(runner.call_contract(path, 'get_value', key))
+        expected_results.append(0)
 
-        result = self.run_smart_contract(engine, path, 'find_by_prefix', prefix)
-        self.assertEqual([], result)
+        invokes.append(runner.call_contract(path, 'find_by_prefix', prefix))
+        expected_results.append([])
 
-        result = self.run_smart_contract(engine, path, 'put_value', key, value)
-        self.assertIsVoid(result)
+        runner.execute()  # getting result of multiple iterators is failing
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
-        result = self.run_smart_contract(engine, path, 'get_value', key)
-        self.assertEqual(value, result)
+        invokes.append(runner.call_contract(path, 'put_value', key, value))
+        expected_results.append(None)
 
-        result = self.run_smart_contract(engine, path, 'find_by_prefix', prefix)
-        self.assertEqual([[key, Integer(value).to_byte_array()]], result)
+        invokes.append(runner.call_contract(path, 'get_value', key))
+        expected_results.append(value)
 
-        result = self.run_smart_contract(engine, path, 'delete_value', key)
-        self.assertIsVoid(result)
+        invokes.append(runner.call_contract(path, 'find_by_prefix', prefix))
+        expected_results.append([[key, Integer(value).to_byte_array()]])
 
-        result = self.run_smart_contract(engine, path, 'get_value', key)
-        self.assertEqual(0, result)
+        runner.execute()  # getting result of multiple iterators is failing
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
-        result = self.run_smart_contract(engine, path, 'find_by_prefix', 'prefix')
-        self.assertEqual([], result)
+        runner.call_contract(path, 'put_value', key, value)
+        runner.call_contract(path, 'get_value', key)
 
-        result = self.run_smart_contract(engine, path, 'find_by_prefix', prefix)
-        self.assertEqual([], result)
+        invokes.append(runner.call_contract(path, 'delete_value', key))
+        expected_results.append(None)
+
+        invokes.append(runner.call_contract(path, 'get_value', key))
+        expected_results.append(0)
+
+        invokes.append(runner.call_contract(path, 'find_by_prefix', prefix))
+        expected_results.append([])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_as_read_only(self):
         path, _ = self.get_deploy_file_paths('StorageAsReadOnly.py')


### PR DESCRIPTION
**Summary or solution description**
Part of an overall refactoring. 
Changed the execution tests of the compiled smart contracts related to Iterators to use TestRunner instead of TestEngine

**Tests**
Rerun the modified unit tests

**(Optional) Additional context**
Since there's an issue in the Test Runner (https://github.com/ngdenterprise/neo-test/issues/46) when returning Iterators in the result stack, the most I managed to do is read what it was returned so the json decode doesn't break. Getting the value directly from neo express doesn't return data from the Iterator
