### PR TITLE
false error on missing NEP-11 transfer event

### DIFF
--- a/boa3/internal/analyser/analyser.py
+++ b/boa3/internal/analyser/analyser.py
@@ -239,3 +239,6 @@ class Analyser:
                 self.symbol_table[file_path] = import_symbol
 
         self._included_imported_files = True
+
+    def get_imports(self) -> List[Analyser]:
+        return list(self._imported_files.values())

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsEventFromPackage.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsEventFromPackage.py
@@ -1,0 +1,43 @@
+from typing import Any
+
+from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.type import UInt160
+from boa3_test.test_sc.metadata_test.aux_package import internal_package
+
+
+@public
+def Main() -> int:
+    return 5
+
+
+@metadata
+def standards_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+    meta.supported_standards = ['NEP-17']
+    return meta
+
+
+@public(safe=True)
+def symbol() -> str:
+    pass
+
+
+@public(safe=True)
+def decimals() -> int:
+    pass
+
+
+@public(name='totalSupply', safe=True)
+def total_supply() -> int:
+    pass
+
+
+@public(name='balanceOf', safe=True)
+def balance_of(account: UInt160) -> int:
+    pass
+
+
+@public
+def transfer(from_address: UInt160, to_address: UInt160, amount: int, data: Any) -> bool:
+    internal_package.method_called(from_address, to_address, amount)
+    return True

--- a/boa3_test/test_sc/metadata_test/aux_package/internal_package/__init__.py
+++ b/boa3_test/test_sc/metadata_test/aux_package/internal_package/__init__.py
@@ -1,0 +1,17 @@
+from boa3.builtin.compile_time import CreateNewEvent
+
+from typing import Union
+from boa3.builtin.type import UInt160
+
+on_transfer = CreateNewEvent(
+    [
+        ('from_addr', Union[UInt160, None]),
+        ('to_addr', Union[UInt160, None]),
+        ('amount', int),
+    ],
+    'Transfer'
+)
+
+
+def method_called(token_owner: Union[UInt160, None], to: Union[UInt160, None], amount: int):
+    on_transfer(token_owner, to, amount)

--- a/boa3_test/tests/compiler_tests/test_metadata.py
+++ b/boa3_test/tests/compiler_tests/test_metadata.py
@@ -190,6 +190,32 @@ class TestMetadata(BoaTest):
         self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
         self.assertEqual(manifest_struct, invoke.result[4])
 
+    def test_metadata_info_supported_standards_from_package(self):
+        path = self.get_contract_path('MetadataInfoSupportedStandardsEventFromPackage.py')
+        output, manifest = self.compile_and_save(path)
+
+        self.assertIn('supportedstandards', manifest)
+        self.assertIsInstance(manifest['supportedstandards'], list)
+        self.assertGreater(len(manifest['supportedstandards']), 0)
+        self.assertIn('NEP-17', manifest['supportedstandards'])
+
+        nef, manifest = self.get_bytes_output(path)
+        path, _ = self.get_deploy_file_paths(path)
+        get_contract_path, _ = self.get_deploy_file_paths('test_sc/native_test/contractmanagement', 'GetContract.py')
+
+        runner = NeoTestRunner(runner_id=self.method_name())
+        # verify using NeoManifestStruct
+        contract = runner.deploy_contract(path)
+        runner.update_contracts(export_checkpoint=True)
+        call_hash = contract.script_hash
+
+        invoke = runner.call_contract(get_contract_path, 'main', call_hash)
+        manifest_struct = NeoManifestStruct.from_json(manifest)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        self.assertEqual(manifest_struct, invoke.result[4])
+
     def test_metadata_info_supported_standards_with_imported_event(self):
         path = self.get_contract_path('MetadataInfoSupportedStandardsImportedEvent.py')
         output, manifest = self.get_output(path)


### PR DESCRIPTION
**Summary or solution description**
When importing a package, the verification would not try and check the events inside the package.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/29eefdeb992db284e87ce438cb78b218316fbd52/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsEventFromPackage.py#L1-L43

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/29eefdeb992db284e87ce438cb78b218316fbd52/boa3_test/tests/compiler_tests/test_metadata.py#L193-L218

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.9
