### PR TITLE
fix CLI tests

### DIFF
--- a/boa3_test/tests/boa_test.py
+++ b/boa3_test/tests/boa_test.py
@@ -183,7 +183,7 @@ class BoaTest(TestCase):
             if len(output_path) == 0:
                 file_path = os.path.dirname(contract_path)
                 file_name, _ = os.path.splitext(os.path.basename(output_name))
-                file_path_without_ext = f'{file_path}/{file_name}'
+                file_path_without_ext = constants.PATH_SEPARATOR.join((file_path, file_name))
             else:
                 file_path_without_ext, _ = os.path.splitext(output_name)
         else:

--- a/boa3_test/tests/boa_test.py
+++ b/boa3_test/tests/boa_test.py
@@ -179,9 +179,13 @@ class BoaTest(TestCase):
 
     def get_deploy_file_paths_without_compiling(self, contract_path: str, output_name: str = None) -> Tuple[str, str]:
         if isinstance(output_name, str):
-            file_path = os.path.dirname(contract_path)
-            file_name, _ = os.path.splitext(os.path.basename(output_name))
-            file_path_without_ext = f'{file_path}/{file_name}'
+            output_path, output_file = os.path.split(output_name)
+            if len(output_path) == 0:
+                file_path = os.path.dirname(contract_path)
+                file_name, _ = os.path.splitext(os.path.basename(output_name))
+                file_path_without_ext = f'{file_path}/{file_name}'
+            else:
+                file_path_without_ext, _ = os.path.splitext(output_name)
         else:
             file_path_without_ext, _ = os.path.splitext(contract_path)
 

--- a/boa3_test/tests/cli_tests/cli_test.py
+++ b/boa3_test/tests/cli_tests/cli_test.py
@@ -1,0 +1,64 @@
+from boa3_test.tests.boa_test import (BoaTest,  # needs to be the first import to avoid circular imports
+                                      _COMPILER_LOCK as LOCK
+                                      )
+
+import abc
+import io
+from contextlib import redirect_stdout, redirect_stderr
+from typing import Tuple
+
+from boa3.cli import main
+from boa3_test.tests.cli_tests import utils
+
+
+class BoaCliTest(BoaTest, abc.ABC):
+    default_folder = 'test_cli'
+
+    EXIT_CODE_SUCCESS = 0
+    EXIT_CODE_ERROR = 1
+    EXIT_CODE_CLI_SYNTAX_ERROR = 2
+
+    def setUp(self):
+        LOCK.acquire()
+
+    def tearDown(self):
+        LOCK.release()
+
+    def _get_cli_log(self):
+        return self._run_cli_log()
+
+    def _get_cli_output(self) -> Tuple[str, str]:
+        return self._run_cli()
+
+    def _assert_cli_raises(self, exception, get_log=False):
+        if get_log:
+            return self._run_cli_log(exception)
+        else:
+            return self._run_cli(exception)
+
+    def _run_cli_log(self, expected_exception=None) -> tuple:
+        with self.assertLogs() as logs:
+            if expected_exception is not None:
+                with self.assertRaises(expected_exception) as error:
+                    main()
+            else:
+                main()
+
+        if expected_exception is None:
+            return logs
+        return logs, error
+
+    def _run_cli(self, expected_exception=None) -> tuple:
+        with redirect_stdout(io.StringIO()) as stdout, redirect_stderr(io.StringIO()) as stderr:
+            if expected_exception is not None:
+                with self.assertRaises(expected_exception) as error:
+                    main()
+            else:
+                main()
+
+        str_stdout = utils.normalize_separators(stdout.getvalue())
+        str_stderr = utils.normalize_separators(stderr.getvalue())
+
+        if expected_exception is None:
+            return str_stdout, str_stderr
+        return str_stdout, str_stderr, error

--- a/boa3_test/tests/cli_tests/cli_test.py
+++ b/boa3_test/tests/cli_tests/cli_test.py
@@ -1,5 +1,6 @@
 from boa3_test.tests.boa_test import (BoaTest,  # needs to be the first import to avoid circular imports
-                                      _COMPILER_LOCK as LOCK
+                                      _COMPILER_LOCK as LOCK,
+                                      _LOGGING_LOCK as LOG_LOCK
                                       )
 
 import abc
@@ -19,10 +20,12 @@ class BoaCliTest(BoaTest, abc.ABC):
     EXIT_CODE_CLI_SYNTAX_ERROR = 2
 
     def setUp(self):
