### PR TITLE
Incorrect result stack size with methods with no return after a call_contract

### DIFF
--- a/boa3/internal/compiler/codegenerator/codegenerator.py
+++ b/boa3/internal/compiler/codegenerator/codegenerator.py
@@ -1792,6 +1792,8 @@ class CodeGenerator:
                 self.convert_literal(function.origin_class.contract_hash.to_array())
                 self.convert_builtin_method_call(Interop.CallContract)
                 self._stack_pop()  # remove call contract 'any' result from the stack
+                self._stack_append(function.return_type)    # add the return type on the stack even if it is None
+
         else:
             from boa3.internal.neo.vm.CallCode import CallCode
             call_code = CallCode(function)
@@ -1803,8 +1805,8 @@ class CodeGenerator:
             if function.is_init:
                 self._stack_pop()  # pop duplicated result if it's init
 
-        if function.return_type is not Type.none:
-            self._stack_append(function.return_type)
+            if function.return_type is not Type.none:
+                self._stack_append(function.return_type)
 
     def convert_method_token_call(self, method_token_id: int):
         """

--- a/boa3_test/test_sc/function_test/CallExternalContractWithReturnNone.py
+++ b/boa3_test/test_sc/function_test/CallExternalContractWithReturnNone.py
@@ -1,0 +1,14 @@
+from boa3.builtin.compile_time import contract, public
+
+
+@contract('0xcd8fe0d1ba2619fc05a1234edc22a6bae363f119')
+class NoReturnContract:
+
+    @staticmethod
+    def Main(a: int):
+        pass
+
+
+@public
+def main():
+    NoReturnContract.Main(10)

--- a/boa3_test/tests/compiler_tests/test_function.py
+++ b/boa3_test/tests/compiler_tests/test_function.py
@@ -1643,3 +1643,17 @@ class TestFunction(BoaTest):
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
+
+    def test_call_external_contract_with_return_none(self):
+        path, _ = self.get_deploy_file_paths('CallExternalContractWithReturnNone.py')
+        no_return_path, _ = self.get_deploy_file_paths('NoReturnFunction.py')
+
+        runner = NeoTestRunner(runner_id=self.method_name())
+        runner.deploy_contract(no_return_path)
+
+        invoke = runner.call_contract(path, 'main')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        self.assertEqual(invoke.result, None)


### PR DESCRIPTION
**Summary or solution description**
The `Opcode.SYSCALL` returns a value even if the return of the method is None. 
Currently, Neo3-boa will only DROP the unused value if the return type is not None. 
So, now, whenever a SYSCALL is being used it will always be followed with a DROP if it's unused

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/e27d57603e1ab75108b1e00cc259dcf841ecf521/boa3_test/test_sc/function_test/NoReturnFunction.py#L1-L6
https://github.com/CityOfZion/neo3-boa/blob/e27d57603e1ab75108b1e00cc259dcf841ecf521/boa3_test/test_sc/function_test/CallExternalContractWithReturnNone.py#L1-L14

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/e27d57603e1ab75108b1e00cc259dcf841ecf521/boa3_test/tests/compiler_tests/test_function.py#L1647-L1659

**Platform:**
 - OS: Windows 11 x64
 - Python version: Python 3.9
