### PR TITLE
"Info" log messages to be shown depending on different log levels

### DIFF
--- a/boa3/boa3.py
+++ b/boa3/boa3.py
@@ -11,7 +11,8 @@ class Boa3:
     """
 
     @staticmethod
-    def compile(path: str, root_folder: str = None, env: str = None, fail_fast: bool = True) -> bytes:
+    def compile(path: str, root_folder: str = None, log_level: str = None,
+                env: str = None, fail_fast: bool = True) -> bytes:
         """
         Load a Python file to be compiled but don't write the result into a file
 
@@ -24,7 +25,7 @@ class Boa3:
         if not path.endswith('.py'):
             raise InvalidPathException(path)
 
-        return Compiler().compile(path, root_folder, env, fail_fast=fail_fast)
+        return Compiler().compile(path, root_folder, env, log_level=log_level, fail_fast=fail_fast)
 
     @staticmethod
     def compile_and_save(path: str, output_path: str = None, root_folder: str = None,

--- a/boa3/boa3.py
+++ b/boa3/boa3.py
@@ -27,7 +27,8 @@ class Boa3:
         return Compiler().compile(path, root_folder, env, fail_fast=fail_fast)
 
     @staticmethod
-    def compile_and_save(path: str, output_path: str = None, root_folder: str = None, show_errors: bool = True,
+    def compile_and_save(path: str, output_path: str = None, root_folder: str = None,
+                         show_errors: bool = True, log_level: str = None,
                          debug: bool = False, env: str = None, fail_fast: bool = True):
         """
         Load a Python file to be compiled and save the result into the files.
@@ -50,4 +51,4 @@ class Boa3:
         elif not output_path.endswith('.nef'):
             raise InvalidPathException(output_path)
 
-        Compiler().compile_and_save(path, output_path, root_folder, show_errors, debug, env, fail_fast)
+        Compiler().compile_and_save(path, output_path, root_folder, show_errors, log_level, debug, env, fail_fast)

--- a/boa3/internal/cli_commands/compile_command.py
+++ b/boa3/internal/cli_commands/compile_command.py
@@ -37,6 +37,9 @@ class CompileCommand(ICommand):
         self.parser.add_argument("--no-failfast",
                                  action='store_true',
                                  help="Do not stop on first compile error")
+        self.parser.add_argument("--log-level",
+                                 type=str,
+                                 help="Log output level")
 
         self.parser.set_defaults(func=self.execute_command)
 
@@ -48,6 +51,7 @@ class CompileCommand(ICommand):
         env: str = args['env']
         output_path: Optional[str] = args['output_path']
         fail_fast: bool = not args['no_failfast']
+        log_level = args['log_level']
 
         if not sc_path.endswith(".py") or not os.path.isfile(sc_path):
             logging.error("Input file is not .py")
@@ -69,7 +73,9 @@ class CompileCommand(ICommand):
                                   debug=debug,
                                   root_folder=project_path,
                                   env=env,
-                                  fail_fast=fail_fast
+                                  fail_fast=fail_fast,
+                                  show_errors=True,
+                                  log_level=log_level
                                   )
             logging.info(f"Wrote {filename.replace('.py', '.nef')} to {path}")
         except NotLoadedException as e:

--- a/boa3/internal/compiler/compiler.py
+++ b/boa3/internal/compiler/compiler.py
@@ -45,6 +45,9 @@ class Compiler:
         filepath, filename = os.path.split(fullpath)
 
         logger = logging.getLogger(constants.BOA_LOGGING_NAME)
+        if log_level:
+            # raise error if log level is invalid
+            logger.setLevel(log_level)
 
         logger.setLevel(logging.INFO)  # just to show initial message
         logger.info(f'neo3-boa v{constants.BOA_VERSION}\tPython {constants.SYS_VERSION}')

--- a/boa3/internal/compiler/compiler.py
+++ b/boa3/internal/compiler/compiler.py
@@ -22,7 +22,8 @@ class Compiler:
         self._entry_smart_contract: str = ''
 
     def compile(self, path: str, root_folder: str = None, env: str = None,
-                log: bool = True, fail_fast: bool = True) -> bytes:
+                log: bool = True, log_level: str = None,
+                fail_fast: bool = True) -> bytes:
         """
         Load a Python file and tries to compile it
 
@@ -33,17 +34,23 @@ class Compiler:
         :param fail_fast: if should stop compilation on first error found.
         :return: the bytecode of the compiled .nef file
         """
-        return self._internal_compile(path, root_folder, env, log, fail_fast).bytecode
+        result = self._internal_compile(path, root_folder, env, log, log_level, fail_fast).bytecode
+        self._restore_log_level()
+        return result
 
     def _internal_compile(self, path: str, root_folder: str = None, env: str = None,
-                          log: bool = True, fail_fast: bool = True) -> CompilerOutput:
+                          log: bool = True, log_level: str = None,
+                          fail_fast: bool = True) -> CompilerOutput:
         fullpath = os.path.realpath(path)
         filepath, filename = os.path.split(fullpath)
 
         logger = logging.getLogger(constants.BOA_LOGGING_NAME)
 
+        logger.setLevel(logging.INFO)  # just to show initial message
         logger.info(f'neo3-boa v{constants.BOA_VERSION}\tPython {constants.SYS_VERSION}')
         logger.info(f'Started compiling\t{filename}')
+        self._change_log_level(log_level)
+
         self._entry_smart_contract = os.path.splitext(filename)[0]
 
         from boa3.internal.compiler.compiledmetadata import CompiledMetadata
@@ -54,7 +61,8 @@ class Compiler:
         self._analyse(fullpath, root_folder, env, log, fail_fast)
         return self._compile()
 
-    def compile_and_save(self, path: str, output_path: str, root_folder: str = None, log: bool = True,
+    def compile_and_save(self, path: str, output_path: str, root_folder: str = None,
+                         log: bool = True, log_level: str = None,
                          debug: bool = False, env: str = None, fail_fast: bool = True):
         """
         Save the compiled file and the metadata files
@@ -67,8 +75,24 @@ class Compiler:
         :param env: specific environment id to compile.
         :param fail_fast: if should stop compilation on first error found.
         """
-        self.result = self._internal_compile(path, root_folder, env, log, fail_fast)
+        self.result = self._internal_compile(path, root_folder, env, log, log_level, fail_fast)
         self._save(output_path, debug)
+        self._restore_log_level()
+
+    def _change_log_level(self, log_level: str = None):
+        if not log_level:
+            log_level = logging.ERROR
+
+        logger = logging.getLogger(constants.BOA_LOGGING_NAME)
+        self._previous_logger_level = logger.level
+
+        logger.setLevel(log_level)
+
+    def _restore_log_level(self):
+        if hasattr(self, '_previous_logger_level'):
+            logger = logging.getLogger(constants.BOA_LOGGING_NAME)
+            logger.setLevel(self._previous_logger_level)
+            del self._previous_logger_level
 
     def _analyse(self, path: str, root_folder: str = None, env: str = None,
                  log: bool = True, fail_fast: bool = True):

--- a/boa3_test/tests/boa_test.py
+++ b/boa3_test/tests/boa_test.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import threading
 from typing import Any, Dict, Optional, Tuple, Union
@@ -249,7 +250,9 @@ class BoaTest(TestCase):
         from boa3.boa3 import Boa3
 
         with _COMPILER_LOCK:
-            result = Boa3.compile(path, root_folder=root_folder, fail_fast=fail_fast)
+            result = Boa3.compile(path, root_folder=root_folder, fail_fast=fail_fast,
+                                  log_level=logging.getLevelName(logging.INFO)
+                                  )
 
         return result
 
@@ -281,7 +284,9 @@ class BoaTest(TestCase):
         from boa3.internal.neo.contracts.neffile import NefFile
         with _COMPILER_LOCK:
             Boa3.compile_and_save(path, output_path=nef_output, root_folder=root_folder,
-                                  env=env, show_errors=log, debug=debug)
+                                  env=env, debug=debug,
+                                  show_errors=log, log_level=logging.getLevelName(logging.INFO)
+                                  )
 
         get_raw_nef = kwargs['get_raw_nef'] if 'get_raw_nef' in kwargs else False
         change_manifest_name = kwargs['change_manifest_name'] if 'change_manifest_name' in kwargs else False

--- a/boa3_test/tests/cli_tests/test_compile.py
+++ b/boa3_test/tests/cli_tests/test_compile.py
@@ -204,3 +204,11 @@ class TestCliCompile(BoaCliTest):
         # 3. cli message when compilation is successful
         self.assertGreater(len(info_logged), 3)
         self.assertIn(f'Wrote {file_name}.nef', info_logged[-1])
+
+    @neo3_boa_cli('compile', get_path_from_boa3_test('test_sc', 'arithmetic_test', 'Addition.py'),
+                  '--log-level', 'FOO')
+    def test_cli_compile_log_level_invalid(self):
+        logs = self.get_cli_log()
+
+        self.assertEqual(1, len(logs.output))
+        self.assertIn("Unknown level: 'FOO'", logs.output[-1])

--- a/boa3_test/tests/cli_tests/test_compile.py
+++ b/boa3_test/tests/cli_tests/test_compile.py
@@ -18,6 +18,7 @@ class TestCliCompile(BoaCliTest):
         self.assertIn('usage: neo3-boa compile [-h] [-db] '
                       '[--project-path PROJECT_PATH] [-e ENV] '
                       '[-o NEF_OUTPUT] [--no-failfast] '
+                      '[--log-level LOG_LEVEL] '
                       'input',
                       cli_output)
 
@@ -37,9 +38,10 @@ class TestCliCompile(BoaCliTest):
 
         logs = self.get_cli_log()
 
-        self.assertTrue(any(f'neo3-boa v{constants.BOA_VERSION}\tPython {constants.SYS_VERSION}' in log for log in logs.output))
-        self.assertTrue(any('Started compiling' in log for log in logs.output))
-        self.assertTrue(any(f'Wrote {sc_nef_name} to ' in log in log for log in logs.output),
+        self.assertEqual(3, len(logs.output))
+        self.assertTrue(f'neo3-boa v{constants.BOA_VERSION}\tPython {constants.SYS_VERSION}' in logs.output[0])
+        self.assertTrue('Started compiling' in logs.output[1])
+        self.assertTrue(f'Wrote {sc_nef_name} to ' in logs.output[-1],
                         msg=f'Something went wrong when compiling {sc_nef_name}')
         self.assertTrue(os.path.isfile(nef_path),
                         msg=f'{nef_path} not found')
@@ -65,9 +67,10 @@ class TestCliCompile(BoaCliTest):
 
         logs = self.get_cli_log()
 
-        self.assertTrue(any(f'neo3-boa v{constants.BOA_VERSION}\tPython {constants.SYS_VERSION}' in log for log in logs.output))
-        self.assertTrue(any('Started compiling' in log for log in logs.output))
-        self.assertTrue(any(f'Wrote {sc_nef_name} to ' in log in log for log in logs.output),
+        self.assertEqual(3, len(logs.output))
+        self.assertTrue(f'neo3-boa v{constants.BOA_VERSION}\tPython {constants.SYS_VERSION}' in logs.output[0])
+        self.assertTrue('Started compiling' in logs.output[1])
+        self.assertTrue(f'Wrote {sc_nef_name} to ' in logs.output[-1],
                         msg=f'Something went wrong when compiling {sc_nef_name}')
         self.assertTrue(os.path.isfile(nef_path),
                         msg=f'{nef_path} not found')
@@ -95,9 +98,10 @@ class TestCliCompile(BoaCliTest):
 
         logs = self.get_cli_log()
 
-        self.assertTrue(any(f'neo3-boa v{constants.BOA_VERSION}\tPython {constants.SYS_VERSION}' in log for log in logs.output))
-        self.assertTrue(any('Started compiling' in log for log in logs.output))
-        self.assertTrue(any(f'Wrote {sc_nef_name} to ' in log in log for log in logs.output),
+        self.assertEqual(3, len(logs.output))
+        self.assertTrue(f'neo3-boa v{constants.BOA_VERSION}\tPython {constants.SYS_VERSION}' in logs.output[0])
+        self.assertTrue('Started compiling' in logs.output[1])
+        self.assertTrue(f'Wrote {sc_nef_name} to ' in logs.output[-1],
                         msg=f'Something went wrong when compiling {sc_nef_name}')
         self.assertTrue(os.path.isfile(nef_path),
                         msg=f'{nef_path} not found')
@@ -117,9 +121,10 @@ class TestCliCompile(BoaCliTest):
 
         logs = self.get_cli_log()
 
-        self.assertTrue(any(f'neo3-boa v{constants.BOA_VERSION}\tPython {constants.SYS_VERSION}' in log for log in logs.output))
-        self.assertTrue(any('Started compiling' in log for log in logs.output))
-        self.assertTrue(any(f'Wrote {nef_generated} to ' in log in log for log in logs.output),
+        self.assertEqual(3, len(logs.output))
+        self.assertTrue(f'neo3-boa v{constants.BOA_VERSION}\tPython {constants.SYS_VERSION}' in logs.output[0])
+        self.assertTrue('Started compiling' in logs.output[1])
+        self.assertTrue(f'Wrote {nef_generated} to ' in logs.output[-1],
                         msg=f'Something went wrong when compiling {nef_generated}')
 
         runner = NeoTestRunner(runner_id=self.method_name())
@@ -137,12 +142,12 @@ class TestCliCompile(BoaCliTest):
         logs, system_exit = self.get_cli_log(get_exit_code=True)
 
         self.assertEqual(self.EXIT_CODE_ERROR, system_exit.exception.code)
-        self.assertTrue(any('Input file is not .py' in log in log for log in logs.output))
+        self.assertTrue('Input file is not .py' in logs.output[-1])
 
     @neo3_boa_cli('compile', get_path_from_boa3_test('test_sc', 'interop_test', 'storage', 'StoragePutStrKeyStrValue.py'))
     def test_cli_compile_invalid_smart_contract(self):
         logs = self.get_cli_log()
-        self.assertTrue(any('Could not compile' in log in log for log in logs.output))
+        self.assertTrue('Could not compile' in logs.output[-1])
 
     @neo3_boa_cli('compile', get_path_from_boa3_test('test_sc', 'boa_built_in_methods_test', 'Env.py'),
                   '-o', 'wrong_output_path')
@@ -150,7 +155,7 @@ class TestCliCompile(BoaCliTest):
         logs, system_exit = self.get_cli_log(get_exit_code=True)
 
         self.assertEqual(self.EXIT_CODE_ERROR, system_exit.exception.code)
-        self.assertTrue(any('Output path file extension is not .nef' in log in log for log in logs.output))
+        self.assertTrue('Output path file extension is not .nef' in logs.output[-1])
 
     @neo3_boa_cli('compile', get_path_from_boa3_test('test_sc', 'import_test', 'ImportFailInnerNotExistingMethod.py'))
     def test_cli_compile_fail_fast_true(self):
@@ -172,3 +177,30 @@ class TestCliCompile(BoaCliTest):
         # the given contract has more than one error, so it should log more than 2 errors with fail fast disabled
         self.assertGreater(len(errors_logged), 2)
         self.assertIn('Could not compile', errors_logged[-1])
+
+    @neo3_boa_cli('compile', get_path_from_boa3_test('test_sc', 'arithmetic_test', 'Addition.py'))
+    def test_cli_compile_log_level_default(self):
+        file_name = 'Addition'
+        logs = self.get_cli_log()
+
+        info_logged = [log for log in logs.output if log.startswith('INFO')]
+        # three info logs are logged regardless of the log level
+        # 1. neo3-boa and python version info
+        # 2. compilation start info
+        # 3. cli message when compilation is successful
+        self.assertEqual(3, len(info_logged))
+        self.assertIn(f'Wrote {file_name}.nef', info_logged[-1])
+
+    @neo3_boa_cli('compile', get_path_from_boa3_test('test_sc', 'arithmetic_test', 'Addition.py'),
+                  '--log-level', 'INFO')
+    def test_cli_compile_log_level_info(self):
+        file_name = 'Addition'
+        logs = self.get_cli_log()
+
+        info_logged = [log for log in logs.output if log.startswith('INFO')]
+        # three info logs are logged regardless of the log level
+        # 1. neo3-boa and python version info
+        # 2. compilation start info
+        # 3. cli message when compilation is successful
+        self.assertGreater(len(info_logged), 3)
+        self.assertIn(f'Wrote {file_name}.nef', info_logged[-1])


### PR DESCRIPTION
**Summary or solution description**
Included `log_level` argument to `compile` and `compile_and_save` and `--log-level` flag to cli `compile` command to change which message are shown on log. Default log level is set to `ERROR`

**How to Reproduce**
```python
from boa3.boa3 import Boa3

Boa3.compile('path/to/smart/contract.py', log_level='INFO')
Boa3.compile_and_save('path/to/smart/contract.py')  # log level is set to ERROR by default
Boa3.compile_and_save('path/to/smart/contract.py', fail_fast='WARN')
```
```shell
 neo3-boa compile path/to/smart/contract.py --log-level INFO
```

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/cae5c9ad1c2eb07c1be9e891358eaf3c318e9710/boa3_test/tests/compiler_tests/test_logger.py#L5-L13

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7+
