### PR TITLE
investigate and fix project-path / root_folder correctness

### DIFF
--- a/boa3/internal/analyser/analyser.py
+++ b/boa3/internal/analyser/analyser.py
@@ -186,7 +186,7 @@ class Analyser:
         """
         Pre executes the instructions of the ast for optimization
         """
-        self.ast_tree = ConstructAnalyser(self.ast_tree, self.symbol_table, log=self._log).tree
+        self.ast_tree = ConstructAnalyser(self, self.ast_tree, self.symbol_table, log=self._log).tree
 
     def __pos_execute(self):
         """

--- a/boa3/internal/analyser/astoptimizer.py
+++ b/boa3/internal/analyser/astoptimizer.py
@@ -30,7 +30,7 @@ class AstOptimizer(IAstAnalyser, ast.NodeTransformer):
     """
 
     def __init__(self, analyser, log: bool = False):
-        super().__init__(analyser.ast_tree, filename=analyser.filename, log=log)
+        super().__init__(analyser.ast_tree, filename=analyser.filename, root_folder=analyser.root, log=log)
         self.modules: Dict[str, Module] = {}
         self.symbols: Dict[str, ISymbol] = analyser.symbol_table
 

--- a/boa3/internal/analyser/builtinfunctioncallanalyser.py
+++ b/boa3/internal/analyser/builtinfunctioncallanalyser.py
@@ -13,7 +13,7 @@ class BuiltinFunctionCallAnalyser(IAstAnalyser):
     def __init__(self, origin: IAstAnalyser, call: ast.Call, method_id: str, builtin_method: IBuiltinMethod, log: bool):
         self._method: IBuiltinMethod = builtin_method
         self.method_id: str = method_id
-        super().__init__(call, log=log)
+        super().__init__(call, root_folder=origin.root_folder, log=log)
 
         self._origin: IAstAnalyser = origin
 

--- a/boa3/internal/analyser/constructanalyser.py
+++ b/boa3/internal/analyser/constructanalyser.py
@@ -14,8 +14,8 @@ class ConstructAnalyser(IAstAnalyser, ast.NodeTransformer):
     These methods are used to walk through the Python abstract syntax tree.
     """
 
-    def __init__(self, ast_tree: ast.AST, symbol_table: Dict[str, ISymbol], log: bool = False):
-        super().__init__(ast_tree, log=log)
+    def __init__(self, analyser, ast_tree: ast.AST, symbol_table: Dict[str, ISymbol], log: bool = False):
+        super().__init__(ast_tree, root_folder=analyser.root, log=log)
         self.symbols = symbol_table.copy()
         self.visit(self._tree)
 

--- a/boa3/internal/analyser/supportedstandard/standardanalyser.py
+++ b/boa3/internal/analyser/supportedstandard/standardanalyser.py
@@ -19,7 +19,7 @@ class StandardAnalyser(IAstAnalyser):
     def __init__(self, analyser, symbol_table: Dict[str, ISymbol], log: bool = False):
         from boa3.builtin.compile_time import NeoMetadata
 
-        super().__init__(analyser.ast_tree, analyser.filename, log=log)
+        super().__init__(analyser.ast_tree, analyser.filename, analyser.root, log=log)
 
         self.symbols: Dict[str, ISymbol] = symbol_table
 

--- a/boa3/internal/analyser/typeanalyser.py
+++ b/boa3/internal/analyser/typeanalyser.py
@@ -48,7 +48,7 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
     """
 
     def __init__(self, analyser, symbol_table: Dict[str, ISymbol], log: bool = False):
-        super().__init__(analyser.ast_tree, analyser.filename, log=log)
+        super().__init__(analyser.ast_tree, analyser.filename, analyser.root, log=log)
         self.type_errors: List[Exception] = []
         self.modules: Dict[str, Module] = {}
         self.symbols: Dict[str, ISymbol] = symbol_table

--- a/boa3/internal/compiler/codegenerator/codegenerator.py
+++ b/boa3/internal/compiler/codegenerator/codegenerator.py
@@ -72,7 +72,7 @@ class CodeGenerator:
         if hasattr(deploy_method, 'origin') and deploy_method.origin in analyser.ast_tree.body:
             analyser.ast_tree.body.remove(deploy_method.origin)
 
-        visitor = VisitorCodeGenerator(generator, analyser.filename)
+        visitor = VisitorCodeGenerator(generator, analyser.filename, analyser.root)
         visitor._root_module = analyser.ast_tree
         visitor.visit_and_update_analyser(analyser.ast_tree, analyser)
 

--- a/boa3/internal/compiler/codegenerator/codegeneratorvisitor.py
+++ b/boa3/internal/compiler/codegenerator/codegeneratorvisitor.py
@@ -39,8 +39,8 @@ class VisitorCodeGenerator(IAstAnalyser):
     :ivar generator:
     """
 
-    def __init__(self, generator: CodeGenerator, filename: str = None):
-        super().__init__(ast.parse(""), filename=filename, log=True)
+    def __init__(self, generator: CodeGenerator, filename: str = None, root: str = None):
+        super().__init__(ast.parse(""), filename=filename, root_folder=root, log=True)
 
         self.generator = generator
         self.current_method: Optional[Method] = None


### PR DESCRIPTION
**Summary or solution description**
The root folder wasn't being used when initializing some classes that inherited `IAstAnalyser`.

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.9
