### PR TITLE
unresolved reference 'Iterator'

### DIFF
--- a/boa3/builtin/compile_time/__init__.py
+++ b/boa3/builtin/compile_time/__init__.py
@@ -1,3 +1,12 @@
+__all__ = [
+    'CreateNewEvent',
+    'public',
+    'metadata',
+    'contract',
+    'display_name',
+    'NeoMetadata',
+]
+
 from typing import List, Dict, Any, Union, Optional, Tuple
 
 from boa3.builtin.type import ByteString, Event

--- a/boa3/builtin/contract/__init__.py
+++ b/boa3/builtin/contract/__init__.py
@@ -1,3 +1,12 @@
+__all__ = [
+    'Nep5TransferEvent',
+    'Nep11TransferEvent',
+    'Nep17TransferEvent',
+    'abort',
+    'NeoAccountState',
+    'to_script_hash',
+]
+
 from typing import Union, Any
 
 from boa3.builtin.compile_time import CreateNewEvent

--- a/boa3/builtin/interop/blockchain/__init__.py
+++ b/boa3/builtin/interop/blockchain/__init__.py
@@ -1,3 +1,19 @@
+__all__ = [
+    'Block',
+    'Signer',
+    'Transaction',
+    'VMState',
+    'get_contract',
+    'get_block',
+    'get_transaction',
+    'get_transaction_from_block',
+    'get_transaction_height',
+    'get_transaction_signers',
+    'get_transaction_vm_state',
+    'current_hash',
+    'current_index',
+]
+
 from typing import List, Union
 
 from boa3.builtin.interop.blockchain.block import Block

--- a/boa3/builtin/interop/blockchain/signer.py
+++ b/boa3/builtin/interop/blockchain/signer.py
@@ -1,3 +1,12 @@
+__all__ = [
+    "Signer",
+    "WitnessRule",
+    "WitnessCondition",
+    "WitnessConditionType",
+    "WitnessRuleAction",
+    "WitnessScope",
+]
+
 from typing import List
 
 from boa3.builtin.type import UInt160

--- a/boa3/builtin/interop/blockchain/transaction.py
+++ b/boa3/builtin/interop/blockchain/transaction.py
@@ -1,3 +1,7 @@
+__all__ = [
+    'Transaction',
+]
+
 from boa3.builtin.type import UInt160, UInt256
 
 

--- a/boa3/builtin/interop/contract/__init__.py
+++ b/boa3/builtin/interop/contract/__init__.py
@@ -1,7 +1,25 @@
+__all__ = [
+    'CallFlags',
+    'Contract',
+    'ContractManifest',
+    'call_contract',
+    'create_contract',
+    'update_contract',
+    'destroy_contract',
+    'get_minimum_deployment_fee',
+    'get_call_flags',
+    'create_standard_account',
+    'create_multisig_account',
+    'NEO',
+    'GAS',
+]
+
+
 from typing import Any, List, Sequence
 
 from boa3.builtin.interop.contract.callflagstype import CallFlags
 from boa3.builtin.interop.contract.contract import Contract
+from boa3.builtin.interop.contract.contractmanifest import ContractManifest
 from boa3.builtin.type import ECPoint, UInt160
 
 

--- a/boa3/builtin/interop/contract/contract.py
+++ b/boa3/builtin/interop/contract/contract.py
@@ -1,3 +1,7 @@
+__all__ = [
+    'Contract',
+]
+
 from boa3.builtin.interop.contract.contractmanifest import ContractManifest
 from boa3.builtin.type import UInt160
 

--- a/boa3/builtin/interop/contract/contractmanifest.py
+++ b/boa3/builtin/interop/contract/contractmanifest.py
@@ -1,3 +1,15 @@
+__all__ = [
+    'ContractManifest',
+    'ContractPermission',
+    'ContractPermissionDescriptor',
+    'ContractGroup',
+    'ContractAbi',
+    'ContractMethodDescriptor',
+    'ContractEventDescriptor',
+    'ContractParameterDefinition',
+    'ContractParameterType',
+]
+
 from typing import List, Optional
 
 from boa3.builtin.type import ECPoint, UInt160