+        LOG_LOCK.acquire()
         LOCK.acquire()
 
     def tearDown(self):
         LOCK.release()
+        LOG_LOCK.release()
 
     def _get_cli_log(self):
         return self._run_cli_log()

--- a/boa3_test/tests/cli_tests/test_cli.py
+++ b/boa3_test/tests/cli_tests/test_cli.py
@@ -1,24 +1,14 @@
-from boa3_test.tests.boa_test import BoaTest, _COMPILER_LOCK as LOCK, _LOGGING_LOCK as LOG_LOCK  # needs to be the first import to avoid circular imports
+from boa3_test.tests.cli_tests.cli_test import BoaCliTest  # needs to be the first import to avoid circular imports
 
-import io
-from boa3.cli import main
 from boa3.internal import constants
-from boa3_test.tests.cli_tests.utils import neo3_boa_cli, normalize_separators
-from contextlib import redirect_stdout, redirect_stderr
+from boa3_test.tests.cli_tests.utils import neo3_boa_cli
 
 
-class TestCli(BoaTest):
-    default_folder = 'test_cli'
-
-    EXIT_CODE_SUCCESS = 0
-    EXIT_CODE_ERROR = 1
-    EXIT_CODE_CLI_SYNTAX_ERROR = 2
+class TestCli(BoaCliTest):
 
     @neo3_boa_cli('-h')
     def test_cli_help(self):
-        with LOCK, LOG_LOCK, redirect_stdout(io.StringIO()) as output, self.assertRaises(SystemExit) as system_exit:
-            main()
-        cli_output = normalize_separators(output.getvalue())
+        cli_output, _, system_exit = self._assert_cli_raises(SystemExit)
 
         self.assertEqual(self.EXIT_CODE_SUCCESS, system_exit.exception.code)
         self.assertIn('usage: neo3-boa [-h] [-v] {compile}', cli_output)
@@ -27,18 +17,14 @@ class TestCli(BoaTest):
 
     @neo3_boa_cli('--version')
     def test_cli_version(self):
-        with LOCK, LOG_LOCK, redirect_stdout(io.StringIO()) as output, self.assertRaises(SystemExit) as system_exit:
-            main()
-        cli_output = normalize_separators(output.getvalue())
+        cli_output, _, system_exit = self._assert_cli_raises(SystemExit)
 
         self.assertEqual(self.EXIT_CODE_SUCCESS, system_exit.exception.code)
         self.assertIn(f'neo3-boa {constants.BOA_VERSION}', cli_output)
 
     @neo3_boa_cli('build')
     def test_cli_wrong_syntax(self):
-        with LOCK, LOG_LOCK, redirect_stderr(io.StringIO()) as output, self.assertRaises(SystemExit) as system_exit:
-            main()
-        cli_output = normalize_separators(output.getvalue())
+        _, cli_output, system_exit = self._assert_cli_raises(SystemExit)
 
         self.assertEqual(self.EXIT_CODE_CLI_SYNTAX_ERROR, system_exit.exception.code)
         self.assertIn("invalid choice: 'build'", cli_output)

--- a/boa3_test/tests/cli_tests/test_cli.py
+++ b/boa3_test/tests/cli_tests/test_cli.py
@@ -1,0 +1,44 @@
+from boa3_test.tests.boa_test import BoaTest, _COMPILER_LOCK as LOCK, _LOGGING_LOCK as LOG_LOCK  # needs to be the first import to avoid circular imports
+
+import io
+from boa3.cli import main
+from boa3.internal import constants
+from boa3_test.tests.cli_tests.utils import neo3_boa_cli, normalize_separators
+from contextlib import redirect_stdout, redirect_stderr
+
+
+class TestCli(BoaTest):
+    default_folder = 'test_cli'
+
+    EXIT_CODE_SUCCESS = 0
+    EXIT_CODE_ERROR = 1
+    EXIT_CODE_CLI_SYNTAX_ERROR = 2
+
+    @neo3_boa_cli('-h')
+    def test_cli_help(self):
+        with LOCK, LOG_LOCK, redirect_stdout(io.StringIO()) as output, self.assertRaises(SystemExit) as system_exit:
+            main()
+        cli_output = normalize_separators(output.getvalue())
+
+        self.assertEqual(self.EXIT_CODE_SUCCESS, system_exit.exception.code)
+        self.assertIn('usage: neo3-boa [-h] [-v] {compile}', cli_output)
+        self.assertIn(f'neo3-boa by COZ - version {constants.BOA_VERSION}', cli_output)
+        self.assertIn('Write smart contracts for Neo3 in Python', cli_output)
+
+    @neo3_boa_cli('--version')
+    def test_cli_version(self):
+        with LOCK, LOG_LOCK, redirect_stdout(io.StringIO()) as output, self.assertRaises(SystemExit) as system_exit:
+            main()
+        cli_output = normalize_separators(output.getvalue())
+
+        self.assertEqual(self.EXIT_CODE_SUCCESS, system_exit.exception.code)
+        self.assertIn(f'neo3-boa {constants.BOA_VERSION}', cli_output)
+
+    @neo3_boa_cli('build')
+    def test_cli_wrong_syntax(self):
+        with LOCK, LOG_LOCK, redirect_stderr(io.StringIO()) as output, self.assertRaises(SystemExit) as system_exit:
+            main()
+        cli_output = normalize_separators(output.getvalue())
+
+        self.assertEqual(self.EXIT_CODE_CLI_SYNTAX_ERROR, system_exit.exception.code)
+        self.assertIn("invalid choice: 'build'", cli_output)

