### PR TITLE
Configure an environment argument to be passed to the compiler and accessible from the smart contract

### DIFF
--- a/boa3/boa3.py
+++ b/boa3/boa3.py
@@ -1,6 +1,8 @@
 from boa3.internal.compiler.compiler import Compiler
 from boa3.internal.exception.InvalidPathException import InvalidPathException
 
+__all__ = ['Boa3']
+
 
 class Boa3:
     """
@@ -9,21 +11,23 @@ class Boa3:
     """
 
     @staticmethod
-    def compile(path: str, root_folder: str = None) -> bytes:
+    def compile(path: str, root_folder: str = None, env: str = None) -> bytes:
         """
         Load a Python file to be compiled but don't write the result into a file
 
         :param path: the path of the Python file to compile
         :param root_folder: the root path of the project
+        :param env: specific environment id to compile
         :return: the bytecode of the compiled .nef file
         """
         if not path.endswith('.py'):
             raise InvalidPathException(path)
 
-        return Compiler().compile(path, root_folder)
+        return Compiler().compile(path, root_folder, env)
 
     @staticmethod
-    def compile_and_save(path: str, output_path: str = None, root_folder: str = None, show_errors: bool = True, debug: bool = False):
+    def compile_and_save(path: str, output_path: str = None, root_folder: str = None, show_errors: bool = True,
+                         debug: bool = False, env: str = None):
         """
         Load a Python file to be compiled and save the result into the files.
         By default, the resultant .nef file is saved in the same folder of the
@@ -34,6 +38,7 @@ class Boa3:
         :param root_folder: the root path of the project
         :param show_errors: if compiler errors should be logged.
         :param debug: if nefdbgnfo file should be generated.
+        :param env: specific environment id to compile.
         """
         if not path.endswith('.py'):
             raise InvalidPathException(path)
@@ -41,6 +46,6 @@ class Boa3:
         if output_path is None:
             output_path = path.replace('.py', '.nef')
         elif not output_path.endswith('.nef'):
-            raise InvalidPathException(path)
+            raise InvalidPathException(output_path)
 
-        Compiler().compile_and_save(path, output_path, root_folder, show_errors, debug)
+        Compiler().compile_and_save(path, output_path, root_folder, show_errors, debug, env)

--- a/boa3/builtin/__init__.py
+++ b/boa3/builtin/__init__.py
@@ -4,3 +4,11 @@ import boa3.builtin.interop
 import boa3.builtin.math
 import boa3.builtin.nativecontract
 import boa3.builtin.vm
+
+
+env: str
+"""
+Gets the compiled environment
+
+:meta hide-value:
+"""

--- a/boa3/internal/analyser/analyser.py
+++ b/boa3/internal/analyser/analyser.py
@@ -60,7 +60,7 @@ class Analyser:
     def analyse(path: str, log: bool = False,
                 imported_files: Optional[Dict[str, Analyser]] = None,
                 import_stack: Optional[List[str]] = None,
-                root: str = None, env: str = None, **kwargs) -> Analyser:
+                root: str = None, env: str = None, compiler_entry: bool = False) -> Analyser:
         """
         Analyses the syntax of the Python code
 
@@ -72,6 +72,7 @@ class Analyser:
                                If it's not triggered by an import, must be None.
         :param root: the path of the project root that the current smart contract is part of.
         :param env: specific environment id to compile.
+        :param compiler_entry: Whether this is the entry compiler analyser. False by default.
         :return: a boolean value that represents if the analysis was successful
         :rtype: Analyser
         """
@@ -81,8 +82,7 @@ class Analyser:
         analyser = Analyser(ast_tree, path, root if isinstance(root, str) else path, env, log)
         CompiledMetadata.set_current_metadata(analyser.metadata)
 
-        from_compiler_entry = 'compiler_entry' in kwargs and kwargs['compiler_entry']
-        if from_compiler_entry:
+        if compiler_entry:
             from boa3.internal.model.imports.builtin import CompilerBuiltin
             CompilerBuiltin.update_with_analyser(analyser)
 

