### PR TITLE
Fix burn() permission on wrapped_neo example

### DIFF
--- a/boa3_test/examples/wrapped_neo.py
+++ b/boa3_test/examples/wrapped_neo.py
@@ -333,7 +333,7 @@ def mint(account: UInt160, amount: int):
         post_transfer(None, account, amount, None, True)
 
 
-@public(safe=True)
+@public
 def burn(account: UInt160, amount: int):
     """
     Burns zNEO tokens.


### PR DESCRIPTION
**Related issue**
`burn` was marked as `safe`, however its implementation modifies storage. Storage cannot be modified when a method is marked safe. ([ref](https://github.com/neo-project/neo/blob/718fc9ff4063ea19cff5818627aff4d908995b8d/src/Neo/SmartContract/ApplicationEngine.cs#L217) this effectively says "safe == READ_ONLY")

**Summary or solution description**
removed the safe flag