--- a/boa3_test/tests/cli_tests/test_compile.py
+++ b/boa3_test/tests/cli_tests/test_compile.py
@@ -1,69 +1,37 @@
-from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to avoid circular imports
+from boa3_test.tests.boa_test import BoaTest, _COMPILER_LOCK as LOCK, _LOGGING_LOCK as LOG_LOCK  # needs to be the first import to avoid circular imports
 
 import io
 import os
 from boa3.cli import main
-from boa3.internal import constants, env
+from boa3.internal import constants
 from boa3.internal.neo3.vm import VMState
+from boa3_test.tests.cli_tests.utils import neo3_boa_cli, get_path_from_boa3_test, normalize_separators
 from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
-from contextlib import redirect_stdout, redirect_stderr
-from unittest.mock import patch
+from contextlib import redirect_stdout
 
 
-def neo3_boa_cli(*args: str):
-    return patch('sys.argv', ['neo3-boa', *args])
-
-
-def get_path_from_boa3_test(*args: str) -> str:
-    return constants.PATH_SEPARATOR.join([env.PROJECT_ROOT_DIRECTORY, 'boa3_test', *args])
-
-
-class TestCli(BoaTest):
+class TestCliCompile(BoaTest):
     default_folder = 'test_cli'
 
     EXIT_CODE_SUCCESS = 0
     EXIT_CODE_ERROR = 1
     EXIT_CODE_CLI_SYNTAX_ERROR = 2
 
-    @neo3_boa_cli('-h')
-    def test_cli_help(self):
-        with redirect_stdout(io.StringIO()) as output, self.assertRaises(SystemExit) as system_exit:
-            main()
-        cli_output = output.getvalue()
-
-        self.assertEqual(self.EXIT_CODE_SUCCESS, system_exit.exception.code)
-        self.assertIn('usage: neo3-boa [-h] [-v] {compile}', cli_output)
-        self.assertIn(f'neo3-boa by COZ - version {constants.BOA_VERSION}', cli_output)
-        self.assertIn('Write smart contracts for Neo3 in Python', cli_output)
-
-    @neo3_boa_cli('--version')
-    def test_cli_version(self):
-        with redirect_stdout(io.StringIO()) as output, self.assertRaises(SystemExit) as system_exit:
-            main()
-        cli_output = output.getvalue()
-
-        self.assertEqual(self.EXIT_CODE_SUCCESS, system_exit.exception.code)
-        self.assertIn(f'neo3-boa {constants.BOA_VERSION}', cli_output)
-
     @neo3_boa_cli('compile', '-h')
     def test_cli_compile_help(self):
-        with redirect_stdout(io.StringIO()) as output, self.assertRaises(SystemExit) as system_exit:
+        with LOCK, LOG_LOCK, redirect_stdout(io.StringIO()) as output, self.assertRaises(SystemExit) as system_exit:
             main()
-        cli_output = output.getvalue()
+        cli_output = normalize_separators(output.getvalue())
 
         self.assertEqual(self.EXIT_CODE_SUCCESS, system_exit.exception.code)
