### PR TITLE
IDE Warning - Manifest type hints classes are not recognized as their parent

### DIFF
--- a/boa3/builtin/type/__init__.py
+++ b/boa3/builtin/type/__init__.py
@@ -21,6 +21,7 @@ class Event:
     """
     Describes an action that happened in the blockchain.
     """
+
     def __call__(self, *args, **kwargs):
         pass
 
@@ -169,50 +170,56 @@ class ByteString:
         pass
 
 
-class Address(str):
-    """
-    A class used only to indicate that a parameter or return on the manifest should be treated as an Address.
-    It's a subclass of str and it doesn't implement new properties or methods.
-    """
-    pass
+Address = str
+"""
+A type used only to indicate that a parameter or return on the manifest should be treated as an Address.
+Same as str.
+
+:meta hide-value:
+"""
 
 
-class BlockHash(UInt256):
-    """
-    A class used only to indicate that a parameter or return on the manifest should be treated as a BlockHash.
-    It's a subclass of UInt256 and it doesn't implement new properties or methods.
-    """
-    pass
+BlockHash = UInt256
+"""
+A type used only to indicate that a parameter or return on the manifest should be treated as a BlockHash.
+Same as UInt256.
+
+:meta hide-value:
+"""
 
 
-class PublicKey(ECPoint):
-    """
-    A class used only to indicate that a parameter or return on the manifest should be treated as a PublicKey.
-    It's a subclass of ECPoint and it doesn't implement new properties or methods.
-    """
-    pass
+PublicKey = ECPoint
+"""
+A type used only to indicate that a parameter or return on the manifest should be treated as a PublicKey.
+Same as ECPoint.
+
+:meta hide-value:
+"""
 
 
-class ScriptHash(UInt160):
-    """
-    A class used only to indicate that a parameter or return on the manifest should be treated as a ScriptHash.
-    It's a subclass of UInt160 and it doesn't implement new properties or methods.
-    """
-    pass
+ScriptHash = UInt160
+"""
+A type used only to indicate that a parameter or return on the manifest should be treated as a ScriptHash.
+Same as UInt160.
+
+:meta hide-value:
+"""
 
 
-class ScriptHashLittleEndian(UInt160):
-    """
-    A class used only to indicate that a parameter or return on the manifest should be treated as a
-    ScriptHashLittleEndian.
-    It's a subclass of UInt160 and it doesn't implement new properties or methods.
-    """
-    pass
+ScriptHashLittleEndian = UInt160
+"""
+A type used only to indicate that a parameter or return on the manifest should be treated as a
+ScriptHashLittleEndian.
+Same as UInt160.
+
+:meta hide-value:
+"""
 
 
-class TransactionId(UInt256):
-    """
-    A class used only to indicate that a parameter or return on the manifest should be treated as a TransactionId.
-    It's a subclass of UInt256 and it doesn't implement new properties or methods.
-    """
-    pass
+TransactionId = UInt256
+"""
+A type used only to indicate that a parameter or return on the manifest should be treated as a TransactionId.
+Same as UInt256.
+
+:meta hide-value:
+"""

--- a/boa3/internal/model/type/collection/sequence/buffertype.py
+++ b/boa3/internal/model/type/collection/sequence/buffertype.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from boa3.internal.model.type.primitive.strtype import StrType
 from boa3.internal.neo.vm.type.StackItem import StackItemType
 
@@ -14,6 +16,12 @@ class BufferType(StrType):
     @property
     def stack_item(self) -> StackItemType:
         return StackItemType.Buffer
+
+    @classmethod
+    def _is_type_of(cls, value: Any) -> bool:
+        if super()._is_type_of(value):
+            return True
+        return isinstance(value, BufferType)
 
 
 Buffer = BufferType()

--- a/boa3/internal/model/type/primitive/strtype.py
+++ b/boa3/internal/model/type/primitive/strtype.py
@@ -51,7 +51,8 @@ class StrType(IByteStringType):
 
     @classmethod
     def _is_type_of(cls, value: Any) -> bool:
-        return type(value) in [str, StrType]
+        from boa3.internal.model.type.collection.sequence.buffertype import BufferType
+        return isinstance(value, (str, StrType)) and not isinstance(value, BufferType)
 
     def is_type_of(self, value: Any) -> bool:
         return self._is_type_of(value)


### PR DESCRIPTION
**Summary or solution description**
The classes created to be used as manifest type hints have a issue with IDEs type checkers where their parent class values is not recognized as valid. This happens because of how Python type checker validates values between inherited classes.
Changed those classes from subclasses to type alias.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/7b53ade962772a59ece4ea45c5e1c2aed722ae76/boa3_test/test_sc/generation_test/ManifestTypeHintFromStrToAddress.py#L1-L7

**Tests**
Rerun `test_file_generation.py` tests. to ensure the output wasn't modified.

**Screenshots**
Before the changes
![image](https://github.com/CityOfZion/neo3-boa/assets/19419485/c7c1d240-1adc-4cec-9b2b-f823c3d77222)

After the changes
![image](https://github.com/CityOfZion/neo3-boa/assets/19419485/17de8a43-3e1d-4f78-bbd7-88041c30d6ea)

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7+

**(Optional) Additional context**
Used IntelliJ IDEA Ultimate 2022.3.2 to verify the type warning.
