### PR TITLE
Fail fast on compilation error

### DIFF
--- a/boa3/boa3.py
+++ b/boa3/boa3.py
@@ -11,23 +11,24 @@ class Boa3:
     """
 
     @staticmethod
-    def compile(path: str, root_folder: str = None, env: str = None) -> bytes:
+    def compile(path: str, root_folder: str = None, env: str = None, fail_fast: bool = True) -> bytes:
         """
         Load a Python file to be compiled but don't write the result into a file
 
         :param path: the path of the Python file to compile
         :param root_folder: the root path of the project
         :param env: specific environment id to compile
+        :param fail_fast: if should stop compilation on first error found.
         :return: the bytecode of the compiled .nef file
         """
         if not path.endswith('.py'):
             raise InvalidPathException(path)
 
-        return Compiler().compile(path, root_folder, env)
+        return Compiler().compile(path, root_folder, env, fail_fast=fail_fast)
 
     @staticmethod
     def compile_and_save(path: str, output_path: str = None, root_folder: str = None, show_errors: bool = True,
-                         debug: bool = False, env: str = None):
+                         debug: bool = False, env: str = None, fail_fast: bool = True):
         """
         Load a Python file to be compiled and save the result into the files.
         By default, the resultant .nef file is saved in the same folder of the
@@ -39,6 +40,7 @@ class Boa3:
         :param show_errors: if compiler errors should be logged.
         :param debug: if nefdbgnfo file should be generated.
         :param env: specific environment id to compile.
+        :param fail_fast: if should stop compilation on first error found.
         """
         if not path.endswith('.py'):
             raise InvalidPathException(path)
@@ -48,4 +50,4 @@ class Boa3:
         elif not output_path.endswith('.nef'):
             raise InvalidPathException(output_path)
 
-        Compiler().compile_and_save(path, output_path, root_folder, show_errors, debug, env)
+        Compiler().compile_and_save(path, output_path, root_folder, show_errors, debug, env, fail_fast)

--- a/boa3/internal/analyser/analyser.py
+++ b/boa3/internal/analyser/analyser.py
@@ -118,7 +118,8 @@ class Analyser:
         return self._env
 
     def copy(self) -> Analyser:
-        copied = Analyser(ast_tree=self.ast_tree, path=self.path, project_root=self.root, env=self._env, log=self._log)
+        copied = Analyser(ast_tree=self.ast_tree, path=self.path, project_root=self.root,
+                          env=self._env, log=self._log, fail_fast=self._fail_fast)
 
         copied.metadata = self.metadata
         copied.is_analysed = self.is_analysed
@@ -141,7 +142,7 @@ class Analyser:
 
         :return: a boolean value that represents if the analysis was successful
         """
-        type_analyser = TypeAnalyser(self, self.symbol_table, log=self._log)
+        type_analyser = TypeAnalyser(self, self.symbol_table, log=self._log, fail_fast=self._fail_fast)
         self._update_logs(type_analyser)
         return not type_analyser.has_errors
 
@@ -177,7 +178,7 @@ class Analyser:
 
         :return: a boolean value that represents if the analysis was successful
         """
-        standards_analyser = StandardAnalyser(self, self.symbol_table, log=self._log)
+        standards_analyser = StandardAnalyser(self, self.symbol_table, log=self._log, fail_fast=self._fail_fast)
         self._update_logs(standards_analyser)
         return not standards_analyser.has_errors
 
@@ -189,13 +190,15 @@ class Analyser:
         """
         Pre executes the instructions of the ast for optimization
         """
-        self.ast_tree = ConstructAnalyser(self, self.ast_tree, self.symbol_table, log=self._log).tree
+        self.ast_tree = ConstructAnalyser(self, self.ast_tree, self.symbol_table,
+                                          log=self._log, fail_fast=self._fail_fast
+                                          ).tree
 
     def __pos_execute(self):
         """
         Tries to optimize the ast after validations
         """
-        optimizer = AstOptimizer(self, log=self._log)
+        optimizer = AstOptimizer(self, log=self._log, fail_fast=self._fail_fast)
         self._update_logs(optimizer)
 
     def update_symbol_table(self, symbol_table: Dict[str, ISymbol]):
@@ -237,7 +240,8 @@ class Analyser:
             if file_path not in paths_already_imported:
                 import_analyser = ImportAnalyser(file_path, self.root,
                                                  already_imported_modules=imports,
-                                                 log=False, get_entry=True)
+                                                 log=False, fail_fast=self._fail_fast,
+                                                 get_entry=True)
                 import_symbol = Import(file_path, analyser.ast_tree, import_analyser, {})
                 self.symbol_table[file_path] = import_symbol
 

--- a/boa3/internal/analyser/analyser.py
+++ b/boa3/internal/analyser/analyser.py
@@ -26,13 +26,14 @@ class Analyser:
     """
 
     def __init__(self, ast_tree: ast.AST, path: str = None, project_root: str = None,
-                 env: str = None, log: bool = False):
+                 env: str = None, log: bool = False, fail_fast: bool = False):
         self.symbol_table: Dict[str, ISymbol] = {}
 
         self.ast_tree: ast.AST = ast_tree
         self.metadata: NeoMetadata = NeoMetadata()
         self.is_analysed: bool = False
         self._log: bool = log