-        self.assertIn('neo3-boa compile', cli_output)
-        self.assertIn('[-h]', cli_output)
-        self.assertIn('[-db]', cli_output)
-        self.assertIn('[--project-path PROJECT_PATH]', cli_output)
-        self.assertIn('[-e ENV]', cli_output)
-        self.assertIn('[-o NEF_OUTPUT]', cli_output)
-        self.assertIn('input', cli_output)
+        self.assertIn('usage: neo3-boa compile [-h] [-db] [--project-path PROJECT_PATH] [-e ENV] [-o NEF_OUTPUT] input',
+                      cli_output)
 
     @neo3_boa_cli('compile', get_path_from_boa3_test('test_sc', 'boa_built_in_methods_test', 'Env.py'))
     def test_cli_compile(self):
-        sc_name = 'Env.py'
-        nef_path, manifest_path = self.get_deploy_file_paths('test_sc/boa_built_in_methods_test', sc_name)
+        sc_nef_name = 'Env.nef'
+        nef_path = get_path_from_boa3_test('test_sc', 'boa_built_in_methods_test', sc_nef_name)
+        manifest_path = nef_path.replace('nef', 'manifest.json')
         debug_info_path = nef_path.replace('nef', 'nefdbgnfo')
 
         if os.path.isfile(nef_path):
@@ -73,12 +41,12 @@ class TestCli(BoaTest):
         if os.path.isfile(debug_info_path):
             os.remove(debug_info_path)
 
-        with self.assertLogs() as logs:
+        with LOCK, LOG_LOCK, self.assertLogs() as logs:
             main()
 
         self.assertTrue(any(f'neo3-boa v{constants.BOA_VERSION}\tPython {constants.SYS_VERSION}' in log for log in logs.output))
         self.assertTrue(any('Started compiling' in log for log in logs.output))
-        self.assertTrue(any(f'Wrote {sc_name.replace("py", "nef")} to ' in log in log for log in logs.output))
+        self.assertTrue(any(f'Wrote {sc_nef_name} to ' in log in log for log in logs.output))
         self.assertTrue(os.path.isfile(nef_path))
         self.assertTrue(os.path.isfile(manifest_path))
         self.assertFalse(os.path.isfile(debug_info_path))
@@ -86,8 +54,9 @@ class TestCli(BoaTest):
     @neo3_boa_cli('compile', get_path_from_boa3_test('test_sc', 'boa_built_in_methods_test', 'Env.py'),
                   '-db')
     def test_cli_compile_debug(self):
-        sc_name = 'Env.py'
-        nef_path, manifest_path = self.get_deploy_file_paths('test_sc/boa_built_in_methods_test', sc_name)
+        sc_nef_name = 'Env.nef'
+        nef_path = get_path_from_boa3_test('test_sc', 'boa_built_in_methods_test', sc_nef_name)
+        manifest_path = nef_path.replace('nef', 'manifest.json')
         debug_info_path = nef_path.replace('nef', 'nefdbgnfo')
 
         if os.path.isfile(nef_path):
@@ -97,12 +66,12 @@ class TestCli(BoaTest):
         if os.path.isfile(debug_info_path):
             os.remove(debug_info_path)
 
-        with self.assertLogs() as logs:
+        with LOCK, LOG_LOCK, self.assertLogs() as logs:
             main()
 
         self.assertTrue(any(f'neo3-boa v{constants.BOA_VERSION}\tPython {constants.SYS_VERSION}' in log for log in logs.output))
         self.assertTrue(any('Started compiling' in log for log in logs.output))
-        self.assertTrue(any(f'Wrote {sc_name.replace("py", "nef")} to ' in log in log for log in logs.output))
+        self.assertTrue(any(f'Wrote {sc_nef_name} to ' in log in log for log in logs.output))
         self.assertTrue(os.path.isfile(nef_path))
         self.assertTrue(os.path.isfile(manifest_path))
         self.assertTrue(os.path.isfile(debug_info_path))
@@ -119,7 +88,7 @@ class TestCli(BoaTest):
         if os.path.isfile(manifest_path):
             os.remove(manifest_path)
 
-        with self.assertLogs() as logs:
+        with LOCK, LOG_LOCK, self.assertLogs() as logs:
             main()
 
         self.assertTrue(any(f'neo3-boa v{constants.BOA_VERSION}\tPython {constants.SYS_VERSION}' in log for log in logs.output))
@@ -133,7 +102,7 @@ class TestCli(BoaTest):
     def test_cli_compile_env(self):
         sc_nef_name = 'Env.nef'
 
-        with self.assertLogs() as logs:
+        with LOCK, LOG_LOCK, self.assertLogs() as logs:
             main()
         self.assertTrue(any(f'neo3-boa v{constants.BOA_VERSION}\tPython {constants.SYS_VERSION}' in log for log in logs.output))
         self.assertTrue(any('Started compiling' in log for log in logs.output))
