### PR TITLE
Fail fast on compilation error

### DIFF
--- a/boa3/boa3.py
+++ b/boa3/boa3.py
@@ -11,23 +11,24 @@ class Boa3:
     """
 
     @staticmethod
-    def compile(path: str, root_folder: str = None, env: str = None) -> bytes:
+    def compile(path: str, root_folder: str = None, env: str = None, fail_fast: bool = True) -> bytes:
         """
         Load a Python file to be compiled but don't write the result into a file
 
         :param path: the path of the Python file to compile
         :param root_folder: the root path of the project
         :param env: specific environment id to compile
+        :param fail_fast: if should stop compilation on first error found.
         :return: the bytecode of the compiled .nef file
         """
         if not path.endswith('.py'):
             raise InvalidPathException(path)
 
-        return Compiler().compile(path, root_folder, env)
+        return Compiler().compile(path, root_folder, env, fail_fast=fail_fast)
 
     @staticmethod
     def compile_and_save(path: str, output_path: str = None, root_folder: str = None, show_errors: bool = True,
-                         debug: bool = False, env: str = None):
+                         debug: bool = False, env: str = None, fail_fast: bool = True):
         """
         Load a Python file to be compiled and save the result into the files.
         By default, the resultant .nef file is saved in the same folder of the
@@ -39,6 +40,7 @@ class Boa3:
         :param show_errors: if compiler errors should be logged.
         :param debug: if nefdbgnfo file should be generated.
         :param env: specific environment id to compile.
+        :param fail_fast: if should stop compilation on first error found.
         """
         if not path.endswith('.py'):
             raise InvalidPathException(path)
@@ -48,4 +50,4 @@ class Boa3:
         elif not output_path.endswith('.nef'):
             raise InvalidPathException(output_path)
 
-        Compiler().compile_and_save(path, output_path, root_folder, show_errors, debug, env)
+        Compiler().compile_and_save(path, output_path, root_folder, show_errors, debug, env, fail_fast)

--- a/boa3/internal/analyser/analyser.py
+++ b/boa3/internal/analyser/analyser.py
@@ -26,13 +26,14 @@ class Analyser:
     """
 
     def __init__(self, ast_tree: ast.AST, path: str = None, project_root: str = None,
-                 env: str = None, log: bool = False):
+                 env: str = None, log: bool = False, fail_fast: bool = False):
         self.symbol_table: Dict[str, ISymbol] = {}
 
         self.ast_tree: ast.AST = ast_tree
         self.metadata: NeoMetadata = NeoMetadata()
         self.is_analysed: bool = False
         self._log: bool = log
+        self._fail_fast: bool = fail_fast
         self._env: str = env if env is not None else constants.DEFAULT_CONTRACT_ENVIRONMENT
 
         self.__include_builtins_symbols()
@@ -57,7 +58,7 @@ class Analyser:
                           else path)
 
     @staticmethod