+        self._fail_fast: bool = fail_fast
         self._env: str = env if env is not None else constants.DEFAULT_CONTRACT_ENVIRONMENT
 
         self.__include_builtins_symbols()
@@ -57,7 +58,7 @@ class Analyser:
                           else path)
 
     @staticmethod
-    def analyse(path: str, log: bool = False,
+    def analyse(path: str, log: bool = False, fail_fast: bool = False,
                 imported_files: Optional[Dict[str, Analyser]] = None,
                 import_stack: Optional[List[str]] = None,
                 root: str = None, env: str = None, compiler_entry: bool = False) -> Analyser:
@@ -66,6 +67,7 @@ class Analyser:
 
         :param path: the path of the Python file
         :param log: if compiler errors should be logged.
+        :param fail_fast: if should stop compilation on first error found.
         :param import_stack: a list that represents the current import stack if it's from an import.
                              If it's not triggered by an import, must be None.
         :param imported_files: a dict that maps the paths of the files that were analysed if it's from an import.
@@ -79,7 +81,7 @@ class Analyser:
         with open(path, 'rb') as source:
             ast_tree = ast.parse(source.read())
 
-        analyser = Analyser(ast_tree, path, root if isinstance(root, str) else path, env, log)
+        analyser = Analyser(ast_tree, path, root if isinstance(root, str) else path, env, log, fail_fast)
         CompiledMetadata.set_current_metadata(analyser.metadata)
 
         if compiler_entry:
@@ -154,6 +156,7 @@ class Analyser:
         current_metadata = self.metadata
         module_analyser = ModuleAnalyser(self, self.symbol_table,
                                          log=self._log,
+                                         fail_fast=self._fail_fast,
                                          filename=self.filename,
                                          root_folder=self.root,
                                          analysed_files=imported_files,

--- a/boa3/internal/analyser/astoptimizer.py
+++ b/boa3/internal/analyser/astoptimizer.py
@@ -29,8 +29,9 @@ class AstOptimizer(IAstAnalyser, ast.NodeTransformer):
     :ivar symbols: a dictionary that maps the global symbols.
     """
 
-    def __init__(self, analyser, log: bool = False):
-        super().__init__(analyser.ast_tree, filename=analyser.filename, root_folder=analyser.root, log=log)
+    def __init__(self, analyser, log: bool = False, fail_fast: bool = True):
+        super().__init__(analyser.ast_tree, filename=analyser.filename, root_folder=analyser.root,
+                         log=log, fail_fast=fail_fast)
         self.modules: Dict[str, Module] = {}
         self.symbols: Dict[str, ISymbol] = analyser.symbol_table
 
@@ -40,7 +41,7 @@ class AstOptimizer(IAstAnalyser, ast.NodeTransformer):
 
         self._current_class: UserClass = None
 
-        self.visit(self._tree)
+        self.analyse_visit(self._tree)
 
     @property
     def tree(self) -> ast.AST:

--- a/boa3/internal/analyser/builtinfunctioncallanalyser.py
+++ b/boa3/internal/analyser/builtinfunctioncallanalyser.py
@@ -10,10 +10,11 @@ from boa3.internal.model.type.itype import IType
 
 
 class BuiltinFunctionCallAnalyser(IAstAnalyser):
-    def __init__(self, origin: IAstAnalyser, call: ast.Call, method_id: str, builtin_method: IBuiltinMethod, log: bool):
+    def __init__(self, origin: IAstAnalyser, call: ast.Call, method_id: str, builtin_method: IBuiltinMethod,
+                 log: bool, fail_fast: bool = True):
         self._method: IBuiltinMethod = builtin_method
         self.method_id: str = method_id
-        super().__init__(call, root_folder=origin.root_folder, log=log)
+        super().__init__(call, root_folder=origin.root_folder, log=log, fail_fast=fail_fast)
 
         self._origin: IAstAnalyser = origin
 

--- a/boa3/internal/analyser/constructanalyser.py
+++ b/boa3/internal/analyser/constructanalyser.py
@@ -14,10 +14,11 @@ class ConstructAnalyser(IAstAnalyser, ast.NodeTransformer):
     These methods are used to walk through the Python abstract syntax tree.
     """
 
-    def __init__(self, analyser, ast_tree: ast.AST, symbol_table: Dict[str, ISymbol], log: bool = False):
-        super().__init__(ast_tree, root_folder=analyser.root, log=log)
+    def __init__(self, analyser, ast_tree: ast.AST, symbol_table: Dict[str, ISymbol],
+                 log: bool = False, fail_fast: bool = True):
+        super().__init__(ast_tree, root_folder=analyser.root, log=log, fail_fast=fail_fast)
         self.symbols = symbol_table.copy()
-        self.visit(self._tree)
+        self.analyse_visit(self._tree)
 
     @property
     def tree(self) -> ast.AST:

--- a/boa3/internal/analyser/supportedstandard/standardanalyser.py
+++ b/boa3/internal/analyser/supportedstandard/standardanalyser.py
@@ -124,7 +124,7 @@ class StandardAnalyser(IAstAnalyser):
                             self._log_error(
                                 CompilerError.MissingStandardDefinition(standard, method_id, optional_method)
                             )
-        except CompilerError:
+        except CompilerError.CompilerError:
             # stops the analyser if fail fast is activated
             pass
 

--- a/boa3/internal/analyser/supportedstandard/standardanalyser.py
+++ b/boa3/internal/analyser/supportedstandard/standardanalyser.py
@@ -16,10 +16,11 @@ class StandardAnalyser(IAstAnalyser):
     :ivar symbols: a dictionary that maps the global symbols.
     """
 
-    def __init__(self, analyser, symbol_table: Dict[str, ISymbol], log: bool = False):
+    def __init__(self, analyser, symbol_table: Dict[str, ISymbol],
+                 log: bool = False, fail_fast: bool = True):
         from boa3.builtin.compile_time import NeoMetadata
 
-        super().__init__(analyser.ast_tree, analyser.filename, analyser.root, log=log)
+        super().__init__(analyser.ast_tree, analyser.filename, analyser.root, log=log, fail_fast=fail_fast)
 
         self.symbols: Dict[str, ISymbol] = symbol_table
 
@@ -65,63 +66,67 @@ class StandardAnalyser(IAstAnalyser):
         return methods
 
     def _validate_standards(self):
-        for standard in self.standards:
-            if standard in supportedstandard.neo_standards:
-                current_standard = supportedstandard.neo_standards[standard]
+        try:
+            for standard in self.standards:
+                if standard in supportedstandard.neo_standards:
+                    current_standard = supportedstandard.neo_standards[standard]
 
-                # validate standard's methods
-                for standard_method in current_standard.methods:
-                    method_id = standard_method.external_name
-                    is_implemented = False
+                    # validate standard's methods
+                    for standard_method in current_standard.methods:
+                        method_id = standard_method.external_name
+                        is_implemented = False
 
-                    found_methods = self.get_methods_by_display_name(method_id)
-                    for method in found_methods:
-                        if isinstance(method, Method) and current_standard.match_definition(standard_method, method):
-                            is_implemented = True
-                            break
+                        found_methods = self.get_methods_by_display_name(method_id)
+                        for method in found_methods:
+                            if isinstance(method, Method) and current_standard.match_definition(standard_method, method):
+                                is_implemented = True
+                                break
 
-                    if not is_implemented:
-                        self._log_error(
-                            CompilerError.MissingStandardDefinition(standard, method_id, standard_method)
-                        )
+                        if not is_implemented:
+                            self._log_error(
+                                CompilerError.MissingStandardDefinition(standard, method_id, standard_method)
+                            )
 
-                # validate standard's events
-                events = [symbol for symbol in self.symbols.values() if isinstance(symbol, Event)]
-                # imported events should be included in the validation
-                for import_ in self._analyser.get_imports():
-                    events.extend([event for event in import_.symbol_table.values()
-                                   if isinstance(event, Event) and event not in events])
+                    # validate standard's events
+                    events = [symbol for symbol in self.symbols.values() if isinstance(symbol, Event)]
+                    # imported events should be included in the validation
+                    for import_ in self._analyser.get_imports():
+                        events.extend([event for event in import_.symbol_table.values()
+                                       if isinstance(event, Event) and event not in events])
 
-                for standard_event in current_standard.events:
-                    is_implemented = False
-                    for event in events:
-                        if (event.name == standard_event.name
-                                and current_standard.match_definition(standard_event, event)):
-                            is_implemented = True
-                            break
+                    for standard_event in current_standard.events:
+                        is_implemented = False
+                        for event in events:
+                            if (event.name == standard_event.name
+                                    and current_standard.match_definition(standard_event, event)):
+                                is_implemented = True
+                                break
 
-                    if not is_implemented:
-                        self._log_error(
-                            CompilerError.MissingStandardDefinition(standard,
-                                                                    standard_event.name,
-                                                                    standard_event)
-                        )
+                        if not is_implemented:
+                            self._log_error(
+                                CompilerError.MissingStandardDefinition(standard,
+                                                                        standard_event.name,
+                                                                        standard_event)
+                            )
 
-                # validate optional methods
-                for optional_method in current_standard.optionals:
-                    method_id = optional_method.external_name
-                    is_implemented = False
+                    # validate optional methods
+                    for optional_method in current_standard.optionals:
+                        method_id = optional_method.external_name
+                        is_implemented = False
 
-                    found_methods = self.get_methods_by_display_name(method_id)
-                    for method in found_methods:
-                        if isinstance(method, Method) and current_standard.match_definition(optional_method, method):
-                            is_implemented = True
-                            break
+                        found_methods = self.get_methods_by_display_name(method_id)
+                        for method in found_methods:
+                            if isinstance(method, Method) and current_standard.match_definition(optional_method, method):
+                                is_implemented = True
+                                break
 
-                    if found_methods and not is_implemented:
-                        self._log_error(
-                            CompilerError.MissingStandardDefinition(standard, method_id, optional_method)
-                        )
+                        if found_methods and not is_implemented:
+                            self._log_error(
+                                CompilerError.MissingStandardDefinition(standard, method_id, optional_method)
+                            )
+        except CompilerError:
+            # stops the analyser if fail fast is activated
+            pass
 
     def _check_other_implemented_standards(self):
         other_standards = supportedstandard.neo_standards.copy()

--- a/boa3/internal/analyser/typeanalyser.py
+++ b/boa3/internal/analyser/typeanalyser.py
@@ -47,8 +47,8 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
     :ivar symbols: a dictionary that maps the global symbols.
     """
 
-    def __init__(self, analyser, symbol_table: Dict[str, ISymbol], log: bool = False):
-        super().__init__(analyser.ast_tree, analyser.filename, analyser.root, log=log)
+    def __init__(self, analyser, symbol_table: Dict[str, ISymbol], log: bool = False, fail_fast: bool = True):
+        super().__init__(analyser.ast_tree, analyser.filename, analyser.root, log=log, fail_fast=fail_fast)
         self.type_errors: List[Exception] = []
         self.modules: Dict[str, Module] = {}
         self.symbols: Dict[str, ISymbol] = symbol_table
@@ -58,7 +58,7 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
         self._scope_stack: List[SymbolScope] = []
 
         self._super_calls: List[IBuiltinMethod] = []
-        self.visit(self._tree)
+        self.analyse_visit(self._tree)
 
     def visit(self, node: ast.AST, get_literal_value: bool = False):
         if get_literal_value:

--- a/boa3/internal/cli_commands/compile_command.py
+++ b/boa3/internal/cli_commands/compile_command.py
@@ -36,8 +36,9 @@ class CompileCommand(ICommand):
                                       "as the python file.")
         self.parser.add_argument("-f", "--failfast",
                                  action='store',
-                                 default=True,
-                                 choices=[True, False],
+                                 type=str,  # had parsing issues when setting this to bool
+                                 default=str(True),
+                                 choices=[str(True), str(False)],
                                  help="Stop on first compile error")
 
         self.parser.set_defaults(func=self.execute_command)
@@ -49,7 +50,7 @@ class CompileCommand(ICommand):
         debug: bool = args['debug']
         env: str = args['env']
         output_path: Optional[str] = args['output_path']
-        fail_fast: bool = args['failfast']
+        fail_fast: bool = args['failfast'] == str(True)
 
         if not sc_path.endswith(".py") or not os.path.isfile(sc_path):
             logging.error("Input file is not .py")

--- a/boa3/internal/cli_commands/compile_command.py
+++ b/boa3/internal/cli_commands/compile_command.py
@@ -34,6 +34,11 @@ class CompileCommand(ICommand):
                                  help="Chooses the name and where the compiled files will be generated, "
                                       "if not specified it will be generated on the same directory with the same name "
                                       "as the python file.")
