### PR TITLE
Fix import error due to incorrect sys.path

### DIFF
--- a/boa3/internal/analyser/importanalyser.py
+++ b/boa3/internal/analyser/importanalyser.py
@@ -53,8 +53,8 @@ class ImportAnalyser(IAstAnalyser):
             return
 
         importer_file_dir = os.path.dirname(importer_file)
-        sys.path.append(self.root_folder)
-        sys.path.append(importer_file_dir)
+        sys.path.insert(0, self.root_folder)
+        sys.path.insert(1, importer_file_dir)
         try:
             import_spec = importlib.util.find_spec(import_target)
             module_origin: str = import_spec.origin


### PR DESCRIPTION
**Related issue**
https://app.clickup.com/t/864emdffj


**Summary or solution description**
`site-packages` modules took precedence over project modules during compilation. If there is a name collision this can lead to confusing import errors because an IDE will not show any errors and will correctly resolve imports, whereas the `importanalyser` will not. This PR makes sure that the project root is the first place searched for instead of the last place

The problematic area was this
https://github.com/CityOfZion/neo3-boa/blob/580de6156cf6acebe18896a6ead3711f535a641c/boa3/internal/analyser/importanalyser.py#L56-L62

Then take a project with a package called `events` but also a 3rd party package installed in the same environment (in this case `neo-mamba`) that happens to have a dependency on a 3rd party package called `Events` (which has a module `events.py`) and you end up with this. 

![Screenshot from 2023-05-22 14-27-35](https://github.com/CityOfZion/neo3-boa/assets/6625537/67273e83-96d6-4b46-a834-2a257eb15a57)

On the left side is a print of `sys.modules` where compilation fails, on the right side the same but where compilation succeeds. The difference is in the path where it thinks the `events` comes from. With the setup on the left side `importlib.util.find_spec` on line 59 will return `None`, then fail to access `origin` on `NoneType` and from there all goes down hill.

By inserting the root folder as the first thing in the `path` the `find_spec()` call will find our project modules first instead of last.