### PR TITLE
verify_with_ecdsa of cryptolib has message param as "Any" instead of byte[], like on C#

### DIFF
--- a/boa3/builtin/interop/crypto/__init__.py
+++ b/boa3/builtin/interop/crypto/__init__.py
@@ -80,12 +80,12 @@ def check_multisig(pubkeys: List[ECPoint], signatures: List[bytes]) -> bool:
     pass
 
 
-def verify_with_ecdsa(message: Any, pubkey: ECPoint, signature: ByteString, curve: NamedCurve) -> bool:
+def verify_with_ecdsa(message: ByteString, pubkey: ECPoint, signature: ByteString, curve: NamedCurve) -> bool:
     """
-    Using the elliptic curve, it checks if the signature of the any item was originally produced by the public key.
+    Using the elliptic curve, it checks if the signature of the message was originally produced by the public key.
 
     :param message: the encrypted message
-    :type message: Any
+    :type message: bytes
     :param pubkey: the public key that might have created the item
     :type pubkey: ECPoint
     :param signature: the signature of the item

--- a/boa3/builtin/nativecontract/cryptolib.py
+++ b/boa3/builtin/nativecontract/cryptolib.py
@@ -50,12 +50,12 @@ class CryptoLib:
         pass
 
     @classmethod
-    def verify_with_ecdsa(cls, message: Any, pubkey: ECPoint, signature: ByteString, curve: NamedCurve) -> bool:
+    def verify_with_ecdsa(cls, message: ByteString, pubkey: ECPoint, signature: ByteString, curve: NamedCurve) -> bool:
         """
-        Using the elliptic curve, it checks if the signature of the any item was originally produced by the public key.
+        Using the elliptic curve, it checks if the signature of the message was originally produced by the public key.
 
         :param message: the encrypted message
-        :type message: Any
+        :type message: bytes
         :param pubkey: the public key that might have created the item
         :type pubkey: ECPoint
         :param signature: the signature of the item

