### PR TITLE
Remove TestEngine from remaining unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,9 +36,6 @@ jobs:
             sudo apt update && \
               sudo apt-get install -y dotnet-sdk-6.0
 
-            git clone https://github.com/simplitech/neo-devpack-dotnet.git -b v3.5.0
-            dotnet build ./neo-devpack-dotnet/src/Neo.TestEngine/Neo.TestEngine.csproj -o ./Neo.TestEngine
-            
             sudo apt install libsnappy-dev libc6-dev librocksdb-dev -y
             dotnet tool install Neo.Express --version 3.5.20 -g
             dotnet tool install Neo.Test.Runner --version 3.5.17 -g

--- a/boa3_test/examples/ico.py
+++ b/boa3_test/examples/ico.py
@@ -110,7 +110,7 @@ def _deploy(data: Any, update: bool):
         container: Transaction = runtime.script_container
         owner = container.sender
         storage.put(TOKEN_OWNER_KEY, owner)
-        
+
         storage.put(TOKEN_TOTAL_SUPPLY_PREFIX, TOKEN_INITIAL_SUPPLY)
         storage.put(owner, TOKEN_INITIAL_SUPPLY)
 

--- a/boa3_test/test_drive/model/invoker/invokeresult.py
+++ b/boa3_test/test_drive/model/invoker/invokeresult.py
@@ -3,6 +3,11 @@ class _NotExecuted:
         return 'Invoke not executed yet'
 
 
+class _TransactionExecuted:
+    def __repr__(self) -> str:
+        return 'Invoke was accepted and persisted. Use the transaction id to get the result'
+
+
 class _Canceled:
     def __repr__(self) -> str:
         return 'Invoke was canceled before being executed'
@@ -10,3 +15,4 @@ class _Canceled:
 
 NOT_EXECUTED = _NotExecuted()
 CANCELED = _Canceled()
+TRANSACTION_EXECUTED = _TransactionExecuted()

--- a/boa3_test/test_drive/model/invoker/neobatchinvoke.py
+++ b/boa3_test/test_drive/model/invoker/neobatchinvoke.py
@@ -47,5 +47,10 @@ class NeoBatchInvoke(ITransactionObject):
 
         return result
 
+    def _set_data_from_match_result(self, match_groups: dict):
+        super()._set_data_from_match_result(match_groups)
+        if self._tx_id is not None and self._result is not invokeresult.TRANSACTION_EXECUTED:
+            self._result = invokeresult.TRANSACTION_EXECUTED
+
     def __repr__(self):
         return f'{self._invoke.__repr__()} -> {self.tx_id.__repr__()}'

--- a/boa3_test/test_drive/model/invoker/neoinvokecollection.py
+++ b/boa3_test/test_drive/model/invoker/neoinvokecollection.py
@@ -1,9 +1,12 @@
 from typing import Any, List, Optional, Type
 
+from boa3.internal.neo3.vm import VMState
 from boa3_test.test_drive.model.invoker.neoinvoke import NeoInvoke
 from boa3_test.test_drive.model.invoker.neoinvokeresult import NeoInvokeResult
 from boa3_test.test_drive.model.smart_contract.testcontract import TestContract
 from boa3_test.test_drive.model.wallet.account import Account
+
+__all__ = ['NeoInvokeCollection']
 
 
 class NeoInvokeCollection:
@@ -27,9 +30,14 @@ class NeoInvokeCollection:
         self._pending_results.append(invoke_result)
         return invoke_result
 
-    def clear(self):
+    def clear(self, *, state: VMState = VMState.HALT):
+        pending_results = self._pending_results.copy()
         self._invoke_results.clear()
         self._pending_results.clear()
+
+        if state != VMState.HALT:
+            for pending_invoke in pending_results:
+                pending_invoke.cancel()
         return self._internal_list.clear()
 
     def to_json(self):

--- a/boa3_test/test_drive/model/invoker/neoinvokeresult.py
+++ b/boa3_test/test_drive/model/invoker/neoinvokeresult.py
@@ -44,5 +44,9 @@ class NeoInvokeResult:
 
         return result
 
+    def cancel(self):
+        if self._result is invokeresult.NOT_EXECUTED:
+            self._result = invokeresult.CANCELED
+
     def __repr__(self):
         return f'{self._invoke.__repr__()} -> {self._result.__repr__()}'

--- a/boa3_test/test_drive/neoxp/batch.py
+++ b/boa3_test/test_drive/neoxp/batch.py
@@ -143,7 +143,7 @@ class NeoExpressBatch:
 
     def _update_logs(self, log: str):
         import re
-        cli_color_change = r'?(?:\[\d+m)?'
+        cli_color_change = r'\xb1?(?:\[\d+m)?'
         log_regex = rf'{cli_color_change}(?P<contract>.+?){cli_color_change}\sLog:\s{cli_color_change}'
         tx_logs = []
 
@@ -158,7 +158,7 @@ class NeoExpressBatch:
                 logs.pop(index)
             index -= 1
 
-        for lineno, line in enumerate(logs[-len(self._instructions):]):
+        for lineno, line in enumerate(logs[-max_log_count:]):
             if lineno in self._transaction_submissions:
                 tx_logs.append(line)
             if lineno in self._tx_invokes_pos:

--- a/boa3_test/test_drive/testrunner/blockchain/notification.py
+++ b/boa3_test/test_drive/testrunner/blockchain/notification.py
@@ -2,8 +2,8 @@ from typing import Dict, Any
 
 from boa3.internal.neo.smart_contract.notification import Notification
 from boa3.internal.neo3.core.types import UInt160