+        self.parser.add_argument("-f", "--failfast",
+                                 action='store',
+                                 default=True,
+                                 choices=[True, False],
+                                 help="Stop on first compile error")
 
         self.parser.set_defaults(func=self.execute_command)
 
@@ -44,6 +49,7 @@ class CompileCommand(ICommand):
         debug: bool = args['debug']
         env: str = args['env']
         output_path: Optional[str] = args['output_path']
+        fail_fast: bool = args['failfast']
 
         if not sc_path.endswith(".py") or not os.path.isfile(sc_path):
             logging.error("Input file is not .py")
@@ -60,7 +66,13 @@ class CompileCommand(ICommand):
             path, filename = os.path.split(os.path.realpath(output_path))
 
         try:
-            Boa3.compile_and_save(sc_path, output_path=output_path, debug=debug, root_folder=project_path, env=env)
+            Boa3.compile_and_save(sc_path,
+                                  output_path=output_path,
+                                  debug=debug,
+                                  root_folder=project_path,
+                                  env=env,
+                                  fail_fast=fail_fast
+                                  )
             logging.info(f"Wrote {filename.replace('.py', '.nef')} to {path}")
         except NotLoadedException as e:
             error_message = e.message

--- a/boa3/internal/cli_commands/compile_command.py
+++ b/boa3/internal/cli_commands/compile_command.py
@@ -34,12 +34,9 @@ class CompileCommand(ICommand):
                                  help="Chooses the name and where the compiled files will be generated, "
                                       "if not specified it will be generated on the same directory with the same name "
                                       "as the python file.")
