### PR TITLE
Access hash property of classes annotated with @contract in the metadata definition function

### DIFF
--- a/boa3/builtin/compile_time/__init__.py
+++ b/boa3/builtin/compile_time/__init__.py
@@ -48,7 +48,13 @@ def contract(script_hash: ByteString):
     :type script_hash: str or bytes
     """
     def decorator_wrapper(cls, *args, **kwargs):
-        cls.hash = script_hash
+        if isinstance(script_hash, str):
+            from boa3.internal.neo import from_hex_str
+            _hash = from_hex_str(script_hash)
+        else:
+            _hash = script_hash
+
+        cls.hash = _hash
         return cls
     return decorator_wrapper
 
@@ -194,6 +200,13 @@ class NeoMetadata:
         :param methods: a list of methods or '*'
         :type methods: Union[List[str], str]
         """
+
+        if isinstance(contract, bytes):
+            try:
+                from boa3.internal.neo3.core.types import UInt160
+                contract = str(UInt160(contract))
+            except BaseException:
+                pass
 
         if not isinstance(contract, str):
             return

--- a/boa3/internal/analyser/moduleanalyser.py
+++ b/boa3/internal/analyser/moduleanalyser.py
@@ -368,7 +368,7 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
             function.decorator_list = []
             module: ast.Module = ast.parse('')
             module.body = [node for node in self._tree.body
-                           if isinstance(node, (ast.ImportFrom, ast.Import))]
+                           if isinstance(node, (ast.ImportFrom, ast.Import, ast.ClassDef))]
             module.body.append(function)
             ast.copy_location(module, function)
 

--- a/boa3_test/test_sc/contract_interface_test/ContractInterfaceGetHashOnMetadata.py
+++ b/boa3_test/test_sc/contract_interface_test/ContractInterfaceGetHashOnMetadata.py
@@ -1,0 +1,22 @@
+from boa3.builtin.compile_time import contract, public, metadata, NeoMetadata
+from boa3.builtin.type import UInt160
+
+
+@contract('0x000102030405060708090A0B0C0D0E0F10111213')
+class ContractInterface:
+
+    @staticmethod
+    def foo():
+        pass
+
+
+@metadata
+def contract_metadata() -> NeoMetadata:
+    obj = NeoMetadata()
+    obj.add_permission(contract=ContractInterface.hash)
+    return obj
+
+
+@public
+def main() -> UInt160:
+    return ContractInterface.hash

--- a/boa3_test/tests/compiler_tests/test_contract_interface.py
+++ b/boa3_test/tests/compiler_tests/test_contract_interface.py
@@ -244,3 +244,31 @@ class TestContractInterface(BoaTest):
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
+
+    def test_get_hash_on_metadata(self):
+        path = self.get_contract_path('ContractInterfaceGetHashOnMetadata.py')
+        _, manifest = self.compile_and_save(path)
+
+        self.assertIn('permissions', manifest)
+        self.assertIsInstance(manifest['permissions'], list)
+        self.assertIn({'contract': '0x000102030405060708090a0b0c0d0e0f10111213',
+                       'methods': '*'
+                       },
+                      manifest['permissions'])
+
+        path, _ = self.get_deploy_file_paths(path)
+        runner = NeoTestRunner(runner_id=self.method_name())
+
+        invokes = []
+        expected_results = []
+
+        contract_script_bytes = bytes(reversed(range(20)))
+        invokes.append(runner.call_contract(path, 'main',
+                                            expected_result_type=bytes))
+        expected_results.append(contract_script_bytes)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)


### PR DESCRIPTION
**Summary or solution description**
Setting permissions on NeoMetadata object only accepted literal string representations of smart contracts script hashes. Modified to also accept bytes data and fixed the missed symbol error raised when trying to use user-implemented contract interface to get its script hash.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/0aa0410c59facf82960e3456000580bbccdbff9d/boa3_test/test_sc/contract_interface_test/ContractInterfaceGetHashOnMetadata.py#L5-L18

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/0aa0410c59facf82960e3456000580bbccdbff9d/boa3_test/tests/compiler_tests/test_contract_interface.py#L248-L274

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7+