@@ -152,7 +121,7 @@ class TestCli(BoaTest):
 
     @neo3_boa_cli('compile', 'wrong_file')
     def test_cli_compile_wrong_file(self):
-        with self.assertLogs() as logs, self.assertRaises(SystemExit) as system_exit:
+        with LOCK, LOG_LOCK, self.assertLogs() as logs, self.assertRaises(SystemExit) as system_exit:
             main()
 
         self.assertEqual(self.EXIT_CODE_ERROR, system_exit.exception.code)
@@ -160,7 +129,7 @@ class TestCli(BoaTest):
 
     @neo3_boa_cli('compile', get_path_from_boa3_test('test_sc', 'interop_test', 'storage', 'StoragePutStrKeyStrValue.py'))
     def test_cli_compile_invalid_smart_contract(self):
-        with self.assertLogs() as logs:
+        with LOCK, LOG_LOCK, self.assertLogs() as logs:
             main()
 
         self.assertTrue(any('Could not compile' in log in log for log in logs.output))
@@ -168,17 +137,8 @@ class TestCli(BoaTest):
     @neo3_boa_cli('compile', get_path_from_boa3_test('test_sc', 'boa_built_in_methods_test', 'Env.py'),
                   '-o', 'wrong_output_path')
     def test_cli_compile_wrong_output_path(self):
-        with self.assertLogs() as logs, self.assertRaises(SystemExit) as system_exit:
+        with LOCK, LOG_LOCK, self.assertLogs() as logs, self.assertRaises(SystemExit) as system_exit:
             main()
 
         self.assertEqual(self.EXIT_CODE_ERROR, system_exit.exception.code)
         self.assertTrue(any('Output path file extension is not .nef' in log in log for log in logs.output))
-
-    @neo3_boa_cli('build')
-    def test_cli_wrong_syntax(self):
-        with redirect_stderr(io.StringIO()) as output, self.assertRaises(SystemExit) as system_exit:
-            main()
-        cli_output = output.getvalue()
-
-        self.assertEqual(self.EXIT_CODE_CLI_SYNTAX_ERROR, system_exit.exception.code)
-        self.assertIn("invalid choice: 'build'", cli_output)

--- a/boa3_test/tests/cli_tests/test_compile.py
+++ b/boa3_test/tests/cli_tests/test_compile.py
@@ -1,27 +1,18 @@
-from boa3_test.tests.boa_test import BoaTest, _COMPILER_LOCK as LOCK, _LOGGING_LOCK as LOG_LOCK  # needs to be the first import to avoid circular imports
+from boa3_test.tests.cli_tests.cli_test import BoaCliTest  # needs to be the first import to avoid circular imports
 
-import io
-import os
-from boa3.cli import main
+import os.path
+
 from boa3.internal import constants
 from boa3.internal.neo3.vm import VMState
-from boa3_test.tests.cli_tests.utils import neo3_boa_cli, get_path_from_boa3_test, normalize_separators
 from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
-from contextlib import redirect_stdout
+from boa3_test.tests.cli_tests.utils import neo3_boa_cli, get_path_from_boa3_test
 
 
-class TestCliCompile(BoaTest):
-    default_folder = 'test_cli'
-
-    EXIT_CODE_SUCCESS = 0
-    EXIT_CODE_ERROR = 1
-    EXIT_CODE_CLI_SYNTAX_ERROR = 2
+class TestCliCompile(BoaCliTest):
 
     @neo3_boa_cli('compile', '-h')
     def test_cli_compile_help(self):
