### PR TITLE
Add all smart contract related files paths and fix file indexes in sequence point on debug file

### DIFF
--- a/boa3/internal/analyser/moduleanalyser.py
+++ b/boa3/internal/analyser/moduleanalyser.py
@@ -781,6 +781,9 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
                         external_name=external_function_name,
                         is_init=is_class_constructor)
 
+        # debug information
+        method.file_origin = self.filename.replace(os.path.sep, constants.PATH_SEPARATOR)
+
         if function.name in Builtin.internal_methods:
             internal_method = Builtin.internal_methods[function.name]
             if not internal_method.is_valid_deploy_method(method):

--- a/boa3/internal/compiler/compiler.py
+++ b/boa3/internal/compiler/compiler.py
@@ -5,7 +5,7 @@ from boa3.internal import constants
 from boa3.internal.analyser.analyser import Analyser
 from boa3.internal.compiler.codegenerator.codegenerator import CodeGenerator
 from boa3.internal.compiler.compileroutput import CompilerOutput
-from boa3.internal.compiler.filegenerator import FileGenerator
+from boa3.internal.compiler.filegenerator.filegenerator import FileGenerator
 from boa3.internal.exception.NotLoadedException import NotLoadedException
 
 

--- a/boa3/internal/compiler/filegenerator/filegenerator.py
+++ b/boa3/internal/compiler/filegenerator/filegenerator.py
@@ -499,11 +499,17 @@ class FileGenerator:
 
         :return: a dictionary with the methods' debug information
         """
-        return [
-            self._get_method_debug_info(module_id, method_id, method)
-            for (module_id, method_id), method in self._methods_with_imports.items()
-            if method.is_compiled
-        ]
+        method_ids = []
+        debug_methods = []
+
+        for (module_id, method_id), method in self._methods_with_imports.items():
+            dbg_method = self._get_method_debug_info(module_id, method_id, method)
+            dbg_id = dbg_method['id']
+            if method.is_compiled and dbg_id not in method_ids:
+                method_ids.append(dbg_id)
+                debug_methods.append(dbg_method)
+
+        return debug_methods
 
     def _get_method_debug_info(self, module_id: str, method_id: str, method: Method) -> Dict[str, Any]:
         from boa3.internal.compiler.codegenerator.vmcodemapping import VMCodeMapping
@@ -557,15 +563,23 @@ class FileGenerator:
 
         :return: a dictionary with the event's debug information
         """
-        return [
-            {
-                "id": str(id(event)),
+        event_ids = []
+        debug_events = []
+
+        for event_id, event in self._events.items():
+            dbg_id = str(id(event))
+            dbg_event = {
+                "id": dbg_id,
                 "name": ',{0}'.format(event_id),  # TODO: include module name
                 "params": [
                     '{0},{1}'.format(name, var.type.abi_type) for name, var in event.args.items()
                 ]
-            } for event_id, event in self._events.items()
-        ]
+            }
+            if dbg_id not in event_ids:
+                event_ids.append(dbg_id)
+                debug_events.append(dbg_event)
+
+        return debug_events
 
     def _get_debug_static_variables(self) -> List[str]:
         """

--- a/boa3/internal/compiler/filegenerator/importdata.py
+++ b/boa3/internal/compiler/filegenerator/importdata.py
@@ -1,0 +1,34 @@
+from typing import Dict
+
+from boa3.internal.model.symbol import ISymbol
+
+
+class ImportData:
+    def __init__(self, import_symbol: ISymbol, origin_id: str, origin_file: str = None):
+        self._imported_symbol = import_symbol
+        self._origin_id = origin_id
+        self._origin_file = origin_file
+
+    @property
+    def origin(self) -> str:
+        if self._origin_id is not None:
+            return self._origin_id
+
+        if hasattr(self._imported_symbol, 'origin'):
+            return self._imported_symbol.origin
+
+        return None
+
+    @property
+    def origin_file(self) -> str:
+        return self._origin_file
+
+    @property
+    def all_symbols(self) -> Dict[str, ISymbol]:
+        if hasattr(self._imported_symbol, 'all_symbols'):
+            return self._imported_symbol.all_symbols
+
+        if hasattr(self._imported_symbol, 'symbols'):
+            return self._imported_symbol.symbols
+
+        return {}

--- a/boa3/internal/model/debuginstruction.py
+++ b/boa3/internal/model/debuginstruction.py
@@ -26,5 +26,5 @@ class DebugInstruction:
     @classmethod
     def build(cls, ast_node: ast.AST, bytecode: VMCode) -> DebugInstruction:
         end_line: int = ast_node.end_lineno if hasattr(ast_node, 'end_lineno') else ast_node.lineno
-        end_col: int = ast_node.end_col_offset if hasattr(ast_node, 'end_lineno') else ast_node.col_offset
+        end_col: int = ast_node.end_col_offset + 1 if hasattr(ast_node, 'end_lineno') else ast_node.col_offset
         return cls(bytecode, ast_node.lineno, ast_node.col_offset, end_line, end_col)

--- a/boa3/internal/model/method.py
+++ b/boa3/internal/model/method.py
@@ -43,6 +43,7 @@ class Method(Callable):
 
         self._debug_map: List[DebugInstruction] = []
         self.origin_class: Optional[ClassType] = None
+        self.file_origin: Optional[str] = None
 
     @property
     def shadowing_name(self) -> str:

--- a/boa3/internal/model/type/classes/classtype.py
+++ b/boa3/internal/model/type/classes/classtype.py
@@ -118,6 +118,16 @@ class ClassType(IType, ABC):
             instance_funcs.update(base.instance_methods)
         return instance_funcs
 
+    @property
+    def methods(self):
+        """
+        :rtype: Dict[str, boa3.internal.model.method.Method]
+        """
+        methods = self.static_methods.copy()
+        methods.update(self.class_methods)
+        methods.update(self.instance_methods)
+        return methods
+
     @abstractmethod
     def constructor_method(self):
         """