-from boa3_test.test_drive.model.smart_contract.testcontract import TestContract
 from boa3_test.test_drive.model.smart_contract.contractcollection import ContractCollection
+from boa3_test.test_drive.model.smart_contract.testcontract import TestContract
 
 
 class TestRunnerNotification(Notification):

--- a/boa3_test/test_drive/testrunner/neo_test_runner.py
+++ b/boa3_test/test_drive/testrunner/neo_test_runner.py
@@ -318,8 +318,9 @@ class NeoTestRunner:
             invoke_file_path_to_batch = self.get_full_path(f'{self._file_name}_{self._invokes_to_batch}.neo-invoke.json')
             shutil.copy(invoke_file_path, invoke_file_path_to_batch)
             self._batch.invoke_file(invoke_file_path_to_batch, account=account)
+
         if clear_invokes:
-            self._invokes.clear()
+            self._invokes.clear(state=self._vm_state)
 
         if self._error_message is not None:
             return self._error_message

--- a/boa3_test/tests/compiler_tests/test_builtin_method.py
+++ b/boa3_test/tests/compiler_tests/test_builtin_method.py
@@ -1,5 +1,3 @@
-import unittest
-
 from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to avoid circular imports
 
 from boa3.internal.exception import CompilerError

--- a/boa3_test/tests/compiler_tests/test_contract_interface.py
+++ b/boa3_test/tests/compiler_tests/test_contract_interface.py
@@ -113,11 +113,15 @@ class TestContractInterface(BoaTest):
         from boa3.internal.neo.vm.opcode.Opcode import Opcode
         from boa3.internal.neo.vm.type.Integer import Integer
         from boa3.internal.neo.vm.type.String import String
-        from boa3.internal.neo3.core.types import UInt160
+
+        nep17_path, _ = self.get_deploy_file_paths('examples', 'nep17.py')
+        runner = NeoTestRunner(runner_id=self.method_name())
+        nep17_contract = runner.deploy_contract(nep17_path)
+        runner.update_contracts(export_checkpoint=True)
 
         external_contract_name = 'symbol'
         function_name_bytes = String(external_contract_name).to_bytes()
-        contract_script_bytes = UInt160.from_string('409eb4868a2c43611b9c0f9df98de3846ada4fcb').to_array()
+        contract_script_bytes = nep17_contract.script_hash
 
         expected_output = (
             Opcode.NEWARRAY0    # arguments list
@@ -137,9 +141,7 @@ class TestContractInterface(BoaTest):
         output, _ = self.compile_and_save(path)
         self.assertEqual(expected_output, output)
 
-        nep17_path, _ = self.get_deploy_file_paths('examples', 'nep17.py')
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -161,11 +163,15 @@ class TestContractInterface(BoaTest):
         from boa3.internal.neo.vm.opcode.Opcode import Opcode
         from boa3.internal.neo.vm.type.Integer import Integer
         from boa3.internal.neo.vm.type.String import String
-        from boa3.internal.neo3.core.types import UInt160
+
+        nep17_path, _ = self.get_deploy_file_paths('examples', 'nep17.py')
+        runner = NeoTestRunner(runner_id=self.method_name())
+        nep17_contract = runner.deploy_contract(nep17_path)
+        runner.update_contracts(export_checkpoint=True)
 
         external_contract_name = 'symbol'
         function_name_bytes = String(external_contract_name).to_bytes()
-        contract_script_bytes = UInt160.from_string('409eb4868a2c43611b9c0f9df98de3846ada4fcb').to_array()
+        contract_script_bytes = nep17_contract.script_hash
 
         expected_output = (
             # start public method
@@ -208,9 +214,7 @@ class TestContractInterface(BoaTest):
         output, _ = self.compile_and_save(path)
         self.assertEqual(expected_output, output)
 
-        nep17_path, _ = self.get_deploy_file_paths('examples', 'nep17.py')
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_file_generation.py
+++ b/boa3_test/tests/compiler_tests/test_file_generation.py
@@ -801,15 +801,17 @@ class TestFileGeneration(BoaTest):
             self.compile_and_save(path)
 
     def test_generation_with_recursive_function(self):
-        path = self.get_contract_path('test_sc/function_test', 'RecursiveFunction.py')
+        path, _ = self.get_deploy_file_paths('test_sc/function_test', 'RecursiveFunction.py')
 
-        from boa3_test.tests.test_classes.testengine import TestEngine
-        engine = TestEngine()
-        engine.use_contract_custom_name = self._use_custom_name
+        from boa3.internal.neo3.vm import VMState
+        from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+        runner = NeoTestRunner(runner_id=self.method_name())
 
         expected = self.fact(57)
-        result = self.run_smart_contract(engine, path, 'main')
-        self.assertEqual(expected, result)
+        invoke = runner.call_contract(path, 'main')
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.cli_log)
+        self.assertEqual(expected, invoke.result)
 
     def fact(self, f: int) -> int:
         if f <= 1:

--- a/boa3_test/tests/examples_tests/test_hello_world.py
+++ b/boa3_test/tests/examples_tests/test_hello_world.py
@@ -1,4 +1,5 @@
 from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to avoid circular imports
+
 from boa3.internal.neo3.vm import VMState
 from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 


### PR DESCRIPTION
**Summary or solution description**
Removed Test Engine from the remaining tests and refactored BoaTest to remove all the unused methods.
Final task related to the overall refactoring to use Test Runner instead of the Test Engine for boa3 unit tests.

**Tests**
Rerun all the unit tests