-        self.parser.add_argument("-f", "--failfast",
-                                 action='store',
-                                 type=str,  # had parsing issues when setting this to bool
-                                 default=str(True),
-                                 choices=[str(True), str(False)],
-                                 help="Stop on first compile error")
+        self.parser.add_argument("--no-failfast",
+                                 action='store_true',
+                                 help="Do not stop on first compile error")
 
         self.parser.set_defaults(func=self.execute_command)
 
@@ -50,7 +47,7 @@ class CompileCommand(ICommand):
         debug: bool = args['debug']
         env: str = args['env']
         output_path: Optional[str] = args['output_path']
-        fail_fast: bool = args['failfast'] == str(True)
+        fail_fast: bool = not args['no_failfast']
 
         if not sc_path.endswith(".py") or not os.path.isfile(sc_path):
             logging.error("Input file is not .py")

--- a/boa3/internal/compiler/codegenerator/codegeneratorvisitor.py
+++ b/boa3/internal/compiler/codegenerator/codegeneratorvisitor.py
@@ -40,7 +40,7 @@ class VisitorCodeGenerator(IAstAnalyser):
     """
 
     def __init__(self, generator: CodeGenerator, filename: str = None, root: str = None):
-        super().__init__(ast.parse(""), filename=filename, root_folder=root, log=True)
+        super().__init__(ast.parse(""), filename=filename, root_folder=root, log=True, fail_fast=True)
 
         self.generator = generator
         self.current_method: Optional[Method] = None

--- a/boa3/internal/compiler/codegenerator/initstatementsvisitor.py
+++ b/boa3/internal/compiler/codegenerator/initstatementsvisitor.py
@@ -16,8 +16,8 @@ class InitStatementsVisitor(IAstAnalyser):
 
     """
 