-    def analyse(path: str, log: bool = False,
+    def analyse(path: str, log: bool = False, fail_fast: bool = False,
                 imported_files: Optional[Dict[str, Analyser]] = None,
                 import_stack: Optional[List[str]] = None,
                 root: str = None, env: str = None, compiler_entry: bool = False) -> Analyser:
@@ -66,6 +67,7 @@ class Analyser:
 
         :param path: the path of the Python file
         :param log: if compiler errors should be logged.
+        :param fail_fast: if should stop compilation on first error found.
         :param import_stack: a list that represents the current import stack if it's from an import.
                              If it's not triggered by an import, must be None.
         :param imported_files: a dict that maps the paths of the files that were analysed if it's from an import.
@@ -79,7 +81,7 @@ class Analyser:
         with open(path, 'rb') as source:
             ast_tree = ast.parse(source.read())
 
-        analyser = Analyser(ast_tree, path, root if isinstance(root, str) else path, env, log)
+        analyser = Analyser(ast_tree, path, root if isinstance(root, str) else path, env, log, fail_fast)
         CompiledMetadata.set_current_metadata(analyser.metadata)
 
         if compiler_entry:
@@ -154,6 +156,7 @@ class Analyser:
         current_metadata = self.metadata
         module_analyser = ModuleAnalyser(self, self.symbol_table,
                                          log=self._log,
+                                         fail_fast=self._fail_fast,
                                          filename=self.filename,
                                          root_folder=self.root,
                                          analysed_files=imported_files,

--- a/boa3/internal/analyser/astoptimizer.py
+++ b/boa3/internal/analyser/astoptimizer.py
@@ -29,8 +29,9 @@ class AstOptimizer(IAstAnalyser, ast.NodeTransformer):
     :ivar symbols: a dictionary that maps the global symbols.
     """
 
-    def __init__(self, analyser, log: bool = False):
-        super().__init__(analyser.ast_tree, filename=analyser.filename, root_folder=analyser.root, log=log)
+    def __init__(self, analyser, log: bool = False, fail_fast: bool = True):
+        super().__init__(analyser.ast_tree, filename=analyser.filename, root_folder=analyser.root,
+                         log=log, fail_fast=fail_fast)
         self.modules: Dict[str, Module] = {}
         self.symbols: Dict[str, ISymbol] = analyser.symbol_table
 
@@ -40,7 +41,7 @@ class AstOptimizer(IAstAnalyser, ast.NodeTransformer):
 
         self._current_class: UserClass = None
 
-        self.visit(self._tree)
+        self.analyse_visit(self._tree)
 
     @property
     def tree(self) -> ast.AST:

--- a/boa3/internal/analyser/builtinfunctioncallanalyser.py
+++ b/boa3/internal/analyser/builtinfunctioncallanalyser.py
@@ -10,10 +10,11 @@ from boa3.internal.model.type.itype import IType
 
 
 class BuiltinFunctionCallAnalyser(IAstAnalyser):
-    def __init__(self, origin: IAstAnalyser, call: ast.Call, method_id: str, builtin_method: IBuiltinMethod, log: bool):
+    def __init__(self, origin: IAstAnalyser, call: ast.Call, method_id: str, builtin_method: IBuiltinMethod,
+                 log: bool, fail_fast: bool = True):
         self._method: IBuiltinMethod = builtin_method
         self.method_id: str = method_id
-        super().__init__(call, root_folder=origin.root_folder, log=log)
+        super().__init__(call, root_folder=origin.root_folder, log=log, fail_fast=fail_fast)
 
         self._origin: IAstAnalyser = origin
 

--- a/boa3/internal/analyser/constructanalyser.py
+++ b/boa3/internal/analyser/constructanalyser.py
@@ -14,10 +14,11 @@ class ConstructAnalyser(IAstAnalyser, ast.NodeTransformer):
     These methods are used to walk through the Python abstract syntax tree.
     """
 
-    def __init__(self, analyser, ast_tree: ast.AST, symbol_table: Dict[str, ISymbol], log: bool = False):
-        super().__init__(ast_tree, root_folder=analyser.root, log=log)
+    def __init__(self, analyser, ast_tree: ast.AST, symbol_table: Dict[str, ISymbol],
+                 log: bool = False, fail_fast: bool = True):
+        super().__init__(ast_tree, root_folder=analyser.root, log=log, fail_fast=fail_fast)
         self.symbols = symbol_table.copy()
-        self.visit(self._tree)
+        self.analyse_visit(self._tree)
 
     @property
     def tree(self) -> ast.AST:

--- a/boa3/internal/analyser/supportedstandard/standardanalyser.py
+++ b/boa3/internal/analyser/supportedstandard/standardanalyser.py
@@ -16,10 +16,11 @@ class StandardAnalyser(IAstAnalyser):
     :ivar symbols: a dictionary that maps the global symbols.
     """
 
-    def __init__(self, analyser, symbol_table: Dict[str, ISymbol], log: bool = False):
+    def __init__(self, analyser, symbol_table: Dict[str, ISymbol],
+                 log: bool = False, fail_fast: bool = True):
         from boa3.builtin.compile_time import NeoMetadata
 
-        super().__init__(analyser.ast_tree, analyser.filename, analyser.root, log=log)
+        super().__init__(analyser.ast_tree, analyser.filename, analyser.root, log=log, fail_fast=fail_fast)
 
         self.symbols: Dict[str, ISymbol] = symbol_table
 
@@ -65,63 +66,67 @@ class StandardAnalyser(IAstAnalyser):
         return methods
 
     def _validate_standards(self):
-        for standard in self.standards:
-            if standard in supportedstandard.neo_standards:
-                current_standard = supportedstandard.neo_standards[standard]
+        try:
+            for standard in self.standards:
+                if standard in supportedstandard.neo_standards:
+                    current_standard = supportedstandard.neo_standards[standard]
 
-                # validate standard's methods
-                for standard_method in current_standard.methods:
-                    method_id = standard_method.external_name
-                    is_implemented = False
+                    # validate standard's methods
+                    for standard_method in current_standard.methods:
+                        method_id = standard_method.external_name
+                        is_implemented = False
 
-                    found_methods = self.get_methods_by_display_name(method_id)
-                    for method in found_methods:
-                        if isinstance(method, Method) and current_standard.match_definition(standard_method, method):
-                            is_implemented = True
-                            break
+                        found_methods = self.get_methods_by_display_name(method_id)
+                        for method in found_methods:
+                            if isinstance(method, Method) and current_standard.match_definition(standard_method, method):
+                                is_implemented = True
+                                break
 
-                    if not is_implemented:
-                        self._log_error(
-                            CompilerError.MissingStandardDefinition(standard, method_id, standard_method)
-                        )
+                        if not is_implemented:
+                            self._log_error(
+                                CompilerError.MissingStandardDefinition(standard, method_id, standard_method)
+                            )
 
-                # validate standard's events
-                events = [symbol for symbol in self.symbols.values() if isinstance(symbol, Event)]
-                # imported events should be included in the validation
-                for import_ in self._analyser.get_imports():
-                    events.extend([event for event in import_.symbol_table.values()
-                                   if isinstance(event, Event) and event not in events])
+                    # validate standard's events
+                    events = [symbol for symbol in self.symbols.values() if isinstance(symbol, Event)]
+                    # imported events should be included in the validation
+                    for import_ in self._analyser.get_imports():
+                        events.extend([event for event in import_.symbol_table.values()
+                                       if isinstance(event, Event) and event not in events])
 
-                for standard_event in current_standard.events:
-                    is_implemented = False
-                    for event in events:
-                        if (event.name == standard_event.name
-                                and current_standard.match_definition(standard_event, event)):
-                            is_implemented = True
-                            break
+                    for standard_event in current_standard.events:
+                        is_implemented = False
+                        for event in events:
+                            if (event.name == standard_event.name
+                                    and current_standard.match_definition(standard_event, event)):
+                                is_implemented = True
+                                break
 
-                    if not is_implemented:
-                        self._log_error(
-                            CompilerError.MissingStandardDefinition(standard,
-                                                                    standard_event.name,
-                                                                    standard_event)
-                        )
+                        if not is_implemented:
+                            self._log_error(
+                                CompilerError.MissingStandardDefinition(standard,
+                                                                        standard_event.name,
+                                                                        standard_event)
+                            )
 
-                # validate optional methods
-                for optional_method in current_standard.optionals:
-                    method_id = optional_method.external_name
-                    is_implemented = False
+                    # validate optional methods
+                    for optional_method in current_standard.optionals:
+                        method_id = optional_method.external_name
+                        is_implemented = False
 
-                    found_methods = self.get_methods_by_display_name(method_id)
-                    for method in found_methods:
-                        if isinstance(method, Method) and current_standard.match_definition(optional_method, method):
-                            is_implemented = True
-                            break
+                        found_methods = self.get_methods_by_display_name(method_id)
+                        for method in found_methods:
+                            if isinstance(method, Method) and current_standard.match_definition(optional_method, method):
+                                is_implemented = True
+                                break
 
-                    if found_methods and not is_implemented:
-                        self._log_error(
-                            CompilerError.MissingStandardDefinition(standard, method_id, optional_method)
-                        )
+                        if found_methods and not is_implemented:
+                            self._log_error(
+                                CompilerError.MissingStandardDefinition(standard, method_id, optional_method)
+                            )
+        except CompilerError:
+            # stops the analyser if fail fast is activated
+            pass
 
     def _check_other_implemented_standards(self):
         other_standards = supportedstandard.neo_standards.copy()

--- a/boa3/internal/analyser/typeanalyser.py
+++ b/boa3/internal/analyser/typeanalyser.py
@@ -47,8 +47,8 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
     :ivar symbols: a dictionary that maps the global symbols.
     """
 
-    def __init__(self, analyser, symbol_table: Dict[str, ISymbol], log: bool = False):
-        super().__init__(analyser.ast_tree, analyser.filename, analyser.root, log=log)
+    def __init__(self, analyser, symbol_table: Dict[str, ISymbol], log: bool = False, fail_fast: bool = True):
+        super().__init__(analyser.ast_tree, analyser.filename, analyser.root, log=log, fail_fast=fail_fast)
         self.type_errors: List[Exception] = []
         self.modules: Dict[str, Module] = {}
         self.symbols: Dict[str, ISymbol] = symbol_table
@@ -58,7 +58,7 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
         self._scope_stack: List[SymbolScope] = []
 
         self._super_calls: List[IBuiltinMethod] = []
-        self.visit(self._tree)
+        self.analyse_visit(self._tree)
 
     def visit(self, node: ast.AST, get_literal_value: bool = False):
         if get_literal_value:

--- a/boa3/internal/cli_commands/compile_command.py
+++ b/boa3/internal/cli_commands/compile_command.py
@@ -34,6 +34,11 @@ class CompileCommand(ICommand):
                                  help="Chooses the name and where the compiled files will be generated, "
                                       "if not specified it will be generated on the same directory with the same name "
                                       "as the python file.")
+        self.parser.add_argument("-f", "--failfast",
+                                 action='store',
+                                 default=True,
+                                 choices=[True, False],
+                                 help="Stop on first compile error")
 
         self.parser.set_defaults(func=self.execute_command)
 
@@ -44,6 +49,7 @@ class CompileCommand(ICommand):
         debug: bool = args['debug']
         env: str = args['env']
         output_path: Optional[str] = args['output_path']
+        fail_fast: bool = args['failfast']
 
         if not sc_path.endswith(".py") or not os.path.isfile(sc_path):
             logging.error("Input file is not .py")
@@ -60,7 +66,13 @@ class CompileCommand(ICommand):
             path, filename = os.path.split(os.path.realpath(output_path))
 
         try:
-            Boa3.compile_and_save(sc_path, output_path=output_path, debug=debug, root_folder=project_path, env=env)
+            Boa3.compile_and_save(sc_path,
+                                  output_path=output_path,
+                                  debug=debug,
+                                  root_folder=project_path,
+                                  env=env,
+                                  fail_fast=fail_fast
+                                  )
             logging.info(f"Wrote {filename.replace('.py', '.nef')} to {path}")
         except NotLoadedException as e:
             error_message = e.message

--- a/boa3/internal/compiler/codegenerator/codegeneratorvisitor.py
+++ b/boa3/internal/compiler/codegenerator/codegeneratorvisitor.py
@@ -40,7 +40,7 @@ class VisitorCodeGenerator(IAstAnalyser):
     """
 
     def __init__(self, generator: CodeGenerator, filename: str = None, root: str = None):
-        super().__init__(ast.parse(""), filename=filename, root_folder=root, log=True)
+        super().__init__(ast.parse(""), filename=filename, root_folder=root, log=True, fail_fast=True)
 
         self.generator = generator
         self.current_method: Optional[Method] = None

--- a/boa3/internal/compiler/codegenerator/initstatementsvisitor.py
+++ b/boa3/internal/compiler/codegenerator/initstatementsvisitor.py
@@ -16,8 +16,8 @@ class InitStatementsVisitor(IAstAnalyser):
 
     """
 
-    def __init__(self, symbols: Dict[str, ISymbol]):
-        super().__init__(ast.parse(""), log=True)
+    def __init__(self, symbols: Dict[str, ISymbol], fail_fast: bool = True):
+        super().__init__(ast.parse(""), log=True, fail_fast=fail_fast)
         self.symbols = symbols.copy()
 
         self._deploy_instructions: List[ast.AST] = []

--- a/boa3/internal/compiler/compiler.py
+++ b/boa3/internal/compiler/compiler.py
@@ -21,7 +21,8 @@ class Compiler:
         self._analyser: Analyser = None
         self._entry_smart_contract: str = ''
 
-    def compile(self, path: str, root_folder: str = None, env: str = None, log: bool = True) -> bytes:
+    def compile(self, path: str, root_folder: str = None, env: str = None,
+                log: bool = True, fail_fast: bool = True) -> bytes:
         """
         Load a Python file and tries to compile it
 
@@ -29,11 +30,13 @@ class Compiler:
         :param root_folder: the root path of the project
         :param log: if compiler errors should be logged.
         :param env: specific environment id to compile.
+        :param fail_fast: if should stop compilation on first error found.
         :return: the bytecode of the compiled .nef file
         """
-        return self._internal_compile(path, root_folder, env, log).bytecode
+        return self._internal_compile(path, root_folder, env, log, fail_fast).bytecode
 
-    def _internal_compile(self, path: str, root_folder: str = None, env: str = None, log: bool = True) -> CompilerOutput:
+    def _internal_compile(self, path: str, root_folder: str = None, env: str = None,
+                          log: bool = True, fail_fast: bool = True) -> CompilerOutput:
         fullpath = os.path.realpath(path)
         filepath, filename = os.path.split(fullpath)
 
@@ -48,11 +51,11 @@ class Compiler:
         CompilerBuiltin.reset()
         CompiledMetadata.reset()
 
-        self._analyse(fullpath, root_folder, env, log)
+        self._analyse(fullpath, root_folder, env, log, fail_fast)
         return self._compile()
 
     def compile_and_save(self, path: str, output_path: str, root_folder: str = None, log: bool = True,
-                         debug: bool = False, env: str = None):
+                         debug: bool = False, env: str = None, fail_fast: bool = True):
         """
         Save the compiled file and the metadata files
 
@@ -62,19 +65,23 @@ class Compiler:
         :param log: if compiler errors should be logged.
         :param debug: if nefdbgnfo file should be generated.
         :param env: specific environment id to compile.
+        :param fail_fast: if should stop compilation on first error found.
         """