--- a/boa3/internal/analyser/importanalyser.py
+++ b/boa3/internal/analyser/importanalyser.py
@@ -162,7 +162,7 @@ class ImportAnalyser(IAstAnalyser):
                         files = self._import_stack
                         files.append(origin)
                         if self.is_namespace_package:
-                            analyser = Analyser(self.tree, module_origin, self.root_folder, self._log)
+                            analyser = Analyser(self.tree, module_origin, self.root_folder, self.analyser.env, self._log)
                             if self._include_inner_packages(analyser):
                                 analyser.is_analysed = True
                                 self._imported_files[self.path] = analyser

--- a/boa3/internal/analyser/importanalyser.py
+++ b/boa3/internal/analyser/importanalyser.py
@@ -162,7 +162,9 @@ class ImportAnalyser(IAstAnalyser):
                         files = self._import_stack
                         files.append(origin)
                         if self.is_namespace_package:
-                            analyser = Analyser(self.tree, module_origin, self.root_folder, self.analyser.env, self._log)
+                            analyser = Analyser(self.tree, module_origin, self.root_folder, log=self._log,
+                                                env=self.analyser.env if hasattr(self.analyser, 'env') else None
+                                                )
                             if self._include_inner_packages(analyser):
                                 analyser.is_analysed = True
                                 self._imported_files[self.path] = analyser

--- a/boa3/internal/cli_commands/build_command.py
+++ b/boa3/internal/cli_commands/build_command.py
@@ -14,9 +14,19 @@ class BuildCommand(ICommand):
         super().__init__(main_parser, 'compile', 'Compiles your smart contract')
 
     def add_arguments_and_callback(self):
-        self.parser.add_argument("input", help=".py smart contract to compile", type=str)
-        self.parser.add_argument("-db", "--debug", action='store_true', help="generates a .nefdbgnfo file")
-        self.parser.add_argument("--project-path", help="Project root path. Path of the contract by default.", type=str)
+        self.parser.add_argument("input",
+                                 type=str,
+                                 help=".py smart contract to compile")
+        self.parser.add_argument("-db", "--debug",
+                                 action='store_true',
+                                 help="generates a .nefdbgnfo file")
+        self.parser.add_argument("--project-path",
+                                 type=str,
+                                 help="Project root path. Path of the contract by default.")
+        self.parser.add_argument("-e", "'--env",
+                                 type=str,
+                                 help="Set the contract environment for compiling.")
+
         self.parser.set_defaults(func=self.execute_command)
 
     @staticmethod
@@ -24,6 +34,7 @@ class BuildCommand(ICommand):
         sc_path: str = args['input']
         project_path: str = args['project_path']
         debug: bool = args['debug']
+        env: str = args['env']
 
         if not sc_path.endswith(".py") or not os.path.isfile(sc_path):
             logging.error("Input file is not .py")
@@ -36,7 +47,7 @@ class BuildCommand(ICommand):
             project_path = os.path.dirname(path)
 
         try:
-            Boa3.compile_and_save(sc_path, debug=debug, root_folder=project_path)
+            Boa3.compile_and_save(sc_path, debug=debug, root_folder=project_path, env=env)
             logging.info(f"Wrote {filename.replace('.py', '.nef')} to {path}")
         except NotLoadedException as e:
             error_message = e.message

--- a/boa3/internal/cli_commands/build_command.py
+++ b/boa3/internal/cli_commands/build_command.py
@@ -23,7 +23,7 @@ class BuildCommand(ICommand):
         self.parser.add_argument("--project-path",
                                  type=str,
                                  help="Project root path. Path of the contract by default.")
