### PR TITLE
Change types for NEP-11 standards checking

### DIFF
--- a/boa3/internal/model/standards/neostandard.py
+++ b/boa3/internal/model/standards/neostandard.py
@@ -45,7 +45,10 @@ class INeoStandard(abc.ABC):
         method_args = list(symbol.args.values())
         other_args = list(other.args.values())
         for index in range(len(method_args)):
-            if method_args[index].type != other_args[index].type:
-                return False
-
+            if hasattr(symbol, 'literal_implementation') and symbol.literal_implementation:
+                if method_args[index].type != other_args[index].type:
+                    return False
+            else:
+                if not method_args[index].type.is_type_of(other_args[index].type):
+                    return False
         return True

--- a/boa3/internal/model/standards/nep11standard.py
+++ b/boa3/internal/model/standards/nep11standard.py
@@ -32,10 +32,12 @@ class Nep11Standard(INeoStandard):
                            args={'to': type_uint160,
                                  'tokenId': type_token_id,
                                  'data': Type.any},
-                           return_type=Type.bool),
+                           return_type=Type.bool,
+                           literal_implementation=False),
             StandardMethod('ownerOf', safe=True,
                            args={'tokenId': type_token_id},
-                           return_type=type_uint160),
+                           return_type=type_uint160,
+                           literal_implementation=False),
         ]
 
         optionals = [
@@ -46,7 +48,8 @@ class Nep11Standard(INeoStandard):
                            args={
                                'tokenId': type_token_id,
                            },
-                           return_type=Type.dict),
+                           return_type=Type.dict,
+                           literal_implementation=False),
         ]
 
         events = [

--- a/boa3/internal/model/standards/standardmethod.py
+++ b/boa3/internal/model/standards/standardmethod.py
@@ -10,9 +10,12 @@ class StandardMethod(Method):
     def __init__(self, display_name: str,
                  args: Dict[str, IType] = None,
                  return_type: IType = Type.none,
-                 safe: bool = False):
+                 safe: bool = False,
+                 literal_implementation: bool = True):
         if not isinstance(args, dict):
             args = {}
         method_args = {key: Variable(value) for key, value in args.items()}
         super().__init__(args=method_args, return_type=return_type, is_public=True,
                          external_name=display_name, is_safe=safe)
+
+        self.literal_implementation = literal_implementation

--- a/boa3_test/examples/nep11_non_divisible.py
+++ b/boa3_test/examples/nep11_non_divisible.py
@@ -83,7 +83,7 @@ on_transfer = CreateNewEvent(
         ('from_addr', Union[UInt160, None]),
         ('to_addr', Union[UInt160, None]),
         ('amount', int),
-        ('tokenId', Union[bytes, str])
+        ('tokenId', bytes)
     ],
     'Transfer'
 )
@@ -210,7 +210,7 @@ def tokensOf(owner: UInt160) -> Iterator:
 
 
 @public
-def transfer(to: UInt160, tokenId: Union[bytes, str], data: Any) -> bool:
+def transfer(to: UInt160, tokenId: bytes, data: Any) -> bool:
     """
     Transfers the token with id tokenId to address to
 
@@ -236,21 +236,20 @@ def transfer(to: UInt160, tokenId: Union[bytes, str], data: Any) -> bool:
     """
     expect(validateAddress(to), "Not a valid address")
     expect(not isPaused(), "Contract is currently paused")
-    token_id: bytes = tokenId
-    token_owner = get_owner_of(token_id)
+    token_owner = get_owner_of(tokenId)
 
     if not check_witness(token_owner):
         return False
 
-    if (token_owner != to):
+    if token_owner != to:
         set_balance(token_owner, -1)
-        remove_token_account(token_owner, token_id)
+        remove_token_account(token_owner, tokenId)
 
         set_balance(to, 1)
 
-        set_owner_of(token_id, to)
-        add_token_account(to, token_id)
-    post_transfer(token_owner, to, token_id, data)
+        set_owner_of(tokenId, to)
+        add_token_account(to, tokenId)
+    post_transfer(token_owner, to, tokenId, data)
     return True
 
 
