### PR TITLE
fix return types of interop.blockchain functions

### DIFF
--- a/boa3/builtin/interop/blockchain/__init__.py
+++ b/boa3/builtin/interop/blockchain/__init__.py
@@ -14,7 +14,7 @@ __all__ = [
     'current_index',
 ]
 
-from typing import List, Union
+from typing import List, Optional, Union
 
 from boa3.builtin.interop.blockchain.block import Block
 from boa3.builtin.interop.blockchain.signer import Signer
@@ -24,7 +24,7 @@ from boa3.builtin.interop.contract import Contract
 from boa3.builtin.type import UInt160, UInt256
 
 
-def get_contract(hash: UInt160) -> Contract:
+def get_contract(hash: UInt160) -> Optional[Contract]:
     """
     Gets a contract with a given hash. If the script hash is not associated with a smart contract, then it will return
     None.
@@ -59,7 +59,7 @@ def get_contract(hash: UInt160) -> Contract:
     pass
 
 
-def get_block(index_or_hash: Union[int, UInt256]) -> Block:
+def get_block(index_or_hash: Union[int, UInt256]) -> Optional[Block]:
     """
     Gets the block with the given index or hash. Will return None if the index or hash is not associated with a Block.
 
@@ -105,7 +105,7 @@ def get_block(index_or_hash: Union[int, UInt256]) -> Block:
     pass
 
 
-def get_transaction(hash_: UInt256) -> Transaction:
+def get_transaction(hash_: UInt256) -> Optional[Transaction]:
     """
     Gets a transaction with the given hash. Will return None if the hash is not associated with a Transaction.
 
@@ -131,7 +131,7 @@ def get_transaction(hash_: UInt256) -> Transaction:
     pass
 
 
-def get_transaction_from_block(block_hash_or_height: Union[UInt256, int], tx_index: int) -> Transaction:
+def get_transaction_from_block(block_hash_or_height: Union[UInt256, int], tx_index: int) -> Optional[Transaction]:
     """
     Gets a transaction from a block. Will return None if the block hash or height is not associated with a Transaction.
 
@@ -158,6 +158,12 @@ def get_transaction_from_block(block_hash_or_height: Union[UInt256, int], tx_ind
         'valid_until_block': 5761,
         'script': b'\\x0c\\x14\\xa6\\xea\\xb0\\xae\\xaf\\xb4\\x96\\xa1\\x1b\\xb0|\\x88\\x17\\xcar\\xa5J\\x00\\x12\\x04\\x11\\xc0\\x1f\\x0c\\tbalanceOf\\x0c\\x14\\xcfv\\xe2\\x8b\\xd0\\x06,JG\\x8e\\xe3Ua\\x01\\x13\\x19\\xf3\\xcf\\xa4\\xd2Ab}[R',
     }
+
+    >>> get_transaction_from_block(123456789, 0)     # height does not exist yet
+    None
+
+    >>> get_transaction_from_block(UInt256(bytes(32)), 0)     # block hash does not exist
+    None
 
     :param block_hash_or_height: a block identifier
     :type block_hash_or_height: UInt256 or int

--- a/boa3/builtin/nativecontract/contractmanagement.py
+++ b/boa3/builtin/nativecontract/contractmanagement.py
@@ -4,7 +4,7 @@ __all__ = [
 ]
 
 
-from typing import Any
+from typing import Any, Optional
 
 from boa3.builtin.interop.contract import Contract
 from boa3.builtin.type import UInt160
@@ -33,7 +33,7 @@ class ContractManagement:
         pass
 
     @classmethod
-    def get_contract(cls, script_hash: UInt160) -> Contract:
+    def get_contract(cls, script_hash: UInt160) -> Optional[Contract]:
         """
         Gets a contract with a given hash. If the script hash is not associated with a smart contract, then it will
         return None.

--- a/boa3/builtin/nativecontract/ledger.py
+++ b/boa3/builtin/nativecontract/ledger.py
@@ -3,7 +3,7 @@ __all__ = [
 ]
 
 
-from typing import List, Union
+from typing import List, Optional, Union
 
 from boa3.builtin.interop.blockchain import Block, Signer, Transaction, VMState
 from boa3.builtin.type import UInt256, UInt160
@@ -20,7 +20,7 @@ class Ledger:
     hash: UInt160
 
     @classmethod
-    def get_block(cls, index_or_hash: Union[int, UInt256]) -> Block:
+    def get_block(cls, index_or_hash: Union[int, UInt256]) -> Optional[Block]:
         """
         Gets the block with the given index or hash.
 
