### PR TITLE
Incorrect type for StorageContext on storage methods

### DIFF
--- a/boa3/builtin/interop/storage/__init__.py
+++ b/boa3/builtin/interop/storage/__init__.py
@@ -19,7 +19,17 @@ from boa3.builtin.interop.storage.storagecontext import StorageContext
 from boa3.builtin.interop.storage.storagemap import StorageMap
 
 
-def get(key: bytes, context: StorageContext = None) -> bytes:
+def get_context() -> StorageContext:
+    """
+    Gets current storage context.
+
+    :return: the current storage context
+    :rtype: StorageContext
+    """
+    pass
+
+
+def get(key: bytes, context: StorageContext = get_context()) -> bytes:
     """
     Gets a value from the persistent store based on the given key.
 
@@ -29,16 +39,6 @@ def get(key: bytes, context: StorageContext = None) -> bytes:
     :type context: StorageContext
     :return: the value corresponding to given key for current storage context
     :rtype: bytes
-    """
-    pass
-
-
-def get_context() -> StorageContext:
-    """
-    Gets current storage context.
-
-    :return: the current storage context
-    :rtype: StorageContext
     """
     pass
 
@@ -53,7 +53,7 @@ def get_read_only_context() -> StorageContext:
     pass
 
 
-def put(key: bytes, value: Union[int, bytes, str], context: StorageContext = None):
+def put(key: bytes, value: Union[int, bytes, str], context: StorageContext = get_context()):
     """
     Inserts a given value in the key-value format into the persistent storage.
 
@@ -67,7 +67,7 @@ def put(key: bytes, value: Union[int, bytes, str], context: StorageContext = Non
     pass
 
 
-def delete(key: bytes, context: StorageContext = None):
+def delete(key: bytes, context: StorageContext = get_context()):
     """
     Removes a given key from the persistent storage if exists.
 
@@ -80,7 +80,7 @@ def delete(key: bytes, context: StorageContext = None):
 
 
 def find(prefix: bytes,
-         context: StorageContext = None,
+         context: StorageContext = get_context(),
          options: FindOptions = FindOptions.NONE) -> Iterator:
     """
     Searches in the storage for keys that start with the given prefix.

--- a/boa3/internal/compiler/filegenerator/filegenerator.py
+++ b/boa3/internal/compiler/filegenerator/filegenerator.py
@@ -258,7 +258,6 @@ class FileGenerator:
             folder = folders_to_generate.pop()
             os.mkdir(folder)
 
-
     # region NEF
 
     @property


### PR DESCRIPTION
**Summary or solution description**
> The signature of find  is defined as
> ```python
> def find(prefix: ByteString,
>          context: StorageContext = None,
>          options: FindOptions = FindOptions.NONE) -> Iterator:
> ```
> This suggests that you can call find with something like this
> ```python
> return find(mk_token_index_key(self._account_id), None, FindOptions.VALUES_ONLY)
> ```
> which actually gives a compilation error
> ```bash
> ERROR: 49:58 - Expected type 'StorageContext', got 'none' instead	 </home/erik/code/props-item-clean/contract/models/user.py>
> ```

The same thing happened with all the storage methods has a StorageContext argument. Fixed by changing the default value in interfaces of those methods to `get_context()`.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/f4058d551858237a3e0251f417b91edd9c15fc92/boa3/builtin/interop/storage/__init__.py#L32-L97

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/f4058d551858237a3e0251f417b91edd9c15fc92/boa3_test/tests/compiler_tests/test_interop/test_storage.py#L271-L300

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7+