### PR TITLE
String slice is incorrectly generated

### DIFF
--- a/boa3/internal/compiler/codegenerator/codegenerator.py
+++ b/boa3/internal/compiler/codegenerator/codegenerator.py
@@ -1910,6 +1910,11 @@ class CodeGenerator:
                 self.convert_literal(index)
                 self.convert_get_item(index_inserted_internally=True)
 
+                symbol_type = class_type.variables[symbol_id].type
+                if self._stack[-1] != symbol_type:
+                    self._stack_pop()
+                    self._stack_append(symbol_type)
+
             return index
 
     def convert_operation(self, operation: IOperation, is_internal: bool = False):

--- a/boa3_test/test_sc/bytes_test/BytesClassVariableSlicing.py
+++ b/boa3_test/test_sc/bytes_test/BytesClassVariableSlicing.py
@@ -1,0 +1,9 @@
+from boa3.builtin.compile_time import public
+
+
+class Example:
+    bytes_value = b'unit test'
+
+@public
+def main(start: int, end: int) -> bytes:
+    return Example.bytes_value[start:end]

--- a/boa3_test/test_sc/bytes_test/BytesInstanceVariableSlicing.py
+++ b/boa3_test/test_sc/bytes_test/BytesInstanceVariableSlicing.py
@@ -1,0 +1,12 @@
+from boa3.builtin.compile_time import public
+
+
+class Example:
+    def __init__(self, bytes_value: bytes):
+        self.bytes_value = bytes_value
+
+
+@public
+def main(bytes_value: bytes, start: int, end: int) -> bytes:
+    obj = Example(bytes_value)
+    return obj.bytes_value[start:end]

--- a/boa3_test/test_sc/bytes_test/BytesPropertySlicing.py
+++ b/boa3_test/test_sc/bytes_test/BytesPropertySlicing.py
@@ -1,0 +1,16 @@
+from boa3.builtin.compile_time import public
+
+
+class Example:
+    def __init__(self, bytes_value: bytes):
+        self._bytes_value = bytes_value
+
+    @property
+    def bytes_prop(self) -> bytes:
+        return self._bytes_value
+
+
+@public
+def main(bytes_value: bytes, start: int, end: int) -> bytes:
+    obj = Example(bytes_value)
+    return obj.bytes_prop[start:end]

--- a/boa3_test/test_sc/string_test/StringClassVariableSlicing.py
+++ b/boa3_test/test_sc/string_test/StringClassVariableSlicing.py
@@ -1,0 +1,9 @@
+from boa3.builtin.compile_time import public
+
+
+class Example:
+    string = 'unit test'
+
+@public
+def main(start: int, end: int) -> str:
+    return Example.string[start:end]

--- a/boa3_test/test_sc/string_test/StringInstanceVariableSlicing.py
+++ b/boa3_test/test_sc/string_test/StringInstanceVariableSlicing.py
@@ -1,0 +1,12 @@
+from boa3.builtin.compile_time import public
+
+
+class Example:
+    def __init__(self, string: str):
+        self.string = string
+
+
+@public
+def main(string: str, start: int, end: int) -> str:
+    obj = Example(string)
+    return obj.string[start:end]

--- a/boa3_test/test_sc/string_test/StringPropertySlicing.py
+++ b/boa3_test/test_sc/string_test/StringPropertySlicing.py
@@ -1,0 +1,16 @@
+from boa3.builtin.compile_time import public
+
+
+class Example:
+    def __init__(self, string_: str):
+        self._string = string_
+
+    @property
+    def string_prop(self) -> str:
+        return self._string
+
+
+@public
+def main(string: str, start: int, end: int) -> str:
+    obj = Example(string)
+    return obj.string_prop[start:end]

--- a/boa3_test/tests/compiler_tests/test_bytes.py
+++ b/boa3_test/tests/compiler_tests/test_bytes.py
@@ -1641,3 +1641,90 @@ class TestBytes(BoaTest):
     def test_bytes_index_mismatched_type(self):
         path = self.get_contract_path('IndexBytesMismatchedType.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+
+    def test_bytes_property_slicing(self):
+        path, _ = self.get_deploy_file_paths('BytesPropertySlicing.py')
+        runner = NeoTestRunner(runner_id=self.method_name())
+
+        invokes = []
+        expected_results = []
+
+        bytes_value = b'unit test'
+        start = 0
+        end = len(bytes_value)
+        invokes.append(runner.call_contract(path, 'main', bytes_value, start, end, expected_result_type=bytes))
+        expected_results.append(bytes_value[start:end])
+
+        start = 2
+        end = len(bytes_value) - 1
+        invokes.append(runner.call_contract(path, 'main', bytes_value, start, end, expected_result_type=bytes))
+        expected_results.append(bytes_value[start:end])
+
+        start = len(bytes_value)
+        end = 0
+        invokes.append(runner.call_contract(path, 'main', bytes_value, start, end, expected_result_type=bytes))
+        expected_results.append(bytes_value[start:end])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result, msg=x)
+
+    def test_bytes_instance_variable_slicing(self):
+        path, _ = self.get_deploy_file_paths('BytesInstanceVariableSlicing.py')
+        runner = NeoTestRunner(runner_id=self.method_name())
+
+        invokes = []
+        expected_results = []
+
+        bytes_value = b'unit test'
+        start = 0
+        end = len(bytes_value)
+        invokes.append(runner.call_contract(path, 'main', bytes_value, start, end, expected_result_type=bytes))
+        expected_results.append(bytes_value[start:end])
+
+        start = 2
+        end = len(bytes_value) - 1
+        invokes.append(runner.call_contract(path, 'main', bytes_value, start, end, expected_result_type=bytes))
+        expected_results.append(bytes_value[start:end])
+
+        start = len(bytes_value)
+        end = 0
+        invokes.append(runner.call_contract(path, 'main', bytes_value, start, end, expected_result_type=bytes))
+        expected_results.append(bytes_value[start:end])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result, msg=x)
+
+    def test_bytes_class_variable_slicing(self):
+        path, _ = self.get_deploy_file_paths('BytesClassVariableSlicing.py')
+        runner = NeoTestRunner(runner_id=self.method_name())
+
+        invokes = []
+        expected_results = []
+
+        bytes_value = b'unit test'
+        start = 0
+        end = len(bytes_value)
+        invokes.append(runner.call_contract(path, 'main', start, end, expected_result_type=bytes))
+        expected_results.append(bytes_value[start:end])
+
+        start = 2
+        end = len(bytes_value) - 1
+        invokes.append(runner.call_contract(path, 'main', start, end, expected_result_type=bytes))
+        expected_results.append(bytes_value[start:end])
+
+        start = len(bytes_value)
+        end = 0
+        invokes.append(runner.call_contract(path, 'main', start, end, expected_result_type=bytes))
+        expected_results.append(bytes_value[start:end])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result, msg=x)

