### PR TITLE
Can't compile smart contract with metadata function

### DIFF
--- a/boa3/builtin/compile_time/__init__.py
+++ b/boa3/builtin/compile_time/__init__.py
@@ -149,7 +149,9 @@ def display_name(name: str):
     :param name: Method identifier from the contract manifest.
     :type name: str
     """
-    pass
+    def decorator_wrapper(*args, **kwargs):
+        pass
+    return decorator_wrapper
 
 
 class NeoMetadata:

--- a/boa3_test/test_sc/metadata_test/MetadataImportingExternalContractBeforeMetadataMethod.py
+++ b/boa3_test/test_sc/metadata_test/MetadataImportingExternalContractBeforeMetadataMethod.py
@@ -1,0 +1,14 @@
+from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3_test.test_sc.metadata_test.aux_package.internal_package.external_contract import ExternalContract
+
+
+@metadata
+def standards_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+    meta.description = 'Test importing a external contract before declaring the metadata'
+    return meta
+
+
+@public
+def main() -> str:
+    return ExternalContract.another_method()

--- a/boa3_test/test_sc/metadata_test/aux_package/internal_package/external_contract.py
+++ b/boa3_test/test_sc/metadata_test/aux_package/internal_package/external_contract.py
@@ -1,0 +1,22 @@
+from typing import Any
+
+from boa3.builtin.type import UInt160
+from boa3.builtin.compile_time import contract, display_name
+
+
+@contract('0x1234567890123456789012345678901234567890')
+class ExternalContract:
+
+    @staticmethod
+    def method1(arg1: bytes, arg2: UInt160, arg3: Any) -> UInt160:
+        pass
+
+    @staticmethod
+    @display_name("anotherMethod")
+    def another_method() -> str:
+        pass
+
+    @staticmethod
+    @display_name("onNEP17Payment")
+    def on_nep_17_payment(from_address: UInt160, amount: int, data: Any) -> None:
+        pass

--- a/boa3_test/tests/compiler_tests/test_metadata.py
+++ b/boa3_test/tests/compiler_tests/test_metadata.py
@@ -579,3 +579,16 @@ class TestMetadata(BoaTest):
     def test_metadata_info_source_mismatched_type(self):
         path = self.get_contract_path('MetadataInfoSourceMismatchedType.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+
+    def test_metadata_importing_external_contract_before_metadata_method(self):
+        path = self.get_contract_path('MetadataImportingExternalContractBeforeMetadataMethod.py')
+        output, manifest = self.compile_and_save(path)
+
+        self.assertIn('extra', manifest)
+        self.assertIsInstance(manifest['extra'], dict)
+        self.assertIn('Description', manifest['extra'])
+        self.assertEqual(manifest['extra']['Description'], 'Test importing a external contract before declaring the metadata')
+
+        self.assertIsInstance(manifest['permissions'], list)
+        self.assertEqual(len(manifest['permissions']), 1)
+        self.assertEqual(manifest['permissions'][0]['contract'], '0x1234567890123456789012345678901234567890')


### PR DESCRIPTION
**Summary or solution description**
When the **ModuleAnalyser** tried to read the metadata object, it would try to compile and execute the code from top to bottom, so the imports will be executed before the `@metadata` function on the main file, however, the decorator `display_name` on `boa3/builtin/compile_time/__init__.py` was returning None instead of a function, thus raising an error and stopping the execution before reaching the `@metadata` function.

https://github.com/CityOfZion/neo3-boa/blob/7eca426d30621d27551bd874cb13fdf21d9c76cf/boa3/internal/analyser/moduleanalyser.py#L367-L399


**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/7eca426d30621d27551bd874cb13fdf21d9c76cf/boa3_test/test_sc/metadata_test/aux_package/internal_package/external_contract.py#L1-L22
https://github.com/CityOfZion/neo3-boa/blob/7eca426d30621d27551bd874cb13fdf21d9c76cf/boa3_test/test_sc/metadata_test/MetadataImportingExternalContractBeforeMetadataMethod.py#L1-L14

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/7eca426d30621d27551bd874cb13fdf21d9c76cf/boa3_test/tests/compiler_tests/test_metadata.py#L583-L594

**Platform:**
 - OS: Windows 11 x64
 - Python version: Python 3.9