@@ -55,6 +55,9 @@ class Ledger:
         >>> Ledger.get_block(9999999)      # block doesn't exist
         None
 
+        >>> Ledger.get_block(UInt256(bytes(32)))   # block doesn't exist
+        None
+
         :param index_or_hash: index or hash identifier of the block
         :type index_or_hash: int or UInt256
         :return: the desired block, if exists. None otherwise
@@ -82,7 +85,7 @@ class Ledger:
         pass
 
     @classmethod
-    def get_transaction(cls, hash_: UInt256) -> Transaction:
+    def get_transaction(cls, hash_: UInt256) -> Optional[Transaction]:
         """
         Gets a transaction with the given hash.
 
@@ -108,7 +111,7 @@ class Ledger:
         pass
 
     @classmethod
-    def get_transaction_from_block(cls, block_hash_or_height: Union[UInt256, int], tx_index: int) -> Transaction:
+    def get_transaction_from_block(cls, block_hash_or_height: Union[UInt256, int], tx_index: int) -> Optional[Transaction]:
         """
         Gets a transaction from a block.
 
@@ -135,6 +138,12 @@ class Ledger:
             'valid_until_block': 5761,
             'script': b'\\x0c\\x14\\xa6\\xea\\xb0\\xae\\xaf\\xb4\\x96\\xa1\\x1b\\xb0|\\x88\\x17\\xcar\\xa5J\\x00\\x12\\x04\\x11\\xc0\\x1f\\x0c\\tbalanceOf\\x0c\\x14\\xcfv\\xe2\\x8b\\xd0\\x06,JG\\x8e\\xe3Ua\\x01\\x13\\x19\\xf3\\xcf\\xa4\\xd2Ab}[R',
         }
+
+        >>> Ledger.get_transaction_from_block(123456789, 0)     # height does not exist yet
+        None
+
+        >>> Ledger.get_transaction_from_block(UInt256(bytes(32)), 0)     # block hash does not exist
+        None
 
         :param block_hash_or_height: a block identifier
         :type block_hash_or_height: UInt256 or int

--- a/boa3/internal/model/builtin/interop/blockchain/getblockmethod.py
+++ b/boa3/internal/model/builtin/interop/blockchain/getblockmethod.py
@@ -15,4 +15,4 @@ class GetBlockMethod(LedgerMethod):
         syscall = 'getBlock'
         args: Dict[str, Variable] = {'index': Variable(Type.union.build([Type.int,
                                                                          UInt256Type.build()]))}
-        super().__init__(identifier, syscall, args, return_type=block_type)
+        super().__init__(identifier, syscall, args, return_type=Type.optional.build(block_type))

--- a/boa3/internal/model/builtin/interop/blockchain/getcontractmethod.py
+++ b/boa3/internal/model/builtin/interop/blockchain/getcontractmethod.py
@@ -10,7 +10,8 @@ class GetContractMethod(ContractManagementMethod):
 
     def __init__(self, contract_type: ContractType):
         from boa3.internal.model.type.collection.sequence.uint160type import UInt160Type
+        from boa3.internal.model.type.type import Type
         identifier = 'get_contract'
         syscall = 'getContract'
         args: Dict[str, Variable] = {'hash': Variable(UInt160Type.build())}
-        super().__init__(identifier, syscall, args, return_type=contract_type)
+        super().__init__(identifier, syscall, args, return_type=Type.optional.build(contract_type))

--- a/boa3/internal/model/builtin/interop/blockchain/gettransactionfromblockmethod.py
+++ b/boa3/internal/model/builtin/interop/blockchain/gettransactionfromblockmethod.py
@@ -16,4 +16,4 @@ class GetTransactionFromBlockMethod(LedgerMethod):
         args: Dict[str, Variable] = {'block_hash_or_height': Variable(Type.union.build([UInt256Type.build(),
                                                                                         Type.int])),
                                      'tx_index': Variable(Type.int)}
-        super().__init__(identifier, syscall, args, return_type=transaction_type)
+        super().__init__(identifier, syscall, args, return_type=Type.optional.build(transaction_type))

--- a/boa3/internal/model/builtin/interop/blockchain/gettransactionmethod.py
+++ b/boa3/internal/model/builtin/interop/blockchain/gettransactionmethod.py
@@ -9,8 +9,9 @@ class GetTransactionMethod(LedgerMethod):
 
     def __init__(self, transaction_type: TransactionType):
         from boa3.internal.model.type.collection.sequence.uint256type import UInt256Type
