### PR TITLE
Include methods from contract interfaces to manifest permissions

### DIFF
--- a/boa3/internal/compiler/codegenerator/codegenerator.py
+++ b/boa3/internal/compiler/codegenerator/codegenerator.py
@@ -1797,6 +1797,7 @@ class CodeGenerator:
                                     for symbol_id, symbol in function.origin_class.symbols.items()
                                     if symbol is function),
                                    None)
+            self._add_to_metadata_permissions(function.origin_class, function_id)
 
             if isinstance(function_id, str):
                 self.convert_new_array(len(function.args))
@@ -2114,6 +2115,10 @@ class CodeGenerator:
 
     def _get_jump_data(self, op_info: OpcodeInformation, jump_to: int) -> bytes:
         return Integer(jump_to).to_byte_array(min_length=op_info.data_len, signed=True)
+
+    def _add_to_metadata_permissions(self, contract_class: ContractInterfaceClass, method_name: str):
+        from boa3.internal.compiler.compiledmetadata import CompiledMetadata
+        CompiledMetadata.instance().add_contract_permission(contract_class.contract_hash, method_name)
 
     def duplicate_stack_top_item(self):
         self.duplicate_stack_item(1)

--- a/boa3/internal/compiler/compiledmetadata.py
+++ b/boa3/internal/compiler/compiledmetadata.py
@@ -27,10 +27,10 @@ class CompiledMetadata:
     def set_current_metadata(cls, metadata: NeoMetadata):
         cls.instance()._metadata = metadata
 
-    def add_contract_permission(self, contract: Union[bytes, str], method: str = None):
+    def add_contract_permission(self, contract: Union[UInt160, bytes, str], method: str = None):
         if isinstance(contract, bytes):
             contract = UInt160(contract)
-        else:
+        elif not isinstance(contract, UInt160):
             contract = UInt160.from_string(contract)
         contract_hex_script = str(contract)
         method_string = method if isinstance(method, str) and len(method) > 0 else constants.IMPORT_WILDCARD

--- a/boa3_test/examples/wrapped_gas.py
+++ b/boa3_test/examples/wrapped_gas.py
@@ -276,7 +276,7 @@ def approve(owner: UInt160, spender: UInt160, amount: int) -> bool:
     return False
 
 
-@public
+@public(safe=True)
 def allowance(owner: UInt160, spender: UInt160) -> int:
     """
     Gets the amount of zGAS from the owner that can be used by the spender.

--- a/boa3_test/tests/examples_tests/test_htlc.py
+++ b/boa3_test/tests/examples_tests/test_htlc.py
@@ -19,7 +19,7 @@ class TestHTLCTemplate(BoaTest):
     OTHER_ACCOUNT_1 = neoxp.utils.get_account_by_name('testAccount1')
     OTHER_ACCOUNT_2 = neoxp.utils.get_account_by_name('testAccount2')
     GAS_TO_DEPLOY = 1000 * 10 ** 8
-    REFUND_WAIT_TIME = 24 * 60 * (60 * 10 ** 3)     # smart contract constant
+    REFUND_WAIT_TIME = 24 * 60 * 60     # smart contract constant in seconds
 
     def _validate_execution_result(self, runner: NeoTestRunner, tx_id: UInt256, expected_result: Any) -> TransactionExecution:
         # Test Runner isn't returning the runtime.time value correctly when using `call_contract`, so we have to get the

--- a/boa3_test/tests/examples_tests/test_update_contract.py
+++ b/boa3_test/tests/examples_tests/test_update_contract.py
@@ -1,8 +1,8 @@
 import json
 
-from boa3.internal import constants
 from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to avoid circular imports
 
+from boa3.internal import constants
 from boa3.internal.neo.vm.type.String import String
 from boa3.internal.neo3.vm import VMState
 from boa3_test.test_drive import neoxp


### PR DESCRIPTION
**Summary or solution description**
Changed code generation to include the called methods from implemented contract interfaces to the manifest permissions, having the same behavior as the called native contract methods

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/a51b934775d2bcc500558d6efe53d163d75204ce/boa3_test/test_sc/contract_interface_test/ContractInterfaceCodeOptimization.py#L7-L35

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/a51b934775d2bcc500558d6efe53d163d75204ce/boa3_test/tests/compiler_tests/test_contract_interface.py#L123-L151

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7+