### PR TITLE
Update Neo Native Contracts interfaces (crypto)

### DIFF
--- a/boa3/builtin/interop/crypto/__init__.py
+++ b/boa3/builtin/interop/crypto/__init__.py
@@ -110,3 +110,85 @@ def murmur32(data: ByteString, seed: int) -> ByteString:
     :rtype: ByteString
     """
     pass
+
+
+def bls12_381_add(x: bytes, y: bytes) -> bytes:
+    """
+    Add operation of two bls12381 points.
+
+    :param x: The first point
+    :type x: bytes
+    :param y: The second point
+    :type y: bytes
+    :return: the two points sum
+    :rtype: bytes
+    """
+    pass
+
+
+def bls12_381_deserialize(data: bytes) -> bytes:
+    """
+    Deserialize a bls12381 point.
+
+    :param data: The point as byte array
+    :type data: bytes
+    :return: the deserialized point
+    :rtype: bytes
+    """
+    pass
+
+
+def bls12_381_equal(x: bytes, y: bytes) -> bool:
+    """
+    Determines whether the specified points are equal.
+
+    :param x: The first point
+    :type x: bytes
+    :param y: The second point
+    :type y: bytes
+    :return: whether the specified points are equal or not
+    :rtype: bool
+    """
+    pass
+
+
+def bls12_381_mul(x: bytes, mul: int, neg: bool) -> bytes:
+    """
+    Mul operation of gt point and multiplier.
+
+    :param x: The point
+    :type x: bytes
+    :param mul: Multiplier, 32 bytes, little-endian
+    :type mul: int
+    :param neg: negative number
+    :type neg: bool
+    :return: the two points product
+    :rtype: bytes
+    """
+    pass
+
+
+def bls12_381_pairing(g1: bytes, g2: bytes) -> bytes:
+    """
+    Pairing operation of g1 and g2.
+
+    :param g1: The g1 point
+    :type g1: bytes
+    :param g2: The g2 point
+    :type g2: bytes
+    :return: the two points pairing
+    :rtype: bytes
+    """
+    pass
+
+
+def bls12_381_serialize(g: bytes) -> bytes:
+    """
+    Serialize a bls12381 point.
+
+    :param g: The point to be serialized.
+    :type g: bytes
+    :return: the serialized point
+    :rtype: bytes
+    """
+    pass

--- a/boa3/internal/model/builtin/interop/crypto/__init__.py
+++ b/boa3/internal/model/builtin/interop/crypto/__init__.py
@@ -1,14 +1,27 @@
-__all__ = ['CheckMultisigMethod',
-           'CheckSigMethod',
-           'Hash160Method',
-           'Hash256Method',
-           'Murmur32Method',
-           'NamedCurveType',
-           'Ripemd160Method',
-           'Sha256Method',
-           'VerifyWithECDsaMethod',
-           ]
+__all__ = [
+    'Bls12381AddMethod',
+    'Bls12381DeserializeMethod',
+    'Bls12381EqualMethod',
+    'Bls12381MulMethod',
+    'Bls12381PairingMethod',
+    'Bls12381SerializeMethod',
+    'CheckMultisigMethod',
+    'CheckSigMethod',
+    'Hash160Method',
+    'Hash256Method',
+    'Murmur32Method',
+    'NamedCurveType',
+    'Ripemd160Method',
+    'Sha256Method',
+    'VerifyWithECDsaMethod',
+]
 
+from boa3.internal.model.builtin.interop.crypto.bls12381addmethod import Bls12381AddMethod
+from boa3.internal.model.builtin.interop.crypto.bls12381deserializemethod import Bls12381DeserializeMethod
+from boa3.internal.model.builtin.interop.crypto.bls12381equalmethod import Bls12381EqualMethod
+from boa3.internal.model.builtin.interop.crypto.bls12381mulmethod import Bls12381MulMethod
+from boa3.internal.model.builtin.interop.crypto.bls12381pairingmethod import Bls12381PairingMethod
+from boa3.internal.model.builtin.interop.crypto.bls12381serializemethod import Bls12381SerializeMethod
 from boa3.internal.model.builtin.interop.crypto.checkmultisigmethod import CheckMultisigMethod
 from boa3.internal.model.builtin.interop.crypto.checksigmethod import CheckSigMethod
 from boa3.internal.model.builtin.interop.crypto.hash160method import Hash160Method

--- a/boa3/internal/model/builtin/interop/crypto/bls12381addmethod.py
+++ b/boa3/internal/model/builtin/interop/crypto/bls12381addmethod.py
@@ -1,0 +1,18 @@
+from typing import Dict
+
+from boa3.internal.model.builtin.interop.nativecontract import CryptoLibMethod
+from boa3.internal.model.variable import Variable
+
+
+class Bls12381AddMethod(CryptoLibMethod):
+
+    def __init__(self):
+        from boa3.internal.model.type.type import Type
+
+        identifier = 'bls12_381_add'
+        native_identifier = 'bls12381Add'
+        args: Dict[str, Variable] = {
+            'x': Variable(Type.bytes),
+            'y': Variable(Type.bytes),
+        }
+        super().__init__(identifier, native_identifier, args, return_type=Type.bytes)

--- a/boa3/internal/model/builtin/interop/crypto/bls12381deserializemethod.py
+++ b/boa3/internal/model/builtin/interop/crypto/bls12381deserializemethod.py
@@ -1,0 +1,17 @@
+from typing import Dict
+
+from boa3.internal.model.builtin.interop.nativecontract import CryptoLibMethod
+from boa3.internal.model.variable import Variable
+
+
+class Bls12381DeserializeMethod(CryptoLibMethod):
+
+    def __init__(self):
+        from boa3.internal.model.type.type import Type
+
+        identifier = 'bls12_381_deserialize'
+        native_identifier = 'bls12381Deserialize'
+        args: Dict[str, Variable] = {
+            'data': Variable(Type.bytes),
+        }
+        super().__init__(identifier, native_identifier, args, return_type=Type.bytes)

--- a/boa3/internal/model/builtin/interop/crypto/bls12381equalmethod.py
+++ b/boa3/internal/model/builtin/interop/crypto/bls12381equalmethod.py
@@ -1,0 +1,18 @@
+from typing import Dict
+
+from boa3.internal.model.builtin.interop.nativecontract import CryptoLibMethod
+from boa3.internal.model.variable import Variable
+
+
+class Bls12381EqualMethod(CryptoLibMethod):
+
+    def __init__(self):
+        from boa3.internal.model.type.type import Type
+
+        identifier = 'bls12_381_equal'
+        native_identifier = 'bls12381Equal'
+        args: Dict[str, Variable] = {
+            'x': Variable(Type.bytes),
+            'y': Variable(Type.bytes),
+        }
+        super().__init__(identifier, native_identifier, args, return_type=Type.bool)

--- a/boa3/internal/model/builtin/interop/crypto/bls12381mulmethod.py
+++ b/boa3/internal/model/builtin/interop/crypto/bls12381mulmethod.py
@@ -1,0 +1,19 @@
+from typing import Dict
+
+from boa3.internal.model.builtin.interop.nativecontract import CryptoLibMethod
+from boa3.internal.model.variable import Variable
+
+
+class Bls12381MulMethod(CryptoLibMethod):
+
+    def __init__(self):
+        from boa3.internal.model.type.type import Type
+
+        identifier = 'bls12_381_mul'
+        native_identifier = 'bls12381Mul'
+        args: Dict[str, Variable] = {
+            'x': Variable(Type.bytes),
+            'mul': Variable(Type.int),
+            'neg': Variable(Type.bool),
+        }
+        super().__init__(identifier, native_identifier, args, return_type=Type.bytes)

--- a/boa3/internal/model/builtin/interop/crypto/bls12381pairingmethod.py
+++ b/boa3/internal/model/builtin/interop/crypto/bls12381pairingmethod.py
@@ -1,0 +1,18 @@
+from typing import Dict
+
+from boa3.internal.model.builtin.interop.nativecontract import CryptoLibMethod
+from boa3.internal.model.variable import Variable
+
+
+class Bls12381PairingMethod(CryptoLibMethod):
+
+    def __init__(self):
+        from boa3.internal.model.type.type import Type
+
+        identifier = 'bls12_381_pairing'
+        native_identifier = 'bls12381Pairing'
+        args: Dict[str, Variable] = {
+            'g1': Variable(Type.bytes),
+            'g2': Variable(Type.bytes),
+        }
+        super().__init__(identifier, native_identifier, args, return_type=Type.bytes)

--- a/boa3/internal/model/builtin/interop/crypto/bls12381serializemethod.py
+++ b/boa3/internal/model/builtin/interop/crypto/bls12381serializemethod.py
@@ -1,0 +1,17 @@
+from typing import Dict
+
+from boa3.internal.model.builtin.interop.nativecontract import CryptoLibMethod
+from boa3.internal.model.variable import Variable
+
+
+class Bls12381SerializeMethod(CryptoLibMethod):
+
+    def __init__(self):
+        from boa3.internal.model.type.type import Type
+
+        identifier = 'bls12_381_serialize'
+        native_identifier = 'bls12381Serialize'
+        args: Dict[str, Variable] = {
+            'g': Variable(Type.bytes),
+        }
+        super().__init__(identifier, native_identifier, args, return_type=Type.bytes)

--- a/boa3/internal/model/builtin/interop/interop.py
+++ b/boa3/internal/model/builtin/interop/interop.py
@@ -114,6 +114,12 @@ class Interop:
     StdLibScriptHash = StdLibContract
 
     # Crypto Interops
+    Bls12381Add = Bls12381AddMethod()
+    Bls12381Deserialize = Bls12381DeserializeMethod()
+    Bls12381Equal = Bls12381EqualMethod()
+    Bls12381Mul = Bls12381MulMethod()
+    Bls12381Pairing = Bls12381PairingMethod()
+    Bls12381Serialize = Bls12381SerializeMethod()
     CheckMultisig = CheckMultisigMethod()
     CheckSig = CheckSigMethod()
     Hash160 = Hash160Method()
@@ -276,7 +282,13 @@ class Interop:
 
     CryptoPackage = Package(identifier=InteropPackage.Crypto,
                             types=[NamedCurveType],
-                            methods=[CheckMultisig,
+                            methods=[Bls12381Add,
+                                     Bls12381Deserialize,
+                                     Bls12381Equal,
+                                     Bls12381Mul,
+                                     Bls12381Pairing,
+                                     Bls12381Serialize,
+                                     CheckMultisig,
                                      CheckSig,
                                      Hash160,
                                      Hash256,

--- a/boa3_test/test_sc/interop_test/crypto/Bls12381Add.py
+++ b/boa3_test/test_sc/interop_test/crypto/Bls12381Add.py
@@ -1,0 +1,7 @@
+from boa3.builtin.compile_time import public
+from boa3.builtin.interop.crypto import bls12_381_add
+
+
+@public
+def main() -> bytes:
+    return bls12_381_add(b'1', b'2')

--- a/boa3_test/test_sc/interop_test/crypto/Bls12381Deserialize.py
+++ b/boa3_test/test_sc/interop_test/crypto/Bls12381Deserialize.py
@@ -1,0 +1,7 @@
+from boa3.builtin.compile_time import public
+from boa3.builtin.interop.crypto import bls12_381_deserialize
+
+
+@public
+def main() -> bytes:
+    return bls12_381_deserialize(b'1')

--- a/boa3_test/test_sc/interop_test/crypto/Bls12381Equal.py
+++ b/boa3_test/test_sc/interop_test/crypto/Bls12381Equal.py
@@ -1,0 +1,7 @@
+from boa3.builtin.compile_time import public
+from boa3.builtin.interop.crypto import bls12_381_equal
+
+
+@public
+def main() -> bool:
+    return bls12_381_equal(b'1', b'2')

--- a/boa3_test/test_sc/interop_test/crypto/Bls12381Mul.py
+++ b/boa3_test/test_sc/interop_test/crypto/Bls12381Mul.py
@@ -1,0 +1,7 @@
+from boa3.builtin.compile_time import public
+from boa3.builtin.interop.crypto import bls12_381_mul
+
+
+@public
+def main() -> bytes:
+    return bls12_381_mul(b'1', 2, True)

--- a/boa3_test/test_sc/interop_test/crypto/Bls12381Pairing.py
+++ b/boa3_test/test_sc/interop_test/crypto/Bls12381Pairing.py
@@ -1,0 +1,7 @@
+from boa3.builtin.compile_time import public
+from boa3.builtin.interop.crypto import bls12_381_pairing
+
+
+@public
+def main() -> bytes:
+    return bls12_381_pairing(b'1', b'2')

--- a/boa3_test/test_sc/interop_test/crypto/Bls12381Serialize.py
+++ b/boa3_test/test_sc/interop_test/crypto/Bls12381Serialize.py
@@ -1,0 +1,7 @@
+from boa3.builtin.compile_time import public
+from boa3.builtin.interop.crypto import bls12_381_serialize
+
+
+@public
+def main() -> bytes:
+    return bls12_381_serialize(b'1')

--- a/boa3_test/tests/compiler_tests/test_interop/test_crypto.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_crypto.py
@@ -708,3 +708,107 @@ class TestCryptoInterop(BoaTest):
         path = self.get_contract_path('Murmur32.py')
         output = Boa3.compile(path)
         self.assertEqual(expected_output, output)
+
+    def test_bls12_381_add(self):
+        gt1 = b'1'
+        gt2 = b'2'
+
+        expected_output = (
+            Opcode.PUSHDATA1
+            + Integer(len(gt2)).to_byte_array(min_length=1)
+            + gt2
+            + Opcode.PUSHDATA1
+            + Integer(len(gt1)).to_byte_array(min_length=1)
+            + gt1
+            + Opcode.CALLT + b'\x00\x00'
+            + Opcode.RET
+        )
+
+        path = self.get_contract_path('Bls12381Add.py')
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_bls12_381_deserialize(self):
+        data = b'1'
+
+        expected_output = (
+            Opcode.PUSHDATA1
+            + Integer(len(data)).to_byte_array(min_length=1)
+            + data
+            + Opcode.CALLT + b'\x00\x00'
+            + Opcode.RET
+        )
+
+        path = self.get_contract_path('Bls12381Deserialize.py')
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_bls12_381_equal(self):
+        gt1 = b'1'
+        gt2 = b'2'
+
+        expected_output = (
+            Opcode.PUSHDATA1
+            + Integer(len(gt2)).to_byte_array(min_length=1)
+            + gt2
+            + Opcode.PUSHDATA1
+            + Integer(len(gt1)).to_byte_array(min_length=1)
+            + gt1
+            + Opcode.CALLT + b'\x00\x00'
+            + Opcode.RET
+        )
+
+        path = self.get_contract_path('Bls12381Equal.py')
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_bls12_381_mul(self):
+        gt = b'1'
+
+        expected_output = (
+            Opcode.PUSHT
+            + Opcode.PUSH2
+            + Opcode.PUSHDATA1
+            + Integer(len(gt)).to_byte_array(min_length=1)
+            + gt
+            + Opcode.CALLT + b'\x00\x00'
+            + Opcode.RET
+        )
+
+        path = self.get_contract_path('Bls12381Mul.py')
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_bls12_381_pairing(self):
+        gt1_bytes = b'1'
+        gt2_bytes = b'2'
+
+        expected_output = (
+            Opcode.PUSHDATA1
+            + Integer(len(gt2_bytes)).to_byte_array(min_length=1)
+            + gt2_bytes
+            + Opcode.PUSHDATA1
+            + Integer(len(gt1_bytes)).to_byte_array(min_length=1)
+            + gt1_bytes
+            + Opcode.CALLT + b'\x00\x00'
+            + Opcode.RET
+        )
+
+        path = self.get_contract_path('Bls12381Pairing.py')
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)
+
+    def test_bls12_381_serialize(self):
+        g = b'1'
+
+        expected_output = (
+            Opcode.PUSHDATA1
+            + Integer(len(g)).to_byte_array(min_length=1)
+            + g
+            + Opcode.CALLT + b'\x00\x00'
+            + Opcode.RET
+        )
+
+        path = self.get_contract_path('Bls12381Serialize.py')
+        output = Boa3.compile(path)
+        self.assertEqual(expected_output, output)


### PR DESCRIPTION
**Summary or solution description**
Added [CryptoLib.BLS12_381.cs ](https://github.com/neo-ngd/neo/blob/29bc3b21ed1c27b8b11e01d2d61f1b9e75b1acd1/src/Neo/SmartContract/Native/CryptoLib.BLS12_381.cs) methods.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/49faa0a9ac87324bf008eebc08d33e93563ce4c4/boa3_test/test_sc/interop_test/crypto/Bls12381Mul.py#L1-L7

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/49faa0a9ac87324bf008eebc08d33e93563ce4c4/boa3_test/tests/compiler_tests/test_interop/test_crypto.py#L712-L814

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8

**(Optional) Additional context**
This issue is not testing the call, just checking the Opcode generated. To test it, it will be necessary to wait for it to be accepted, merged into Neo, and released. Also, some parameters are InteropInterface and were added as bytes here.