--- a/boa3/builtin/interop/crypto/__init__.py
+++ b/boa3/builtin/interop/crypto/__init__.py
@@ -1,3 +1,22 @@
+__all__ = [
+    'NamedCurve',
+    'sha256',
+    'ripemd160',
+    'hash160',
+    'hash256',
+    'check_sig',
+    'check_multisig',
+    'verify_with_ecdsa',
+    'murmur32',
+    'bls12_381_add',
+    'bls12_381_deserialize',
+    'bls12_381_equal',
+    'bls12_381_mul',
+    'bls12_381_pairing',
+    'bls12_381_serialize',
+]
+
+
 from typing import Any, List
 
 from boa3.builtin.interop.crypto.namedcurve import NamedCurve

--- a/boa3/builtin/interop/iterator/__init__.py
+++ b/boa3/builtin/interop/iterator/__init__.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+__all__ = [
+    'Iterator',
+]
+
+
 from typing import Any
 
 

--- a/boa3/builtin/interop/json/__init__.py
+++ b/boa3/builtin/interop/json/__init__.py
@@ -1,3 +1,9 @@
+__all__ = [
+    'json_serialize',
+    'json_deserialize',
+]
+
+
 from typing import Any
 
 

--- a/boa3/builtin/interop/policy/__init__.py
+++ b/boa3/builtin/interop/policy/__init__.py
@@ -1,3 +1,11 @@
+__all__ = [
+    'get_exec_fee_factor',
+    'get_fee_per_byte',
+    'get_storage_price',
+    'is_blocked',
+]
+
+
 from boa3.builtin.type import UInt160
 
 

--- a/boa3/builtin/interop/role/__init__.py
+++ b/boa3/builtin/interop/role/__init__.py
@@ -1,3 +1,9 @@
+__all__ = [
+    'Role',
+    'get_designated_by_role',
+]
+
+
 from boa3.builtin.interop.role.roletype import Role
 from boa3.builtin.type import ECPoint
 

--- a/boa3/builtin/interop/runtime/__init__.py
+++ b/boa3/builtin/interop/runtime/__init__.py
@@ -1,3 +1,27 @@
+__all__ = [
+    'Notification',
+    'TriggerType',
+    'check_witness',
+    'notify',
+    'log',
+    'get_trigger',
+    'get_notifications',
+    'get_network',
+    'burn_gas',
+    'get_random',
+    'load_script',
+    'address_version',
+    'executing_script_hash',
+    'calling_script_hash',
+    'time',
+    'gas_left',
+    'platform',
+    'invocation_counter',
+    'entry_script_hash',
+    'script_container',
+]
+
+
 from typing import Any, List, Union, Sequence
 
 from boa3.builtin.interop.contract.callflagstype import CallFlags

--- a/boa3/builtin/interop/runtime/notification.py
+++ b/boa3/builtin/interop/runtime/notification.py
@@ -1,3 +1,6 @@
+__all__ = ['Notification']
+
+
 from boa3.builtin.type import UInt160
 
 

--- a/boa3/builtin/interop/stdlib/__init__.py
+++ b/boa3/builtin/interop/stdlib/__init__.py
@@ -1,3 +1,19 @@
+__all__ = [
+    'base58_encode',
+    'base58_decode',
+    'base58_check_encode',
+    'base58_check_decode',
+    'base64_encode',
+    'base64_decode',
+    'serialize',
+    'deserialize',
+    'atoi',
+    'itoa',
+    'memory_search',
+    'memory_compare',
+]
+
+
 from typing import Any
 
 from boa3.builtin.type import ByteString