@@ -130,9 +140,7 @@ class ClassType(IType, ABC):
     @property
     def symbols(self) -> Dict[str, ISymbol]:
         s = {}
-        s.update(self.static_methods)
-        s.update(self.class_methods)
-        s.update(self.instance_methods)
+        s.update(self.methods)
         s.update(self.variables)
         s.update(self.properties)
         return s

--- a/boa3_test/test_sc/generation_test/GenerationWithUserModuleNameImports.py
+++ b/boa3_test/test_sc/generation_test/GenerationWithUserModuleNameImports.py
@@ -3,9 +3,9 @@ from typing import List
 from boa3.builtin.compile_time import public
 from boa3.builtin.interop.runtime import Notification
 from boa3.builtin.type import UInt160
-from boa3_test.test_sc.interop_test.runtime.GetNotifications import with_param
+from boa3_test.test_sc.interop_test.runtime import GetNotifications
 
 
 @public
 def main(args: list, key: UInt160) -> List[Notification]:
-    return with_param(args, key)
+    return GetNotifications.with_param(args, key)

--- a/boa3_test/tests/boa_test.py
+++ b/boa3_test/tests/boa_test.py
@@ -65,7 +65,7 @@ class BoaTest(TestCase):
         return compiler._analyser
 
     def get_all_imported_methods(self, compiler: Compiler) -> Dict[str, Method]:
-        from boa3.internal.compiler.filegenerator import FileGenerator
+        from boa3.internal.compiler.filegenerator.filegenerator import FileGenerator
         generator = FileGenerator(compiler.result, compiler._analyser, compiler._entry_smart_contract)
         return {constants.VARIABLE_NAME_SEPARATOR.join(name): value for name, value in generator._methods_with_imports.items()}
 
@@ -173,6 +173,8 @@ class BoaTest(TestCase):
         path = '{0}/{1}'.format(dir_folder, contract_name)
         if not os.path.isfile(path):
             raise FileNotFoundError(path)
+        else:
+            path = os.path.abspath(path).replace(os.path.sep, constants.PATH_SEPARATOR)
         return path
 
     def get_deploy_file_paths_without_compiling(self, contract_path: str, output_name: str = None) -> Tuple[str, str]:

--- a/docs/ContractExamplesTest.md
+++ b/docs/ContractExamplesTest.md
@@ -543,7 +543,7 @@
 
 #### Import
 - <a href="/boa3_test/test_sc/generation_test/GenerationWithUserModuleImports.py">GenerationWithUserModuleImports.py</a>,
-- <a href="/boa3_test/test_sc/generation_test/GenerationWithUserModuleImportsDupNames.py">GenerationWithUserModuleImportsDupNames.py</a>,
+- <a href="/boa3_test/test_sc/generation_test/GenerationWithUserModuleNameImports.py">GenerationWithUserModuleNameImports.py</a>,
 - <a href="/boa3_test/test_sc/import_test/ImportUserModuleWithNotImportedSymbols.py">ImportUserModuleWithNotImportedSymbols.py</a>,
 - <a href="/boa3_test/test_sc/import_test/ImportUserModuleWithNotImportedVariables.py">ImportUserModuleWithNotImportedVariables.py</a>
 


### PR DESCRIPTION
**Summary or solution description**
Fixed debug info generation when there are files importing user modules instead of directly importing methods or variables.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/2b626a84d7c0a954736222949ce2e7c51cf8b63c/boa3_test/test_sc/import_test/ImportModuleWithoutInit.py#L1-L14

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/2b626a84d7c0a954736222949ce2e7c51cf8b63c/boa3_test/tests/compiler_tests/test_file_generation.py#L575-L600

**Platform:**
 - OS: tested on Windows 10 x64
 - Python version: Python 3.7+