+        from boa3.internal.model.type.type import Type
 
         identifier = 'get_transaction'
         syscall = 'getTransaction'
         args: Dict[str, Variable] = {'hash_': Variable(UInt256Type.build())}
-        super().__init__(identifier, syscall, args, return_type=transaction_type)
+        super().__init__(identifier, syscall, args, return_type=Type.optional.build(transaction_type))

--- a/boa3_test/examples/nep11_non_divisible.py
+++ b/boa3_test/examples/nep11_non_divisible.py
@@ -267,9 +267,9 @@ def post_transfer(token_owner: Union[UInt160, None], to: Union[UInt160, None], t
     :type data: Any
     """
     on_transfer(token_owner, to, 1, tokenId)
-    if not isinstance(to, None):
+    if to is not None:
         contract = get_contract(to)
-        if not isinstance(contract, None):
+        if contract is not None:
             call_contract(to, 'onNEP11Payment', [token_owner, 1, tokenId, data])
             pass
 

--- a/boa3_test/test_sc/interop_test/blockchain/GetBlockByHash.py
+++ b/boa3_test/test_sc/interop_test/blockchain/GetBlockByHash.py
@@ -1,8 +1,10 @@
+from typing import Optional
+
 from boa3.builtin.compile_time import public
 from boa3.builtin.interop.blockchain import Block, get_block
 from boa3.builtin.type import UInt256
 
 
 @public
-def Main(block_hash: UInt256) -> Block:
+def Main(block_hash: UInt256) -> Optional[Block]:
     return get_block(block_hash)

--- a/boa3_test/test_sc/interop_test/blockchain/GetBlockByIndex.py
+++ b/boa3_test/test_sc/interop_test/blockchain/GetBlockByIndex.py
@@ -1,7 +1,9 @@
+from typing import Optional
+
 from boa3.builtin.compile_time import public
 from boa3.builtin.interop.blockchain import Block, get_block
 
 
 @public
-def Main(index: int) -> Block:
+def Main(index: int) -> Optional[Block]:
     return get_block(index)

--- a/boa3_test/test_sc/interop_test/blockchain/GetContract.py
+++ b/boa3_test/test_sc/interop_test/blockchain/GetContract.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from boa3.builtin.compile_time import public
 from boa3.builtin.interop.blockchain import get_contract
 from boa3.builtin.interop.contract import Contract
@@ -5,5 +7,5 @@ from boa3.builtin.type import UInt160
 
 
 @public
-def main(hash: UInt160) -> Contract:
+def main(hash: UInt160) -> Optional[Contract]:
     return get_contract(hash)

--- a/boa3_test/test_sc/interop_test/blockchain/GetTransaction.py
+++ b/boa3_test/test_sc/interop_test/blockchain/GetTransaction.py
@@ -1,8 +1,10 @@
+from typing import Optional
+
 from boa3.builtin.compile_time import public
 from boa3.builtin.interop.blockchain import Transaction, get_transaction
 from boa3.builtin.type import UInt256
 
 
 @public
-def main(hash_: UInt256) -> Transaction:
+def main(hash_: UInt256) -> Optional[Transaction]:
     return get_transaction(hash_)

--- a/boa3_test/test_sc/interop_test/blockchain/GetTransactionFromBlockInt.py
+++ b/boa3_test/test_sc/interop_test/blockchain/GetTransactionFromBlockInt.py
@@ -1,7 +1,9 @@
+from typing import Optional
+
 from boa3.builtin.compile_time import public
 from boa3.builtin.interop.blockchain import Transaction, get_transaction_from_block
 
 
 @public
-def main(height: int, tx_index: int) -> Transaction:
+def main(height: int, tx_index: int) -> Optional[Transaction]:
     return get_transaction_from_block(height, tx_index)

--- a/boa3_test/test_sc/interop_test/blockchain/GetTransactionFromBlockUInt256.py
+++ b/boa3_test/test_sc/interop_test/blockchain/GetTransactionFromBlockUInt256.py
@@ -1,8 +1,10 @@
+from typing import Optional
+
 from boa3.builtin.compile_time import public
 from boa3.builtin.interop.blockchain import Transaction, get_transaction_from_block
 from boa3.builtin.type import UInt256
 
 
 @public
-def main(hash_: UInt256, tx_index: int) -> Transaction:
+def main(hash_: UInt256, tx_index: int) -> Optional[Transaction]:
     return get_transaction_from_block(hash_, tx_index)

--- a/boa3_test/test_sc/interop_test/blockchain/ImportBlockchain.py
+++ b/boa3_test/test_sc/interop_test/blockchain/ImportBlockchain.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from boa3.builtin.compile_time import public
 from boa3.builtin.interop import blockchain
 from boa3.builtin.interop.contract import Contract
@@ -5,5 +7,5 @@ from boa3.builtin.type import UInt160
 
 
 @public
-def main(hash_: UInt160) -> Contract:
+def main(hash_: UInt160) -> Optional[Contract]:
     return blockchain.get_contract(hash_)

--- a/boa3_test/test_sc/interop_test/blockchain/ImportInteropBlockchain.py
+++ b/boa3_test/test_sc/interop_test/blockchain/ImportInteropBlockchain.py
@@ -1,7 +1,9 @@
+from typing import Optional
+
 from boa3.builtin import interop, type
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(hash_: type.UInt160) -> interop.contract.Contract:
+def main(hash_: type.UInt160) -> Optional[interop.contract.Contract]:
     return interop.blockchain.get_contract(hash_)

--- a/boa3_test/test_sc/native_test/contractmanagement/GetContract.py
+++ b/boa3_test/test_sc/native_test/contractmanagement/GetContract.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from boa3.builtin.compile_time import public
 from boa3.builtin.interop.contract import Contract
 from boa3.builtin.nativecontract.contractmanagement import ContractManagement
@@ -5,5 +7,5 @@ from boa3.builtin.type import UInt160
 
 
 @public
-def main(hash: UInt160) -> Contract:
+def main(hash: UInt160) -> Optional[Contract]:
     return ContractManagement.get_contract(hash)

--- a/boa3_test/test_sc/native_test/ledger/GetBlockByHash.py
+++ b/boa3_test/test_sc/native_test/ledger/GetBlockByHash.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from boa3.builtin.compile_time import public
 from boa3.builtin.interop.blockchain import Block
 from boa3.builtin.nativecontract.ledger import Ledger
@@ -5,5 +7,5 @@ from boa3.builtin.type import UInt256
 
 
 @public
-def Main(block_hash: UInt256) -> Block:
+def Main(block_hash: UInt256) -> Optional[Block]:
     return Ledger.get_block(block_hash)

--- a/boa3_test/test_sc/native_test/ledger/GetBlockByIndex.py
+++ b/boa3_test/test_sc/native_test/ledger/GetBlockByIndex.py
@@ -1,8 +1,10 @@
+from typing import Optional
+
 from boa3.builtin.compile_time import public
 from boa3.builtin.interop.blockchain import Block
 from boa3.builtin.nativecontract.ledger import Ledger
 
 
 @public
-def Main(index: int) -> Block:
+def Main(index: int) -> Optional[Block]:
     return Ledger.get_block(index)

--- a/boa3_test/test_sc/native_test/ledger/GetBlockMismatchedTypes.py
+++ b/boa3_test/test_sc/native_test/ledger/GetBlockMismatchedTypes.py
@@ -1,6 +1,8 @@
+from typing import Optional
+
 from boa3.builtin.interop.blockchain import Block
 from boa3.builtin.nativecontract.ledger import Ledger
 
 
-def Main(index: str) -> Block:
+def Main(index: str) -> Optional[Block]:
     return Ledger.get_block(index)

--- a/boa3_test/test_sc/native_test/ledger/GetTransaction.py
+++ b/boa3_test/test_sc/native_test/ledger/GetTransaction.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from boa3.builtin.compile_time import public
 from boa3.builtin.interop.blockchain import Transaction
 from boa3.builtin.nativecontract.ledger import Ledger
@@ -5,5 +7,5 @@ from boa3.builtin.type import UInt256
 
 
 @public
-def main(hash_: UInt256) -> Transaction:
+def main(hash_: UInt256) -> Optional[Transaction]:
     return Ledger.get_transaction(hash_)

--- a/boa3_test/test_sc/native_test/ledger/GetTransactionFromBlockInt.py
+++ b/boa3_test/test_sc/native_test/ledger/GetTransactionFromBlockInt.py
@@ -1,8 +1,10 @@
+from typing import Optional
+
 from boa3.builtin.compile_time import public
 from boa3.builtin.interop.blockchain import Transaction
 from boa3.builtin.nativecontract.ledger import Ledger
 
 
 @public
-def main(height: int, tx_index: int) -> Transaction:
+def main(height: int, tx_index: int) -> Optional[Transaction]:
     return Ledger.get_transaction_from_block(height, tx_index)

--- a/boa3_test/test_sc/native_test/ledger/GetTransactionFromBlockUInt256.py
+++ b/boa3_test/test_sc/native_test/ledger/GetTransactionFromBlockUInt256.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from boa3.builtin.compile_time import public
 from boa3.builtin.interop.blockchain import Transaction
 from boa3.builtin.nativecontract.ledger import Ledger
@@ -5,5 +7,5 @@ from boa3.builtin.type import UInt256
 
 
 @public
-def main(hash_: UInt256, tx_index: int) -> Transaction:
+def main(hash_: UInt256, tx_index: int) -> Optional[Transaction]:
     return Ledger.get_transaction_from_block(hash_, tx_index)

--- a/boa3_test/tests/compiler_tests/test_interop/test_blockchain.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_blockchain.py
@@ -187,9 +187,14 @@ class TestBlockchainInterop(BoaTest):
         tx = runner.get_transaction(hash_)
         self.assertIsNotNone(tx)
 
+        nonexistent_tx = runner.call_contract(path, 'main', UInt256(bytes(32)).to_array())
+
         invoke = runner.call_contract(path, 'main', hash_.to_array())
         runner.execute()
         self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        result = nonexistent_tx.result
+        self.assertIsNone(result)
 
         result = invoke.result
         self.assertIsInstance(result, list)
@@ -240,9 +245,14 @@ class TestBlockchainInterop(BoaTest):
         tx = runner.get_transaction(hash_)
         self.assertIsNotNone(tx)
 
+        nonexistent_tx = runner.call_contract(path, 'main', 123456789, 0)
+
         invoke = runner.call_contract(path, 'main', expected_block_index, 0)
         runner.execute()
         self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        result = nonexistent_tx.result
+        self.assertIsNone(result)
 
         result = invoke.result
         self.assertIsInstance(result, list)
@@ -287,9 +297,14 @@ class TestBlockchainInterop(BoaTest):
         tx_index = 0
         expected_tx = txs[tx_index]
 
+        nonexistent_tx = runner.call_contract(path, 'main', UInt256(bytes(32)).to_array(), 0)
+
         invoke = runner.call_contract(path, 'main', block_hash, tx_index)
         runner.execute()
         self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        result = nonexistent_tx.result
+        self.assertIsNone(result)
 
         result = invoke.result
         self.assertIsInstance(result, list)

--- a/boa3_test/tests/compiler_tests/test_native/test_ledger.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_ledger.py
@@ -120,9 +120,14 @@ class TestLedgerContract(BoaTest):
         tx = runner.get_transaction(hash_)
         self.assertIsNotNone(tx)
 
+        nonexistent_tx = runner.call_contract(path, 'main', UInt256(bytes(32)).to_array())
+
         invoke = runner.call_contract(path, 'main', hash_.to_array())
         runner.execute()
         self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        result = nonexistent_tx.result
+        self.assertIsNone(result)
 
         result = invoke.result
         self.assertIsInstance(result, list)
@@ -173,9 +178,14 @@ class TestLedgerContract(BoaTest):
         tx = runner.get_transaction(hash_)
         self.assertIsNotNone(tx)
 
+        nonexistent_tx = runner.call_contract(path, 'main', 123456789, 0)
+
         invoke = runner.call_contract(path, 'main', expected_block_index, 0)
         runner.execute()
         self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        result = nonexistent_tx.result
+        self.assertIsNone(result)
 
         result = invoke.result
         self.assertIsInstance(result, list)
@@ -220,9 +230,14 @@ class TestLedgerContract(BoaTest):
         tx_index = 0
         expected_tx = txs[tx_index]
 
+        nonexistent_tx = runner.call_contract(path, 'main', UInt256(bytes(32)).to_array(), 0)
+
         invoke = runner.call_contract(path, 'main', block_hash, tx_index)
         runner.execute()
         self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        result = nonexistent_tx.result
+        self.assertIsNone(result)
 
         result = invoke.result
         self.assertIsInstance(result, list)


### PR DESCRIPTION
**Summary or solution description**
Some functions on interop.blockchain were not properly indicating that they had an Optional return type. Changed the return type and added some more docstring examples

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/3bfe91adb9218995c92a08e4e52a95f8e6c8647b/boa3_test/test_sc/interop_test/blockchain/GetContract.py#L1-L11

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/3bfe91adb9218995c92a08e4e52a95f8e6c8647b/boa3_test/tests/compiler_tests/test_interop/test_blockchain.py#L45-L76

**Platform:**
 - OS: Windows 11 x64
 - Python version: Python 3.7