--- a/boa3/builtin/interop/storage/__init__.py
+++ b/boa3/builtin/interop/storage/__init__.py
@@ -1,3 +1,16 @@
+__all__ = [
+    'FindOptions',
+    'StorageContext',
+    'StorageMap',
+    'get',
+    'get_context',
+    'get_read_only_context',
+    'put',
+    'delete',
+    'find',
+]
+
+
 from typing import Union
 
 from boa3.builtin.interop.iterator import Iterator

--- a/boa3/builtin/interop/storage/storagecontext.py
+++ b/boa3/builtin/interop/storage/storagecontext.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__all__ = ['StorageContext']
+
 from boa3.builtin.interop.storage.storagemap import StorageMap
 from boa3.builtin.type import ByteString
 

--- a/boa3/builtin/interop/storage/storagemap.py
+++ b/boa3/builtin/interop/storage/storagemap.py
@@ -1,3 +1,5 @@
+__all__ = ['StorageMap']
+
 from typing import Union
 
 from boa3.builtin.type import ByteString

--- a/boa3/builtin/nativecontract/__init__.py
+++ b/boa3/builtin/nativecontract/__init__.py
@@ -1,0 +1,21 @@
+__all__ = [
+    'ContractManagement',
+    'CryptoLib',
+    'GAS',
+    'Ledger',
+    'NEO',
+    'Oracle',
+    'Policy',
+    'RoleManagement',
+    'StdLib',
+]
+
+from boa3.builtin.nativecontract.contractmanagement import ContractManagement
+from boa3.builtin.nativecontract.cryptolib import CryptoLib
+from boa3.builtin.nativecontract.gas import GAS
+from boa3.builtin.nativecontract.ledger import Ledger
+from boa3.builtin.nativecontract.neo import NEO
+from boa3.builtin.nativecontract.oracle import Oracle
+from boa3.builtin.nativecontract.policy import Policy
+from boa3.builtin.nativecontract.rolemanagement import RoleManagement
+from boa3.builtin.nativecontract.stdlib import StdLib

--- a/boa3/builtin/nativecontract/contractmanagement.py
+++ b/boa3/builtin/nativecontract/contractmanagement.py
@@ -1,3 +1,9 @@
+__all__ = [
+    'ContractManagement',
+    'Contract',
+]
+
+
 from typing import Any
 
 from boa3.builtin.interop.contract import Contract

--- a/boa3/builtin/nativecontract/cryptolib.py
+++ b/boa3/builtin/nativecontract/cryptolib.py
@@ -1,3 +1,8 @@
+__all__ = [
+    'CryptoLib',
+    'NamedCurve',
+]
+
 from typing import Any
 
 from boa3.builtin.interop.crypto import NamedCurve

--- a/boa3/builtin/nativecontract/gas.py
+++ b/boa3/builtin/nativecontract/gas.py
@@ -1,3 +1,8 @@
+__all__ = [
+    'GAS',
+]
+
+
 from typing import Any
 
 from boa3.builtin.type import UInt160

--- a/boa3/builtin/nativecontract/ledger.py
+++ b/boa3/builtin/nativecontract/ledger.py
@@ -1,3 +1,8 @@
+__all__ = [
+    'Ledger',
+]
+
+
 from typing import List, Union
 
 from boa3.builtin.interop.blockchain import Block, Signer, Transaction, VMState

--- a/boa3/builtin/nativecontract/neo.py
+++ b/boa3/builtin/nativecontract/neo.py
@@ -1,3 +1,8 @@
+__all__ = [
+    'NEO',
+]
+
+
 from typing import Any, List, Tuple
 
 from boa3.builtin.contract import NeoAccountState

--- a/boa3/builtin/nativecontract/oracle.py
+++ b/boa3/builtin/nativecontract/oracle.py
@@ -1,3 +1,8 @@
+__all__ = [
+    'Oracle',
+]
+
+
 from typing import Union, Any
 
 from boa3.builtin.type import UInt160