--- a/boa3/internal/model/builtin/interop/crypto/verifywithecdsa.py
+++ b/boa3/internal/model/builtin/interop/crypto/verifywithecdsa.py
@@ -15,7 +15,7 @@ class VerifyWithECDsaMethod(CryptoLibMethod):
         identifier = 'verify_with_ecdsa'
         native_identifier = 'verifyWithECDsa'
         args: Dict[str, Variable] = {
-            'data': Variable(Type.any),
+            'data': Variable(ByteStringType.build()),
             'pubkey': Variable(ECPointType.build()),
             'signature': Variable(ByteStringType.build()),
             'curve': Variable(NamedCurveType.build())

--- a/boa3_test/test_sc/interop_test/crypto/VerifyWithECDsa.py
+++ b/boa3_test/test_sc/interop_test/crypto/VerifyWithECDsa.py
@@ -1,10 +1,8 @@
-from typing import Any
-
 from boa3.builtin.compile_time import public
 from boa3.builtin.interop.crypto import NamedCurve, verify_with_ecdsa
 from boa3.builtin.type import ByteString, ECPoint
 
 
 @public
-def Main(message: Any, pubkey: ECPoint, signature: ByteString, curve: NamedCurve) -> bool:
+def Main(message: ByteString, pubkey: ECPoint, signature: ByteString, curve: NamedCurve) -> bool:
     return verify_with_ecdsa(message, pubkey, signature, curve)

--- a/boa3_test/test_sc/interop_test/crypto/VerifyWithECDsaSecp256k1Bool.py
+++ b/boa3_test/test_sc/interop_test/crypto/VerifyWithECDsaSecp256k1Bool.py
@@ -1,8 +1,6 @@
-from boa3.builtin.compile_time import public
 from boa3.builtin.interop.crypto import NamedCurve, verify_with_ecdsa
 from boa3.builtin.type import ECPoint
 
 
-@public
 def Main():
     verify_with_ecdsa(False, ECPoint(b'0123456789ABCDEFGHIJKLMNOPQRSTUVW'), b'signature', NamedCurve.SECP256K1)

--- a/boa3_test/test_sc/interop_test/crypto/VerifyWithECDsaSecp256k1Int.py
+++ b/boa3_test/test_sc/interop_test/crypto/VerifyWithECDsaSecp256k1Int.py
@@ -1,8 +1,6 @@
-from boa3.builtin.compile_time import public
 from boa3.builtin.interop.crypto import NamedCurve, verify_with_ecdsa
 from boa3.builtin.type import ECPoint
 
 
-@public
 def Main():
     verify_with_ecdsa(10, ECPoint(b'0123456789ABCDEFGHIJKLMNOPQRSTUVW'), b'signature', NamedCurve.SECP256K1)

--- a/boa3_test/test_sc/interop_test/crypto/VerifyWithECDsaSecp256r1Bool.py
+++ b/boa3_test/test_sc/interop_test/crypto/VerifyWithECDsaSecp256r1Bool.py
@@ -1,8 +1,6 @@
-from boa3.builtin.compile_time import public
 from boa3.builtin.interop.crypto import NamedCurve, verify_with_ecdsa
 from boa3.builtin.type import ECPoint
 
 
-@public
 def Main():
     verify_with_ecdsa(False, ECPoint(b'0123456789ABCDEFGHIJKLMNOPQRSTUVW'), b'signature', NamedCurve.SECP256R1)

--- a/boa3_test/test_sc/interop_test/crypto/VerifyWithECDsaSecp256r1Int.py
+++ b/boa3_test/test_sc/interop_test/crypto/VerifyWithECDsaSecp256r1Int.py
@@ -1,8 +1,6 @@
-from boa3.builtin.compile_time import public
 from boa3.builtin.interop.crypto import NamedCurve, verify_with_ecdsa
 from boa3.builtin.type import ECPoint
 
 
-@public
 def Main():
     verify_with_ecdsa(10, ECPoint(b'0123456789ABCDEFGHIJKLMNOPQRSTUVW'), b'signature', NamedCurve.SECP256R1)

--- a/boa3_test/test_sc/native_test/cryptolib/VerifyWithECDsa.py
+++ b/boa3_test/test_sc/native_test/cryptolib/VerifyWithECDsa.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from boa3.builtin.compile_time import public
 from boa3.builtin.interop.crypto import NamedCurve
 from boa3.builtin.nativecontract.cryptolib import CryptoLib
@@ -7,5 +5,5 @@ from boa3.builtin.type import ByteString, ECPoint
 
 
 @public
-def Main(message: Any, pubkey: ECPoint, signature: ByteString, curve: NamedCurve) -> bool:
+def Main(message: ByteString, pubkey: ECPoint, signature: ByteString, curve: NamedCurve) -> bool:
     return CryptoLib.verify_with_ecdsa(message, pubkey, signature, curve)

--- a/boa3_test/test_sc/native_test/cryptolib/VerifyWithECDsaSecp256k1Bool.py
+++ b/boa3_test/test_sc/native_test/cryptolib/VerifyWithECDsaSecp256k1Bool.py
@@ -1,9 +1,7 @@
-from boa3.builtin.compile_time import public
 from boa3.builtin.interop.crypto import NamedCurve
 from boa3.builtin.nativecontract.cryptolib import CryptoLib
 from boa3.builtin.type import ECPoint
 
 
-@public
 def Main():
     CryptoLib.verify_with_ecdsa(False, ECPoint(b'0123456789ABCDEFGHIJKLMNOPQRSTUVW'), b'signature', NamedCurve.SECP256K1)

--- a/boa3_test/test_sc/native_test/cryptolib/VerifyWithECDsaSecp256k1Int.py
+++ b/boa3_test/test_sc/native_test/cryptolib/VerifyWithECDsaSecp256k1Int.py
@@ -1,9 +1,7 @@
-from boa3.builtin.compile_time import public
 from boa3.builtin.interop.crypto import NamedCurve
 from boa3.builtin.nativecontract.cryptolib import CryptoLib
 from boa3.builtin.type import ECPoint
 
 
-@public
 def Main():
     CryptoLib.verify_with_ecdsa(10, ECPoint(b'0123456789ABCDEFGHIJKLMNOPQRSTUVW'), b'signature', NamedCurve.SECP256K1)

--- a/boa3_test/test_sc/native_test/cryptolib/VerifyWithECDsaSecp256r1Bool.py
+++ b/boa3_test/test_sc/native_test/cryptolib/VerifyWithECDsaSecp256r1Bool.py
@@ -1,9 +1,7 @@
-from boa3.builtin.compile_time import public
 from boa3.builtin.interop.crypto import NamedCurve
 from boa3.builtin.nativecontract.cryptolib import CryptoLib
 from boa3.builtin.type import ECPoint
 
 
-@public
 def Main():
     CryptoLib.verify_with_ecdsa(False, ECPoint(b'0123456789ABCDEFGHIJKLMNOPQRSTUVW'), b'signature', NamedCurve.SECP256R1)

--- a/boa3_test/test_sc/native_test/cryptolib/VerifyWithECDsaSecp256r1Int.py
+++ b/boa3_test/test_sc/native_test/cryptolib/VerifyWithECDsaSecp256r1Int.py
@@ -1,9 +1,7 @@
-from boa3.builtin.compile_time import public
 from boa3.builtin.interop.crypto import NamedCurve
 from boa3.builtin.nativecontract.cryptolib import CryptoLib
 from boa3.builtin.type import ECPoint
 
 
-@public
 def Main():
     CryptoLib.verify_with_ecdsa(10, ECPoint(b'0123456789ABCDEFGHIJKLMNOPQRSTUVW'), b'signature', NamedCurve.SECP256R1)

--- a/boa3_test/tests/compiler_tests/test_interop/test_crypto.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_crypto.py
@@ -434,8 +434,6 @@ class TestCryptoInterop(BoaTest):
         byte_input2 = b'signature'
         string = b'unit test'
         named_curve = Integer(NamedCurve.SECP256R1).to_byte_array(signed=True, min_length=1)
-        function_id = String(Interop.VerifyWithECDsa._sys_call).to_bytes()
-        call_flag = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
 
         expected_output = (
             Opcode.PUSHINT8 + named_curve
@@ -459,64 +457,18 @@ class TestCryptoInterop(BoaTest):
         self.assertEqual(expected_output, output)
 
     def test_verify_with_ecdsa_secp256r1_bool(self):
-        byte_input1 = b'0123456789ABCDEFGHIJKLMNOPQRSTUVW'
-        byte_input2 = b'signature'
-        named_curve = Integer(NamedCurve.SECP256R1).to_byte_array(signed=True, min_length=1)
-        function_id = String(Interop.VerifyWithECDsa._sys_call).to_bytes()
-        call_flag = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
-
-        expected_output = (
-            Opcode.PUSHINT8 + named_curve
-            + Opcode.PUSHDATA1
-            + Integer(len(byte_input2)).to_byte_array(min_length=1)
-            + byte_input2
-            + Opcode.PUSHDATA1
-            + Integer(len(byte_input1)).to_byte_array(min_length=1)
-            + byte_input1
-            + self.ecpoint_init
-            + Opcode.PUSHF
-            + Opcode.CALLT + b'\x00\x00'
-            + Opcode.DROP
-            + Opcode.RET
-        )
-
         path = self.get_contract_path('VerifyWithECDsaSecp256r1Bool.py')
-        output = self.compile(path)
-        self.assertEqual(expected_output, output)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_verify_with_ecdsa_secp256r1_int(self):
-        byte_input1 = b'0123456789ABCDEFGHIJKLMNOPQRSTUVW'
-        byte_input2 = b'signature'
-        named_curve = Integer(NamedCurve.SECP256R1).to_byte_array(signed=True, min_length=1)
-        function_id = String(Interop.VerifyWithECDsa._sys_call).to_bytes()
-        call_flag = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
-
-        expected_output = (
-            Opcode.PUSHINT8 + named_curve
-            + Opcode.PUSHDATA1
-            + Integer(len(byte_input2)).to_byte_array(min_length=1)
-            + byte_input2
-            + Opcode.PUSHDATA1
-            + Integer(len(byte_input1)).to_byte_array(min_length=1)
-            + byte_input1
-            + self.ecpoint_init
-            + Opcode.PUSH10
-            + Opcode.CALLT + b'\x00\x00'
-            + Opcode.DROP
-            + Opcode.RET
-        )
-
         path = self.get_contract_path('VerifyWithECDsaSecp256r1Int.py')
-        output = self.compile(path)
-        self.assertEqual(expected_output, output)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_verify_with_ecdsa_secp256r1_bytes(self):
         byte_input1 = b'0123456789ABCDEFGHIJKLMNOPQRSTUVW'
         byte_input2 = b'signature'
         string = b'unit test'
         named_curve = Integer(NamedCurve.SECP256R1).to_byte_array(signed=True, min_length=1)
-        function_id = String(Interop.VerifyWithECDsa._sys_call).to_bytes()
-        call_flag = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
 
         expected_output = (
             Opcode.PUSHINT8 + named_curve
@@ -548,8 +500,6 @@ class TestCryptoInterop(BoaTest):
         byte_input2 = b'signature'
         string = b'unit test'
         named_curve = Integer(NamedCurve.SECP256K1).to_byte_array(signed=True, min_length=1)
-        function_id = String(Interop.VerifyWithECDsa._sys_call).to_bytes()
-        call_flag = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
 
         expected_output = (
             Opcode.PUSHINT8 + named_curve
@@ -573,64 +523,18 @@ class TestCryptoInterop(BoaTest):
         self.assertEqual(expected_output, output)
 
     def test_verify_with_ecdsa_secp256k1_bool(self):
-        byte_input1 = b'0123456789ABCDEFGHIJKLMNOPQRSTUVW'
-        byte_input2 = b'signature'
-        named_curve = Integer(NamedCurve.SECP256K1).to_byte_array(signed=True, min_length=1)
-        function_id = String(Interop.VerifyWithECDsa._sys_call).to_bytes()
-        call_flag = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
-
-        expected_output = (
-            Opcode.PUSHINT8 + named_curve
-            + Opcode.PUSHDATA1
-            + Integer(len(byte_input2)).to_byte_array(min_length=1)
-            + byte_input2
-            + Opcode.PUSHDATA1
-            + Integer(len(byte_input1)).to_byte_array(min_length=1)
-            + byte_input1
-            + self.ecpoint_init
-            + Opcode.PUSHF
-            + Opcode.CALLT + b'\x00\x00'
-            + Opcode.DROP
-            + Opcode.RET
-        )
-
         path = self.get_contract_path('VerifyWithECDsaSecp256k1Bool.py')
-        output = self.compile(path)
-        self.assertEqual(expected_output, output)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_verify_with_ecdsa_secp256k1_int(self):
-        byte_input1 = b'0123456789ABCDEFGHIJKLMNOPQRSTUVW'
-        byte_input2 = b'signature'
-        named_curve = Integer(NamedCurve.SECP256K1).to_byte_array(signed=True, min_length=1)
-        function_id = String(Interop.VerifyWithECDsa._sys_call).to_bytes()
-        call_flag = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
-
-        expected_output = (
-            Opcode.PUSHINT8 + named_curve
-            + Opcode.PUSHDATA1
-            + Integer(len(byte_input2)).to_byte_array(min_length=1)
-            + byte_input2
-            + Opcode.PUSHDATA1
-            + Integer(len(byte_input1)).to_byte_array(min_length=1)
-            + byte_input1
-            + self.ecpoint_init
-            + Opcode.PUSH10
-            + Opcode.CALLT + b'\x00\x00'
-            + Opcode.DROP
-            + Opcode.RET
-        )
-
         path = self.get_contract_path('VerifyWithECDsaSecp256k1Int.py')
-        output = self.compile(path)
-        self.assertEqual(expected_output, output)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_verify_with_ecdsa_secp256k1_bytes(self):
         byte_input1 = b'0123456789ABCDEFGHIJKLMNOPQRSTUVW'
         byte_input2 = b'signature'
         string = b'unit test'
         named_curve = Integer(NamedCurve.SECP256K1).to_byte_array(signed=True, min_length=1)
-        function_id = String(Interop.VerifyWithECDsa._sys_call).to_bytes()
-        call_flag = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
 
         expected_output = (
             Opcode.PUSHINT8 + named_curve

--- a/boa3_test/tests/compiler_tests/test_native/test_cryptolib.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_cryptolib.py
@@ -234,52 +234,12 @@ class TestCryptoLibClass(BoaTest):
         self.assertEqual(expected_output, output)
 
     def test_verify_with_ecdsa_secp256r1_bool(self):
-        byte_input1 = b'0123456789ABCDEFGHIJKLMNOPQRSTUVW'
-        byte_input2 = b'signature'
-        named_curve = Integer(NamedCurve.SECP256R1).to_byte_array(signed=True, min_length=1)
-
-        expected_output = (
-            Opcode.PUSHINT8 + named_curve
-            + Opcode.PUSHDATA1
-            + Integer(len(byte_input2)).to_byte_array(min_length=1)
-            + byte_input2
-            + Opcode.PUSHDATA1
-            + Integer(len(byte_input1)).to_byte_array(min_length=1)
-            + byte_input1
-            + self.ecpoint_init
-            + Opcode.PUSHF
-            + Opcode.CALLT + b'\x00\x00'
-            + Opcode.DROP
-            + Opcode.RET
-        )
-
         path = self.get_contract_path('VerifyWithECDsaSecp256r1Bool.py')
-        output = self.compile(path)
-        self.assertEqual(expected_output, output)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_verify_with_ecdsa_secp256r1_int(self):
-        byte_input1 = b'0123456789ABCDEFGHIJKLMNOPQRSTUVW'
-        byte_input2 = b'signature'
-        named_curve = Integer(NamedCurve.SECP256R1).to_byte_array(signed=True, min_length=1)
-
-        expected_output = (
-            Opcode.PUSHINT8 + named_curve
-            + Opcode.PUSHDATA1
-            + Integer(len(byte_input2)).to_byte_array(min_length=1)
-            + byte_input2
-            + Opcode.PUSHDATA1
-            + Integer(len(byte_input1)).to_byte_array(min_length=1)
-            + byte_input1
-            + self.ecpoint_init
-            + Opcode.PUSH10
-            + Opcode.CALLT + b'\x00\x00'
-            + Opcode.DROP
-            + Opcode.RET
-        )
-
         path = self.get_contract_path('VerifyWithECDsaSecp256r1Int.py')
-        output = self.compile(path)
-        self.assertEqual(expected_output, output)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_verify_with_ecdsa_secp256r1_bytes(self):
         byte_input1 = b'0123456789ABCDEFGHIJKLMNOPQRSTUVW'
@@ -340,52 +300,12 @@ class TestCryptoLibClass(BoaTest):
         self.assertEqual(expected_output, output)
 
     def test_verify_with_ecdsa_secp256k1_bool(self):
-        byte_input1 = b'0123456789ABCDEFGHIJKLMNOPQRSTUVW'
-        byte_input2 = b'signature'
-        named_curve = Integer(NamedCurve.SECP256K1).to_byte_array(signed=True, min_length=1)
-
-        expected_output = (
-            Opcode.PUSHINT8 + named_curve
-            + Opcode.PUSHDATA1
-            + Integer(len(byte_input2)).to_byte_array(min_length=1)
-            + byte_input2
-            + Opcode.PUSHDATA1
-            + Integer(len(byte_input1)).to_byte_array(min_length=1)
-            + byte_input1
-            + self.ecpoint_init
-            + Opcode.PUSHF
-            + Opcode.CALLT + b'\x00\x00'
-            + Opcode.DROP
-            + Opcode.RET
-        )
-
         path = self.get_contract_path('VerifyWithECDsaSecp256k1Bool.py')
-        output = self.compile(path)
-        self.assertEqual(expected_output, output)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_verify_with_ecdsa_secp256k1_int(self):
-        byte_input1 = b'0123456789ABCDEFGHIJKLMNOPQRSTUVW'
-        byte_input2 = b'signature'
-        named_curve = Integer(NamedCurve.SECP256K1).to_byte_array(signed=True, min_length=1)
-
-        expected_output = (
-            Opcode.PUSHINT8 + named_curve
-            + Opcode.PUSHDATA1
-            + Integer(len(byte_input2)).to_byte_array(min_length=1)
-            + byte_input2
-            + Opcode.PUSHDATA1
-            + Integer(len(byte_input1)).to_byte_array(min_length=1)
-            + byte_input1
-            + self.ecpoint_init
-            + Opcode.PUSH10
-            + Opcode.CALLT + b'\x00\x00'
-            + Opcode.DROP
-            + Opcode.RET
-        )
-
         path = self.get_contract_path('VerifyWithECDsaSecp256k1Int.py')
-        output = self.compile(path)
-        self.assertEqual(expected_output, output)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     def test_verify_with_ecdsa_secp256k1_bytes(self):
         byte_input1 = b'0123456789ABCDEFGHIJKLMNOPQRSTUVW'


### PR DESCRIPTION
**Summary or solution description**
Changed the `verify_with_ecdsa` first parameter type to be the same as the signature parameter type

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/2a87a32d8ec7e9900368cc232a8d65aa6a14f54d/boa3_test/test_sc/interop_test/crypto/VerifyWithECDsa.py#L1C1-L10

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/2a87a32d8ec7e9900368cc232a8d65aa6a14f54d/boa3_test/tests/compiler_tests/test_interop/test_crypto.py#L428-L430

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8
