### PR TITLE
Fix storage.find FindOptions are ignored and generates incorrect code

### DIFF
--- a/boa3/internal/compiler/codegenerator/codegenerator.py
+++ b/boa3/internal/compiler/codegenerator/codegenerator.py
@@ -419,6 +419,9 @@ class CodeGenerator:
                 else:
                     # the symbol may be a built-in. If not, returns None
                     symbol = Builtin.get_symbol(identifier)
+                    if symbol is None:
+                        symbol = Interop.get_symbol(identifier)
+
                     if symbol is not None:
                         found_id, found_symbol = identifier, symbol
 

--- a/boa3/internal/model/builtin/interop/interop.py
+++ b/boa3/internal/model/builtin/interop/interop.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from boa3.internal.model.builtin.interop.blockchain import *
 from boa3.internal.model.builtin.interop.contract import *
@@ -38,6 +38,12 @@ class InteropPackage(str, Enum):
 
 
 class Interop:
+    @classmethod
+    def get_symbol(cls, symbol_id: str) -> Optional[IdentifiedSymbol]:
+        for pkg_symbols in cls._interop_symbols.values():
+            for method in pkg_symbols:
+                if method.identifier == symbol_id:
+                    return method
 
     @classmethod
     def interop_symbols(cls, package: str = None) -> List[IdentifiedSymbol]:


### PR DESCRIPTION
**Summary or solution description**
There was an error in `CodeGenerator` `get_symbol` that didn't find interop symbols in class methods even when those symbols are imported in the file. Replicated the logic used to ensure built-in symbols are properly generated