--- a/boa3/builtin/nativecontract/policy.py
+++ b/boa3/builtin/nativecontract/policy.py
@@ -1,3 +1,8 @@
+__all__ = [
+    'Policy',
+]
+
+
 from boa3.builtin.type import UInt160
 
 

--- a/boa3/builtin/nativecontract/rolemanagement.py
+++ b/boa3/builtin/nativecontract/rolemanagement.py
@@ -1,3 +1,9 @@
+__all__ = [
+    'RoleManagement',
+    'Role',
+]
+
+
 from boa3.builtin.interop.role.roletype import Role
 from boa3.builtin.type import ECPoint, UInt160
 

--- a/boa3/builtin/nativecontract/stdlib.py
+++ b/boa3/builtin/nativecontract/stdlib.py
@@ -1,3 +1,8 @@
+__all__ = [
+    'StdLib',
+]
+
+
 from typing import Any
 
 from boa3.builtin.type import ByteString, UInt160

--- a/boa3/builtin/type/__init__.py
+++ b/boa3/builtin/type/__init__.py
@@ -1,5 +1,19 @@
 from __future__ import annotations
 
+__all__ = [
+    'Event',
+    'UInt160',
+    'UInt256',
+    'ECPoint',
+    'ByteString',
+    'Address',
+    'BlockHash',
+    'PublicKey',
+    'ScriptHash',
+    'ScriptHashLittleEndian',
+    'TransactionId',
+]
+
 from typing import Sequence, Union
 
 

--- a/boa3/internal/model/builtin/interop/interop.py
+++ b/boa3/internal/model/builtin/interop/interop.py
@@ -342,9 +342,14 @@ class Interop:
                                      ]
                             )
 
+    RoleTypeModule = Package(identifier=RoleType.identifier.lower(),
+                             types=[RoleType]
+                             )
+
     RolePackage = Package(identifier=InteropPackage.Role,
                           types=[RoleType],
-                          methods=[GetDesignatedByRole]
+                          methods=[GetDesignatedByRole],
+                          packages=[RoleTypeModule]
                           )
 
     RuntimePackage = Package(identifier=InteropPackage.Runtime,

--- a/boa3/internal/model/builtin/native/nativecontract.py
+++ b/boa3/internal/model/builtin/native/nativecontract.py
@@ -24,8 +24,7 @@ class NativeContract:
 
     ContractManagementModule = Package(identifier=ContractManagement.identifier.lower(),
                                        types=[ContractManagement,
-                                              Interop.ContractType,
-                                              Builtin.UInt160])
+                                              Interop.ContractType])
 
     CryptoLibModule = Package(identifier=CryptoLib.identifier.lower(),
                               types=[CryptoLib,
@@ -36,9 +35,7 @@ class NativeContract:
                         )
 
     LedgerModule = Package(identifier=Ledger.identifier.lower(),
-                           types=[Ledger,
-                                  Interop.BlockType,
-                                  Interop.TransactionType]
+                           types=[Ledger]
                            )
 
     NeoModule = Package(identifier=NEO.identifier.lower(),


### PR DESCRIPTION
**Summary or solution description**
Python lets you import from an import inside a file, but neo3-boa doesn't have those imports internally, for example, inside the following file Python would let you import `ECPoint`, `Any` or `CallFlags`, but Neo3-boa doesn't:
```python
# runtime\__init__.py

from typing import Any, List, Union, Sequence

from boa3.builtin.interop.contract.callflagstype import CallFlags
from boa3.builtin.interop.runtime.notification import Notification
from boa3.builtin.interop.runtime.triggertype import TriggerType
from boa3.builtin.type import ECPoint, UInt160, ByteString
```
a `__all__ = []` was added, so now if you do something like `from boa3.builtin.interop.runtime import *`, only the methods/variables/classes inside the list will be imported, and if another value is imported, then the IDE will send a warning.

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8
