### PR TITLE
Fix make docs browser url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,4 +61,4 @@ coverage: ## check code coverage quickly with the default Python
 
 docs: ## generate Sphinx HTML documentation, including API docs
 	$(MAKE) -C docs html
-	$(BROWSER) docs/_build/html/index.html
+	$(BROWSER) docs/build/html/index.html


### PR DESCRIPTION
Seems like building documentation with `make docs` outputs the documentation in `/docs/build/` not `/docs/_build/`. The browser that automatically opens will fail. This fixes the path that the browser opens.