--- a/boa3_test/tests/compiler_tests/test_string.py
+++ b/boa3_test/tests/compiler_tests/test_string.py
@@ -1389,3 +1389,90 @@ class TestString(BoaTest):
     def test_string_index_mismatched_type(self):
         path = self.get_contract_path('IndexStringMismatchedType.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+
+    def test_string_property_slicing(self):
+        path, _ = self.get_deploy_file_paths('StringPropertySlicing.py')
+        runner = NeoTestRunner(runner_id=self.method_name())
+
+        invokes = []
+        expected_results = []
+
+        string = 'unit test'
+        start = 0
+        end = len(string)
+        invokes.append(runner.call_contract(path, 'main', string, start, end))
+        expected_results.append(string[start:end])
+
+        start = 2
+        end = len(string) - 1
+        invokes.append(runner.call_contract(path, 'main', string, start, end))
+        expected_results.append(string[start:end])
+
+        start = len(string)
+        end = 0
+        invokes.append(runner.call_contract(path, 'main', string, start, end))
+        expected_results.append(string[start:end])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result, msg=x)
+
+    def test_string_instance_variable_slicing(self):
+        path, _ = self.get_deploy_file_paths('StringInstanceVariableSlicing.py')
+        runner = NeoTestRunner(runner_id=self.method_name())
+
+        invokes = []
+        expected_results = []
+
+        string = 'unit test'
+        start = 0
+        end = len(string)
+        invokes.append(runner.call_contract(path, 'main', string, start, end))
+        expected_results.append(string[start:end])
+
+        start = 2
+        end = len(string) - 1
+        invokes.append(runner.call_contract(path, 'main', string, start, end))
+        expected_results.append(string[start:end])
+
+        start = len(string)
+        end = 0
+        invokes.append(runner.call_contract(path, 'main', string, start, end))
+        expected_results.append(string[start:end])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result, msg=x)
+
+    def test_string_class_variable_slicing(self):
+        path, _ = self.get_deploy_file_paths('StringClassVariableSlicing.py')
+        runner = NeoTestRunner(runner_id=self.method_name())
+
+        invokes = []
+        expected_results = []
+
+        string = 'unit test'
+        start = 0
+        end = len(string)
+        invokes.append(runner.call_contract(path, 'main', start, end))
+        expected_results.append(string[start:end])
+
+        start = 2
+        end = len(string) - 1
+        invokes.append(runner.call_contract(path, 'main', start, end))
+        expected_results.append(string[start:end])
+
+        start = len(string)
+        end = 0
+        invokes.append(runner.call_contract(path, 'main', start, end))
+        expected_results.append(string[start:end])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result, msg=x)


### PR DESCRIPTION
**Summary or solution description**
Internally, the function that is used to get an instance variable is the same that gets an element from an array, but by itself, it can't get the type of the instance variable from a class, so it will be changed to the correct value after the function is over.

In other words, inside `codegenerator.py`, on `convert_get_item`, it won't be possible to find the `value_type` inside it, because it's a class, not an array.

https://github.com/CityOfZion/neo3-boa/blob/8341a68b4d0ec62a9e7150869aadea1e3539275f/boa3/internal/compiler/codegenerator/codegenerator.py#L1208-L1211


So, on `convert_class_variable`, it will change to the correct value if it's not `any`.
https://github.com/CityOfZion/neo3-boa/blob/8341a68b4d0ec62a9e7150869aadea1e3539275f/boa3/internal/compiler/codegenerator/codegenerator.py#L1913-L1916

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/8341a68b4d0ec62a9e7150869aadea1e3539275f/boa3_test/test_sc/bytes_test/BytesInstanceVariableSlicing.py#L1-L12

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/8341a68b4d0ec62a9e7150869aadea1e3539275f/boa3_test/tests/compiler_tests/test_bytes.py#L1674-L1702

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7

**Additional context:**
It seems like this problem only affected instance variables. It generated the right code for class variables and properties, but tests were added to test those cases too.