### PR TITLE
Boa cli commands should show help message by default

### DIFF
--- a/boa3/cli.py
+++ b/boa3/cli.py
@@ -1,10 +1,16 @@
-from argparse import ArgumentParser
+from argparse import ArgumentParser, RawDescriptionHelpFormatter
 
+from boa3.internal import constants
 from boa3.internal.cli_commands import commands
 
 
 def main():
-    n3boa = ArgumentParser()
+    n3boa = ArgumentParser(description=f"neo3-boa by COZ - version {constants.BOA_VERSION}"
+                                       "\nWrite smart contracts for Neo3 in Python",
+                           formatter_class=RawDescriptionHelpFormatter,
+                           )
+    n3boa.add_argument("-v", "--version", action="version",
+                       version=f"neo3-boa {constants.BOA_VERSION}")
 
     n3_subparser = n3boa.add_subparsers(title='Commands')
 
@@ -15,9 +21,12 @@ def main():
     # read command line and get the correct command requested
     args = n3boa.parse_args()
 
-    # execute command
+    # execute subparser commands
     if hasattr(args, 'func'):
         args.func(vars(args))
+    else:
+        import sys
+        n3boa.print_help(sys.stderr)
 
 
 if __name__ == "__main__":

--- a/boa3/internal/cli_commands/__init__.py
+++ b/boa3/internal/cli_commands/__init__.py
@@ -1,5 +1,5 @@
-from boa3.internal.cli_commands.build_command import BuildCommand
+from boa3.internal.cli_commands.compile_command import CompileCommand
 
 commands = (
-    BuildCommand,
+    CompileCommand,
 )

--- a/boa3/internal/cli_commands/compile_command.py
+++ b/boa3/internal/cli_commands/compile_command.py
@@ -9,7 +9,7 @@ from boa3.internal.cli_commands.icommand import ICommand
 from boa3.internal.exception.NotLoadedException import NotLoadedException
 
 
-class BuildCommand(ICommand):
+class CompileCommand(ICommand):
 
     def __init__(self, main_parser: _SubParsersAction):
         super().__init__(main_parser, 'compile', 'Compiles your smart contract')


### PR DESCRIPTION
**Summary or solution description**
When using `neo3-boa` on the terminal it shows the help, also a `-v` and `--version` flags for version were added.

**How to Reproduce**
`neo3-boa` to show the help
`neo3-boa -v` to show the version
`neo3-boa --version` to show the version

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8

**(Optional) Additional context**
Also changed the name of the `build_command` and `BuildCommand` to `compile_command` and `CompileCommand`. (The CLI command was already `compile`, I just renamed the files/class)
