### PR TITLE
Compilation should stop with KeyboardInterrupt

### DIFF
--- a/boa3/internal/analyser/astanalyser.py
+++ b/boa3/internal/analyser/astanalyser.py
@@ -80,6 +80,8 @@ class IAstAnalyser(ABC, ast.NodeVisitor):
             self._log_error(error)
         except CompilerWarning as warning:
             self._log_warning(warning)
+        except KeyboardInterrupt as interrupt:
+            raise interrupt
         except BaseException as exception:
             if hasattr(node, 'lineno'):
                 self._log_error(


### PR DESCRIPTION
**Summary or solution description**
Stopped code from compiling when pressing Crtl+C

**Platform:**
 - OS: Windows 10 x64
 - Python version: 3.8

**(Optional) Additional context**
Had to use the `from None` to [suppress exception context](https://peps.python.org/pep-0409/), otherwise it would print a lot of tracebacks