-        with LOCK, LOG_LOCK, redirect_stdout(io.StringIO()) as output, self.assertRaises(SystemExit) as system_exit:
-            main()
-        cli_output = normalize_separators(output.getvalue())
+        cli_output, _, system_exit = self._assert_cli_raises(SystemExit)
 
         self.assertEqual(self.EXIT_CODE_SUCCESS, system_exit.exception.code)
         self.assertIn('usage: neo3-boa compile [-h] [-db] [--project-path PROJECT_PATH] [-e ENV] [-o NEF_OUTPUT] input',
@@ -41,8 +32,7 @@ class TestCliCompile(BoaTest):
         if os.path.isfile(debug_info_path):
             os.remove(debug_info_path)
 
-        with LOCK, LOG_LOCK, self.assertLogs() as logs:
-            main()
+        logs = self._get_cli_log()
 
         self.assertTrue(any(f'neo3-boa v{constants.BOA_VERSION}\tPython {constants.SYS_VERSION}' in log for log in logs.output))
         self.assertTrue(any('Started compiling' in log for log in logs.output))
@@ -66,8 +56,7 @@ class TestCliCompile(BoaTest):
         if os.path.isfile(debug_info_path):
             os.remove(debug_info_path)
 
-        with LOCK, LOG_LOCK, self.assertLogs() as logs:
-            main()
+        logs = self._get_cli_log()
 
         self.assertTrue(any(f'neo3-boa v{constants.BOA_VERSION}\tPython {constants.SYS_VERSION}' in log for log in logs.output))
         self.assertTrue(any('Started compiling' in log for log in logs.output))
@@ -77,19 +66,23 @@ class TestCliCompile(BoaTest):
         self.assertTrue(os.path.isfile(debug_info_path))
 
     @neo3_boa_cli('compile', get_path_from_boa3_test('test_sc', 'boa_built_in_methods_test', 'Env.py'),
-                  '-o', get_path_from_boa3_test('test_cli', 'smart_contract.nef'))
+                  '-o', get_path_from_boa3_test('test_cli', 'smart_contract.nef', get_unique=True))
     def test_cli_compile_new_output_path(self):
         sc_nef_name = 'smart_contract.nef'
-        nef_path = get_path_from_boa3_test('test_cli', sc_nef_name)
-        manifest_path = nef_path.replace('nef', 'manifest.json')
+
+        nef_path, manifest_path = self.get_deploy_file_paths(
+            get_path_from_boa3_test('test_sc', 'boa_built_in_methods_test', 'Env.py'),
+            output_name=get_path_from_boa3_test('test_cli', sc_nef_name),
+            compile_if_found=False
+        )
+        sc_nef_name = os.path.basename(nef_path)
 
         if os.path.isfile(nef_path):
             os.remove(nef_path)
         if os.path.isfile(manifest_path):
             os.remove(manifest_path)
 
-        with LOCK, LOG_LOCK, self.assertLogs() as logs:
-            main()
+        logs = self._get_cli_log()
 
         self.assertTrue(any(f'neo3-boa v{constants.BOA_VERSION}\tPython {constants.SYS_VERSION}' in log for log in logs.output))
         self.assertTrue(any('Started compiling' in log for log in logs.output))
@@ -98,21 +91,25 @@ class TestCliCompile(BoaTest):
         self.assertTrue(os.path.isfile(manifest_path))
 
     @neo3_boa_cli('compile', get_path_from_boa3_test('test_sc', 'boa_built_in_methods_test', 'Env.py'),
-                  '-e', 'env_changed')
+                  '-e', 'env_changed',
+                  '-o', get_path_from_boa3_test('test_sc', 'boa_built_in_methods_test', 'Env.nef', get_unique=True))
     def test_cli_compile_env(self):
-        sc_nef_name = 'Env.nef'
+        nef_path, _ = self.get_deploy_file_paths(
+            get_path_from_boa3_test('test_sc', 'boa_built_in_methods_test', 'Env.py'),
+            compile_if_found=False
+        )
+        nef_generated = nef_path.split(constants.PATH_SEPARATOR)[-1]
 
-        with LOCK, LOG_LOCK, self.assertLogs() as logs:
-            main()
+        logs = self._get_cli_log()
+
         self.assertTrue(any(f'neo3-boa v{constants.BOA_VERSION}\tPython {constants.SYS_VERSION}' in log for log in logs.output))
         self.assertTrue(any('Started compiling' in log for log in logs.output))
-        self.assertTrue(any(f'Wrote {sc_nef_name} to ' in log in log for log in logs.output))
+        self.assertTrue(any(f'Wrote {nef_generated} to ' in log in log for log in logs.output))
 
-        path = get_path_from_boa3_test('test_sc', 'boa_built_in_methods_test', sc_nef_name)
         runner = NeoTestRunner(runner_id=self.method_name())
 
-        runner.deploy_contract(path)
-        invoke = runner.call_contract(path, 'main')
+        runner.deploy_contract(nef_path)
+        invoke = runner.call_contract(nef_path, 'main')
         expected_result = 'env_changed'
         runner.execute()
         self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
@@ -121,24 +118,20 @@ class TestCliCompile(BoaTest):
 
     @neo3_boa_cli('compile', 'wrong_file')
     def test_cli_compile_wrong_file(self):