-        self.parser.add_argument("-e", "'--env",
+        self.parser.add_argument("-e", "--env",
                                  type=str,
                                  help="Set the contract environment for compiling.")
 

--- a/boa3/internal/compiler/compiler.py
+++ b/boa3/internal/compiler/compiler.py
@@ -21,18 +21,19 @@ class Compiler:
         self._analyser: Analyser = None
         self._entry_smart_contract: str = ''
 
-    def compile(self, path: str, root_folder: str = None, log: bool = True) -> bytes:
+    def compile(self, path: str, root_folder: str = None, env: str = None, log: bool = True) -> bytes:
         """
         Load a Python file and tries to compile it
 
         :param path: the path of the Python file to compile
         :param root_folder: the root path of the project
         :param log: if compiler errors should be logged.
+        :param env: specific environment id to compile.
         :return: the bytecode of the compiled .nef file
         """
-        return self._internal_compile(path, root_folder, log).bytecode
+        return self._internal_compile(path, root_folder, env, log).bytecode
 
-    def _internal_compile(self, path: str, root_folder: str = None, log: bool = True) -> CompilerOutput:
+    def _internal_compile(self, path: str, root_folder: str = None, env: str = None, log: bool = True) -> CompilerOutput:
         fullpath = os.path.realpath(path)
         filepath, filename = os.path.split(fullpath)
 
@@ -47,10 +48,11 @@ class Compiler:
         CompilerBuiltin.reset()
         CompiledMetadata.reset()
 
-        self._analyse(fullpath, root_folder, log)
+        self._analyse(fullpath, root_folder, env, log)
         return self._compile()
 
-    def compile_and_save(self, path: str, output_path: str, root_folder: str = None, log: bool = True, debug: bool = False):
+    def compile_and_save(self, path: str, output_path: str, root_folder: str = None, log: bool = True,
+                         debug: bool = False, env: str = None):
         """
         Save the compiled file and the metadata files
 
@@ -59,11 +61,12 @@ class Compiler:
         :param root_folder: the root path of the project
         :param log: if compiler errors should be logged.
         :param debug: if nefdbgnfo file should be generated.
+        :param env: specific environment id to compile.
         """
-        self.result = self._internal_compile(path, root_folder, log)
+        self.result = self._internal_compile(path, root_folder, env, log)
         self._save(output_path, debug)
 
-    def _analyse(self, path: str, root_folder: str = None, log: bool = True):
+    def _analyse(self, path: str, root_folder: str = None, env: str = None, log: bool = True):
         """
         Load a Python file and analyses its syntax
 
@@ -71,7 +74,7 @@ class Compiler:
         :param root_folder: the root path of the project
         :param log: if compiler errors should be logged.
         """
-        self._analyser = Analyser.analyse(path, log=log, root=root_folder)
+        self._analyser = Analyser.analyse(path, log=log, root=root_folder, env=env, compiler_entry=True)
 
     def _compile(self) -> CompilerOutput:
         """

--- a/boa3/internal/constants.py
+++ b/boa3/internal/constants.py
@@ -20,6 +20,7 @@ BOA_VERSION = _actual_boa_version  # for logging only
 BOA_LOGGING_NAME = 'neo3-boa-log'
 COMPILER_VERSION = BOA_VERSION
 BOA_PACKAGE_PATH = os.path.abspath(f'{__file__}/..')
+DEFAULT_CONTRACT_ENVIRONMENT = 'mainnet'
 
 locale.setlocale(locale.LC_ALL, '')
 SYS_LOCALE = locale.localeconv()

--- a/boa3/internal/model/builtin/builtin.py
+++ b/boa3/internal/model/builtin/builtin.py
@@ -6,7 +6,7 @@ from boa3.internal.model.builtin.classmethod import *
 from boa3.internal.model.builtin.compile_time import *
 from boa3.internal.model.builtin.contract import *
 from boa3.internal.model.builtin.decorator import *
-from boa3.internal.model.builtin.internal.innerdeploymethod import InnerDeployMethod
+from boa3.internal.model.builtin.internal import *
 from boa3.internal.model.builtin.interop.interop import Interop
 from boa3.internal.model.builtin.math import *
 from boa3.internal.model.builtin.method import *
@@ -24,11 +24,11 @@ from boa3.internal.model.type.primitive.bytestringtype import ByteStringType
 
 
 class BoaPackage(str, Enum):
+    CompileTime = 'compile_time'
     Contract = 'contract'
     Interop = 'interop'
     Type = 'type'
     VM = 'vm'
-    CompileTime = 'compile_time'
 
 
 class Builtin:
@@ -193,6 +193,7 @@ class Builtin:
 
     # boa smart contract methods
     Abort = AbortMethod()
+    Env = EnvProperty.build()
 
     # region boa builtin modules
 
@@ -204,11 +205,14 @@ class Builtin:
                                   BuiltinMathCeil,
                                   BuiltinMathFloor])
 
+    _symbols = [Env]
     _modules = [MathModule]
 
     # endregion
 
-    boa_builtins: List[IdentifiedSymbol] = _modules
+    boa_builtins: List[IdentifiedSymbol] = []
+    boa_builtins.extend(_modules)
+    boa_builtins.extend(_symbols)
 
     metadata_fields: Dict[str, Union[type, Tuple[type]]] = {
         'name': str,

--- a/boa3/internal/model/builtin/builtincallable.py
+++ b/boa3/internal/model/builtin/builtincallable.py
@@ -2,14 +2,14 @@ import ast
 from abc import ABC
 from typing import Dict, List, Optional, Tuple
 
+from boa3.internal.model.builtin.builtinsymbol import IBuiltinSymbol
 from boa3.internal.model.callable import Callable
-from boa3.internal.model.identifiedsymbol import IdentifiedSymbol
 from boa3.internal.model.type.itype import IType
 from boa3.internal.model.variable import Variable
 from boa3.internal.neo.vm.opcode.Opcode import Opcode
 
 
-class IBuiltinCallable(Callable, IdentifiedSymbol, ABC):
+class IBuiltinCallable(Callable, IBuiltinSymbol, ABC):
     def __init__(self, identifier: str, args: Dict[str, Variable] = None,
                  vararg: Optional[Tuple[str, Variable]] = None,
                  kwargs: Optional[Dict[str, Variable]] = None,

--- a/boa3/internal/model/builtin/builtinproperty.py
+++ b/boa3/internal/model/builtin/builtinproperty.py
@@ -1,11 +1,20 @@
 from abc import ABC
 
-from boa3.internal.model.identifiedsymbol import IdentifiedSymbol
+from boa3.internal.model.builtin.builtinsymbol import IBuiltinSymbol
 from boa3.internal.model.method import Method
 from boa3.internal.model.property import Property
 
 
-class IBuiltinProperty(Property, IdentifiedSymbol, ABC):
+class IBuiltinProperty(Property, IBuiltinSymbol, ABC):
     def __init__(self, identifier: str, getter: Method, setter: Method = None):
         super().__init__(getter, setter)
         self._identifier = identifier
+
+    def update_with_analyser(self, analyser):
+        super().update_with_analyser(analyser)
+
+        if hasattr(self._getter, 'update_with_analyser'):
+            self._getter.update_with_analyser(analyser)
+
+        if hasattr(self._setter, 'update_with_analyser'):
+            self._setter.update_with_analyser(analyser)

--- a/boa3/internal/model/builtin/builtinsymbol.py
+++ b/boa3/internal/model/builtin/builtinsymbol.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from abc import ABC
+
+from boa3.internal.model.identifiedsymbol import IdentifiedSymbol
+
+
+class IBuiltinSymbol(IdentifiedSymbol, ABC):
+
+    def build(self, *args, **kwargs) -> IBuiltinSymbol:
+        """
+        Creates a symbol instance with the given value as self
+
+        :return: The built method if the value is valid. The current object otherwise
+        :rtype: IBuiltinSymbol
+        """
+        return self
+
+    def update_with_analyser(self, analyser):
+        return

--- a/boa3/internal/model/builtin/internal/__init__.py
+++ b/boa3/internal/model/builtin/internal/__init__.py
@@ -1,0 +1,6 @@
+__all__ = ['InnerDeployMethod',
+           'EnvProperty',
+           ]
+
+from boa3.internal.model.builtin.internal.getenvmethod import Env as EnvProperty
+from boa3.internal.model.builtin.internal.innerdeploymethod import InnerDeployMethod

--- a/boa3/internal/model/builtin/internal/getenvmethod.py
+++ b/boa3/internal/model/builtin/internal/getenvmethod.py
@@ -1,0 +1,65 @@
+from typing import Optional, List, Tuple, Any
+
+from boa3.internal.model.builtin.builtinproperty import IBuiltinProperty
+from boa3.internal.model.builtin.method import IBuiltinMethod
+from boa3.internal.neo.vm.opcode.Opcode import Opcode
+
+
+class GetEnvMethod(IBuiltinMethod):
+    def __init__(self, env: str = None):
+        from boa3.internal import constants
+        from boa3.internal.model.type.type import Type
+
+        identifier = '-get_env'
+        super().__init__(identifier, return_type=Type.str)
+        self._env = env if isinstance(env, str) and len(env) > 0 else constants.DEFAULT_CONTRACT_ENVIRONMENT
+
+    @property
+    def _args_on_stack(self) -> int:
+        return super()._args_on_stack
+
+    @property
+    def _opcode(self) -> List[Tuple[Opcode, bytes]]:
+        from boa3.internal.neo.vm.opcode import OpcodeHelper
+        return [
+            OpcodeHelper.get_pushdata_and_data(self._env)
+        ]
+
+    @property
+    def _body(self) -> Optional[str]:
+        return None
+
+    def update_with_analyser(self, analyser):
+        from boa3.internal.analyser.analyser import Analyser
+        if isinstance(analyser, Analyser):
+            self.reset()
+            self._env = analyser.env
+
+        super().update_with_analyser(analyser)
+
+    def build(self, value: Any = None) -> IBuiltinMethod:
+        if isinstance(value, str):
+            result = GetEnvMethod(value)
+        else:
+            result = super().build(value)
+        return result
+
+
+class EnvProperty(IBuiltinProperty):
+    def __init__(self):
+        identifier = 'env'
+        getter = GetEnvMethod()
+        super().__init__(identifier, getter)
+        self._getter: GetEnvMethod = self._getter  # ensure typing
+
+    def build(self, env: str = None, *args, **kwargs) -> IBuiltinProperty:
+        getter = self._getter.build(env)
+        if getter != self._getter:
+            result = EnvProperty()
+            result._getter = getter
+        else:
+            result = super().build(env, *args, **kwargs)
+        return result
+
+
+Env = EnvProperty()

--- a/boa3/internal/model/imports/builtin.py
+++ b/boa3/internal/model/imports/builtin.py
@@ -58,6 +58,12 @@ class CompilerBuiltin:
             for event in cls._instance._events:
                 event.reset_calls()
 
+    @classmethod
+    def update_with_analyser(cls, analyser):
+        for pkg in cls.instance().packages:
+            if hasattr(pkg, 'update_with_analyser'):
+                pkg.update_with_analyser(analyser)
+
     def _set_events(self, events: List[Event]):
         self._events.extend(events)
 

--- a/boa3/internal/model/imports/package.py
+++ b/boa3/internal/model/imports/package.py
@@ -118,5 +118,14 @@ class Package(IdentifiedSymbol):
             else:
                 self._all_symbols.append(symbol)
 
+    def update_with_analyser(self, analyser):
+        from boa3.internal.analyser.analyser import Analyser
+        if isinstance(analyser, Analyser):
+            for symbol in self._all_symbols:
+                if hasattr(symbol, 'update_with_analyser'):
+                    symbol.update_with_analyser(analyser)
+            for pkg in self._packages:
+                pkg.update_with_analyser(analyser)
+
     def __repr__(self) -> str:
         return self.identifier

--- a/boa3_test/test_sc/boa_built_in_methods_test/Env.py
+++ b/boa3_test/test_sc/boa_built_in_methods_test/Env.py
@@ -1,0 +1,7 @@
+from boa3.builtin import env
+from boa3.builtin.compile_time import public
+
+
+@public
+def main() -> str:
+    return env

--- a/boa3_test/tests/boa_test.py
+++ b/boa3_test/tests/boa_test.py
@@ -189,23 +189,33 @@ class BoaTest(TestCase):
             raise FileNotFoundError(path)
         return path
 
-    def get_deploy_file_paths_without_compiling(self, contract_path: str) -> Tuple[str, str]:
-        file_path_without_ext, _ = os.path.splitext(contract_path)
+    def get_deploy_file_paths_without_compiling(self, contract_path: str, output_name: str = None) -> Tuple[str, str]:
+        if isinstance(output_name, str):
+            file_path = os.path.dirname(contract_path)
+            file_name, _ = os.path.splitext(os.path.basename(output_name))
+            file_path_without_ext = f'{file_path}/{file_name}'
+        else:
+            file_path_without_ext, _ = os.path.splitext(contract_path)
+
         if USE_UNIQUE_NAME:
             from boa3_test.test_drive import utils
             file_path_without_ext = utils.create_custom_id(file_path_without_ext, use_time=False)
 
         return f'{file_path_without_ext}.nef', f'{file_path_without_ext}.manifest.json'
 
-    def get_deploy_file_paths(self, *args: str, compile_if_found: bool = False) -> Tuple[str, str]:
+    def get_deploy_file_paths(self, *args: str, output_name: str = None,
+                              compile_if_found: bool = False, change_manifest_name: bool = False) -> Tuple[str, str]:
         contract_path = self.get_contract_path(*args)
         if isinstance(contract_path, str):
-            nef_path, manifest_path = self.get_deploy_file_paths_without_compiling(contract_path)
+            nef_path, manifest_path = self.get_deploy_file_paths_without_compiling(contract_path, output_name)
             if contract_path.endswith('.py'):
                 with _COMPILER_LOCK:
                     if compile_if_found or not (os.path.isfile(nef_path) and os.path.isfile(manifest_path)):
                         # both .nef and .manifest.json are required to execute the smart contract
-                        self.compile_and_save(contract_path, output_path=nef_path, log=False)
+                        self.compile_and_save(contract_path, output_name=nef_path, log=True,
+                                              change_manifest_name=change_manifest_name,
+                                              use_unique_name=False  # already using unique name
+                                              )
 
             return nef_path, manifest_path
 
@@ -220,12 +230,24 @@ class BoaTest(TestCase):
         return result
 
     def compile_and_save(self, path: str, root_folder: str = None, debug: bool = False, log: bool = True,
-                         output_path: str = None, **kwargs) -> Tuple[bytes, Dict[str, Any]]:
+                         output_name: str = None, env: str = None, **kwargs) -> Tuple[bytes, Dict[str, Any]]:
 
-        if not isinstance(output_path, str) or not output_path.endswith('.nef'):
-            nef_output, _ = self.get_deploy_file_paths_without_compiling(path)
+        if output_name is not None:
+            output_dir, manifest_name = os.path.split(output_name)  # get name
+            if len(output_dir) == 0:
+                output_dir, _ = os.path.split(path)
+                output_name = f'{output_dir}/{manifest_name}'
+            manifest_name, _ = os.path.splitext(manifest_name)  # remove extension
         else:
-            nef_output = output_path
+            manifest_name = None
+
+        use_unique_name = kwargs['use_unique_name'] if 'use_unique_name' in kwargs else True
+        if not isinstance(output_name, str) or not output_name.endswith('.nef'):
+            nef_output, _ = self.get_deploy_file_paths_without_compiling(path)
+        elif use_unique_name and USE_UNIQUE_NAME:
+            nef_output, _ = self.get_deploy_file_paths_without_compiling(output_name)
+        else:
+            nef_output = output_name
 
         if nef_output.endswith('.py'):
             nef_output = nef_output.replace('.py', '.nef')
@@ -235,9 +257,11 @@ class BoaTest(TestCase):
         from boa3.internal.neo.contracts.neffile import NefFile
         with _COMPILER_LOCK:
             Boa3.compile_and_save(path, output_path=nef_output, root_folder=root_folder,
-                                  show_errors=log, debug=debug)
+                                  env=env, show_errors=log, debug=debug)
 
         get_raw_nef = kwargs['get_raw_nef'] if 'get_raw_nef' in kwargs else False
+        change_manifest_name = kwargs['change_manifest_name'] if 'change_manifest_name' in kwargs else False
+
         with open(nef_output, mode='rb') as nef:
             file = nef.read()
             if get_raw_nef:
@@ -245,9 +269,15 @@ class BoaTest(TestCase):
             else:
                 output = NefFile.deserialize(file).script
 
-        with open(manifest_output) as manifest_output:
+        with open(manifest_output) as manifest_file:
             import json
-            manifest = json.loads(manifest_output.read())
+            manifest = json.loads(manifest_file.read())
+
+        if change_manifest_name and manifest_name is not None:
+            manifest['name'] = manifest_name
+            with _COMPILER_LOCK:
+                with open(manifest_output, mode='w') as manifest_file:
+                    manifest_file.write(json.dumps(manifest, indent=4))
 
         return output, manifest
 
@@ -331,7 +361,7 @@ class BoaTest(TestCase):
             with _COMPILER_LOCK:
                 if not (os.path.isfile(nef_path) and os.path.isfile(manifest_path)):
                     # both .nef and .manifest.json are required to execute the smart contract
-                    self.compile_and_save(smart_contract_path, log=False, output_path=nef_path)
+                    self.compile_and_save(smart_contract_path, log=False, output_name=nef_path)
             smart_contract_path = nef_path
         elif isinstance(smart_contract_path, bytes):
             from boa3.internal.neo3.core.types import UInt160

--- a/boa3_test/tests/boa_test.py
+++ b/boa3_test/tests/boa_test.py
@@ -361,7 +361,9 @@ class BoaTest(TestCase):
             with _COMPILER_LOCK:
                 if not (os.path.isfile(nef_path) and os.path.isfile(manifest_path)):
                     # both .nef and .manifest.json are required to execute the smart contract
-                    self.compile_and_save(smart_contract_path, log=False, output_name=nef_path)
+                    self.compile_and_save(smart_contract_path, log=False, output_name=nef_path,
+                                          use_unique_name=False  # already using unique name
+                                          )
             smart_contract_path = nef_path
         elif isinstance(smart_contract_path, bytes):
             from boa3.internal.neo3.core.types import UInt160

--- a/boa3_test/tests/compiler_tests/test_variable.py
+++ b/boa3_test/tests/compiler_tests/test_variable.py
@@ -30,10 +30,14 @@ class TestVariable(BoaTest):
             + b'\x00'
             + Opcode.RET        # return
         )
-        compiler_output = compiler.compile(path)
+
+        from boa3_test.tests.boa_test import _COMPILER_LOCK as LOCK
+        with LOCK:
+            compiler_output = compiler.compile(path)
+            main_symbol_table: Dict[str, ISymbol] = self.get_compiler_analyser(compiler).symbol_table
+
         self.assertEqual(expected_compiler_output, compiler_output)
 
-        main_symbol_table: Dict[str, ISymbol] = self.get_compiler_analyser(compiler).symbol_table
         # the variable is local to a method, so it shouldn't be in the main symbol table
         self.assertFalse(test_variable_id in main_symbol_table)
 


### PR DESCRIPTION
**Summary or solution description**
Included an optional argument to the compiler to be able to pass a given environment identifier to the smart contract. This allows specific environment validations to be easily included in the smart contract logic without the need to rewrite anything before compiling (i.e. changes in smart contracts hashes between testnet and mainnet)

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/edaed98f7c082ca4c8e1b261eb9ee6788d30cab4/boa3_test/test_sc/boa_built_in_methods_test/Env.py#L1-L7
![image](https://user-images.githubusercontent.com/19419485/231821716-95e6265e-b12a-4a1a-8401-9b3e1e98adbd.png)


**Tests**
https://github.com/CityOfZion/neo3-boa/blob/edaed98f7c082ca4c8e1b261eb9ee6788d30cab4/boa3_test/tests/compiler_tests/test_boa_builtin_method.py#L33-L57

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7+
