### PR TITLE
Change the documentation to avoid IDE errors - ContractInterface has no attribute "hash"

### DIFF
--- a/boa3/builtin/compile_time/__init__.py
+++ b/boa3/builtin/compile_time/__init__.py
@@ -104,17 +104,25 @@ def contract(script_hash: Union[str, bytes]):
     """
     This decorator identifies a class that should be interpreted as an interface to an existing contract.
 
+    If you want to use the script hash as a UInt160, you can create a `hash: UInt160` class attribute without
+    attributing a value to it.
+
     Check out `Our Documentation <https://dojo.coz.io/neo3/boa/calling-smart-contracts.html#with-interface>`__ to learn
     more about this decorator.
 
     >>> @contract('0xd2a4cff31913016155e38e474a2c06d08be276cf')
     ... class GASInterface:
+    ...     hash: UInt160      # this class variable will reflect the value you passed to the `contract` decorator
+    ...                        # you should import the type UInt160 from boa3.builtin.type
     ...     @staticmethod
     ...     def symbol() -> str:
     ...         pass
     ... @public
     ... def main() -> str:
     ...     return "Symbol is " + GASInterface.symbol()
+    ... @public
+    ... def return_hash() -> UInt160:
+    ...     return GASInterface.hash
 
     :param script_hash: Script hash of the interfaced contract
     :type script_hash: str or bytes

--- a/boa3/builtin/compile_time/__init__.py
+++ b/boa3/builtin/compile_time/__init__.py
@@ -104,16 +104,17 @@ def contract(script_hash: Union[str, bytes]):
     """
     This decorator identifies a class that should be interpreted as an interface to an existing contract.
 
-    If you want to use the script hash as a UInt160, you can create a `hash: UInt160` class attribute without
-    attributing a value to it.
+    If you want to use the script hash in your code, you can use the `hash` class attribute that automatically maps the
+    script hash parameter onto it. You don't need to declare it in your class, but your IDE might send a warning about
+    the attribute if you don't.
 
     Check out `Our Documentation <https://dojo.coz.io/neo3/boa/calling-smart-contracts.html#with-interface>`__ to learn
     more about this decorator.
 
     >>> @contract('0xd2a4cff31913016155e38e474a2c06d08be276cf')
     ... class GASInterface:
-    ...     hash: UInt160      # this class variable will reflect the value you passed to the `contract` decorator
-    ...                        # you should import the type UInt160 from boa3.builtin.type
+    ...     hash: UInt160      # you don't need to declare this class variable, we are only doing it to avoid IDE warnings
+    ...                        # but if you do declare, you need to import the type UInt160 from boa3.builtin.type
     ...     @staticmethod
     ...     def symbol() -> str:
     ...         pass
@@ -122,7 +123,7 @@ def contract(script_hash: Union[str, bytes]):
     ...     return "Symbol is " + GASInterface.symbol()
     ... @public
     ... def return_hash() -> UInt160:
-    ...     return GASInterface.hash
+    ...     return GASInterface.hash    # neo3-boa will understand that this attribute exists even if you don't declare it
 
     :param script_hash: Script hash of the interfaced contract
     :type script_hash: str or bytes

--- a/boa3_test/test_sc/contract_interface_test/ContractInterfaceGetHash.py
+++ b/boa3_test/test_sc/contract_interface_test/ContractInterfaceGetHash.py
@@ -4,6 +4,7 @@ from boa3.builtin.type import UInt160
 
 @contract('0x000102030405060708090A0B0C0D0E0F10111213')
 class ContractInterface:
+    hash: UInt160
 
     @staticmethod
     def foo():

--- a/boa3_test/test_sc/contract_interface_test/ContractInterfaceGetHashOnMetadata.py
+++ b/boa3_test/test_sc/contract_interface_test/ContractInterfaceGetHashOnMetadata.py
@@ -4,6 +4,7 @@ from boa3.builtin.type import UInt160
 
 @contract('0x000102030405060708090A0B0C0D0E0F10111213')
 class ContractInterface:
+    hash: UInt160
 
     @staticmethod
     def foo():

--- a/docs/source/calling-smart-contracts.md
+++ b/docs/source/calling-smart-contracts.md
@@ -44,6 +44,7 @@ same methods you want call.
 ```python
 # calling_with_interface.py
 from boa3.builtin.compile_time import public, contract
+from boa3.builtin.type import UInt160
 
 @public
 def calling_other_contract() -> str:
@@ -53,6 +54,8 @@ def calling_other_contract() -> str:
 
 @contract('0x000102030405060708090A0B0C0D0E0F10111213')
 class HelloStrangerContract:
+    hash: UInt160   # this class variable will reflect the value you passed to the `contract` decorator
+    
     @staticmethod
     def hello_stranger(name: str) -> str:
         pass
@@ -65,7 +68,7 @@ that you can import from `boa3.builtin.nativecontract`
 ```python
 # calling_native_contract.py
 from boa3.builtin.compile_time import public
-from boa3.builtin.nativecontract import NEO
+from boa3.builtin.nativecontract.neo import NEO
 
 @public
 def calling_other_contract() -> str:
@@ -90,6 +93,7 @@ from typing import cast, Any
 
 @contract('0x4380f2c1de98bb267d3ea821897ec571a04fe3e0')
 class Dice:
+    hash: UInt160
 
     @staticmethod
     def rand_between(start: int, end: int) -> int: 


### PR DESCRIPTION
**Summary or solution description**
Some IDEs were giving a warning that `hash` did not exist, even tho it exists when you use the `@contract` decorator.
So, the `hash: UInt160` variable was added on contract interfaces when it was being used. 

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7

**(Optional) Additional context**

Changed import, because I think it should have been done on https://github.com/CityOfZion/neo3-boa/commit/5fa9250d874ddc4a27bd38c8459b9be1716fe009
https://github.com/CityOfZion/neo3-boa/blob/9e304af862361f8b91a4846b08e01281ad1cf1c5/docs/source/calling-smart-contracts.md?plain=1#L71