@@ -276,7 +275,7 @@ def post_transfer(token_owner: Union[UInt160, None], to: Union[UInt160, None], t
 
 
 @public(safe=True)
-def ownerOf(tokenId: Union[bytes, str]) -> UInt160:
+def ownerOf(tokenId: bytes) -> UInt160:
     """
     Get the owner of the specified token.
 
@@ -287,7 +286,7 @@ def ownerOf(tokenId: Union[bytes, str]) -> UInt160:
     :return: the owner of the specified token.
     :raise AssertionError: raised if `tokenId` is not a valid NFT.
     """
-    owner = get_owner_of(cast(bytes, tokenId))
+    owner = get_owner_of(tokenId)
     debug(['ownerOf: ', owner])
     return owner
 
@@ -305,7 +304,7 @@ def tokens() -> Iterator:
 
 
 @public(safe=True)
-def properties(tokenId: Union[bytes, str]) -> Dict[Any, Any]:
+def properties(tokenId: bytes) -> Dict[Any, Any]:
     """
     Get the properties of a token.
 
@@ -316,7 +315,7 @@ def properties(tokenId: Union[bytes, str]) -> Dict[Any, Any]:
     :return: a serialized NVM object containing the properties for the given NFT.
     :raise AssertionError: raised if `tokenId` is not a valid NFT, or if no metadata available.
     """
-    metaBytes = cast(str, get_meta(cast(bytes, tokenId)))
+    metaBytes = cast(str, get_meta(tokenId))
     expect(len(metaBytes) != 0, 'No metadata available for token')
     metaObject = cast(Dict[str, str], json_deserialize(metaBytes))
 

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsByteStringAsBytes.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsByteStringAsBytes.py
@@ -1,0 +1,69 @@
+from typing import Any, Dict, Union
+
+from boa3.builtin.compile_time import NeoMetadata, metadata, public, CreateNewEvent
+from boa3.builtin.interop.iterator import Iterator
+from boa3.builtin.type import UInt160
+
+on_transfer = CreateNewEvent(
+    # trigger when tokens are transferred, including zero value transfers.
+    [
+        ('from_addr', Union[UInt160, None]),
+        ('to_addr', Union[UInt160, None]),
+        ('amount', int),
+        ('tokenId', bytes)
+    ],
+    'Transfer'
+)
+
+
+@metadata
+def standards_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+    meta.supported_standards = ['NEP-11']
+    return meta
+
+
+@public(safe=True)
+def symbol() -> str:
+    pass
+
+
+@public(safe=True)
+def decimals() -> int:
+    pass
+
+
+@public(safe=True)
+def totalSupply() -> int:
+    pass
+
+
+@public(safe=True)
+def balanceOf(owner: UInt160) -> int:
+    pass
+
+
+@public(safe=True)
+def tokensOf(owner: UInt160) -> Iterator:
+    pass
+
+
+@public
+def transfer(to: UInt160, tokenId: bytes, data: Any) -> bool:
+    on_transfer(to, to, 1, tokenId)
+    pass
+
+
+@public(safe=True)
+def ownerOf(tokenId: bytes) -> UInt160:
+    pass
+
+
+@public(safe=True)
+def tokens() -> Iterator:
+    pass
+
+
+@public(safe=True)
+def properties(tokenId: bytes) -> Dict[Any, Any]:
+    pass

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsByteStringAsStr.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsByteStringAsStr.py
@@ -1,0 +1,69 @@
+from typing import Any, Dict, Union
+
+from boa3.builtin.compile_time import NeoMetadata, metadata, public, CreateNewEvent
+from boa3.builtin.interop.iterator import Iterator
+from boa3.builtin.type import UInt160
+
+on_transfer = CreateNewEvent(
+    # trigger when tokens are transferred, including zero value transfers.
+    [
+        ('from_addr', Union[UInt160, None]),
+        ('to_addr', Union[UInt160, None]),
+        ('amount', int),
+        ('tokenId', str)
+    ],
+    'Transfer'
+)
+
+
+@metadata
+def standards_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+    meta.supported_standards = ['NEP-11']
+    return meta
+
+
+@public(safe=True)
+def symbol() -> str:
+    pass
+
+
+@public(safe=True)
+def decimals() -> int:
+    pass
+
+
+@public(safe=True)
+def totalSupply() -> int:
+    pass
+
+
+@public(safe=True)
+def balanceOf(owner: UInt160) -> int:
+    pass
+
+
+@public(safe=True)
+def tokensOf(owner: UInt160) -> Iterator:
+    pass
+
+
+@public
+def transfer(to: UInt160, tokenId: str, data: Any) -> bool:
+    on_transfer(to, to, 1, tokenId)
+    pass
+
+
+@public(safe=True)
+def ownerOf(tokenId: str) -> UInt160:
+    pass
+
+
+@public(safe=True)
+def tokens() -> Iterator:
+    pass
+
+
+@public(safe=True)
+def properties(tokenId: str) -> Dict[Any, Any]:
+    pass

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsMissingImplementationNEP11OptionalMethods.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsMissingImplementationNEP11OptionalMethods.py
@@ -17,7 +17,7 @@ def standards_manifest() -> NeoMetadata:
 
 # this method has the same name as an NEP-11 optional method, but with a different signature
 @public(safe=True)
-def properties(token_id: str) -> Dict[Any, Any]:
+def properties(token_id: int) -> Dict[Any, Any]:
     pass
 
 

--- a/boa3_test/tests/compiler_tests/test_metadata.py
+++ b/boa3_test/tests/compiler_tests/test_metadata.py
@@ -292,6 +292,24 @@ class TestMetadata(BoaTest):
         path = self.get_contract_path('MetadataInfoDescriptionMismatchedType.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
+    def test_metadata_info_supported_standards_bytestring_as_bytes(self):
+        path = self.get_contract_path('MetadataInfoSupportedStandardsByteStringAsBytes.py')
+        output, manifest = self.compile_and_save(path)
+
+        self.assertIn('supportedstandards', manifest)
+        self.assertIsInstance(manifest['supportedstandards'], list)
+        self.assertGreater(len(manifest['supportedstandards']), 0)
+        self.assertIn('NEP-11', manifest['supportedstandards'])
+
+    def test_metadata_info_supported_standards_bytestring_as_str(self):
+        path = self.get_contract_path('MetadataInfoSupportedStandardsByteStringAsStr.py')
+        output, manifest = self.compile_and_save(path)
+
+        self.assertIn('supportedstandards', manifest)
+        self.assertIsInstance(manifest['supportedstandards'], list)
+        self.assertGreater(len(manifest['supportedstandards']), 0)
+        self.assertIn('NEP-11', manifest['supportedstandards'])
+
     def test_metadata_info_trusts(self):
         path = self.get_contract_path('MetadataInfoTrusts.py')
         output, manifest = self.compile_and_save(path)


### PR DESCRIPTION
**Summary or solution description**
It's now possible to use just `bytes` or `str` when trying to implement a `ByteString` parameter.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/9e242717637d5045ab069f454134691e183921f2/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsByteStringAsBytes.py#L51C1-L54
https://github.com/CityOfZion/neo3-boa/blob/9e242717637d5045ab069f454134691e183921f2/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsByteStringAsStr.py#L51-L54

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/9e242717637d5045ab069f454134691e183921f2/boa3_test/tests/compiler_tests/test_metadata.py#L295-L311

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.8
