### PR TITLE
Fix default permissions value on metadata

### DIFF
--- a/boa3/internal/compiler/filegenerator.py
+++ b/boa3/internal/compiler/filegenerator.py
@@ -255,8 +255,7 @@ class FileGenerator:
 
         :return: a dictionary with the permission information
         """
-        return self._metadata.permissions if self._metadata.permissions else [{"contract": constants.IMPORT_WILDCARD,
-                                                                               "methods": constants.IMPORT_WILDCARD}]
+        return self._metadata.permissions
 
     def _get_groups(self) -> List[Dict[str, Any]]:
         """

--- a/boa3_test/test_sc/interop_test/contract/CallScriptHash.py
+++ b/boa3_test/test_sc/interop_test/contract/CallScriptHash.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from boa3.builtin.compile_time import public
+from boa3.builtin.compile_time import metadata, NeoMetadata, public
 from boa3.builtin.interop.contract import call_contract
 from boa3.builtin.type import UInt160
 
@@ -8,3 +8,11 @@ from boa3.builtin.type import UInt160
 @public
 def Main(scripthash: UInt160, method: str, args: list) -> Any:
     return call_contract(scripthash, method, args)
+
+
+@metadata
+def manifest_metadata() -> NeoMetadata:
+    # since this smart contract will call another, it needs to have permission to do so on the manifest
+    meta = NeoMetadata()
+    meta.add_permission(contract='*', methods='*')
+    return meta

--- a/boa3_test/test_sc/interop_test/contract/CallScriptHashWithCast.py
+++ b/boa3_test/test_sc/interop_test/contract/CallScriptHashWithCast.py
@@ -1,6 +1,6 @@
 from typing import cast
 
-from boa3.builtin.compile_time import public
+from boa3.builtin.compile_time import metadata, NeoMetadata, public
 from boa3.builtin.interop.contract import call_contract
 from boa3.builtin.type import UInt160
 
@@ -9,3 +9,11 @@ from boa3.builtin.type import UInt160
 def Main(scripthash: bytes, method: str, args: list) -> bool:
     call_contract(cast(UInt160, scripthash), method, args)
     return True
+
+
+@metadata
+def manifest_metadata() -> NeoMetadata:
+    # since this smart contract will call another, it needs to have permission to do so on the manifest
+    meta = NeoMetadata()
+    meta.add_permission(contract='*', methods='*')
+    return meta

--- a/boa3_test/test_sc/interop_test/contract/CallScriptHashWithFlags.py
+++ b/boa3_test/test_sc/interop_test/contract/CallScriptHashWithFlags.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from boa3.builtin.compile_time import public
+from boa3.builtin.compile_time import metadata, NeoMetadata, public
 from boa3.builtin.interop.contract import CallFlags, call_contract
 from boa3.builtin.type import UInt160
 
@@ -8,3 +8,11 @@ from boa3.builtin.type import UInt160
 @public
 def Main(scripthash: UInt160, method: str, args: list, flags: CallFlags) -> Any:
     return call_contract(scripthash, method, args, flags)
+
+
+@metadata
+def manifest_metadata() -> NeoMetadata:
+    # since this smart contract will call another, it needs to have permission to do so on the manifest
+    meta = NeoMetadata()
+    meta.add_permission(contract='*', methods='*')
+    return meta

--- a/boa3_test/test_sc/interop_test/contract/CallScriptHashWithoutArgs.py
+++ b/boa3_test/test_sc/interop_test/contract/CallScriptHashWithoutArgs.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from boa3.builtin.compile_time import public
+from boa3.builtin.compile_time import metadata, NeoMetadata, public
 from boa3.builtin.interop.contract import call_contract
 from boa3.builtin.type import UInt160
 
@@ -8,3 +8,11 @@ from boa3.builtin.type import UInt160
 @public
 def Main(scripthash: UInt160, method: str) -> Any:
     return call_contract(scripthash, method)
+
+
+@metadata
+def manifest_metadata() -> NeoMetadata:
+    # since this smart contract will call another, it needs to have permission to do so on the manifest
+    meta = NeoMetadata()
+    meta.add_permission(contract='*', methods='*')
+    return meta

--- a/boa3_test/test_sc/interop_test/contract/ImportContract.py
+++ b/boa3_test/test_sc/interop_test/contract/ImportContract.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from boa3.builtin.compile_time import public
+from boa3.builtin.compile_time import metadata, NeoMetadata, public
 from boa3.builtin.interop import contract
 from boa3.builtin.type import UInt160
 
@@ -13,3 +13,11 @@ def call_flags_all() -> contract.CallFlags:
 @public
 def main(scripthash: UInt160, method: str, args: list) -> Any:
     return contract.call_contract(scripthash, method, args)
+
+
+@metadata
+def manifest_metadata() -> NeoMetadata:
+    # since this smart contract will call another, it needs to have permission to do so on the manifest
+    meta = NeoMetadata()
+    meta.add_permission(contract='*', methods='*')
+    return meta

--- a/boa3_test/test_sc/interop_test/contract/ImportInteropContract.py
+++ b/boa3_test/test_sc/interop_test/contract/ImportInteropContract.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from boa3.builtin import interop, type
-from boa3.builtin.compile_time import public
+from boa3.builtin.compile_time import metadata, NeoMetadata, public
 
 
 @public
@@ -12,3 +12,11 @@ def call_flags_all() -> interop.contract.CallFlags:
 @public
 def main(scripthash: type.UInt160, method: str, args: list) -> Any:
     return interop.contract.call_contract(scripthash, method, args)
+
+
+@metadata
+def manifest_metadata() -> NeoMetadata:
+    # since this smart contract will call another, it needs to have permission to do so on the manifest
+    meta = NeoMetadata()
+    meta.add_permission(contract='*', methods='*')
+    return meta

--- a/boa3_test/tests/compiler_tests/test_metadata.py
+++ b/boa3_test/tests/compiler_tests/test_metadata.py
@@ -396,8 +396,7 @@ class TestMetadata(BoaTest):
 
         self.assertIn('permissions', manifest)
         self.assertIsInstance(manifest['permissions'], list)
-        self.assertEqual(len(manifest['permissions']), 1)
-        self.assertIn({"contract": "*", "methods": "*"}, manifest['permissions'])
+        self.assertEqual(len(manifest['permissions']), 0)
 
     def test_metadata_info_permissions_default(self):
         path = self.get_contract_path('MetadataInfoPermissionsDefault.py')
@@ -405,8 +404,7 @@ class TestMetadata(BoaTest):
 
         self.assertIn('permissions', manifest)
         self.assertIsInstance(manifest['permissions'], list)
-        self.assertEqual(len(manifest['permissions']), 1)
-        self.assertIn({"contract": "*", "methods": "*"}, manifest['permissions'])
+        self.assertEqual(len(manifest['permissions']), 0)
 
     def test_metadata_info_permissions_wildcard(self):
         path = self.get_contract_path('MetadataInfoPermissionsWildcard.py')


### PR DESCRIPTION
**Summary or solution description**
The default permissions value on metadata was implemented as the wildcard, but now will be empty

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/5f01fb1d1d88b7fec130ff80bfa1e63f807dc690/boa3_test/tests/compiler_tests/test_metadata.py#L401-L407

**Platform:**
 - OS: Windows 10 x64
 - Python version:Python 3.8