### PR TITLE
Fix bug when importing packages in the same directory of a file, but this isn't the root directory of the project

### DIFF
--- a/boa3/internal/analyser/importanalyser.py
+++ b/boa3/internal/analyser/importanalyser.py
@@ -52,13 +52,16 @@ class ImportAnalyser(IAstAnalyser):
             self._find_package(import_target, importer_file)
             return
 
+        importer_file_dir = os.path.dirname(importer_file)
         sys.path.append(self.root_folder)
+        sys.path.append(importer_file_dir)
         try:
             import_spec = importlib.util.find_spec(import_target)
             module_origin: str = import_spec.origin
         except BaseException:
             return
         finally:
+            sys.path.remove(importer_file_dir)
             sys.path.remove(self.root_folder)
 
         self._importer_file = importer_file

--- a/boa3_test/test_sc/import_test/FromImportUserModuleFromRootAndFileDir.py
+++ b/boa3_test/test_sc/import_test/FromImportUserModuleFromRootAndFileDir.py
@@ -1,0 +1,17 @@
+from typing import Any, List
+
+from boa3.builtin.compile_time import public
+from boa3_test.test_sc.import_test.FromImportTyping import EmptyList as RootImportedFunction
+from package_with_import.Module import EmptyList as FileDirImportedFunction
+
+
+@public
+def call_imported_from_root() -> list:
+    a: List[Any] = RootImportedFunction()
+    return a
+
+
+@public
+def call_imported_from_file_dir() -> list:
+    a: List[Any] = FileDirImportedFunction()
+    return a

--- a/boa3_test/tests/boa_test.py
+++ b/boa3_test/tests/boa_test.py
@@ -116,8 +116,8 @@ class BoaTest(TestCase):
                     # when an compiler error is logged this exception is raised.
                     pass
 
-        expected_logged = [exception for exception in log.records
-                           if isinstance(exception.msg, expected_logged_exception)]
+            expected_logged = [exception for exception in log.records
+                               if isinstance(exception.msg, expected_logged_exception)]
         return output, expected_logged
 
     def assertIsVoid(self, obj: Any):

--- a/boa3_test/tests/compiler_tests/test_import.py
+++ b/boa3_test/tests/compiler_tests/test_import.py
@@ -351,6 +351,27 @@ class TestImport(BoaTest):
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
 
+    def test_from_import_user_module_from_root_and_file_directories(self):
+        path = self.get_contract_path('FromImportUserModuleFromRootAndFileDir.py')
+        self.compile_and_save(path, root_folder=self.get_dir_path(self.test_root_dir))
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner()
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'call_imported_from_root'))
+        expected_results.append([])
+
+        invokes.append(runner.call_contract(path, 'call_imported_from_file_dir'))
+        expected_results.append([])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
     def test_import_non_existent_package(self):
         path = self.get_contract_path('ImportNonExistentPackage.py')
         self.assertCompilerLogs(CompilerError.UnresolvedReference, path)


### PR DESCRIPTION
**Summary or solution description**
The compiler would allow user module importing only if imported from the root module.
Changed to accept imports relative to the importer file folder as well.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/5d91d7d564ebcf4b0acda349c66c28ce71fa5408/boa3_test/test_sc/import_test/FromImportUserModuleFromRootAndFileDir.py#L4-L17

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/5d91d7d564ebcf4b0acda349c66c28ce71fa5408/boa3_test/tests/compiler_tests/test_import.py#L354-L373

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7+
