### PR TITLE
Log message path does not match actual output path when using -o

### DIFF
--- a/boa3/internal/cli_commands/compile_command.py
+++ b/boa3/internal/cli_commands/compile_command.py
@@ -49,12 +49,15 @@ class CompileCommand(ICommand):
             logging.error("Input file is not .py")
             sys.exit(1)
 
-        if isinstance(output_path, str) and not output_path.endswith('.nef'):
-            logging.error("Output path file extension is not .nef")
-            sys.exit(1)
-
         fullpath = os.path.realpath(sc_path)
         path, filename = os.path.split(fullpath)
+
+        if isinstance(output_path, str):
+            if not output_path.endswith('.nef'):
+                logging.error("Output path file extension is not .nef")
+                sys.exit(1)
+
+            path, _ = os.path.split(os.path.realpath(output_path))
 
         try:
             Boa3.compile_and_save(sc_path, output_path=output_path, debug=debug, root_folder=project_path, env=env)

--- a/boa3/internal/compiler/compiler.py
+++ b/boa3/internal/compiler/compiler.py
@@ -115,7 +115,15 @@ class Compiler:
                 or is_bytecode_empty):
             raise NotLoadedException(empty_script=is_bytecode_empty)
 
+        if not os.path.isdir(output_path):
+            output_folder = os.path.abspath(os.path.dirname(output_path))
+        else:
+            output_folder = os.path.abspath(output_path)
+
         generator = FileGenerator(self.result, self._analyser, self._entry_smart_contract)
+
+        generator.create_folder(output_folder)
+
         with open(output_path, 'wb+') as nef_file:
             nef_bytes = generator.generate_nef_file()
             nef_file.write(nef_bytes)

--- a/boa3/internal/compiler/filegenerator/filegenerator.py
+++ b/boa3/internal/compiler/filegenerator/filegenerator.py
@@ -243,6 +243,22 @@ class FileGenerator:
 
         return self.__all_imports
 
+    def create_folder(self, output_folder: str):
+        if os.path.isfile(output_folder):
+            output_folder = os.path.abspath(os.path.dirname(output_folder))
+        else:
+            output_folder = os.path.abspath(output_folder)
+
+        folders_to_generate = []
+        while not os.path.exists(output_folder):
+            folders_to_generate.append(output_folder)
+            output_folder = os.path.dirname(output_folder)
+
+        while len(folders_to_generate) > 0:
+            folder = folders_to_generate.pop()
+            os.mkdir(folder)
+
+
     # region NEF
 
     @property


### PR DESCRIPTION
**Summary or solution description**
Fixed inconsistent log when the ouput_path is explicit. The success log message informed that the files were included in the python contract folder when the compiler correctly saved it on the given output directory.
Also fixed an error raised when passing an inexistent folder to the output. The compiler now creates a folder if it doesn't exist.

**How to Reproduce**
```
$ neo3-boa compile -db --project-path . -o ../some/other/directory/contract.nef contract.py
```