-        with LOCK, LOG_LOCK, self.assertLogs() as logs, self.assertRaises(SystemExit) as system_exit:
-            main()
+        logs, system_exit = self._assert_cli_raises(SystemExit, get_log=True)
 
         self.assertEqual(self.EXIT_CODE_ERROR, system_exit.exception.code)
         self.assertTrue(any('Input file is not .py' in log in log for log in logs.output))
 
     @neo3_boa_cli('compile', get_path_from_boa3_test('test_sc', 'interop_test', 'storage', 'StoragePutStrKeyStrValue.py'))
     def test_cli_compile_invalid_smart_contract(self):
-        with LOCK, LOG_LOCK, self.assertLogs() as logs:
-            main()
-
+        logs = self._get_cli_log()
         self.assertTrue(any('Could not compile' in log in log for log in logs.output))
 
     @neo3_boa_cli('compile', get_path_from_boa3_test('test_sc', 'boa_built_in_methods_test', 'Env.py'),
                   '-o', 'wrong_output_path')
     def test_cli_compile_wrong_output_path(self):
-        with LOCK, LOG_LOCK, self.assertLogs() as logs, self.assertRaises(SystemExit) as system_exit:
-            main()
+        logs, system_exit = self._assert_cli_raises(SystemExit, get_log=True)
 
         self.assertEqual(self.EXIT_CODE_ERROR, system_exit.exception.code)
         self.assertTrue(any('Output path file extension is not .nef' in log in log for log in logs.output))

--- a/boa3_test/tests/cli_tests/test_compile.py
+++ b/boa3_test/tests/cli_tests/test_compile.py
@@ -36,10 +36,14 @@ class TestCliCompile(BoaCliTest):
 
         self.assertTrue(any(f'neo3-boa v{constants.BOA_VERSION}\tPython {constants.SYS_VERSION}' in log for log in logs.output))
         self.assertTrue(any('Started compiling' in log for log in logs.output))
-        self.assertTrue(any(f'Wrote {sc_nef_name} to ' in log in log for log in logs.output))
-        self.assertTrue(os.path.isfile(nef_path))
-        self.assertTrue(os.path.isfile(manifest_path))
-        self.assertFalse(os.path.isfile(debug_info_path))
+        self.assertTrue(any(f'Wrote {sc_nef_name} to ' in log in log for log in logs.output),
+                        msg=f'Something went wrong when compiling {sc_nef_name}')
+        self.assertTrue(os.path.isfile(nef_path),
+                        msg=f'{nef_path} not found')
+        self.assertTrue(os.path.isfile(manifest_path),
+                        msg=f'{manifest_path} not found')
+        self.assertFalse(os.path.isfile(debug_info_path),
+                         msg=f'{debug_info_path} exists')
 
     @neo3_boa_cli('compile', get_path_from_boa3_test('test_sc', 'boa_built_in_methods_test', 'Env.py'),
                   '-db')
@@ -60,10 +64,14 @@ class TestCliCompile(BoaCliTest):
 
         self.assertTrue(any(f'neo3-boa v{constants.BOA_VERSION}\tPython {constants.SYS_VERSION}' in log for log in logs.output))
         self.assertTrue(any('Started compiling' in log for log in logs.output))
-        self.assertTrue(any(f'Wrote {sc_nef_name} to ' in log in log for log in logs.output))
-        self.assertTrue(os.path.isfile(nef_path))
-        self.assertTrue(os.path.isfile(manifest_path))
-        self.assertTrue(os.path.isfile(debug_info_path))
+        self.assertTrue(any(f'Wrote {sc_nef_name} to ' in log in log for log in logs.output),
+                        msg=f'Something went wrong when compiling {sc_nef_name}')
+        self.assertTrue(os.path.isfile(nef_path),
+                        msg=f'{nef_path} not found')
+        self.assertTrue(os.path.isfile(manifest_path),
+                        msg=f'{manifest_path} not found')
+        self.assertTrue(os.path.isfile(debug_info_path),
+                        msg=f'{debug_info_path} not found')
 
     @neo3_boa_cli('compile', get_path_from_boa3_test('test_sc', 'boa_built_in_methods_test', 'Env.py'),
                   '-o', get_path_from_boa3_test('test_cli', 'smart_contract.nef', get_unique=True))
@@ -86,16 +94,20 @@ class TestCliCompile(BoaCliTest):
 
         self.assertTrue(any(f'neo3-boa v{constants.BOA_VERSION}\tPython {constants.SYS_VERSION}' in log for log in logs.output))
         self.assertTrue(any('Started compiling' in log for log in logs.output))