-    def __init__(self, symbols: Dict[str, ISymbol]):
-        super().__init__(ast.parse(""), log=True)
+    def __init__(self, symbols: Dict[str, ISymbol], fail_fast: bool = True):
+        super().__init__(ast.parse(""), log=True, fail_fast=fail_fast)
         self.symbols = symbols.copy()
 
         self._deploy_instructions: List[ast.AST] = []

--- a/boa3/internal/compiler/compiler.py
+++ b/boa3/internal/compiler/compiler.py
@@ -21,7 +21,8 @@ class Compiler:
         self._analyser: Analyser = None
         self._entry_smart_contract: str = ''
 
-    def compile(self, path: str, root_folder: str = None, env: str = None, log: bool = True) -> bytes:
+    def compile(self, path: str, root_folder: str = None, env: str = None,
+                log: bool = True, fail_fast: bool = True) -> bytes:
         """
         Load a Python file and tries to compile it
 
@@ -29,11 +30,13 @@ class Compiler:
         :param root_folder: the root path of the project
         :param log: if compiler errors should be logged.
         :param env: specific environment id to compile.
+        :param fail_fast: if should stop compilation on first error found.
         :return: the bytecode of the compiled .nef file
         """
-        return self._internal_compile(path, root_folder, env, log).bytecode
+        return self._internal_compile(path, root_folder, env, log, fail_fast).bytecode
 
-    def _internal_compile(self, path: str, root_folder: str = None, env: str = None, log: bool = True) -> CompilerOutput:
+    def _internal_compile(self, path: str, root_folder: str = None, env: str = None,
+                          log: bool = True, fail_fast: bool = True) -> CompilerOutput:
         fullpath = os.path.realpath(path)
         filepath, filename = os.path.split(fullpath)
 
@@ -48,11 +51,11 @@ class Compiler:
         CompilerBuiltin.reset()
         CompiledMetadata.reset()
 
-        self._analyse(fullpath, root_folder, env, log)
+        self._analyse(fullpath, root_folder, env, log, fail_fast)
         return self._compile()
 
     def compile_and_save(self, path: str, output_path: str, root_folder: str = None, log: bool = True,
-                         debug: bool = False, env: str = None):
+                         debug: bool = False, env: str = None, fail_fast: bool = True):
         """
         Save the compiled file and the metadata files
 
@@ -62,19 +65,23 @@ class Compiler:
         :param log: if compiler errors should be logged.
         :param debug: if nefdbgnfo file should be generated.
         :param env: specific environment id to compile.
+        :param fail_fast: if should stop compilation on first error found.
         """
-        self.result = self._internal_compile(path, root_folder, env, log)
+        self.result = self._internal_compile(path, root_folder, env, log, fail_fast)
         self._save(output_path, debug)
 
-    def _analyse(self, path: str, root_folder: str = None, env: str = None, log: bool = True):
+    def _analyse(self, path: str, root_folder: str = None, env: str = None,
+                 log: bool = True, fail_fast: bool = True):
         """
         Load a Python file and analyses its syntax
 
         :param path: the path of the Python file to compile
         :param root_folder: the root path of the project
         :param log: if compiler errors should be logged.
+        :param fail_fast: if should stop compilation on first error found.
         """
