### PR TITLE
Add support to int constructor with str and bytes values

### DIFF
--- a/boa3/internal/analyser/typeanalyser.py
+++ b/boa3/internal/analyser/typeanalyser.py
@@ -1312,10 +1312,14 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
         if not isinstance(callable_target, Callable):
             # verify if it is a builtin method with its name shadowed
             call_target = Builtin.get_symbol(callable_id)
-            if not isinstance(call_target, Callable) and self.is_exception(callable_id):
-                call_target = Builtin.Exception
+            if not isinstance(call_target, Callable):
+                if self.is_exception(callable_id):
+                    call_target = Builtin.Exception
+                elif hasattr(callable_target, 'constructor_method'):
+                    call_target = callable_target.constructor_method()
 
             callable_target = call_target if call_target is not None else callable_target
+
         if isinstance(callable_target, IBuiltinMethod):
             # verify if it's a variation of the default builtin method
             args = [self.get_type(param, use_metatype=True) for param in call_args]

--- a/boa3/internal/model/builtin/method/intmethod.py
+++ b/boa3/internal/model/builtin/method/intmethod.py
@@ -21,10 +21,10 @@ class IntMethod(IBuiltinMethod):
         from boa3.internal.model.type.type import Type
 
         if self._arg_value.type is Type.int:
-            return '-{0}_{1}'.format(self._identifier, Type.str.identifier + Type.bytes.identifier)
+            return '-{0}_{1}'.format(self._identifier, Type.int)
 
-        if self._arg_value.type is Type.str or self._arg_value.type is Type.bytes:
-            return '-{0}_{1}'.format(self._identifier, Type.sequence.identifier)
+        if self._arg_value.type.is_type_of(Type.str) or self._arg_value.type.is_type_of(Type.bytes):
+            return '-{0}_{1}'.format(self._identifier, Type.str)
 
         return self._identifier
 

--- a/boa3_test/tests/compiler_tests/test_builtin_method.py
+++ b/boa3_test/tests/compiler_tests/test_builtin_method.py
@@ -2265,13 +2265,8 @@ class TestBuiltinMethod(BoaTest):
 
     # region int test
 
-    # TODO: Int constructor is not accepting more than one method
-    @unittest.skip('Int constructor is not accepting more than one method')
     def test_int_str(self):
-        path = self.get_contract_path('IntStr.py')
-        self.compile_and_save(path)  # it doesn't compile, it isn't implemented yet
-
-        path, _ = self.get_deploy_file_paths(path)
+        path, _ = self.get_deploy_file_paths('IntStr.py')
         runner = NeoTestRunner(runner_id=self.method_name())
 
         invokes = []
@@ -2374,13 +2369,8 @@ class TestBuiltinMethod(BoaTest):
         with self.assertRaises(ValueError):
             int(value, base)
 
-    # TODO: Int constructor is not accepting more than one method
-    @unittest.skip('Int constructor is not accepting more than one method')
     def test_int_bytes(self):
-        path = self.get_contract_path('IntBytes.py')
-        self.compile_and_save(path)  # it doesn't compile, it isn't implemented yet
-
-        path, _ = self.get_deploy_file_paths(path)
+        path, _ = self.get_deploy_file_paths('IntBytes.py')
         runner = NeoTestRunner(runner_id=self.method_name())
 
         invokes = []


### PR DESCRIPTION
**Related issue**
#770

**Summary or solution description**
It fixed incorrect type-checking validation that caused this implementation of the int constructor not to compile.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/499b46534aad1d244df0793baf82d210ef8c2d6f/boa3_test/test_sc/built_in_methods_test/IntStr.py#L4-L7

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/499b46534aad1d244df0793baf82d210ef8c2d6f/boa3_test/tests/compiler_tests/test_builtin_method.py#L2270-L2476

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7+