### PR TITLE
Compilation should fail with not supported feature

### DIFF
--- a/boa3/internal/analyser/moduleanalyser.py
+++ b/boa3/internal/analyser/moduleanalyser.py
@@ -1377,7 +1377,7 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
         self._log_error(
             CompilerError.NotSupportedOperation(
                 node.lineno, node.col_offset,
-                symbol_id='comprehension'
+                symbol_id='list comprehension'
             )
         )
         self.generic_visit(node)

--- a/boa3/internal/analyser/moduleanalyser.py
+++ b/boa3/internal/analyser/moduleanalyser.py
@@ -963,7 +963,7 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
             symbol_id = self.visit(ret.value)
             symbol = self.get_symbol(symbol_id)
             if symbol is None:
-                # the symbol doesn't exists
+                # the symbol doesn't exist
                 self._log_error(
                     CompilerError.UnresolvedReference(ret.value.lineno, ret.value.col_offset, symbol_id)
                 )
@@ -982,7 +982,7 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
         if isinstance(target_type, str) and not isinstance(target, ast.Str):
             symbol = self.get_symbol(target_type)
             if symbol is None:
-                # the symbol doesn't exists
+                # the symbol doesn't exist
                 self._log_error(
                     CompilerError.UnresolvedReference(target.lineno, target.col_offset, target_type)
                 )
@@ -1213,7 +1213,7 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
                 func_symbol = func_symbol.constructor_method()
 
         if not isinstance(func_symbol, Callable):
-            # the symbol doesn't exists
+            # the symbol doesn't exist
             self._log_error(
                 CompilerError.UnresolvedReference(call.func.lineno, call.func.col_offset, func_id)
             )
@@ -1362,6 +1362,26 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
 
         # continue to walk through the tree
         self.generic_visit(for_node)
+
+    def visit_ListComp(self, node: ast.ListComp):
+        return self._visit_comprehension(node)
+
+    def visit_SetComp(self, node: ast.SetComp):
+        return self._visit_comprehension(node)
+
+    def visit_DictComp(self, node: ast.DictComp):
+        return self._visit_comprehension(node)
+
+    def _visit_comprehension(self, node):
+        # TODO: refactor when comprehension is implemented
+        self._log_error(
+            CompilerError.NotSupportedOperation(
+                node.lineno, node.col_offset,
+                symbol_id='comprehension'
+            )
+        )
+        self.generic_visit(node)
+        return node
 
     def visit_Name(self, name: ast.Name) -> str:
         """

--- a/boa3_test/test_sc/list_test/ListComprehensionStr.py
+++ b/boa3_test/test_sc/list_test/ListComprehensionStr.py
@@ -1,0 +1,7 @@
+from boa3.builtin.compile_time import public
+
+
+@public
+def get_list() -> list:
+    x = [l for l in 'word']
+    return x

--- a/boa3_test/tests/compiler_tests/test_list.py
+++ b/boa3_test/tests/compiler_tests/test_list.py
@@ -2103,3 +2103,11 @@ class TestList(BoaTest):
             self.assertEqual(expected_results[x], invokes[x].result)
 
     # endregion
+
+    # region TestComprehension
+
+    def test_list_comprehension_str(self):
+        path = self.get_contract_path('ListComprehensionStr.py')
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+
+    # endregion


### PR DESCRIPTION
**Summary or solution description**
List comprehension is not supported, but the compiler doesn't raise any errors when it is used in a smart contract script.
Changed to raise compiler error when list comprehension is used. It's going to be implemented in future tasks.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/3d257251d5991ac2c5c9f45d226d9181f0f3c928/boa3_test/test_sc/list_test/ListComprehensionStr.py#L4-L7

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/3d257251d5991ac2c5c9f45d226d9181f0f3c928/boa3_test/tests/compiler_tests/test_list.py#L2107-L2112

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7+
