### PR TITLE
Can't create an event with a InteropInterface parameter

### DIFF
--- a/boa3/internal/model/type/annotation/metatype.py
+++ b/boa3/internal/model/type/annotation/metatype.py
@@ -19,7 +19,7 @@ class MetaType(IType):
         return AbiType.Any
 
     @classmethod
-    def build(cls, value: Any) -> IType:
+    def build(cls, value: Any = None) -> IType:
         if isinstance(value, MetaType):
             return value
         if isinstance(value, IType):

--- a/boa3_test/test_sc/event_test/MismatchedTypeCreateEventWithInteropInterface.py
+++ b/boa3_test/test_sc/event_test/MismatchedTypeCreateEventWithInteropInterface.py
@@ -3,10 +3,10 @@ from boa3.builtin.interop.iterator import Iterator
 
 Event = CreateNewEvent(
     [
-        ('a', Iterator)
+        ('a', Iterator)  # this shouldn't compile
     ]
 )
 
 
-def Main():
-    Event(b'10')
+def Main() -> bool:
+    return False

--- a/boa3_test/tests/compiler_tests/test_event.py
+++ b/boa3_test/tests/compiler_tests/test_event.py
@@ -348,8 +348,8 @@ class TestEvent(BoaTest):
         path = self.get_contract_path('MismatchedTypeCallEventMap.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
-    def test_event_call_mismatched_type_interop_interface(self):
-        path = self.get_contract_path('MismatchedTypeCallEventInteropInterface.py')
+    def test_event_with_interop_interface_argument_mismatched_type(self):
+        path = self.get_contract_path('MismatchedTypeCreateEventWithInteropInterface.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_event_with_abort(self):


### PR DESCRIPTION
**Summary or solution description**
Trying to use InteropInterfaces as event arguments failed when executing the smart contract in the blockchain, but neo3-boa allowed it to compile. Changed to not compile when trying to create an event with an InteropInterface argument type.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/3cab3ddcc0372e5523ba8d263238795e4ee8f64f/boa3_test/test_sc/event_test/MismatchedTypeCreateEventWithInteropInterface.py#L1-L8

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/3cab3ddcc0372e5523ba8d263238795e4ee8f64f/boa3_test/tests/compiler_tests/test_event.py#L351-L354

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7+