-        self._analyser = Analyser.analyse(path, log=log, root=root_folder, env=env, compiler_entry=True)
+        self._analyser = Analyser.analyse(path, log=log, fail_fast=fail_fast,
+                                          root=root_folder, env=env, compiler_entry=True)
 
     def _compile(self) -> CompilerOutput:
         """

--- a/boa3_test/test_sc/import_test/ImportFailInnerNotExistingMethod.py
+++ b/boa3_test/test_sc/import_test/ImportFailInnerNotExistingMethod.py
@@ -1,0 +1,5 @@
+from boa3_test.test_sc.import_test.ImportNotExistingMethod import get_token_json
+
+
+def call_imported() -> dict:
+    return get_token_json()

--- a/boa3_test/tests/boa_test.py
+++ b/boa3_test/tests/boa_test.py
@@ -95,14 +95,14 @@ class BoaTest(TestCase):
             raise AssertionError('{0} not logged'.format(expected_logged_exception.__name__))
         return output, expected_logged[0].message
 
-    def _get_compiler_log_data(self, expected_logged_exception, path):
+    def _get_compiler_log_data(self, expected_logged_exception, path, fail_fast=False):
         output = None
 
         with _LOGGING_LOCK:
             with self.assertLogs() as log:
                 from boa3.internal.exception.NotLoadedException import NotLoadedException
                 try:
-                    output = self.compile(path)
+                    output = self.compile(path, fail_fast=fail_fast)
                 except NotLoadedException:
                     # when an compiler error is logged this exception is raised.
                     pass
@@ -110,6 +110,38 @@ class BoaTest(TestCase):
             expected_logged = [exception for exception in log.records
                                if isinstance(exception.msg, expected_logged_exception)]
         return output, expected_logged
+
+    def get_all_compile_log_data(self, path: str, *,
+                                 get_errors: bool = True,
+                                 get_warnings: bool = False,
+                                 fail_fast: bool = False) -> Tuple[list, list]:
+        from boa3.internal.exception.CompilerWarning import CompilerWarning
+
+        instance_logs = []
+        if get_errors:
+            instance_logs.append(CompilerError)
+        if get_warnings:
+            instance_logs.append(CompilerWarning)
+
+        errors = []
+        warnings = []
+        _, expected_logged = self._get_compiler_log_data(*instance_logs, path, fail_fast=fail_fast)
+
+        if not get_errors:
+            if not get_warnings:
+                return errors, warnings
+            warnings = [log.msg for log in expected_logged]
+        else:
+            if get_warnings:
+                for log in expected_logged:
+                    if isinstance(log.msg, CompilerError):
+                        errors.append(log.msg)
+                    elif isinstance(log.msg, CompilerWarning):
+                        warnings.append(log.msg)
+            else:
+                errors = [log.msg for log in expected_logged]
+
+        return errors, warnings
 
     def assertStartsWith(self, first: Any, second: Any):
         if not (hasattr(first, 'startswith') and first.startswith(second)):
@@ -213,11 +245,11 @@ class BoaTest(TestCase):
 
         return contract_path, contract_path
 
-    def compile(self, path: str, root_folder: str = None) -> bytes:
+    def compile(self, path: str, root_folder: str = None, fail_fast: bool = False) -> bytes:
         from boa3.boa3 import Boa3
 
         with _COMPILER_LOCK:
-            result = Boa3.compile(path, root_folder=root_folder)
+            result = Boa3.compile(path, root_folder=root_folder, fail_fast=fail_fast)
 
         return result
 

--- a/boa3_test/tests/cli_tests/cli_test.py
+++ b/boa3_test/tests/cli_tests/cli_test.py
@@ -27,10 +27,14 @@ class BoaCliTest(BoaTest, abc.ABC):
         LOCK.release()
         LOG_LOCK.release()
 
-    def _get_cli_log(self):
+    def get_cli_log(self, get_exit_code: bool = False):
+        if get_exit_code:
+            return self._assert_cli_raises(SystemExit, get_log=True)
         return self._run_cli_log()
 
-    def _get_cli_output(self) -> Tuple[str, str]:
+    def get_cli_output(self, get_exit_code: bool = False):
+        if get_exit_code:
+            return self._assert_cli_raises(SystemExit, get_log=False)
         return self._run_cli()
 
     def _assert_cli_raises(self, exception, get_log=False):

--- a/boa3_test/tests/cli_tests/test_cli.py
+++ b/boa3_test/tests/cli_tests/test_cli.py
@@ -8,7 +8,7 @@ class TestCli(BoaCliTest):
 
     @neo3_boa_cli('-h')
     def test_cli_help(self):
-        cli_output, _, system_exit = self._assert_cli_raises(SystemExit)
+        cli_output, _, system_exit = self.get_cli_output(get_exit_code=True)
 
         self.assertEqual(self.EXIT_CODE_SUCCESS, system_exit.exception.code)
         self.assertIn('usage: neo3-boa [-h] [-v] {compile}', cli_output)
@@ -17,14 +17,14 @@ class TestCli(BoaCliTest):
 
     @neo3_boa_cli('--version')
     def test_cli_version(self):
-        cli_output, _, system_exit = self._assert_cli_raises(SystemExit)
+        cli_output, _, system_exit = self.get_cli_output(get_exit_code=True)
 
         self.assertEqual(self.EXIT_CODE_SUCCESS, system_exit.exception.code)
         self.assertIn(f'neo3-boa {constants.BOA_VERSION}', cli_output)
 
     @neo3_boa_cli('build')
     def test_cli_wrong_syntax(self):
-        _, cli_output, system_exit = self._assert_cli_raises(SystemExit)
+        _, cli_output, system_exit = self.get_cli_output(get_exit_code=True)
 
         self.assertEqual(self.EXIT_CODE_CLI_SYNTAX_ERROR, system_exit.exception.code)
         self.assertIn("invalid choice: 'build'", cli_output)

--- a/boa3_test/tests/cli_tests/test_compile.py
+++ b/boa3_test/tests/cli_tests/test_compile.py
@@ -12,10 +12,13 @@ class TestCliCompile(BoaCliTest):
 
     @neo3_boa_cli('compile', '-h')
     def test_cli_compile_help(self):
-        cli_output, _, system_exit = self._assert_cli_raises(SystemExit)
+        cli_output, _, system_exit = self.get_cli_output(get_exit_code=True)
 
         self.assertEqual(self.EXIT_CODE_SUCCESS, system_exit.exception.code)
-        self.assertIn('usage: neo3-boa compile [-h] [-db] [--project-path PROJECT_PATH] [-e ENV] [-o NEF_OUTPUT] input',
+        self.assertIn('usage: neo3-boa compile [-h] [-db] '
+                      '[--project-path PROJECT_PATH] [-e ENV] '
+                      '[-o NEF_OUTPUT] [-f {True,False}] '
+                      'input',
                       cli_output)
 
     @neo3_boa_cli('compile', get_path_from_boa3_test('test_sc', 'boa_built_in_methods_test', 'Env.py'))
@@ -32,7 +35,7 @@ class TestCliCompile(BoaCliTest):
         if os.path.isfile(debug_info_path):
             os.remove(debug_info_path)
 
-        logs = self._get_cli_log()
+        logs = self.get_cli_log()
 
         self.assertTrue(any(f'neo3-boa v{constants.BOA_VERSION}\tPython {constants.SYS_VERSION}' in log for log in logs.output))
         self.assertTrue(any('Started compiling' in log for log in logs.output))
@@ -60,7 +63,7 @@ class TestCliCompile(BoaCliTest):
         if os.path.isfile(debug_info_path):
             os.remove(debug_info_path)
 
-        logs = self._get_cli_log()
+        logs = self.get_cli_log()
 
         self.assertTrue(any(f'neo3-boa v{constants.BOA_VERSION}\tPython {constants.SYS_VERSION}' in log for log in logs.output))
         self.assertTrue(any('Started compiling' in log for log in logs.output))
@@ -90,7 +93,7 @@ class TestCliCompile(BoaCliTest):
         if os.path.isfile(manifest_path):
             os.remove(manifest_path)
 
-        logs = self._get_cli_log()
+        logs = self.get_cli_log()
 
         self.assertTrue(any(f'neo3-boa v{constants.BOA_VERSION}\tPython {constants.SYS_VERSION}' in log for log in logs.output))
         self.assertTrue(any('Started compiling' in log for log in logs.output))
@@ -112,7 +115,7 @@ class TestCliCompile(BoaCliTest):
         )
         nef_generated = nef_path.split(constants.PATH_SEPARATOR)[-1]
 
-        logs = self._get_cli_log()
+        logs = self.get_cli_log()
 
         self.assertTrue(any(f'neo3-boa v{constants.BOA_VERSION}\tPython {constants.SYS_VERSION}' in log for log in logs.output))
         self.assertTrue(any('Started compiling' in log for log in logs.output))
@@ -131,20 +134,42 @@ class TestCliCompile(BoaCliTest):
 
     @neo3_boa_cli('compile', 'wrong_file')
     def test_cli_compile_wrong_file(self):
-        logs, system_exit = self._assert_cli_raises(SystemExit, get_log=True)
+        logs, system_exit = self.get_cli_log(get_exit_code=True)
 
         self.assertEqual(self.EXIT_CODE_ERROR, system_exit.exception.code)
         self.assertTrue(any('Input file is not .py' in log in log for log in logs.output))
 
     @neo3_boa_cli('compile', get_path_from_boa3_test('test_sc', 'interop_test', 'storage', 'StoragePutStrKeyStrValue.py'))
     def test_cli_compile_invalid_smart_contract(self):
-        logs = self._get_cli_log()
+        logs = self.get_cli_log()
         self.assertTrue(any('Could not compile' in log in log for log in logs.output))
 
     @neo3_boa_cli('compile', get_path_from_boa3_test('test_sc', 'boa_built_in_methods_test', 'Env.py'),
                   '-o', 'wrong_output_path')
     def test_cli_compile_wrong_output_path(self):
-        logs, system_exit = self._assert_cli_raises(SystemExit, get_log=True)
+        logs, system_exit = self.get_cli_log(get_exit_code=True)
 
         self.assertEqual(self.EXIT_CODE_ERROR, system_exit.exception.code)
         self.assertTrue(any('Output path file extension is not .nef' in log in log for log in logs.output))
+
+    @neo3_boa_cli('compile', get_path_from_boa3_test('test_sc', 'import_test', 'ImportFailInnerNotExistingMethod.py'),
+                  '-f', 'True')
+    def test_cli_compile_fail_fast_true(self):
+        logs = self.get_cli_log()
+
+        errors_logged = [log for log in logs.output if log.startswith('ERROR')]
+        # with fail fast, only two errors are logged
+        # 1. the actual compiler error
+        # 2. the cli error informing that the compilation failed
+        self.assertEqual(2, len(errors_logged))
+        self.assertIn('Could not compile', errors_logged[-1])
+
+    @neo3_boa_cli('compile', get_path_from_boa3_test('test_sc', 'import_test', 'ImportFailInnerNotExistingMethod.py'),
+                  '-f', 'False')
+    def test_cli_compile_fail_fast_false(self):
+        logs = self.get_cli_log()
+
+        errors_logged = [log for log in logs.output if log.startswith('ERROR')]
+        # the given contract has more than one error, so it should log more than 2 errors with fail fast disabled
+        self.assertGreater(len(errors_logged), 2)
+        self.assertIn('Could not compile', errors_logged[-1])

--- a/boa3_test/tests/cli_tests/test_compile.py
+++ b/boa3_test/tests/cli_tests/test_compile.py
@@ -17,7 +17,7 @@ class TestCliCompile(BoaCliTest):
         self.assertEqual(self.EXIT_CODE_SUCCESS, system_exit.exception.code)
         self.assertIn('usage: neo3-boa compile [-h] [-db] '
                       '[--project-path PROJECT_PATH] [-e ENV] '
-                      '[-o NEF_OUTPUT] [-f {True,False}] '
+                      '[-o NEF_OUTPUT] [--no-failfast] '
                       'input',
                       cli_output)
 
@@ -152,8 +152,7 @@ class TestCliCompile(BoaCliTest):
         self.assertEqual(self.EXIT_CODE_ERROR, system_exit.exception.code)
         self.assertTrue(any('Output path file extension is not .nef' in log in log for log in logs.output))
 
-    @neo3_boa_cli('compile', get_path_from_boa3_test('test_sc', 'import_test', 'ImportFailInnerNotExistingMethod.py'),
-                  '-f', 'True')
+    @neo3_boa_cli('compile', get_path_from_boa3_test('test_sc', 'import_test', 'ImportFailInnerNotExistingMethod.py'))
     def test_cli_compile_fail_fast_true(self):
         logs = self.get_cli_log()
 
@@ -165,7 +164,7 @@ class TestCliCompile(BoaCliTest):
         self.assertIn('Could not compile', errors_logged[-1])
 
     @neo3_boa_cli('compile', get_path_from_boa3_test('test_sc', 'import_test', 'ImportFailInnerNotExistingMethod.py'),
-                  '-f', 'False')
+                  '--no-failfast')
     def test_cli_compile_fail_fast_false(self):
         logs = self.get_cli_log()
 

--- a/boa3_test/tests/compiler_tests/test_logger.py
+++ b/boa3_test/tests/compiler_tests/test_logger.py
@@ -1,0 +1,13 @@
+from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to avoid circular imports
+
+
+class TestImport(BoaTest):
+    def test_log_multiple_errors_on_import(self):
+        path = self.get_contract_path('test_sc/import_test', 'ImportFailInnerNotExistingMethod.py')
+        errors, _ = self.get_all_compile_log_data(path, fail_fast=False)
+        self.assertGreater(len(errors), 1)
+
+    def test_log_fail_fast_error_on_import(self):
+        path = self.get_contract_path('test_sc/import_test', 'ImportFailInnerNotExistingMethod.py')
+        errors, _ = self.get_all_compile_log_data(path, fail_fast=True)
+        self.assertEqual(1, len(errors))


### PR DESCRIPTION
**Summary or solution description**
Changed to stop the compilation on the first error found.
The previous behavior of trying to get all errors weren't removed to ensure the correct behavior on unit tests that expect a specific compiler error.
Added a flag on cli to disable fail fast. It's true by default.

**How to Reproduce**
```python
from boa3.boa3 import Boa3

Boa3.compile('path/to/smart/contract.py', fail_fast=True)
Boa3.compile_and_save('path/to/smart/contract.py')  # fail fast is True by default
Boa3.compile_and_save('path/to/smart/contract.py', fail_fast=False)
```

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/cae5c9ad1c2eb07c1be9e891358eaf3c318e9710/boa3_test/tests/compiler_tests/test_logger.py#L5-L13

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7+

**(Optional) Additional context**
Waiting #1083 to add fail fast cli tests