### PR TITLE
No code generated for onNEP11Payment and onNEP17Payment function

### DIFF
--- a/boa3/internal/compiler/codegenerator/codegeneratorvisitor.py
+++ b/boa3/internal/compiler/codegenerator/codegeneratorvisitor.py
@@ -345,10 +345,16 @@ class VisitorCodeGenerator(IAstAnalyser):
         """
         if self.generator.stack_size > 0:
             self.generator.clear_stack(True)
+
         if self.current_method.return_type is not Type.none:
             result = self.visit_to_generate(ret.value)
             if result.type is Type.none and not self.generator.is_none_inserted():
                 self.generator.convert_literal(None)
+        elif ret.value is not None:
+            self.visit_to_generate(ret.value)
+            if self.generator.stack_size > 0:
+                self.generator.remove_stack_top_item()
+
         self.generator.insert_return()
 
         return self.build_data(ret)


### PR DESCRIPTION
**Summary or solution description**
`return` statements that are not empty were not being generated if the method return type is omitted.

**How to Reproduce**
```python
def Main(): 
     return TestFunction()
```

**Tests**
Rerun the tests on `test_function.py`, which broke with other attempts to fix the generating bug.

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7+