-        self.assertTrue(any(f'Wrote {sc_nef_name} to ' in log in log for log in logs.output))
-        self.assertTrue(os.path.isfile(nef_path))
-        self.assertTrue(os.path.isfile(manifest_path))
+        self.assertTrue(any(f'Wrote {sc_nef_name} to ' in log in log for log in logs.output),
+                        msg=f'Something went wrong when compiling {sc_nef_name}')
+        self.assertTrue(os.path.isfile(nef_path),
+                        msg=f'{nef_path} not found')
+        self.assertTrue(os.path.isfile(manifest_path),
+                        msg=f'{manifest_path} not found')
 
     @neo3_boa_cli('compile', get_path_from_boa3_test('test_sc', 'boa_built_in_methods_test', 'Env.py'),
                   '-e', 'env_changed',
-                  '-o', get_path_from_boa3_test('test_sc', 'boa_built_in_methods_test', 'Env.nef', get_unique=True))
+                  '-o', get_path_from_boa3_test('test_sc', 'boa_built_in_methods_test', 'Env_cli.nef', get_unique=True))
     def test_cli_compile_env(self):
         nef_path, _ = self.get_deploy_file_paths(
             get_path_from_boa3_test('test_sc', 'boa_built_in_methods_test', 'Env.py'),
+            output_name='Env_cli.nef',
             compile_if_found=False
         )
         nef_generated = nef_path.split(constants.PATH_SEPARATOR)[-1]
@@ -104,7 +116,8 @@ class TestCliCompile(BoaCliTest):
 
         self.assertTrue(any(f'neo3-boa v{constants.BOA_VERSION}\tPython {constants.SYS_VERSION}' in log for log in logs.output))
         self.assertTrue(any('Started compiling' in log for log in logs.output))
-        self.assertTrue(any(f'Wrote {nef_generated} to ' in log in log for log in logs.output))
+        self.assertTrue(any(f'Wrote {nef_generated} to ' in log in log for log in logs.output),
+                        msg=f'Something went wrong when compiling {nef_generated}')
 
         runner = NeoTestRunner(runner_id=self.method_name())
 

--- a/boa3_test/tests/cli_tests/utils.py
+++ b/boa3_test/tests/cli_tests/utils.py
@@ -1,13 +1,26 @@
-from boa3.internal import constants, env
 from unittest.mock import patch
+
+from boa3.internal import constants, env
 
 
 def neo3_boa_cli(*args: str):
     return patch('sys.argv', ['neo3-boa', *args])
 
 
-def get_path_from_boa3_test(*args: str) -> str:
-    return constants.PATH_SEPARATOR.join([env.PROJECT_ROOT_DIRECTORY, 'boa3_test', *args])
+def get_path_from_boa3_test(*args: str, get_unique=False) -> str:
+    result = constants.PATH_SEPARATOR.join([env.PROJECT_ROOT_DIRECTORY, 'boa3_test', *args])
+
+    if get_unique:
+        from boa3_test.tests.boa_test import USE_UNIQUE_NAME
+
+        if USE_UNIQUE_NAME:
+            import os.path
+            from boa3_test.test_drive import utils
+
+            file_path_without_ext, ext = os.path.splitext(result)
+            file_path_without_ext = utils.create_custom_id(file_path_without_ext, use_time=False)
+            result = file_path_without_ext + ext
+    return result
 
 
 def normalize_separators(original_string: str) -> str:

--- a/boa3_test/tests/cli_tests/utils.py
+++ b/boa3_test/tests/cli_tests/utils.py
@@ -1,0 +1,18 @@
+from boa3.internal import constants, env
+from unittest.mock import patch
+
+
+def neo3_boa_cli(*args: str):
+    return patch('sys.argv', ['neo3-boa', *args])
+
+
+def get_path_from_boa3_test(*args: str) -> str:
+    return constants.PATH_SEPARATOR.join([env.PROJECT_ROOT_DIRECTORY, 'boa3_test', *args])
+
+
+def normalize_separators(original_string: str) -> str:
+    """
+    This function will try to normalize all separators (e.g., '\t', '\n', multiple spaces) into a single white space,
+    because the stdout sometimes might have different spacing depending on console size.
+    """
+    return ' '.join(original_string.split())


### PR DESCRIPTION
**Summary or solution description**
Transformed the `cli_tests` folder into a Python package with the `__init__.py` file and separated the tests into different classes for each command. Also added _COMPILER_LOCK on the compiler tests

**Platform:**
 - OS: Windows 11 x64
 - Python version: Python 3.9

