### PR TITLE
Default the execution path to the execution directory

### DIFF
--- a/boa3/internal/cli_commands/compile_command.py
+++ b/boa3/internal/cli_commands/compile_command.py
@@ -56,9 +56,6 @@ class CompileCommand(ICommand):
         fullpath = os.path.realpath(sc_path)
         path, filename = os.path.split(fullpath)
 
-        if not project_path:
-            project_path = os.path.dirname(path)
-
         try:
             Boa3.compile_and_save(sc_path, output_path=output_path, debug=debug, root_folder=project_path, env=env)
             logging.info(f"Wrote {filename.replace('.py', '.nef')} to {path}")


### PR DESCRIPTION
**Summary or solution description**
Removed the piece of code that used the shell path instead of the smart contract path.

**How to Reproduce**
`neo3-boa compile path/to/smartcontract.py` now has the same behaviour as `neo3-boa compile path/to/smartcontract.py  --project-path path/to` 

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.9

**(Optional) Additional context**
Add any other context about the problem here. 
