### PR TITLE
Refactor NEP-11 unit tests to use Test Runner

### DIFF
--- a/boa3/internal/neo/smart_contract/notification.py
+++ b/boa3/internal/neo/smart_contract/notification.py
@@ -29,7 +29,7 @@ class Notification:
         return self._value
 
     @classmethod
-    def from_json(cls, json: Dict[str, Any]) -> Notification:
+    def from_json(cls, json: Dict[str, Any], *args, **kwargs) -> Notification:
         """
         Creates a Notification object from a json.
 

--- a/boa3_test/test_drive/model/network/payloads/testtransaction.py
+++ b/boa3_test/test_drive/model/network/payloads/testtransaction.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 from typing import List, Dict, Any, Union, Optional
 
 from boa3.internal.neo import from_hex_str, utils
-from boa3.internal.neo.smart_contract.notification import Notification
 from boa3.internal.neo3.core.types import UInt256
 from boa3.internal.neo3.vm import VMState
 from boa3_test.test_drive.model.network.payloads.signer import Signer
 from boa3_test.test_drive.model.network.payloads.witness import Witness
+from boa3_test.test_drive.model.smart_contract.contractcollection import ContractCollection
 from boa3_test.test_drive.model.smart_contract.triggertype import TriggerType
+from boa3_test.test_drive.testrunner.blockchain.notification import TestRunnerNotification as Notification
 
 
 class TestTransaction:
@@ -113,7 +114,7 @@ class TransactionExecution:
         return self._notifications.copy()
 
     @classmethod
-    def from_json(cls, json: Dict[str, Any]) -> TransactionExecution:
+    def from_json(cls, json: Dict[str, Any], contract_collection: ContractCollection = None) -> TransactionExecution:
         tx_exec = cls()
 
         tx_exec._trigger = TriggerType[json['trigger']]
@@ -121,6 +122,6 @@ class TransactionExecution:
         tx_exec._gas_consumed = int(json['gasconsumed'])
         tx_exec._exception = str(json['exception']) if json['exception'] is not None else None
         tx_exec._stack = [utils.stack_item_from_json(value) for value in json['stack']]
-        tx_exec._notifications = [Notification.from_json(notification) for notification in json['notifications']]
+        tx_exec._notifications = [Notification.from_json(notification, contract_collection) for notification in json['notifications']]
 
         return tx_exec

--- a/boa3_test/test_drive/neoxp/utils.py
+++ b/boa3_test/test_drive/neoxp/utils.py
@@ -146,14 +146,14 @@ def get_transaction(neoxp_path: str, tx_hash: UInt256, check_point_file: str = N
     return tx
 
 
-def get_transaction_log(neoxp_path: str, tx_hash: UInt256, check_point_file: str = None) -> TransactionLog:
+def get_transaction_log(neoxp_path: str, tx_hash: UInt256, check_point_file: str = None, contract_collection=None) -> TransactionLog:
     raw_result = _get_transaction_raw(neoxp_path, tx_hash, check_point_file)
 
     tx_log: TransactionLog
     try:
         import json
         result_json = json.loads(raw_result)
-        tx_log = TransactionLog.from_json(result_json['application-log'])
+        tx_log = TransactionLog.from_json(result_json['application-log'], contract_collection)
         tx_log._tx_id = tx_hash
     except:
         tx_log = None

--- a/boa3_test/test_drive/testrunner/blockchain/notification.py
+++ b/boa3_test/test_drive/testrunner/blockchain/notification.py
@@ -1,11 +1,34 @@
+from typing import Dict, Any
+
 from boa3.internal.neo.smart_contract.notification import Notification
 from boa3.internal.neo3.core.types import UInt160
+from boa3_test.test_drive.model.smart_contract.testcontract import TestContract
+from boa3_test.test_drive.model.smart_contract.contractcollection import ContractCollection
 
 
 class TestRunnerNotification(Notification):
-    _event_name_key = 'eventname'
     _script_hash_key = 'contract'
     _value_key = 'state'
+
+    def __init__(self, event_name: str, script_hash: bytes, *value: Any):
+        super().__init__(event_name, script_hash, *value)
+        self._contract = None
+
+    @property
+    def contract(self) -> TestContract:
+        return self._contract
+
+    @classmethod
+    def from_json(cls, json: Dict[str, Any], contract_collection: ContractCollection = None,
+                  *args, **kwargs) -> Notification:
+
+        result = super().from_json(json)
+        if result is None:
+            return result
+
+        if isinstance(contract_collection, ContractCollection) and result.origin in contract_collection:
+            result._contract = contract_collection[result.origin]
+        return result
 
     @classmethod
     def _get_script_from_str(cls, script: str) -> bytes:

--- a/boa3_test/test_drive/testrunner/blockchain/transactionlog.py
+++ b/boa3_test/test_drive/testrunner/blockchain/transactionlog.py
@@ -4,6 +4,7 @@ from typing import List, Dict, Any
 
 from boa3_test.test_drive.model.interface.itransactionobject import ITransactionObject
 from boa3_test.test_drive.model.network.payloads.testtransaction import TransactionExecution
+from boa3_test.test_drive.model.smart_contract.contractcollection import ContractCollection
 
 
 class TestRunnerTransactionLog(ITransactionObject):
@@ -16,9 +17,9 @@ class TestRunnerTransactionLog(ITransactionObject):
         return self._executions.copy()
 
     @classmethod
-    def from_json(cls, json: Dict[str, Any]) -> TestRunnerTransactionLog:
+    def from_json(cls, json: Dict[str, Any], contract_collection: ContractCollection = None) -> TestRunnerTransactionLog:
         tx_log = cls()
 
-        tx_log._executions = [TransactionExecution.from_json(execution) for execution in json['executions']]
+        tx_log._executions = [TransactionExecution.from_json(execution, contract_collection) for execution in json['executions']]
 
         return tx_log

--- a/boa3_test/tests/boa_test.py
+++ b/boa3_test/tests/boa_test.py
@@ -32,6 +32,7 @@ class BoaTest(TestCase):
     CANT_FIND_METHOD_MSG_PREFIX = "Can't find method"
     CANT_PARSE_VALUE_MSG = "The value could not be parsed."
     CALLED_CONTRACT_DOES_NOT_EXIST_MSG = 'Called Contract Does Not Exist'
+    CONTRACT_NOT_FOUND_MSG_REGEX = 'contract "(.*?)" not found'
     GAS_MUST_BE_POSITIVE_MSG = 'GAS must be positive.'
     GIVEN_KEY_NOT_PRESENT_IN_DICT_MSG_REGEX = "The given key '\\S+' was not present in the dictionary."
     INSUFFICIENT_GAS = 'Insufficient GAS.'

--- a/boa3_test/tests/examples_tests/test_nep11_non_divisible.py
+++ b/boa3_test/tests/examples_tests/test_nep11_non_divisible.py
@@ -1,21 +1,20 @@
 import json
-from typing import Dict, List
 
 from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to avoid circular imports
 
-from boa3.internal.neo import to_script_hash
 from boa3.internal.neo.vm.type.String import String
-from boa3.internal.neo3.core.types import UInt160
-from boa3_test.tests.test_classes.TestExecutionException import TestExecutionException
-from boa3_test.tests.test_classes.testengine import TestEngine
+from boa3.internal.neo3.vm import VMState
+from boa3_test.test_drive import neoxp
+from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 
 
 class TestNEP11Template(BoaTest):
     default_folder: str = 'examples'
 
-    OWNER_SCRIPT_HASH = to_script_hash(b'NZcuGiwRu1QscpmCyxj5XwQBUf6sk7dJJN')
-    OTHER_ACCOUNT_1 = to_script_hash(b'NiNmXL8FjEUEs1nfX9uHFBNaenxDHJtmuB')
-    OTHER_ACCOUNT_2 = to_script_hash(b'NNLi44dJNXtDNSBkofB48aTVYtb1zZrNEs')
+    OWNER = neoxp.utils.get_account_by_name('owner')
+    OTHER_ACCOUNT_1 = neoxp.utils.get_account_by_name('testAccount1')
+    OTHER_ACCOUNT_2 = neoxp.utils.get_account_by_name('testAccount2')
+    GAS_TO_DEPLOY = 100 * 10 ** 8
 
     TOKEN_META = bytes(
         '{ "name": "NEP11", "description": "Some description", "image": "{some image URI}", "tokenURI": "{some URI}" }',
@@ -25,12 +24,6 @@ class TestNEP11Template(BoaTest):
         '[{"address": "NZcuGiwRu1QscpmCyxj5XwQBUf6sk7dJJN", "value": 2000}, '
         '{"address": "NiNmXL8FjEUEs1nfX9uHFBNaenxDHJtmuB", "value": 3000}]',
         'utf-8')
-
-    def deploy_contract(self, engine, path):
-        engine.add_signer_account(self.OWNER_SCRIPT_HASH)
-        self.run_smart_contract(engine, path, '_deploy', self.OWNER_SCRIPT_HASH, False,
-                                signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                expected_result_type=bool)
 
     def test_nep11_compile(self):
         path = self.get_contract_path('nep11_non_divisible.py')
@@ -42,398 +35,489 @@ class TestNEP11Template(BoaTest):
         self.assertIn('NEP-11', manifest['supportedstandards'])
 
     def test_nep11_symbol(self):
-        path = self.get_contract_path('nep11_non_divisible.py')
-        engine = TestEngine()
-        engine.use_contract_custom_name = self._use_custom_name
-        self.deploy_contract(engine, path)
-        result = self.run_smart_contract(engine, path, 'symbol')
-        self.assertEqual('EXMP', result)
+        path, _ = self.get_deploy_file_paths('nep11_non_divisible.py')
+        runner = NeoTestRunner(runner_id=self.method_name())
+
+        runner.add_gas(self.OWNER.address, self.GAS_TO_DEPLOY)
+        runner.deploy_contract(path, account=self.OWNER)
+
+        invoke = runner.call_contract(path, 'symbol')
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        self.assertEqual('EXMP', invoke.result)
 
     def test_nep11_decimals(self):
-        path = self.get_contract_path('nep11_non_divisible.py')
-        engine = TestEngine()
-        engine.use_contract_custom_name = self._use_custom_name
-        self.deploy_contract(engine, path)
-        result = self.run_smart_contract(engine, path, 'decimals')
-        self.assertEqual(0, result)
+        path, _ = self.get_deploy_file_paths('nep11_non_divisible.py')
+        runner = NeoTestRunner(runner_id=self.method_name())
+
+        runner.add_gas(self.OWNER.address, self.GAS_TO_DEPLOY)
+        runner.deploy_contract(path, account=self.OWNER)
+
+        invoke = runner.call_contract(path, 'decimals')
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        self.assertEqual(0, invoke.result)
+
+    def test_nep11_balance_of(self):
+        path, _ = self.get_deploy_file_paths('nep11_non_divisible.py')
+        runner = NeoTestRunner(runner_id=self.method_name())
+
+        invokes = []
+        expected_results = []
+
+        runner.add_gas(self.OWNER.address, self.GAS_TO_DEPLOY)
+        runner.deploy_contract(path, account=self.OWNER)
+
+        # add some gas for fees
+        add_amount = 10 * 10 ** 8
+        runner.add_gas(self.OTHER_ACCOUNT_1.address, add_amount)
+        other_account_script_hash = self.OTHER_ACCOUNT_1.script_hash.to_array()
+
+        # mint
+        token_1 = '\x01'
+        invokes.append(runner.call_contract(path, 'mint',
+                                            other_account_script_hash, self.TOKEN_META,
+                                            self.TOKEN_LOCKED, self.ROYALTIES))
+        expected_results.append(token_1)
+
+        # balance should be one
+        invokes.append(runner.call_contract(path, 'balanceOf', other_account_script_hash))
+        expected_results.append(1)
+
+        # minting another token
+        token_2 = '\x02'
+        invokes.append(runner.call_contract(path, 'mint',
+                                            other_account_script_hash, self.TOKEN_META,
+                                            self.TOKEN_LOCKED, self.ROYALTIES))
+        expected_results.append(token_2)
+
+        # balance should increase again
+        invokes.append(runner.call_contract(path, 'balanceOf', other_account_script_hash))
+        expected_results.append(2)
+
+        runner.execute(account=self.OTHER_ACCOUNT_1)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+    def test_nep11_tokens_of(self):
+        path, _ = self.get_deploy_file_paths('nep11_non_divisible.py')
+        runner = NeoTestRunner(runner_id=self.method_name())
+
+        invokes = []
+        expected_results = []
+
+        runner.add_gas(self.OWNER.address, self.GAS_TO_DEPLOY)
+        runner.deploy_contract(path, account=self.OWNER)
+
+        # add some gas for fees
+        add_amount = 10 * 10 ** 8
+        runner.add_gas(self.OTHER_ACCOUNT_1.address, add_amount)
+        other_account_script_hash = self.OTHER_ACCOUNT_1.script_hash.to_array()
+
+        tokens = []
+        expected_minted_token_1 = '\x01'
+        expected_minted_token_2 = '\x02'
+
+        # initial tokensOf is an empty iterator
+        invokes.append(runner.call_contract(path, 'tokensOf', other_account_script_hash))
+        expected_results.append(tokens.copy())
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        # mint
+        runner.run_contract(path, 'mint',
+                            other_account_script_hash, self.TOKEN_META,
+                            self.TOKEN_LOCKED, self.ROYALTIES, account=self.OTHER_ACCOUNT_1)
+        tokens.append(expected_minted_token_1)
+
+        # tokensOf should return ['\x01']
+        invokes.append(runner.call_contract(path, 'tokensOf', other_account_script_hash))
+        expected_results.append(tokens.copy())
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        # minting another token
+        runner.run_contract(path, 'mint',
+                            other_account_script_hash, self.TOKEN_META,
+                            self.TOKEN_LOCKED, self.ROYALTIES, account=self.OTHER_ACCOUNT_1)
+        tokens.append(expected_minted_token_2)
+
+        # tokens should increase again
+        invokes.append(runner.call_contract(path, 'tokensOf', other_account_script_hash))
+        expected_results.append(tokens)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_nep11_total_supply(self):
+        path, _ = self.get_deploy_file_paths('nep11_non_divisible.py')
+        runner = NeoTestRunner(runner_id=self.method_name())
+
         # smart contract deploys with zero tokens minted
         total_supply = 0
 
-        path = self.get_contract_path('nep11_non_divisible.py')
-        engine = TestEngine()
-        engine.use_contract_custom_name = self._use_custom_name
-        self.deploy_contract(engine, path)
-        result = self.run_smart_contract(engine, path, 'totalSupply')
-        self.assertEqual(total_supply, result)
+        runner.add_gas(self.OWNER.address, self.GAS_TO_DEPLOY)
+        runner.deploy_contract(path, account=self.OWNER)
+
+        invoke = runner.call_contract(path, 'totalSupply')
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        self.assertEqual(total_supply, invoke.result)
+
+    def test_nep11_transfer(self):
+        path, _ = self.get_deploy_file_paths('nep11_non_divisible.py')
+        runner = NeoTestRunner(runner_id=self.method_name())
+
+        invokes = []
+        expected_results = []
+
+        runner.add_gas(self.OWNER.address, self.GAS_TO_DEPLOY)
+        runner.deploy_contract(path, account=self.OWNER)
+
+        # add some gas for fees
+        add_amount = 10 * 10 ** 8
+        runner.add_gas(self.OTHER_ACCOUNT_1.address, add_amount)
+        other_account_1_script_hash = self.OTHER_ACCOUNT_1.script_hash.to_array()
+        other_account_2_script_hash = self.OTHER_ACCOUNT_2.script_hash.to_array()
+
+        # mint
+        token = '\x01'
+        invokes.append(runner.call_contract(path, 'mint',
+                                            other_account_1_script_hash, self.TOKEN_META,
+                                            self.TOKEN_LOCKED, self.ROYALTIES))
+        expected_results.append(token)
+
+        # check owner before
+        invokes.append(runner.call_contract(path, 'ownerOf', token))
+        expected_results.append(other_account_1_script_hash)
+
+        # transfer
+        invokes.append(runner.call_contract(path, 'transfer',
+                                            other_account_2_script_hash, token, None,
+                                            expected_result_type=bool))
+        expected_results.append(True)
+
+        # check owner after
+        invokes.append(runner.call_contract(path, 'ownerOf', token))
+        expected_results.append(other_account_2_script_hash)
+
+        # check balances after
+        invokes.append(runner.call_contract(path, 'balanceOf', other_account_1_script_hash))
+        expected_results.append(0)
+        invokes.append(runner.call_contract(path, 'totalSupply'))
+        expected_results.append(1)
+
+        runner.execute(account=self.OTHER_ACCOUNT_1)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+        runner.call_contract(path, 'transfer', other_account_2_script_hash, b'thisisanonexistingtoken', None)
+        runner.execute(account=self.OTHER_ACCOUNT_1)
+        self.assertEqual(VMState.FAULT, runner.vm_state, msg=runner.cli_log)
+        self.assertRegex(runner.error, self.ASSERT_RESULTED_FALSE_MSG)
+
+    def test_nep11_onNEP11Payment(self):
+        path, _ = self.get_deploy_file_paths('nep11_non_divisible.py')
+        runner = NeoTestRunner(runner_id=self.method_name())
+
+        runner.add_gas(self.OWNER.address, self.GAS_TO_DEPLOY)
+        runner.deploy_contract(path, account=self.OWNER)
+
+        # add some gas for fees
+        add_amount = 10 * 10 ** 8
+        runner.add_gas(self.OTHER_ACCOUNT_1.address, add_amount)
+        other_account_script_hash = self.OTHER_ACCOUNT_1.script_hash.to_array()
+
+        # mint
+        token = '\x01'
+        runner.run_contract(path, 'mint',
+                            other_account_script_hash, self.TOKEN_META,
+                            self.TOKEN_LOCKED, self.ROYALTIES,
+                            account=self.OTHER_ACCOUNT_1)
+
+        # the smart contract will abort if any address calls the NEP11 onPayment method
+        runner.call_contract(path, 'onNEP11Payment',
+                             other_account_script_hash, 1, token, None)
+        runner.execute(account=self.OTHER_ACCOUNT_1)
+        self.assertEqual(VMState.FAULT, runner.vm_state, msg=runner.cli_log)
+        self.assertRegex(runner.error, self.ABORTED_CONTRACT_MSG)
 
     def test_nep11_deploy(self):
-        path = self.get_contract_path('nep11_non_divisible.py')
-        engine = TestEngine()
-        engine.use_contract_custom_name = self._use_custom_name
-        self.deploy_contract(engine, path)
-        # contract is already deployed
+        path, _ = self.get_deploy_file_paths('nep11_non_divisible.py')
+        runner = NeoTestRunner(runner_id=self.method_name())
 
-        result = self.run_smart_contract(engine, path, '_deploy', None, False,
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
-        self.assertIsVoid(result)
+        runner.add_gas(self.OWNER.address, self.GAS_TO_DEPLOY)
+        contract = runner.deploy_contract(path, account=self.OWNER)
+        runner.update_contracts(export_checkpoint=True)
+
+        tx_id = contract.tx_id
+        self.assertIsNotNone(tx_id)
+
+        tx = runner.get_transaction_result(tx_id)
+        self.assertIsInstance(tx.executions, list)
+        self.assertEqual(1, len(tx.executions))
+        tx_result = tx.executions[0]
+
         # contract was deployed only once
-        self.assertEqual(1, len([notification for notification in engine.notifications if notification.name == "Deploy"]))
+        self.assertEqual(1, len([notification for notification in tx_result.notifications if notification.name == "Deploy"]))
 
     def test_nep11_update(self):
-        path = self.get_contract_path('nep11_non_divisible.py')
-        engine = TestEngine()
-        engine.use_contract_custom_name = self._use_custom_name
-        self.deploy_contract(engine, path)
+        path, _ = self.get_deploy_file_paths('nep11_non_divisible.py')
+        runner = NeoTestRunner(runner_id=self.method_name())
+
+        runner.add_gas(self.OWNER.address, self.GAS_TO_DEPLOY)
+        runner.deploy_contract(path, account=self.OWNER)
 
         new_nef, new_manifest = self.get_bytes_output(path)
         arg_manifest = String(json.dumps(new_manifest, separators=(',', ':'))).to_bytes()
 
         # update contract
-        result = self.run_smart_contract(engine, path, 'update',
-                                         new_nef, arg_manifest,
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
-        self.assertIsVoid(result)
+        invoke = runner.call_contract(path, 'update',
+                                      new_nef, arg_manifest)
+        runner.execute(account=self.OWNER)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        self.assertIsNone(invoke.result)
 
     def test_nep11_destroy(self):
-        path = self.get_contract_path('nep11_non_divisible.py')
-        engine = TestEngine()
-        engine.use_contract_custom_name = self._use_custom_name
-        self.deploy_contract(engine, path)
+        path, _ = self.get_deploy_file_paths('nep11_non_divisible.py')
+        runner = NeoTestRunner(runner_id=self.method_name())
+
+        runner.add_gas(self.OWNER.address, self.GAS_TO_DEPLOY)
+        runner.deploy_contract(path, account=self.OWNER)
 
         # destroy contract
-        result = self.run_smart_contract(engine, path, 'destroy',
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH])
-        self.assertIsVoid(result)
+        invoke = runner.call_contract(path, 'destroy')
+        runner.execute(account=self.OWNER)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        self.assertIsNone(invoke.result)
+
+        runner.run_contract(path, 'destroy', account=self.OWNER)
 
         # should not exist anymore
-        result = self.run_smart_contract(engine, path, 'symbol')
-        self.assertNotEqual('', result)
+        runner.call_contract(path, 'symbol')
+        runner.execute(account=self.OWNER)
+        self.assertNotEqual(VMState.HALT, runner.vm_state, msg=runner.cli_log)
+        self.assertRegex(runner.error, self.CONTRACT_NOT_FOUND_MSG_REGEX)
 
     def test_nep11_verify(self):
-        path = self.get_contract_path('nep11_non_divisible.py')
-        engine = TestEngine()
-        engine.use_contract_custom_name = self._use_custom_name
-        self.deploy_contract(engine, path)
+        path, _ = self.get_deploy_file_paths('nep11_non_divisible.py')
+        runner = NeoTestRunner(runner_id=self.method_name())
 
-        # should fail because account does not have enough for fees
-        verified = self.run_smart_contract(engine, path, 'verify',
-                                           signer_accounts=[self.OTHER_ACCOUNT_2],
-                                           expected_result_type=bool)
-        self.assertEqual(verified, False)
+        invokes = []
+        expected_results = []
 
-        addresses = self.run_smart_contract(engine, path, 'getAuthorizedAddress',
-                                            expected_result_type=List[UInt160],
-                                            signer_accounts=[self.OWNER_SCRIPT_HASH])
-        self.assertEqual(addresses[0], self.OWNER_SCRIPT_HASH)
-        self.assertEqual(len(addresses), 1)
+        runner.add_gas(self.OWNER.address, self.GAS_TO_DEPLOY)
+        runner.deploy_contract(path, account=self.OWNER)
 
-        verified = self.run_smart_contract(engine, path, 'verify',
-                                           signer_accounts=[self.OTHER_ACCOUNT_1],
-                                           expected_result_type=bool)
-        self.assertEqual(verified, False)
+        invokes.append(runner.call_contract(path, 'getAuthorizedAddress',
+                                            expected_result_type=list))
+        expected_results.append([self.OWNER.script_hash.to_array()])
 
-        verified = self.run_smart_contract(engine, path, 'verify',
-                                           signer_accounts=[self.OTHER_ACCOUNT_2],
-                                           expected_result_type=bool)
-        self.assertEqual(verified, False)
+        invokes.append(runner.call_contract(path, 'verify',
+                                            expected_result_type=bool))
+        expected_results.append(True)
 
-        verified = self.run_smart_contract(engine, path, 'verify',
-                                           signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                           expected_result_type=bool)
-        self.assertEqual(verified, True)
+        runner.execute(account=self.OWNER)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
-    def test_nep11_authorize_2(self):
-        path = self.get_contract_path('nep11_non_divisible.py')
-        engine = TestEngine()
-        engine.use_contract_custom_name = self._use_custom_name
-        self.deploy_contract(engine, path)
+        invokes.append(runner.call_contract(path, 'verify',
+                                            expected_result_type=bool))
+        expected_results.append(False)
 
-        self.run_smart_contract(engine, path, 'setAuthorizedAddress',
-                                self.OTHER_ACCOUNT_1, True,
-                                signer_accounts=[self.OWNER_SCRIPT_HASH])
-        auth_events = engine.get_events('Authorized')
+        runner.execute(account=self.OTHER_ACCOUNT_1)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
-        # check if the event was triggered and the address was authorized
-        self.assertEqual(0, auth_events[0].arguments[1])
-        self.assertEqual(1, auth_events[0].arguments[2])
+        invokes.append(runner.call_contract(path, 'verify',
+                                            expected_result_type=bool))
+        expected_results.append(False)
 
-        # now deauthorize the address
-        self.run_smart_contract(engine, path, 'setAuthorizedAddress',
-                                self.OTHER_ACCOUNT_1, False,
-                                signer_accounts=[self.OWNER_SCRIPT_HASH])
-        auth_events = engine.get_events('Authorized')
-        # check if the event was triggered and the address was authorized
-        self.assertEqual(0, auth_events[1].arguments[1])
-        self.assertEqual(0, auth_events[1].arguments[2])
+        runner.execute(account=self.OTHER_ACCOUNT_2)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_nep11_authorize(self):
-        path = self.get_contract_path('nep11_non_divisible.py')
-        engine = TestEngine()
-        engine.use_contract_custom_name = self._use_custom_name
-        self.deploy_contract(engine, path)
+        path, _ = self.get_deploy_file_paths('nep11_non_divisible.py')
+        runner = NeoTestRunner(runner_id=self.method_name())
 
-        self.run_smart_contract(engine, path, 'setAuthorizedAddress',
-                                self.OTHER_ACCOUNT_1, True,
-                                signer_accounts=[self.OWNER_SCRIPT_HASH])
-        auth_events = engine.get_events('Authorized')
+        other_account_script_hash = self.OTHER_ACCOUNT_1.script_hash.to_array()
+        runner.add_gas(self.OWNER.address, self.GAS_TO_DEPLOY)
+        runner.deploy_contract(path, account=self.OWNER)
 
-        # check if the event was triggered and the address was authorized
-        self.assertEqual(0, auth_events[0].arguments[1])
-        self.assertEqual(1, auth_events[0].arguments[2])
+        runner.call_contract(path, 'setAuthorizedAddress', other_account_script_hash, True)
 
         # now deauthorize the address
-        self.run_smart_contract(engine, path, 'setAuthorizedAddress',
-                                self.OTHER_ACCOUNT_1, False,
-                                signer_accounts=[self.OWNER_SCRIPT_HASH])
-        auth_events = engine.get_events('Authorized')
+        runner.call_contract(path, 'setAuthorizedAddress', other_account_script_hash, False)
+
+        runner.execute(account=self.OWNER)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        auth_events = runner.get_events('Authorized')
+        self.assertEqual(2, len(auth_events))
+
+        authorize_event = auth_events[0]
+        deauthorize_event = auth_events[1]
+
         # check if the event was triggered and the address was authorized
-        self.assertEqual(0, auth_events[1].arguments[1])
-        self.assertEqual(0, auth_events[1].arguments[2])
+        self.assertEqual(0, authorize_event.arguments[1])
+        self.assertEqual(1, authorize_event.arguments[2])
+
+        # check if the event was triggered and the address was authorized
+        self.assertEqual(0, deauthorize_event.arguments[1])
+        self.assertEqual(0, deauthorize_event.arguments[2])
 
     def test_nep11_pause(self):
-        path = self.get_contract_path('nep11_non_divisible.py')
-        engine = TestEngine()
-        engine.use_contract_custom_name = self._use_custom_name
-        self.deploy_contract(engine, path)
+        path, _ = self.get_deploy_file_paths('nep11_non_divisible.py')
+        runner = NeoTestRunner(runner_id=self.method_name())
 
-        nef_path, _ = self.get_deploy_file_paths_without_compiling(path)
-        engine.add_contract(nef_path)
+        invokes = []
+        expected_results = []
+
+        runner.add_gas(self.OWNER.address, self.GAS_TO_DEPLOY)
+        runner.deploy_contract(path, account=self.OWNER)
 
         # add some gas for fees
         add_amount = 10 * 10 ** 8
-        engine.add_gas(self.OTHER_ACCOUNT_1, add_amount)
+        runner.add_gas(self.OTHER_ACCOUNT_1.address, add_amount)
+        other_account_script_hash = self.OTHER_ACCOUNT_1.script_hash.to_array()
 
         # pause contract
-        result = self.run_smart_contract(engine, path, 'updatePause', True,
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
-        self.assertEqual(True, result)
+        invokes.append(runner.call_contract(path, 'updatePause', True,
+                                            expected_result_type=bool))
+        expected_results.append(True)
+
+        runner.execute(account=self.OWNER)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        runner.run_contract(path, 'updatePause', True, account=self.OWNER)
 
         # should fail because contract is paused
-        with self.assertRaisesRegex(TestExecutionException, self.ASSERT_RESULTED_FALSE_MSG):
-            self.run_smart_contract(engine, path, 'mint',
-                                    self.OTHER_ACCOUNT_1, self.TOKEN_META, self.TOKEN_LOCKED, self.ROYALTIES,
-                                    signer_accounts=[self.OTHER_ACCOUNT_1])
+        runner.call_contract(path, 'mint',
+                             other_account_script_hash, self.TOKEN_META, self.TOKEN_LOCKED, self.ROYALTIES)
+        runner.execute(account=self.OTHER_ACCOUNT_1)
+        self.assertEqual(VMState.FAULT, runner.vm_state, msg=runner.cli_log)
+        self.assertRegex(runner.error, self.ASSERT_RESULTED_FALSE_MSG)
 
         # unpause contract
-        result = self.run_smart_contract(engine, path, 'updatePause', False,
-                                         signer_accounts=[self.OWNER_SCRIPT_HASH],
-                                         expected_result_type=bool)
-        self.assertEqual(False, result)
+        invokes.append(runner.call_contract(path, 'updatePause', False,
+                                            expected_result_type=bool))
+        expected_results.append(False)
+
+        runner.execute(account=self.OWNER)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        runner.run_contract(path, 'updatePause', False, account=self.OWNER)
 
         # mint
-        result = self.run_smart_contract(engine, path, 'mint',
-                                         self.OTHER_ACCOUNT_1, self.TOKEN_META, self.TOKEN_LOCKED, self.ROYALTIES,
-                                         signer_accounts=[self.OTHER_ACCOUNT_1])
-        self.assertEqual('\x01', result)
+        invokes.append(runner.call_contract(path, 'mint',
+                                            other_account_script_hash, self.TOKEN_META,
+                                            self.TOKEN_LOCKED, self.ROYALTIES))
+        expected_results.append('\x01')
+
+        runner.execute(account=self.OTHER_ACCOUNT_1)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_nep11_mint(self):
-        path = self.get_contract_path('nep11_non_divisible.py')
-        engine = TestEngine()
-        engine.use_contract_custom_name = self._use_custom_name
-        self.deploy_contract(engine, path)
+        path, _ = self.get_deploy_file_paths('nep11_non_divisible.py')
+        runner = NeoTestRunner(runner_id=self.method_name())
 
-        nef_path, _ = self.get_deploy_file_paths_without_compiling(path)
-        engine.add_contract(nef_path)
+        invokes = []
+        expected_results = []
+
+        runner.add_gas(self.OWNER.address, self.GAS_TO_DEPLOY)
+        runner.deploy_contract(path, account=self.OWNER)
 
         # add some gas for fees
         add_amount = 10 * 10 ** 8
-        engine.add_gas(self.OTHER_ACCOUNT_1, add_amount)
+        runner.add_gas(self.OTHER_ACCOUNT_1.address, add_amount)
+        other_account_script_hash = self.OTHER_ACCOUNT_1.script_hash.to_array()
 
         # should succeed now that account has enough fees
-        token = self.run_smart_contract(engine, path, 'mint',
-                                        self.OTHER_ACCOUNT_1, self.TOKEN_META, self.TOKEN_LOCKED, self.ROYALTIES,
-                                        signer_accounts=[self.OTHER_ACCOUNT_1])
+        mint = runner.call_contract(path, 'mint',
+                                    other_account_script_hash, self.TOKEN_META,
+                                    self.TOKEN_LOCKED, self.ROYALTIES)
 
-        properties = self.run_smart_contract(engine, path, 'properties', token, expected_result_type=Dict[str, str])
+        runner.execute(account=self.OTHER_ACCOUNT_1, add_invokes_to_batch=True)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        token = mint.result
+        invokes.append(runner.call_contract(path, 'properties', token, expected_result_type=dict))
         token_property = json.loads(self.TOKEN_META.decode('utf-8').replace("'", "\""))
-        self.assertEqual(token_property, properties)
+        expected_results.append(token_property)
 
-        royalties = self.run_smart_contract(engine, path, 'getRoyalties', token, expected_result_type=str)
-        self.assertEqual(royalties, self.ROYALTIES.decode('utf-8'))
-
-        with self.assertRaisesRegex(TestExecutionException, self.ASSERT_RESULTED_FALSE_MSG):
-            self.run_smart_contract(engine, path, 'properties',
-                                    bytes('thisisanonexistingtoken', 'utf-8'),
-                                    expected_result_type=str)
+        invokes.append(runner.call_contract(path, 'getRoyalties', token, expected_result_type=str))
+        expected_results.append(self.ROYALTIES.decode('utf-8'))
 
         # check balances after
-        nep11_balance_after = self.run_smart_contract(engine, path, 'balanceOf', self.OTHER_ACCOUNT_1)
-        nep11_supply_after = self.run_smart_contract(engine, path, 'totalSupply')
-        self.assertEqual(1, nep11_balance_after)
-        self.assertEqual(1, nep11_supply_after)
+        invokes.append(runner.call_contract(path, 'balanceOf', other_account_script_hash))
+        expected_results.append(1)
 
-    def test_nep11_transfer(self):
-        path = self.get_contract_path('nep11_non_divisible.py')
-        engine = TestEngine()
-        engine.use_contract_custom_name = self._use_custom_name
-        self.deploy_contract(engine, path)
+        invokes.append(runner.call_contract(path, 'totalSupply'))
+        expected_results.append(1)
 
-        nef_path, _ = self.get_deploy_file_paths_without_compiling(path)
-        engine.add_contract(nef_path)
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
-        # add some gas for fees
-        add_amount = 10 * 10 ** 8
-        engine.add_gas(self.OTHER_ACCOUNT_1, add_amount)
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
 
-        # mint
-        token = self.run_smart_contract(engine, path, 'mint',
-                                        self.OTHER_ACCOUNT_1, self.TOKEN_META, self.TOKEN_LOCKED, self.ROYALTIES,
-                                        signer_accounts=[self.OTHER_ACCOUNT_1])
-        self.assertEqual('\x01', token)
-
-        # check owner before
-        nep11_owner_of_before = self.run_smart_contract(engine, path, 'ownerOf', token)
-        self.assertEqual(self.OTHER_ACCOUNT_1, nep11_owner_of_before)
-
-        # transfer
-        result = self.run_smart_contract(engine, path, 'transfer',
-                                         self.OTHER_ACCOUNT_2, token, None,
-                                         signer_accounts=[self.OTHER_ACCOUNT_1],
-                                         expected_result_type=bool)
-        self.assertEqual(True, result)
-
-        # check owner after
-        nep11_owner_of_after = self.run_smart_contract(engine, path, 'ownerOf', token)
-        self.assertEqual(self.OTHER_ACCOUNT_2, nep11_owner_of_after)
-
-        # check balances after
-        nep11_balance_after_transfer = self.run_smart_contract(engine, path, 'balanceOf', self.OTHER_ACCOUNT_1)
-        nep11_supply_after_transfer = self.run_smart_contract(engine, path, 'totalSupply')
-        self.assertEqual(0, nep11_balance_after_transfer)
-        self.assertEqual(1, nep11_supply_after_transfer)
-
-        # try to transfer non existing token id
-        with self.assertRaisesRegex(TestExecutionException, self.ASSERT_RESULTED_FALSE_MSG):
-            self.run_smart_contract(engine, path, 'transfer',
-                                    self.OTHER_ACCOUNT_2, bytes('thisisanonexistingtoken', 'utf-8'), None,
-                                    signer_accounts=[self.OTHER_ACCOUNT_1])
+        runner.call_contract(path, 'properties', b'thisisanonexistingtoken')
+        runner.execute()
+        self.assertEqual(VMState.FAULT, runner.vm_state, msg=runner.cli_log)
+        self.assertRegex(runner.error, self.ASSERT_RESULTED_FALSE_MSG)
 
     def test_nep11_burn(self):
-        path = self.get_contract_path('nep11_non_divisible.py')
-        engine = TestEngine()
-        engine.use_contract_custom_name = self._use_custom_name
-        self.deploy_contract(engine, path)
+        path, _ = self.get_deploy_file_paths('nep11_non_divisible.py')
+        runner = NeoTestRunner(runner_id=self.method_name())
 
-        nef_path, _ = self.get_deploy_file_paths_without_compiling(path)
-        engine.add_contract(nef_path)
+        invokes = []
+        expected_results = []
+
+        runner.add_gas(self.OWNER.address, self.GAS_TO_DEPLOY)
+        runner.deploy_contract(path, account=self.OWNER)
 
         # add some gas for fees
         add_amount = 10 * 10 ** 8
-        engine.add_gas(self.OTHER_ACCOUNT_1, add_amount)
+        runner.add_gas(self.OTHER_ACCOUNT_1.address, add_amount)
+        other_account_script_hash = self.OTHER_ACCOUNT_1.script_hash.to_array()
 
         # mint
-        token = self.run_smart_contract(engine, path, 'mint',
-                                        self.OTHER_ACCOUNT_1, self.TOKEN_META, self.TOKEN_LOCKED, self.ROYALTIES,
-                                        signer_accounts=[self.OTHER_ACCOUNT_1])
-        self.assertEqual('\x01', token)
+        token = '\x01'
+        invokes.append(runner.call_contract(path, 'mint',
+                                            other_account_script_hash, self.TOKEN_META,
+                                            self.TOKEN_LOCKED, self.ROYALTIES))
+        expected_results.append(token)
 
         # burn
-        burn = self.run_smart_contract(engine, path, 'burn', token,
-                                       signer_accounts=[self.OTHER_ACCOUNT_1],
-                                       expected_result_type=bool)
-        self.assertEqual(True, burn)
+        invokes.append(runner.call_contract(path, 'burn', token,
+                                            expected_result_type=bool))
+        expected_results.append(True)
 
         # check balances after
-        nep11_balance_after = self.run_smart_contract(engine, path, 'balanceOf', self.OTHER_ACCOUNT_1)
-        self.assertEqual(0, nep11_balance_after)
-        nep11_supply_after = self.run_smart_contract(engine, path, 'totalSupply')
-        self.assertEqual(0, nep11_supply_after)
+        invokes.append(runner.call_contract(path, 'balanceOf', other_account_script_hash))
+        expected_results.append(0)
 
-    def test_nep11_onNEP11Payment(self):
-        path = self.get_contract_path('nep11_non_divisible.py')
-        engine = TestEngine()
-        engine.use_contract_custom_name = self._use_custom_name
-        self.deploy_contract(engine, path)
+        invokes.append(runner.call_contract(path, 'totalSupply'))
+        expected_results.append(0)
 
-        nef_path, _ = self.get_deploy_file_paths_without_compiling(path)
-        engine.add_contract(nef_path)
+        runner.execute(account=self.OTHER_ACCOUNT_1)
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
-        # add some gas for fees
-        add_amount = 10 * 10 ** 8
-        engine.add_gas(self.OTHER_ACCOUNT_1, add_amount)
-
-        # mint
-        token = self.run_smart_contract(engine, path, 'mint',
-                                        self.OTHER_ACCOUNT_1, self.TOKEN_META, self.TOKEN_LOCKED, self.ROYALTIES,
-                                        signer_accounts=[self.OTHER_ACCOUNT_1])
-        self.assertEqual('\x01', token)
-
-        # the smart contract will abort if any address calls the NEP11 onPayment method
-        with self.assertRaisesRegex(TestExecutionException, self.ABORTED_CONTRACT_MSG):
-            self.run_smart_contract(engine, path, 'onNEP11Payment',
-                                    self.OTHER_ACCOUNT_1, 1, token, None,
-                                    signer_accounts=[self.OTHER_ACCOUNT_1])
-
-    def test_nep11_balance_of(self):
-        path = self.get_contract_path('nep11_non_divisible.py')
-        engine = TestEngine()
-        engine.use_contract_custom_name = self._use_custom_name
-        self.deploy_contract(engine, path)
-
-        # add some gas for fees
-        add_amount = 10 * 10 ** 8
-        engine.add_gas(self.OTHER_ACCOUNT_1, add_amount)
-
-        # mint
-        token = self.run_smart_contract(engine, path, 'mint',
-                                        self.OTHER_ACCOUNT_1, self.TOKEN_META, self.TOKEN_LOCKED, self.ROYALTIES,
-                                        signer_accounts=[self.OTHER_ACCOUNT_1])
-        self.assertEqual('\x01', token)
-
-        # balance should be one
-        amount_of_tokens = self.run_smart_contract(engine, path, 'balanceOf', self.OTHER_ACCOUNT_1)
-        self.assertEqual(1, amount_of_tokens)
-
-        # minting another token
-        token = self.run_smart_contract(engine, path, 'mint',
-                                        self.OTHER_ACCOUNT_1, self.TOKEN_META, self.TOKEN_LOCKED, self.ROYALTIES,
-                                        signer_accounts=[self.OTHER_ACCOUNT_1])
-        self.assertEqual('\x02', token)
-
-        # balance should increase again
-        amount_of_tokens = self.run_smart_contract(engine, path, 'balanceOf', self.OTHER_ACCOUNT_1)
-        self.assertEqual(2, amount_of_tokens)
-
-    def test_nep11_tokens_of(self):
-        path = self.get_contract_path('nep11_non_divisible.py')
-        engine = TestEngine()
-        engine.use_contract_custom_name = self._use_custom_name
-        self.deploy_contract(engine, path)
-
-        # add some gas for fees
-        add_amount = 10 * 10 ** 8
-        engine.add_gas(self.OTHER_ACCOUNT_1, add_amount)
-
-        tokens = []
-
-        # initial tokensOf is an empty iterator
-        account_tokens = self.run_smart_contract(engine, path, 'tokensOf', self.OTHER_ACCOUNT_1)
-        self.assertEqual(tokens, account_tokens)
-
-        # mint
-        token = self.run_smart_contract(engine, path, 'mint',
-                                        self.OTHER_ACCOUNT_1, self.TOKEN_META, self.TOKEN_LOCKED, self.ROYALTIES,
-                                        signer_accounts=[self.OTHER_ACCOUNT_1])
-        self.assertEqual('\x01', token)
-
-        tokens.append('\x01')
-
-        # tokensOf should return ['\x01']
-        account_tokens = self.run_smart_contract(engine, path, 'tokensOf', self.OTHER_ACCOUNT_1)
-        self.assertEqual(tokens, account_tokens)
-
-        # minting another token
-        token = self.run_smart_contract(engine, path, 'mint',
-                                        self.OTHER_ACCOUNT_1, self.TOKEN_META, self.TOKEN_LOCKED, self.ROYALTIES,
-                                        signer_accounts=[self.OTHER_ACCOUNT_1])
-        self.assertEqual('\x02', token)
-
-        tokens.append('\x02')
-
-        # tokens should increase again
-        account_tokens = self.run_smart_contract(engine, path, 'tokensOf', self.OTHER_ACCOUNT_1)
-        self.assertEqual(tokens, account_tokens)
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)

--- a/boa3_test/tests/examples_tests/test_nep11_non_divisible.py
+++ b/boa3_test/tests/examples_tests/test_nep11_non_divisible.py
@@ -274,14 +274,15 @@ class TestNEP11Template(BoaTest):
         self.assertEqual(1, len([notification for notification in tx_result.notifications if notification.name == "Deploy"]))
 
     def test_nep11_update(self):
-        path, _ = self.get_deploy_file_paths('nep11_non_divisible.py')
+        path = self.get_contract_path('nep11_non_divisible.py')
+        new_nef, new_manifest = self.get_bytes_output(path)
+        arg_manifest = String(json.dumps(new_manifest, separators=(',', ':'))).to_bytes()
+
+        path, _ = self.get_deploy_file_paths(path)
         runner = NeoTestRunner(runner_id=self.method_name())
 
         runner.add_gas(self.OWNER.address, self.GAS_TO_DEPLOY)
         runner.deploy_contract(path, account=self.OWNER)
-
-        new_nef, new_manifest = self.get_bytes_output(path)
-        arg_manifest = String(json.dumps(new_manifest, separators=(',', ':'))).to_bytes()
 
         # update contract
         invoke = runner.call_contract(path, 'update',

--- a/boa3_test/tests/run_unit_tests.py
+++ b/boa3_test/tests/run_unit_tests.py
@@ -1,5 +1,3 @@
-import time
-
 if __name__ == '__main__':
     import sys
     import os.path


### PR DESCRIPTION
**Summary or solution description**
Part of an overall refactoring. 
Changed the execution tests of the NEP-11 example to use TestRunner instead of TestEngine

**Tests**
Rerun the modified unit tests