-        self.result = self._internal_compile(path, root_folder, env, log)
+        self.result = self._internal_compile(path, root_folder, env, log, fail_fast)
         self._save(output_path, debug)
 
-    def _analyse(self, path: str, root_folder: str = None, env: str = None, log: bool = True):
+    def _analyse(self, path: str, root_folder: str = None, env: str = None,
+                 log: bool = True, fail_fast: bool = True):
         """
         Load a Python file and analyses its syntax
 
         :param path: the path of the Python file to compile
         :param root_folder: the root path of the project
         :param log: if compiler errors should be logged.
+        :param fail_fast: if should stop compilation on first error found.
         """
-        self._analyser = Analyser.analyse(path, log=log, root=root_folder, env=env, compiler_entry=True)
+        self._analyser = Analyser.analyse(path, log=log, fail_fast=fail_fast,
+                                          root=root_folder, env=env, compiler_entry=True)
 
     def _compile(self) -> CompilerOutput:
         """

--- a/boa3_test/test_sc/import_test/ImportFailInnerNotExistingMethod.py
+++ b/boa3_test/test_sc/import_test/ImportFailInnerNotExistingMethod.py
@@ -1,0 +1,5 @@
+from boa3_test.test_sc.import_test.ImportNotExistingMethod import get_token_json
+
+
+def call_imported() -> dict:
+    return get_token_json()

--- a/boa3_test/tests/compiler_tests/test_logger.py
+++ b/boa3_test/tests/compiler_tests/test_logger.py
@@ -1,0 +1,13 @@
+from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to avoid circular imports
+
+
+class TestImport(BoaTest):
+    def test_log_multiple_errors_on_import(self):
+        path = self.get_contract_path('test_sc/import_test', 'ImportFailInnerNotExistingMethod.py')
+        errors, _ = self.get_all_compile_log_data(path, fail_fast=False)
+        self.assertGreater(len(errors), 1)
+
+    def test_log_fail_fast_error_on_import(self):
+        path = self.get_contract_path('test_sc/import_test', 'ImportFailInnerNotExistingMethod.py')
+        errors, _ = self.get_all_compile_log_data(path, fail_fast=True)
+        self.assertEqual(1, len(errors))


### PR DESCRIPTION
**Summary or solution description**
Changed to stop the compilation on the first error found.
The previous behavior of trying to get all errors weren't removed to ensure the correct behavior on unit tests that expect a specific compiler error.
Added a flag on cli to disable fail fast. It's true by default.

**How to Reproduce**
```python
from boa3.boa3 import Boa3

Boa3.compile('path/to/smart/contract.py', fail_fast=True)
Boa3.compile_and_save('path/to/smart/contract.py')  # fail fast is True by default
Boa3.compile_and_save('path/to/smart/contract.py', fail_fast=False)
```

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/cae5c9ad1c2eb07c1be9e891358eaf3c318e9710/boa3_test/tests/compiler_tests/test_logger.py#L5-L13

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7+

**(Optional) Additional context**
Waiting #1083 to add fail fast cli tests