### PR TITLE
Fix example in docstring

### DIFF
--- a/boa3/builtin/interop/contract/__init__.py
+++ b/boa3/builtin/interop/contract/__init__.py
@@ -37,7 +37,7 @@ def call_contract(script_hash: UInt160, method: str, args: Sequence = (), call_f
     Calls a smart contract given the method and the arguments. Since the return is type Any, you'll probably need to
     type cast the return.
 
-    >>> call_contract(NEO, 'balanceOf', UInt160(b'\\xcfv\\xe2\\x8b\\xd0\\x06,JG\\x8e\\xe3Ua\\x01\\x13\\x19\\xf3\\xcf\\xa4\\xd2'))
+    >>> call_contract(NEO, 'balanceOf', (UInt160(b'\\xcfv\\xe2\\x8b\\xd0\\x06,JG\\x8e\\xe3Ua\\x01\\x13\\x19\\xf3\\xcf\\xa4\\xd2')))
     100
 
     :param script_hash: the target smart contract's script hash


### PR DESCRIPTION
The signature of `call_contract()` specifies args as `args: Sequence = ()`, the example in the docstrings does not provide a sequence.