### PR TITLE
Move Neo3Boa unit tests logics from test-runner and neo-express interfaces to other classes

### DIFF
--- a/boa3_test/tests/cli_tests/test_compile.py
+++ b/boa3_test/tests/cli_tests/test_compile.py
@@ -1,11 +1,11 @@
-from boa3_test.tests.cli_tests.cli_test import BoaCliTest  # needs to be the first import to avoid circular imports
-
 import os.path
+
+from boa3_test.tests.cli_tests.cli_test import BoaCliTest  # needs to be the first import to avoid circular imports
 
 from boa3.internal import constants
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.cli_tests.utils import neo3_boa_cli, get_path_from_boa3_test
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestCliCompile(BoaCliTest):
@@ -127,7 +127,7 @@ class TestCliCompile(BoaCliTest):
         self.assertTrue(f'Wrote {nef_generated} to ' in logs.output[-1],
                         msg=f'Something went wrong when compiling {nef_generated}')
 
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         runner.deploy_contract(nef_path)
         invoke = runner.call_contract(nef_path, 'main')

--- a/boa3_test/tests/compiler_tests/test_arithmetic.py
+++ b/boa3_test/tests/compiler_tests/test_arithmetic.py
@@ -1,14 +1,13 @@
 from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to avoid circular imports
 
 from boa3.internal.exception import CompilerError
-from boa3.internal.model.operation.binaryop import BinaryOp
 from boa3.internal.model.type.type import Type
 from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo3.contracts import FindOptions
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive import neoxp
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive import neoxp
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestArithmetic(BoaTest):
@@ -18,7 +17,7 @@ class TestArithmetic(BoaTest):
 
     def test_boa2_add_test(self):
         path, _ = self.get_deploy_file_paths('AddBoa2Test.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -43,7 +42,7 @@ class TestArithmetic(BoaTest):
 
     def test_boa2_add_test1(self):
         path, _ = self.get_deploy_file_paths('AddBoa2Test1.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -65,7 +64,7 @@ class TestArithmetic(BoaTest):
 
     def test_boa2_add_test2(self):
         path, _ = self.get_deploy_file_paths('AddBoa2Test2.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -81,7 +80,7 @@ class TestArithmetic(BoaTest):
 
     def test_boa2_add_test3(self):
         path, _ = self.get_deploy_file_paths('AddBoa2Test3.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -97,7 +96,7 @@ class TestArithmetic(BoaTest):
 
     def test_boa2_add_test4(self):
         path, _ = self.get_deploy_file_paths('AddBoa2Test4.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -113,7 +112,7 @@ class TestArithmetic(BoaTest):
 
     def test_boa2_add_test_void(self):
         path, _ = self.get_deploy_file_paths('AddBoa2TestVoid.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -143,7 +142,7 @@ class TestArithmetic(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -179,7 +178,7 @@ class TestArithmetic(BoaTest):
 
     def test_addition_builtin_type(self):
         path, _ = self.get_deploy_file_paths('AdditionBuiltinType.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -204,7 +203,7 @@ class TestArithmetic(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -234,7 +233,7 @@ class TestArithmetic(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -270,7 +269,7 @@ class TestArithmetic(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -312,7 +311,7 @@ class TestArithmetic(BoaTest):
         path_1, _ = self.get_deploy_file_paths(path_1)
         path_2, _ = self.get_deploy_file_paths(path_2)
         path_3, _ = self.get_deploy_file_paths(path_3)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -353,7 +352,7 @@ class TestArithmetic(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -378,7 +377,7 @@ class TestArithmetic(BoaTest):
     def test_concat_bytes_variables_and_constants(self):
         path, _ = self.get_deploy_file_paths('ConcatBytesVariablesAndConstants.py')
         address_version = Integer(neoxp.utils.get_address_version()).to_byte_array()
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -419,7 +418,7 @@ class TestArithmetic(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -456,7 +455,7 @@ class TestArithmetic(BoaTest):
     def test_concat_string_variables_and_constants(self):
         path, _ = self.get_deploy_file_paths('ConcatStringVariablesAndConstants.py')
 
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -484,7 +483,7 @@ class TestArithmetic(BoaTest):
 
     def test_division_builtin_type(self):
         path, _ = self.get_deploy_file_paths('DivisionBuiltinType.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -514,7 +513,7 @@ class TestArithmetic(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -554,7 +553,7 @@ class TestArithmetic(BoaTest):
 
     def test_list_addition(self):
         path, _ = self.get_deploy_file_paths('ListAddition.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -613,7 +612,7 @@ class TestArithmetic(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -650,7 +649,7 @@ class TestArithmetic(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -670,7 +669,7 @@ class TestArithmetic(BoaTest):
 
     def test_modulo_operation(self):
         path, _ = self.get_deploy_file_paths('Modulo.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -707,7 +706,7 @@ class TestArithmetic(BoaTest):
 
     def test_modulo_augmented_assignment(self):
         path, _ = self.get_deploy_file_paths('ModuloAugmentedAssignment.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -744,7 +743,7 @@ class TestArithmetic(BoaTest):
 
     def test_modulo_builtin_type(self):
         path, _ = self.get_deploy_file_paths('ModuloBuiltinType.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -778,7 +777,7 @@ class TestArithmetic(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -816,7 +815,7 @@ class TestArithmetic(BoaTest):
 
     def test_multiplication_builtin_type(self):
         path, _ = self.get_deploy_file_paths('MultiplicationBuiltinType.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -849,7 +848,7 @@ class TestArithmetic(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -891,7 +890,7 @@ class TestArithmetic(BoaTest):
 
     def test_power_builtin_type(self):
         path, _ = self.get_deploy_file_paths('PowerBuiltinType.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -924,7 +923,7 @@ class TestArithmetic(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -944,7 +943,7 @@ class TestArithmetic(BoaTest):
 
     def test_negative_builtin_type(self):
         path, _ = self.get_deploy_file_paths('NegativeBuiltinType.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -972,7 +971,7 @@ class TestArithmetic(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -992,7 +991,7 @@ class TestArithmetic(BoaTest):
 
     def test_positive_builtin_type(self):
         path, _ = self.get_deploy_file_paths('PositiveBuiltinType.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1043,7 +1042,7 @@ class TestArithmetic(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1079,7 +1078,7 @@ class TestArithmetic(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1096,7 +1095,7 @@ class TestArithmetic(BoaTest):
 
     def test_bytes_multiplication_builtin_type(self):
         path, _ = self.get_deploy_file_paths('BytesMultiplicationBuiltinType.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1128,7 +1127,7 @@ class TestArithmetic(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1163,7 +1162,7 @@ class TestArithmetic(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1179,7 +1178,7 @@ class TestArithmetic(BoaTest):
 
     def test_str_multiplication_builtin_type(self):
         path, _ = self.get_deploy_file_paths('StringMultiplicationBuiltinType.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1213,7 +1212,7 @@ class TestArithmetic(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1249,7 +1248,7 @@ class TestArithmetic(BoaTest):
 
     def test_subtraction_builtin_type(self):
         path, _ = self.get_deploy_file_paths('SubtractionBuiltinType.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_assert.py
+++ b/boa3_test/tests/compiler_tests/test_assert.py
@@ -5,7 +5,7 @@ from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo.vm.type.StackItem import StackItemType
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestAssert(BoaTest):
@@ -28,7 +28,7 @@ class TestAssert(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -65,7 +65,7 @@ class TestAssert(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -86,7 +86,7 @@ class TestAssert(BoaTest):
 
     def test_assert_with_message(self):
         path, _ = self.get_deploy_file_paths('AssertWithMessage.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -107,7 +107,7 @@ class TestAssert(BoaTest):
 
     def test_assert_with_bytes_message(self):
         path, _ = self.get_deploy_file_paths('AssertWithBytesMessage.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -140,7 +140,7 @@ class TestAssert(BoaTest):
 
     def test_assert_with_str_var_message(self):
         path, _ = self.get_deploy_file_paths('AssertWithStrVarMessage.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -161,7 +161,7 @@ class TestAssert(BoaTest):
 
     def test_assert_with_str_function_message(self):
         path, _ = self.get_deploy_file_paths('AssertWithStrFunctionMessage.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -196,7 +196,7 @@ class TestAssert(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -233,7 +233,7 @@ class TestAssert(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -268,7 +268,7 @@ class TestAssert(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -306,7 +306,7 @@ class TestAssert(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -343,7 +343,7 @@ class TestAssert(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -387,7 +387,7 @@ class TestAssert(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -403,7 +403,7 @@ class TestAssert(BoaTest):
 
     def test_boa2_throw_test(self):
         path, _ = self.get_deploy_file_paths('ThrowBoa2Test.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_boa_builtin_method.py
+++ b/boa3_test/tests/compiler_tests/test_boa_builtin_method.py
@@ -3,7 +3,7 @@ from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to 
 from boa3.internal import constants
 from boa3.internal.exception import CompilerError
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestBoaBuiltinMethod(BoaTest):
@@ -11,7 +11,7 @@ class TestBoaBuiltinMethod(BoaTest):
 
     def test_abort(self):
         path, _ = self.get_deploy_file_paths('Abort.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -39,7 +39,7 @@ class TestBoaBuiltinMethod(BoaTest):
         self.compile_and_save(path, env=custom_env, output_name=custom_name, change_manifest_name=True)
         path_custom_env, _ = self.get_deploy_file_paths(path, output_name=custom_name)
 
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -58,7 +58,7 @@ class TestBoaBuiltinMethod(BoaTest):
 
     def test_deploy_def(self):
         path, _ = self.get_deploy_file_paths('DeployDef.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -84,7 +84,7 @@ class TestBoaBuiltinMethod(BoaTest):
 
     def test_sqrt_method(self):
         path, _ = self.get_deploy_file_paths('Sqrt.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -133,7 +133,7 @@ class TestBoaBuiltinMethod(BoaTest):
 
     def test_sqrt_method_from_math(self):
         path, _ = self.get_deploy_file_paths('SqrtFromMath.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -153,7 +153,7 @@ class TestBoaBuiltinMethod(BoaTest):
 
     def test_decimal_floor_method(self):
         path, _ = self.get_deploy_file_paths('DecimalFloor.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -200,7 +200,7 @@ class TestBoaBuiltinMethod(BoaTest):
 
     def test_decimal_ceil_method(self):
         path, _ = self.get_deploy_file_paths('DecimalCeiling.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_builtin_method.py
+++ b/boa3_test/tests/compiler_tests/test_builtin_method.py
@@ -6,7 +6,7 @@ from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo.vm.type.String import String
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestBuiltinMethod(BoaTest):
@@ -36,7 +36,7 @@ class TestBuiltinMethod(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -72,7 +72,7 @@ class TestBuiltinMethod(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -108,7 +108,7 @@ class TestBuiltinMethod(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -124,7 +124,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_len_of_bytes(self):
         path, _ = self.get_deploy_file_paths('LenBytes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -195,7 +195,7 @@ class TestBuiltinMethod(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -242,7 +242,7 @@ class TestBuiltinMethod(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -308,7 +308,7 @@ class TestBuiltinMethod(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -358,7 +358,7 @@ class TestBuiltinMethod(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -409,7 +409,7 @@ class TestBuiltinMethod(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -425,7 +425,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_reverse_mutable_sequence_with_builtin(self):
         path, _ = self.get_deploy_file_paths('ReverseMutableSequenceBuiltinCall.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -462,7 +462,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_extend_mutable_sequence(self):
         path, _ = self.get_deploy_file_paths('ExtendMutableSequence.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -478,7 +478,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_extend_mutable_sequence_with_builtin(self):
         path, _ = self.get_deploy_file_paths('ExtendMutableSequenceBuiltinCall.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -506,7 +506,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_script_hash_int(self):
         path, _ = self.get_deploy_file_paths('ScriptHashInt.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -529,7 +529,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_script_hash_str(self):
         path, _ = self.get_deploy_file_paths('ScriptHashStr.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -557,7 +557,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_script_hash_variable(self):
         path, _ = self.get_deploy_file_paths('ScriptHashVariable.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -610,7 +610,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_int_to_bytes(self):
         path, _ = self.get_deploy_file_paths('IntToBytes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -628,7 +628,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_int_zero_to_bytes(self):
         path, _ = self.get_deploy_file_paths('IntZeroToBytes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -650,7 +650,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_int_to_bytes_as_parameter(self):
         path, _ = self.get_deploy_file_paths('IntToBytesAsParameter.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -680,7 +680,7 @@ class TestBuiltinMethod(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -709,7 +709,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_print_int(self):
         path, _ = self.get_deploy_file_paths('PrintInt.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -729,7 +729,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_print_str(self):
         path, _ = self.get_deploy_file_paths('PrintStr.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -749,7 +749,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_print_bytes(self):
         path, _ = self.get_deploy_file_paths('PrintBytes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -769,7 +769,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_print_bool(self):
         path, _ = self.get_deploy_file_paths('PrintBool.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -789,7 +789,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_print_list(self):
         path, _ = self.get_deploy_file_paths('PrintList.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -812,7 +812,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_print_user_class(self):
         path, _ = self.get_deploy_file_paths('PrintClass.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -838,7 +838,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_print_many_values(self):
         path, _ = self.get_deploy_file_paths('PrintManyValues.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -859,7 +859,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_print_no_args(self):
         path, _ = self.get_deploy_file_paths('PrintNoArgs.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -886,7 +886,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_isinstance_int_literal(self):
         path, _ = self.get_deploy_file_paths('IsInstanceIntLiteral.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -902,7 +902,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_isinstance_int_variable(self):
         path, _ = self.get_deploy_file_paths('IsInstanceIntVariable.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -924,7 +924,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_isinstance_bool_literal(self):
         path, _ = self.get_deploy_file_paths('IsInstanceBoolLiteral.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -940,7 +940,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_isinstance_bool_variable(self):
         path, _ = self.get_deploy_file_paths('IsInstanceBoolVariable.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -962,7 +962,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_isinstance_str_literal(self):
         path, _ = self.get_deploy_file_paths('IsInstanceStrLiteral.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -978,7 +978,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_isinstance_str_variable(self):
         path, _ = self.get_deploy_file_paths('IsInstanceStrVariable.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1000,7 +1000,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_isinstance_list_literal(self):
         path, _ = self.get_deploy_file_paths('IsInstanceListLiteral.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1016,7 +1016,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_isinstance_tuple_literal(self):
         path, _ = self.get_deploy_file_paths('IsInstanceTupleLiteral.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1032,7 +1032,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_isinstance_tuple_variable(self):
         path, _ = self.get_deploy_file_paths('IsInstanceTupleVariable.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1057,7 +1057,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_isinstance_many_types(self):
         path, _ = self.get_deploy_file_paths('IsInstanceManyTypes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1082,7 +1082,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_isinstance_many_types_with_class(self):
         path, _ = self.get_deploy_file_paths('IsInstanceManyTypesWithClass.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1116,7 +1116,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_isinstance_uint160(self):
         path, _ = self.get_deploy_file_paths('IsInstanceUInt160.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1141,7 +1141,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_isinstance_uint256(self):
         path, _ = self.get_deploy_file_paths('IsInstanceUInt256.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1170,7 +1170,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_exit(self):
         path, _ = self.get_deploy_file_paths('Exit.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1195,7 +1195,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_max_int(self):
         path, _ = self.get_deploy_file_paths('MaxInt.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1214,7 +1214,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_max_int_more_arguments(self):
         path, _ = self.get_deploy_file_paths('MaxIntMoreArguments.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1232,7 +1232,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_max_str(self):
         path, _ = self.get_deploy_file_paths('MaxStr.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1265,7 +1265,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_max_str_more_arguments(self):
         path, _ = self.get_deploy_file_paths('MaxStrMoreArguments.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1283,7 +1283,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_max_bytes(self):
         path, _ = self.get_deploy_file_paths('MaxBytes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1316,7 +1316,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_max_bytes_more_arguments(self):
         path, _ = self.get_deploy_file_paths('MaxBytesMoreArguments.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1346,7 +1346,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_min_int(self):
         path, _ = self.get_deploy_file_paths('MinInt.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1365,7 +1365,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_min_int_more_arguments(self):
         path, _ = self.get_deploy_file_paths('MinIntMoreArguments.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1383,7 +1383,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_min_str(self):
         path, _ = self.get_deploy_file_paths('MinStr.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1416,7 +1416,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_min_str_more_arguments(self):
         path, _ = self.get_deploy_file_paths('MinStrMoreArguments.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1434,7 +1434,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_min_bytes(self):
         path, _ = self.get_deploy_file_paths('MinBytes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1467,7 +1467,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_min_bytes_more_arguments(self):
         path, _ = self.get_deploy_file_paths('MinBytesMoreArguments.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1497,7 +1497,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_abs(self):
         path, _ = self.get_deploy_file_paths('Abs.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1543,7 +1543,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_sum(self):
         path, _ = self.get_deploy_file_paths('Sum.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1566,7 +1566,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_sum_with_start(self):
         path, _ = self.get_deploy_file_paths('SumWithStart.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1605,7 +1605,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_str_split(self):
         path, _ = self.get_deploy_file_paths('StrSplit.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1646,7 +1646,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_str_split_maxsplit_default(self):
         path, _ = self.get_deploy_file_paths('StrSplitMaxsplitDefault.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1671,7 +1671,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_str_split_default(self):
         path, _ = self.get_deploy_file_paths('StrSplitSeparatorDefault.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1693,7 +1693,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_count_list_int(self):
         path, _ = self.get_deploy_file_paths('CountListInt.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1711,7 +1711,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_count_list_str(self):
         path, _ = self.get_deploy_file_paths('CountListStr.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1729,7 +1729,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_count_list_bytes(self):
         path, _ = self.get_deploy_file_paths('CountListBytes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1747,7 +1747,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_count_list_different_primitive_types(self):
         path, _ = self.get_deploy_file_paths('CountListDifferentPrimitiveTypes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1766,7 +1766,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_count_list_different_any_types(self):
         path, _ = self.get_deploy_file_paths('CountListAnyType.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1790,7 +1790,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_count_list_only_sequences(self):
         path, _ = self.get_deploy_file_paths('CountListOnlySequences.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1814,7 +1814,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_count_list_empty(self):
         path, _ = self.get_deploy_file_paths('CountListEmpty.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1832,7 +1832,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_count_tuple_int(self):
         path, _ = self.get_deploy_file_paths('CountTupleInt.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1850,7 +1850,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_count_tuple_str(self):
         path, _ = self.get_deploy_file_paths('CountTupleStr.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1868,7 +1868,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_count_tuple_bytes(self):
         path, _ = self.get_deploy_file_paths('CountTupleBytes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1886,7 +1886,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_count_tuple_different_types(self):
         path, _ = self.get_deploy_file_paths('CountTupleDifferentTypes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1905,7 +1905,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_count_tuple_different_non_primitive_types(self):
         path, _ = self.get_deploy_file_paths('CountTupleDifferentNonPrimitiveTypes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1928,7 +1928,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_count_tuple_empty(self):
         path, _ = self.get_deploy_file_paths('CountTupleEmpty.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1946,7 +1946,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_count_range(self):
         path, _ = self.get_deploy_file_paths('CountRange.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1971,7 +1971,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_count_str(self):
         path, _ = self.get_deploy_file_paths('CountStr.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -2056,7 +2056,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_count_str_end_default(self):
         path, _ = self.get_deploy_file_paths('CountStrEndDefault.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -2097,7 +2097,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_count_str_default(self):
         path, _ = self.get_deploy_file_paths('CountStrDefault.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -2139,7 +2139,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_super_call_method(self):
         path, _ = self.get_deploy_file_paths('SuperCallMethod.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -2169,7 +2169,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_int_str(self):
         path, _ = self.get_deploy_file_paths('IntStr.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -2273,7 +2273,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_int_bytes(self):
         path, _ = self.get_deploy_file_paths('IntBytes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -2377,7 +2377,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_int_int(self):
         path, _ = self.get_deploy_file_paths('IntInt.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -2402,7 +2402,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_int_no_parameters(self):
         path, _ = self.get_deploy_file_paths('IntNoParameters.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -2422,7 +2422,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_bool(self):
         path, _ = self.get_deploy_file_paths('Bool.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -2455,7 +2455,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_bool_bytes(self):
         path, _ = self.get_deploy_file_paths('BoolBytes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -2476,7 +2476,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_bool_class(self):
         path, _ = self.get_deploy_file_paths('BoolClass.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -2497,7 +2497,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_bool_dict(self):
         path, _ = self.get_deploy_file_paths('BoolDict.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -2518,7 +2518,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_bool_int(self):
         path, _ = self.get_deploy_file_paths('BoolInt.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -2543,7 +2543,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_bool_list(self):
         path, _ = self.get_deploy_file_paths('BoolList.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -2564,7 +2564,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_bool_range(self):
         path, _ = self.get_deploy_file_paths('BoolRange.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -2583,7 +2583,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_bool_str(self):
         path, _ = self.get_deploy_file_paths('BoolStr.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -2608,7 +2608,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_list_any(self):
         path, _ = self.get_deploy_file_paths('ListAny.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -2642,7 +2642,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_list_default(self):
         path, _ = self.get_deploy_file_paths('ListDefault.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -2658,7 +2658,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_list_sequence(self):
         path, _ = self.get_deploy_file_paths('ListSequence.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -2693,7 +2693,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_list_mapping(self):
         path, _ = self.get_deploy_file_paths('ListMapping.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -2732,7 +2732,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_list_bytes(self):
         path, _ = self.get_deploy_file_paths('ListBytes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -2753,7 +2753,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_list_str(self):
         path, _ = self.get_deploy_file_paths('ListString.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -2774,7 +2774,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_list_bytes_str(self):
         path, _ = self.get_deploy_file_paths('ListBytesString.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -2800,7 +2800,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_str_bytes_str(self):
         path, _ = self.get_deploy_file_paths('StrByteString.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -2825,7 +2825,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_str_int(self):
         path, _ = self.get_deploy_file_paths('StrInt.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -2846,7 +2846,7 @@ class TestBuiltinMethod(BoaTest):
 
     def test_str_bool(self):
         path, _ = self.get_deploy_file_paths('StrBool.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_bytes.py
+++ b/boa3_test/tests/compiler_tests/test_bytes.py
@@ -5,7 +5,7 @@ from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo.vm.type.StackItem import StackItemType
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestBytes(BoaTest):
@@ -46,7 +46,7 @@ class TestBytes(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -81,7 +81,7 @@ class TestBytes(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -111,7 +111,7 @@ class TestBytes(BoaTest):
 
     def test_bytes_to_int(self):
         path, _ = self.get_deploy_file_paths('BytesToInt.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -131,7 +131,7 @@ class TestBytes(BoaTest):
 
     def test_bytes_to_bool(self):
         path, _ = self.get_deploy_file_paths('BytesToBool.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -157,7 +157,7 @@ class TestBytes(BoaTest):
 
     def test_bytes_to_str(self):
         path, _ = self.get_deploy_file_paths('BytesToStr.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -197,7 +197,7 @@ class TestBytes(BoaTest):
 
     def test_assign_with_slice(self):
         path, _ = self.get_deploy_file_paths('AssignSlice.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -222,7 +222,7 @@ class TestBytes(BoaTest):
 
     def test_slice_with_cast(self):
         path, _ = self.get_deploy_file_paths('SliceWithCast.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -251,7 +251,7 @@ class TestBytes(BoaTest):
 
     def test_slice_with_stride(self):
         path, _ = self.get_deploy_file_paths('SliceWithStride.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -324,7 +324,7 @@ class TestBytes(BoaTest):
 
     def test_slice_with_negative_stride(self):
         path, _ = self.get_deploy_file_paths('SliceWithNegativeStride.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -397,7 +397,7 @@ class TestBytes(BoaTest):
 
     def test_slice_omitted_with_stride(self):
         path, _ = self.get_deploy_file_paths('SliceOmittedWithStride.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -464,7 +464,7 @@ class TestBytes(BoaTest):
 
     def test_slice_omitted_with_negative_stride(self):
         path, _ = self.get_deploy_file_paths('SliceOmittedWithNegativeStride.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -545,7 +545,7 @@ class TestBytes(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -580,7 +580,7 @@ class TestBytes(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -625,7 +625,7 @@ class TestBytes(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -672,7 +672,7 @@ class TestBytes(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -719,7 +719,7 @@ class TestBytes(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -789,7 +789,7 @@ class TestBytes(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -827,7 +827,7 @@ class TestBytes(BoaTest):
 
     def test_byte_array_string(self):
         path, _ = self.get_deploy_file_paths('BytearrayFromString.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -853,7 +853,7 @@ class TestBytes(BoaTest):
 
     def test_byte_array_append(self):
         path, _ = self.get_deploy_file_paths('BytearrayAppend.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -870,7 +870,7 @@ class TestBytes(BoaTest):
 
     def test_byte_array_append_with_builtin(self):
         path, _ = self.get_deploy_file_paths('BytearrayAppendWithBuiltin.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -887,7 +887,7 @@ class TestBytes(BoaTest):
 
     def test_byte_array_append_mutable_sequence_with_builtin(self):
         path, _ = self.get_deploy_file_paths('BytearrayAppendWithMutableSequence.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -904,7 +904,7 @@ class TestBytes(BoaTest):
 
     def test_byte_array_clear(self):
         path, _ = self.get_deploy_file_paths('BytearrayClear.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -921,7 +921,7 @@ class TestBytes(BoaTest):
 
     def test_byte_array_reverse(self):
         path, _ = self.get_deploy_file_paths('BytearrayReverse.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -938,7 +938,7 @@ class TestBytes(BoaTest):
 
     def test_byte_array_extend(self):
         path, _ = self.get_deploy_file_paths('BytearrayExtend.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -955,7 +955,7 @@ class TestBytes(BoaTest):
 
     def test_byte_array_extend_with_builtin(self):
         path, _ = self.get_deploy_file_paths('BytearrayExtendWithBuiltin.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -972,7 +972,7 @@ class TestBytes(BoaTest):
 
     def test_byte_array_to_int(self):
         path, _ = self.get_deploy_file_paths('BytearrayToInt.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -996,7 +996,7 @@ class TestBytes(BoaTest):
 
     def test_boa2_byte_array_test(self):
         path, _ = self.get_deploy_file_paths('BytearrayBoa2Test.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1017,7 +1017,7 @@ class TestBytes(BoaTest):
 
     def test_boa2_byte_array_test3(self):
         path, _ = self.get_deploy_file_paths('BytearrayBoa2Test3.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1033,7 +1033,7 @@ class TestBytes(BoaTest):
 
     def test_boa2_slice_test(self):
         path, _ = self.get_deploy_file_paths('SliceBoa2Test.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1050,7 +1050,7 @@ class TestBytes(BoaTest):
 
     def test_boa2_slice_test2(self):
         path, _ = self.get_deploy_file_paths('SliceBoa2Test2.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1067,7 +1067,7 @@ class TestBytes(BoaTest):
 
     def test_uint160_bytes(self):
         path, _ = self.get_deploy_file_paths('UInt160Bytes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1084,7 +1084,7 @@ class TestBytes(BoaTest):
 
     def test_uint160_int(self):
         path, _ = self.get_deploy_file_paths('UInt160Int.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1101,7 +1101,7 @@ class TestBytes(BoaTest):
 
     def test_uint256_bytes(self):
         path, _ = self.get_deploy_file_paths('UInt256Bytes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1118,7 +1118,7 @@ class TestBytes(BoaTest):
 
     def test_uint256_int(self):
         path, _ = self.get_deploy_file_paths('UInt256Int.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1135,7 +1135,7 @@ class TestBytes(BoaTest):
 
     def test_bytes_upper(self):
         path, _ = self.get_deploy_file_paths('UpperBytesMethod.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1160,7 +1160,7 @@ class TestBytes(BoaTest):
 
     def test_bytes_lower(self):
         path, _ = self.get_deploy_file_paths('LowerBytesMethod.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1185,7 +1185,7 @@ class TestBytes(BoaTest):
 
     def test_bytes_startswith_method(self):
         path, _ = self.get_deploy_file_paths('StartswithBytesMethod.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1247,7 +1247,7 @@ class TestBytes(BoaTest):
 
     def test_bytes_startswith_method_default_end(self):
         path, _ = self.get_deploy_file_paths('StartswithBytesMethodDefaultEnd.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1308,7 +1308,7 @@ class TestBytes(BoaTest):
 
     def test_bytes_startswith_method_defaults(self):
         path, _ = self.get_deploy_file_paths('StartswithBytesMethodDefaults.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1346,7 +1346,7 @@ class TestBytes(BoaTest):
 
     def test_bytes_strip(self):
         path, _ = self.get_deploy_file_paths('StripBytesMethod.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1377,7 +1377,7 @@ class TestBytes(BoaTest):
 
     def test_bytes_strip_default(self):
         path, _ = self.get_deploy_file_paths('StripBytesMethodDefault.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1410,7 +1410,7 @@ class TestBytes(BoaTest):
 
     def test_isdigit_method(self):
         path, _ = self.get_deploy_file_paths('IsdigitMethod.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1439,7 +1439,7 @@ class TestBytes(BoaTest):
 
     def test_bytes_join_with_sequence(self):
         path, _ = self.get_deploy_file_paths('JoinBytesMethodWithSequence.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1470,7 +1470,7 @@ class TestBytes(BoaTest):
 
     def test_bytes_join_with_dictionary(self):
         path, _ = self.get_deploy_file_paths('JoinBytesMethodWithDictionary.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1501,7 +1501,7 @@ class TestBytes(BoaTest):
 
     def test_bytes_index(self):
         path, _ = self.get_deploy_file_paths('IndexBytes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1557,7 +1557,7 @@ class TestBytes(BoaTest):
 
     def test_bytes_index_end_default(self):
         path, _ = self.get_deploy_file_paths('IndexBytesEndDefault.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1612,7 +1612,7 @@ class TestBytes(BoaTest):
 
     def test_bytes_index_defaults(self):
         path, _ = self.get_deploy_file_paths('IndexBytesDefaults.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1644,7 +1644,7 @@ class TestBytes(BoaTest):
 
     def test_bytes_property_slicing(self):
         path, _ = self.get_deploy_file_paths('BytesPropertySlicing.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1673,7 +1673,7 @@ class TestBytes(BoaTest):
 
     def test_bytes_instance_variable_slicing(self):
         path, _ = self.get_deploy_file_paths('BytesInstanceVariableSlicing.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1702,7 +1702,7 @@ class TestBytes(BoaTest):
 
     def test_bytes_class_variable_slicing(self):
         path, _ = self.get_deploy_file_paths('BytesClassVariableSlicing.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_class.py
+++ b/boa3_test/tests/compiler_tests/test_class.py
@@ -4,7 +4,7 @@ from boa3.internal.exception import CompilerError
 from boa3.internal.exception.NotLoadedException import NotLoadedException
 from boa3.internal.neo.vm.type.String import String
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestClass(BoaTest):
@@ -12,7 +12,7 @@ class TestClass(BoaTest):
 
     def test_notification_get_variables(self):
         path, _ = self.get_deploy_file_paths('NotificationGetVariables.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -72,7 +72,7 @@ class TestClass(BoaTest):
 
     def test_notification_set_variables(self):
         path, _ = self.get_deploy_file_paths('NotificationSetVariables.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -103,7 +103,7 @@ class TestClass(BoaTest):
 
     def test_contract_constructor(self):
         path, _ = self.get_deploy_file_paths('ContractConstructor.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = runner.call_contract(path, 'new_contract')
         runner.execute()
@@ -135,7 +135,7 @@ class TestClass(BoaTest):
 
     def test_user_class_with_static_method_from_class(self):
         path, _ = self.get_deploy_file_paths('UserClassWithStaticMethodFromClass.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -151,7 +151,7 @@ class TestClass(BoaTest):
 
     def test_user_class_with_static_method_from_class_with_same_method_name(self):
         path, _ = self.get_deploy_file_paths('UserClassWithStaticMethodFromClassWithSameNameMethod.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -171,7 +171,7 @@ class TestClass(BoaTest):
 
     def test_user_class_with_static_method_with_args(self):
         path, _ = self.get_deploy_file_paths('UserClassWithStaticMethodWithArgs.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -193,7 +193,7 @@ class TestClass(BoaTest):
 
     def test_user_class_with_static_method_with_vararg(self):
         path, _ = self.get_deploy_file_paths('UserClassWithStaticMethodWithVararg.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -217,7 +217,7 @@ class TestClass(BoaTest):
 
     def test_user_class_with_static_method_not_class_method(self):
         path, _ = self.get_deploy_file_paths('UserClassWithStaticMethodNotClassMethod.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -233,7 +233,7 @@ class TestClass(BoaTest):
 
     def test_user_class_with_class_method_called_from_class_name(self):
         path, _ = self.get_deploy_file_paths('UserClassWithClassMethodFromClass.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -249,7 +249,7 @@ class TestClass(BoaTest):
 
     def test_user_class_with_class_method_called_from_object(self):
         path, _ = self.get_deploy_file_paths('UserClassWithClassMethodFromObject.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -265,7 +265,7 @@ class TestClass(BoaTest):
 
     def test_user_class_with_class_method_called_from_variable(self):
         path, _ = self.get_deploy_file_paths('UserClassWithClassMethodFromVariable.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -281,7 +281,7 @@ class TestClass(BoaTest):
 
     def test_user_class_with_class_method_with_args(self):
         path, _ = self.get_deploy_file_paths('UserClassWithClassMethodWithArgs.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -303,7 +303,7 @@ class TestClass(BoaTest):
 
     def test_user_class_with_class_method_with_vararg(self):
         path, _ = self.get_deploy_file_paths('UserClassWithClassMethodWithVararg.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -327,7 +327,7 @@ class TestClass(BoaTest):
 
     def test_user_class_with_class_variable_from_class(self):
         path, _ = self.get_deploy_file_paths('UserClassWithClassVariableFromClass.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -346,7 +346,7 @@ class TestClass(BoaTest):
 
     def test_user_class_with_class_variable_from_object(self):
         path, _ = self.get_deploy_file_paths('UserClassWithClassVariableFromObject.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -365,7 +365,7 @@ class TestClass(BoaTest):
 
     def test_user_class_with_class_variable_from_variable(self):
         path, _ = self.get_deploy_file_paths('UserClassWithClassVariableFromVariable.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -392,7 +392,7 @@ class TestClass(BoaTest):
 
     def test_user_class_with_class_variable_and_class_method(self):
         path, _ = self.get_deploy_file_paths('UserClassWithClassVariableAndClassMethod.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -411,7 +411,7 @@ class TestClass(BoaTest):
 
     def test_user_class_with_init(self):
         path, _ = self.get_deploy_file_paths('UserClassWithInit.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -427,7 +427,7 @@ class TestClass(BoaTest):
 
     def test_user_class_with_init_with_args(self):
         path, _ = self.get_deploy_file_paths('UserClassWithInitWithArgs.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -443,7 +443,7 @@ class TestClass(BoaTest):
 
     def test_user_class_with_instance_method(self):
         path, _ = self.get_deploy_file_paths('UserClassWithInstanceMethod.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -459,7 +459,7 @@ class TestClass(BoaTest):
 
     def test_user_class_with_instance_method_from_variable(self):
         path, _ = self.get_deploy_file_paths('UserClassWithInstanceMethodFromVariable.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -479,7 +479,7 @@ class TestClass(BoaTest):
 
     def test_user_class_with_instance_variable_from_object(self):
         path, _ = self.get_deploy_file_paths('UserClassWithInstanceVariableFromObject.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -498,7 +498,7 @@ class TestClass(BoaTest):
 
     def test_user_class_with_instance_variable_from_variable(self):
         path, _ = self.get_deploy_file_paths('UserClassWithInstanceVariableFromVariable.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -517,7 +517,7 @@ class TestClass(BoaTest):
 
     def test_user_class_update_instance_variable(self):
         path, _ = self.get_deploy_file_paths('UserClassUpdateInstanceVariable.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -536,7 +536,7 @@ class TestClass(BoaTest):
 
     def test_user_class_access_variable_on_init(self):
         path, _ = self.get_deploy_file_paths('UserClassAccessInstanceVariableOnInit.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -552,7 +552,7 @@ class TestClass(BoaTest):
 
     def test_user_class_access_variable_on_method(self):
         path, _ = self.get_deploy_file_paths('UserClassAccessInstanceVariableOnMethod.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -575,7 +575,7 @@ class TestClass(BoaTest):
 
     def test_user_class_with_created_base(self):
         path, _ = self.get_deploy_file_paths('UserClassWithCreatedBase.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -594,7 +594,7 @@ class TestClass(BoaTest):
 
     def test_user_class_with_cascated_created_base(self):
         path, _ = self.get_deploy_file_paths('UserClassWithCascadeCreatedBase.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -613,7 +613,7 @@ class TestClass(BoaTest):
 
     def test_user_class_with_created_base_with_variable(self):
         path, _ = self.get_deploy_file_paths('UserClassWithCreatedBaseWithVariables.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -644,7 +644,7 @@ class TestClass(BoaTest):
 
     def test_user_class_with_created_base_with_args(self):
         path, _ = self.get_deploy_file_paths('UserClassWithCreatedBaseWithArgs.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -678,7 +678,7 @@ class TestClass(BoaTest):
 
     def test_user_class_with_created_base_with_init(self):
         path, _ = self.get_deploy_file_paths('UserClassWithCreatedBaseWithInit.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -695,7 +695,7 @@ class TestClass(BoaTest):
 
     def test_user_class_with_created_base_with_init_with_args(self):
         path, _ = self.get_deploy_file_paths('UserClassWithCreatedBaseWithInitWithArgs.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -712,7 +712,7 @@ class TestClass(BoaTest):
 
     def test_user_class_with_created_base_with_more_variables(self):
         path, _ = self.get_deploy_file_paths('UserClassWithCreatedBaseWithMoreVariables.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -745,7 +745,7 @@ class TestClass(BoaTest):
 
     def test_user_class_with_property_from_object(self):
         path, _ = self.get_deploy_file_paths('UserClassWithPropertyFromObject.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -761,7 +761,7 @@ class TestClass(BoaTest):
 
     def test_user_class_with_property_using_instance_variables_from_object(self):
         path, _ = self.get_deploy_file_paths('UserClassWithPropertyUsingInstanceVariablesFromObject.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -777,7 +777,7 @@ class TestClass(BoaTest):
 
     def test_user_class_with_property_using_class_variables_from_object(self):
         path, _ = self.get_deploy_file_paths('UserClassWithPropertyUsingClassVariablesFromObject.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -793,7 +793,7 @@ class TestClass(BoaTest):
 
     def test_user_class_with_property_using_variables_from_object(self):
         path, _ = self.get_deploy_file_paths('UserClassWithPropertyUsingVariablesFromObject.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -825,7 +825,7 @@ class TestClass(BoaTest):
 
     def test_user_class_with_augmented_assignment_operator_with_variable(self):
         path, _ = self.get_deploy_file_paths('UserClassWithAugmentedAssignmentOperatorWithVariable.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -856,7 +856,7 @@ class TestClass(BoaTest):
 
     def test_user_class_with_deploy_method(self):
         path, _ = self.get_deploy_file_paths('UserClassWithDeployMethod.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_contract_interface.py
+++ b/boa3_test/tests/compiler_tests/test_contract_interface.py
@@ -2,7 +2,7 @@ from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to 
 
 from boa3.internal.exception import CompilerError
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestContractInterface(BoaTest):
@@ -47,7 +47,7 @@ class TestContractInterface(BoaTest):
     def test_contract_interface_nep17(self):
         path, _ = self.get_deploy_file_paths('Nep17Interface.py')
         nep17_path, _ = self.get_deploy_file_paths('examples', 'nep17.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -91,7 +91,7 @@ class TestContractInterface(BoaTest):
     def test_contract_interface_nep17_with_display_name(self):
         path, _ = self.get_deploy_file_paths('Nep17InterfaceWithDisplayName.py')
         nep17_path, _ = self.get_deploy_file_paths('examples', 'nep17.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -116,7 +116,7 @@ class TestContractInterface(BoaTest):
         from boa3.internal.neo3.core.types import UInt160
 
         nep17_path, _ = self.get_deploy_file_paths('examples', 'nep17.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
         nep17_contract = runner.deploy_contract(nep17_path)
         runner.update_contracts(export_checkpoint=True)
 
@@ -174,7 +174,7 @@ class TestContractInterface(BoaTest):
         from boa3.internal.neo.vm.type.String import String
 
         nep17_path, _ = self.get_deploy_file_paths('examples', 'nep17.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
         nep17_contract = runner.deploy_contract(nep17_path)
         runner.update_contracts(export_checkpoint=True)
 
@@ -242,7 +242,7 @@ class TestContractInterface(BoaTest):
 
     def test_get_hash(self):
         path, _ = self.get_deploy_file_paths('ContractInterfaceGetHash.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -270,7 +270,7 @@ class TestContractInterface(BoaTest):
                       manifest['permissions'])
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_dict.py
+++ b/boa3_test/tests/compiler_tests/test_dict.py
@@ -5,7 +5,7 @@ from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo.vm.type.String import String
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestDict(BoaTest):
@@ -241,7 +241,7 @@ class TestDict(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -287,7 +287,7 @@ class TestDict(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -348,7 +348,7 @@ class TestDict(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -403,7 +403,7 @@ class TestDict(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -458,7 +458,7 @@ class TestDict(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -513,7 +513,7 @@ class TestDict(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -529,7 +529,7 @@ class TestDict(BoaTest):
 
     def test_dict_boa2_test2(self):
         path, _ = self.get_deploy_file_paths('DictBoa2Test2.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -545,7 +545,7 @@ class TestDict(BoaTest):
 
     def test_dict_any_key_and_value(self):
         path, _ = self.get_deploy_file_paths('DictAnyKeyAndValue.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -561,7 +561,7 @@ class TestDict(BoaTest):
 
     def test_boa2_dict_test1(self):
         path, _ = self.get_deploy_file_paths('DictBoa2Test1.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -576,7 +576,7 @@ class TestDict(BoaTest):
 
     def test_boa2_dict_test3(self):
         path, _ = self.get_deploy_file_paths('DictBoa2Test3.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = runner.call_contract(path, 'main')
 
@@ -589,7 +589,7 @@ class TestDict(BoaTest):
 
     def test_boa2_dict_test4(self):
         path, _ = self.get_deploy_file_paths('DictBoa2Test4.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -606,7 +606,7 @@ class TestDict(BoaTest):
     def test_boa2_dict_test5_should_not_compile(self):
         # this doesn't compile in boa2, but should compile here
         path, _ = self.get_deploy_file_paths('DictBoa2Test5ShouldNotCompile.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -623,7 +623,7 @@ class TestDict(BoaTest):
     def test_boa2_dict_test6_should_not_compile(self):
         # this doesn't compile in boa2, but should compile here
         path, _ = self.get_deploy_file_paths('DictBoa2Test6ShouldNotCompile.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -639,7 +639,7 @@ class TestDict(BoaTest):
 
     def test_boa2_dict_test_keys(self):
         path, _ = self.get_deploy_file_paths('DictBoa2TestKeys.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -655,7 +655,7 @@ class TestDict(BoaTest):
 
     def test_boa2_dict_test_values(self):
         path, _ = self.get_deploy_file_paths('DictBoa2TestValues.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -671,7 +671,7 @@ class TestDict(BoaTest):
 
     def test_dict_pop(self):
         path, _ = self.get_deploy_file_paths('DictPop.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -705,7 +705,7 @@ class TestDict(BoaTest):
 
     def test_dict_pop_default(self):
         path, _ = self.get_deploy_file_paths('DictPopDefault.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -746,7 +746,7 @@ class TestDict(BoaTest):
 
     def test_dict_copy(self):
         path, _ = self.get_deploy_file_paths('DictCopy.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -765,7 +765,7 @@ class TestDict(BoaTest):
 
     def test_dict_copy_builtin_call(self):
         path, _ = self.get_deploy_file_paths('CopyDictBuiltinCall.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_event.py
+++ b/boa3_test/tests/compiler_tests/test_event.py
@@ -6,7 +6,7 @@ from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo.vm.type.String import String
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestEvent(BoaTest):
@@ -30,7 +30,7 @@ class TestEvent(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
         invoke = runner.call_contract(path, 'Main')
 
         runner.execute()
@@ -62,7 +62,7 @@ class TestEvent(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
         invoke = runner.call_contract(path, 'Main')
 
         runner.execute()
@@ -94,7 +94,7 @@ class TestEvent(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
         invoke = runner.call_contract(path, 'Main')
 
         runner.execute()
@@ -126,7 +126,7 @@ class TestEvent(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
         invoke = runner.call_contract(path, 'Main')
 
         runner.execute()
@@ -162,7 +162,7 @@ class TestEvent(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
         invoke = runner.call_contract(path, 'Main', b'1', b'2', 10)
 
         runner.execute()
@@ -198,7 +198,7 @@ class TestEvent(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
         invoke = runner.call_contract(path, 'Main', b'1', b'2', 10)
 
         runner.execute()
@@ -235,7 +235,7 @@ class TestEvent(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
         invoke = runner.call_contract(path, 'Main', b'1', b'2', 10, b'someToken')
 
         runner.execute()
@@ -253,7 +253,7 @@ class TestEvent(BoaTest):
 
     def test_event_with_duplicated_name(self):
         path, _ = self.get_deploy_file_paths('EventWithDuplicatedName.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         arg = 10
         event_id = 'example'
@@ -321,7 +321,7 @@ class TestEvent(BoaTest):
         self.compile_and_save(path)
         path, _ = self.get_deploy_file_paths(path)
 
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
         runner.call_contract(path, 'send_event_with_abort')
         runner.execute()
         self.assertEqual(VMState.FAULT, runner.vm_state, msg=runner.cli_log)
@@ -336,7 +336,7 @@ class TestEvent(BoaTest):
 
     def test_boa2_event_test(self):
         path, _ = self.get_deploy_file_paths('EventBoa2Test.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
         invoke = runner.call_contract(path, 'main')
 
         runner.execute()

--- a/boa3_test/tests/compiler_tests/test_exception.py
+++ b/boa3_test/tests/compiler_tests/test_exception.py
@@ -6,7 +6,7 @@ from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo.vm.type.String import String
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestException(BoaTest):
@@ -36,7 +36,7 @@ class TestException(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         runner.call_contract(path, 'test_raise', 10)
         runner.execute()
@@ -70,7 +70,7 @@ class TestException(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         runner.call_contract(path, 'test_raise', 10)
         runner.execute()
@@ -103,7 +103,7 @@ class TestException(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         runner.call_contract(path, 'test_raise', 10)
         runner.execute()
@@ -138,7 +138,7 @@ class TestException(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         runner.call_contract(path, 'test_raise', 10)
         runner.execute()
@@ -177,7 +177,7 @@ class TestException(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         runner.call_contract(path, 'test_raise', 10)
         runner.execute()
@@ -210,7 +210,7 @@ class TestException(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         runner.call_contract(path, 'test_raise', 10)
         runner.execute()
@@ -251,7 +251,7 @@ class TestException(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -293,7 +293,7 @@ class TestException(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -335,7 +335,7 @@ class TestException(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -393,7 +393,7 @@ class TestException(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -440,7 +440,7 @@ class TestException(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -500,7 +500,7 @@ class TestException(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_file_generation.py
+++ b/boa3_test/tests/compiler_tests/test_file_generation.py
@@ -830,8 +830,8 @@ class TestFileGeneration(BoaTest):
         path, _ = self.get_deploy_file_paths('test_sc/function_test', 'RecursiveFunction.py')
 
         from boa3.internal.neo3.vm import VMState
-        from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
-        runner = NeoTestRunner(runner_id=self.method_name())
+        from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         expected = self.fact(57)
         invoke = runner.call_contract(path, 'main')

--- a/boa3_test/tests/compiler_tests/test_for.py
+++ b/boa3_test/tests/compiler_tests/test_for.py
@@ -4,7 +4,7 @@ from boa3.internal.exception import CompilerError
 from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestFor(BoaTest):
@@ -63,7 +63,7 @@ class TestFor(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -79,7 +79,7 @@ class TestFor(BoaTest):
 
     def test_for_string_condition(self):
         path, _ = self.get_deploy_file_paths('StringCondition.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -188,7 +188,7 @@ class TestFor(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -261,7 +261,7 @@ class TestFor(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -277,7 +277,7 @@ class TestFor(BoaTest):
 
     def test_for_continue(self):
         path, _ = self.get_deploy_file_paths('ForContinue.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -293,7 +293,7 @@ class TestFor(BoaTest):
 
     def test_for_break(self):
         path, _ = self.get_deploy_file_paths('ForBreak.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -309,7 +309,7 @@ class TestFor(BoaTest):
 
     def test_for_break_else(self):
         path, _ = self.get_deploy_file_paths('ForBreakElse.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -329,7 +329,7 @@ class TestFor(BoaTest):
 
     def test_boa2_iteration_test(self):
         path, _ = self.get_deploy_file_paths('IterBoa2Test.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -345,7 +345,7 @@ class TestFor(BoaTest):
 
     def test_boa2_iteration_test2(self):
         path, _ = self.get_deploy_file_paths('IterBoa2Test2.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -361,7 +361,7 @@ class TestFor(BoaTest):
 
     def test_boa2_iteration_test3(self):
         path, _ = self.get_deploy_file_paths('IterBoa2Test3.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -381,7 +381,7 @@ class TestFor(BoaTest):
 
     def test_boa2_iteration_test5(self):
         path, _ = self.get_deploy_file_paths('IterBoa2Test5.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -397,7 +397,7 @@ class TestFor(BoaTest):
 
     def test_boa2_iteration_test6(self):
         path, _ = self.get_deploy_file_paths('IterBoa2Test6.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -413,7 +413,7 @@ class TestFor(BoaTest):
 
     def test_boa2_iteration_test7(self):
         path, _ = self.get_deploy_file_paths('IterBoa2Test7.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -429,7 +429,7 @@ class TestFor(BoaTest):
 
     def test_boa2_iteration_test8(self):
         path, _ = self.get_deploy_file_paths('IterBoa2Test8.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -449,7 +449,7 @@ class TestFor(BoaTest):
         self.assertIn(Opcode.NOP, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -467,7 +467,7 @@ class TestFor(BoaTest):
         path, _ = self.get_deploy_file_paths('ForWithContractInterface.py')
         path_contract_called, _ = self.get_deploy_file_paths('ForWithContractInterfaceCalled.py')
 
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_function.py
+++ b/boa3_test/tests/compiler_tests/test_function.py
@@ -5,7 +5,7 @@ from boa3.internal.exception import CompilerError
 from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestFunction(BoaTest):
@@ -25,7 +25,7 @@ class TestFunction(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -56,7 +56,7 @@ class TestFunction(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -82,7 +82,7 @@ class TestFunction(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -102,7 +102,7 @@ class TestFunction(BoaTest):
         self.assertIn(Opcode.NOP, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -118,7 +118,7 @@ class TestFunction(BoaTest):
 
     def test_none_function_return_none(self):
         path, _ = self.get_deploy_file_paths('NoneFunctionReturnNone.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -134,7 +134,7 @@ class TestFunction(BoaTest):
 
     def test_none_function_changing_values_with_return(self):
         path, _ = self.get_deploy_file_paths('NoneFunctionChangingValuesWithReturn.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -150,7 +150,7 @@ class TestFunction(BoaTest):
 
     def test_none_function_changing_values_without_return(self):
         path, _ = self.get_deploy_file_paths('NoneFunctionChangingValuesWithoutReturn.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -181,7 +181,7 @@ class TestFunction(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -197,7 +197,7 @@ class TestFunction(BoaTest):
 
     def test_no_return_hint_function_with_condition_empty_return_statement(self):
         path, _ = self.get_deploy_file_paths('ConditionEmptyReturnFunction.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -216,7 +216,7 @@ class TestFunction(BoaTest):
 
     def test_empty_return_with_optional_return_type(self):
         path, _ = self.get_deploy_file_paths('EmptyReturnWithOptionalReturnType.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -247,7 +247,7 @@ class TestFunction(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -288,7 +288,7 @@ class TestFunction(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -331,7 +331,7 @@ class TestFunction(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -366,7 +366,7 @@ class TestFunction(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -405,7 +405,7 @@ class TestFunction(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -447,7 +447,7 @@ class TestFunction(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -493,7 +493,7 @@ class TestFunction(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -539,7 +539,7 @@ class TestFunction(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -583,7 +583,7 @@ class TestFunction(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -639,7 +639,7 @@ class TestFunction(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -682,7 +682,7 @@ class TestFunction(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -717,7 +717,7 @@ class TestFunction(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -737,7 +737,7 @@ class TestFunction(BoaTest):
 
     def test_return_inside_if(self):
         path, _ = self.get_deploy_file_paths('ReturnIf.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -771,7 +771,7 @@ class TestFunction(BoaTest):
 
     def test_return_inside_multiple_inner_if(self):
         path, _ = self.get_deploy_file_paths('ReturnMultipleInnerIf.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -812,7 +812,7 @@ class TestFunction(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -878,7 +878,7 @@ class TestFunction(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -945,7 +945,7 @@ class TestFunction(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -999,7 +999,7 @@ class TestFunction(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1050,7 +1050,7 @@ class TestFunction(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1079,7 +1079,7 @@ class TestFunction(BoaTest):
 
     def test_multiple_function_large_call(self):
         path, _ = self.get_deploy_file_paths('MultipleFunctionLargeCall.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1163,7 +1163,7 @@ class TestFunction(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1217,7 +1217,7 @@ class TestFunction(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1238,7 +1238,7 @@ class TestFunction(BoaTest):
 
     def test_call_function_with_kwarg(self):
         path, _ = self.get_deploy_file_paths('CallFunctionWithKwarg.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1254,7 +1254,7 @@ class TestFunction(BoaTest):
 
     def test_call_function_with_kwargs(self):
         path, _ = self.get_deploy_file_paths('CallFunctionWithKwargs.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1279,7 +1279,7 @@ class TestFunction(BoaTest):
 
     def test_call_function_with_kwargs_with_default_values(self):
         path, _ = self.get_deploy_file_paths('CallFunctionWithKwargsWithDefaultValues.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1336,7 +1336,7 @@ class TestFunction(BoaTest):
 
     def test_boa2_fibonacci_test(self):
         path, _ = self.get_deploy_file_paths('FibonacciBoa2Test.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1364,7 +1364,7 @@ class TestFunction(BoaTest):
 
     def test_boa2_method_test(self):
         path, _ = self.get_deploy_file_paths('MethodBoa2Test.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1383,7 +1383,7 @@ class TestFunction(BoaTest):
 
     def test_boa2_method_test2(self):
         path, _ = self.get_deploy_file_paths('MethodBoa2Test2.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1399,7 +1399,7 @@ class TestFunction(BoaTest):
 
     def test_boa2_method_test3(self):
         path, _ = self.get_deploy_file_paths('MethodBoa2Test3.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1415,7 +1415,7 @@ class TestFunction(BoaTest):
 
     def test_boa2_method_test4(self):
         path, _ = self.get_deploy_file_paths('MethodBoa2Test4.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1431,7 +1431,7 @@ class TestFunction(BoaTest):
 
     def test_boa2_method_test5(self):
         path, _ = self.get_deploy_file_paths('MethodBoa2Test5.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1447,7 +1447,7 @@ class TestFunction(BoaTest):
 
     def test_boa2_module_method_test1(self):
         path, _ = self.get_deploy_file_paths('ModuleMethodBoa2Test1.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1463,7 +1463,7 @@ class TestFunction(BoaTest):
 
     def test_boa2_module_method_test2(self):
         path, _ = self.get_deploy_file_paths('ModuleMethodBoa2Test2.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1479,7 +1479,7 @@ class TestFunction(BoaTest):
 
     def test_boa2_module_variable_test(self):
         path, _ = self.get_deploy_file_paths('ModuleVariableBoa2Test.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1495,7 +1495,7 @@ class TestFunction(BoaTest):
 
     def test_boa2_module_variable_test1(self):
         path, _ = self.get_deploy_file_paths('ModuleVariableBoa2Test1.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1511,7 +1511,7 @@ class TestFunction(BoaTest):
 
     def test_call_void_function_with_stared_argument(self):
         path, _ = self.get_deploy_file_paths('CallVoidFunctionWithStarredArgument.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1527,7 +1527,7 @@ class TestFunction(BoaTest):
 
     def test_call_return_function_with_stared_argument(self):
         path, _ = self.get_deploy_file_paths('CallReturnFunctionWithStarredArgument.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1543,7 +1543,7 @@ class TestFunction(BoaTest):
 
     def test_return_starred_argument(self):
         path, _ = self.get_deploy_file_paths('ReturnStarredArgumentCount.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1568,7 +1568,7 @@ class TestFunction(BoaTest):
 
     def test_call_function_with_same_name_in_different_scopes(self):
         path, _ = self.get_deploy_file_paths('CallFunctionsWithSameNameInDifferentScopes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1592,7 +1592,7 @@ class TestFunction(BoaTest):
 
     def test_function_as_arg(self):
         path, _ = self.get_deploy_file_paths('FunctionAsArg.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1608,7 +1608,7 @@ class TestFunction(BoaTest):
 
     def test_function_with_arg_as_arg(self):
         path, _ = self.get_deploy_file_paths('FunctionWithArgAsArg.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1626,7 +1626,7 @@ class TestFunction(BoaTest):
 
     def test_function_with_args_as_arg(self):
         path, _ = self.get_deploy_file_paths('FunctionWithArgsAsArg.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1648,7 +1648,7 @@ class TestFunction(BoaTest):
         path, _ = self.get_deploy_file_paths('CallExternalContractWithReturnNone.py')
         no_return_path, _ = self.get_deploy_file_paths('NoReturnFunction.py')
 
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
         runner.deploy_contract(no_return_path)
 
         invoke = runner.call_contract(path, 'main')

--- a/boa3_test/tests/compiler_tests/test_if.py
+++ b/boa3_test/tests/compiler_tests/test_if.py
@@ -4,7 +4,7 @@ from boa3.internal.exception import CompilerWarning
 from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestIf(BoaTest):
@@ -31,7 +31,7 @@ class TestIf(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -66,7 +66,7 @@ class TestIf(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -124,7 +124,7 @@ class TestIf(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -169,7 +169,7 @@ class TestIf(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -218,7 +218,7 @@ class TestIf(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -269,7 +269,7 @@ class TestIf(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -338,7 +338,7 @@ class TestIf(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -384,7 +384,7 @@ class TestIf(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -427,7 +427,7 @@ class TestIf(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -445,7 +445,7 @@ class TestIf(BoaTest):
 
     def test_inner_if_else(self):
         path, _ = self.get_deploy_file_paths('InnerIfElse.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -476,7 +476,7 @@ class TestIf(BoaTest):
 
     def test_if_is_instance_condition(self):
         path, _ = self.get_deploy_file_paths('IfIsInstanceCondition.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -501,7 +501,7 @@ class TestIf(BoaTest):
 
     def test_if_else_is_instance_condition(self):
         path, _ = self.get_deploy_file_paths('IfElseIsInstanceCondition.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -526,7 +526,7 @@ class TestIf(BoaTest):
 
     def test_if_else_is_instance_condition_with_union_variable(self):
         path, _ = self.get_deploy_file_paths('IfElseIsInstanceConditionWithUnionVariable.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -555,7 +555,7 @@ class TestIf(BoaTest):
 
     def test_if_else_multiple_is_instance_condition_with_union_variable(self):
         path, _ = self.get_deploy_file_paths('IfElseMultipleIsInstanceConditionWithUnionVariable.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -583,7 +583,7 @@ class TestIf(BoaTest):
 
     def test_variable_in_if_scopes(self):
         path, _ = self.get_deploy_file_paths('VariablesInIfScopes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -620,7 +620,7 @@ class TestIf(BoaTest):
 
     def test_boa2_compare_test0int(self):
         path, _ = self.get_deploy_file_paths('CompareBoa2Test0int.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -642,7 +642,7 @@ class TestIf(BoaTest):
 
     def test_boa2_compare_test0str(self):
         path, _ = self.get_deploy_file_paths('CompareBoa2Test0str.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -661,7 +661,7 @@ class TestIf(BoaTest):
 
     def test_boa2_compare_test1(self):
         path, _ = self.get_deploy_file_paths('CompareBoa2Test1.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -692,7 +692,7 @@ class TestIf(BoaTest):
 
     def test_boa2_compare_test2(self):
         path, _ = self.get_deploy_file_paths('CompareBoa2Test2.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -711,7 +711,7 @@ class TestIf(BoaTest):
 
     def test_boa2_op_call_test(self):
         path, _ = self.get_deploy_file_paths('OpCallBoa2Test.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -750,7 +750,7 @@ class TestIf(BoaTest):
 
     def test_boa2_test_many_elif(self):
         path, _ = self.get_deploy_file_paths('TestManyElifBoa2.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -775,7 +775,7 @@ class TestIf(BoaTest):
 
     def test_if_with_inner_while(self):
         path, _ = self.get_deploy_file_paths('IfWithInnerWhile.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -794,7 +794,7 @@ class TestIf(BoaTest):
 
     def test_if_with_inner_for(self):
         path, _ = self.get_deploy_file_paths('IfWithInnerFor.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -813,7 +813,7 @@ class TestIf(BoaTest):
 
     def test_if_implicit_boolean(self):
         path, _ = self.get_deploy_file_paths('IfImplicitBoolean.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -856,7 +856,7 @@ class TestIf(BoaTest):
 
     def test_if_implicit_boolean_literal(self):
         path, _ = self.get_deploy_file_paths('IfImplicitBooleanLiteral.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -876,7 +876,7 @@ class TestIf(BoaTest):
         self.assertIn(Opcode.NOP, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -896,7 +896,7 @@ class TestIf(BoaTest):
         self.assertIn(Opcode.NOP, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -922,7 +922,7 @@ class TestIf(BoaTest):
         self.assertEqual(n_nop, 2)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -938,7 +938,7 @@ class TestIf(BoaTest):
 
     def test_if_is_none(self):
         path, _ = self.get_deploy_file_paths('IfIsNone.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -956,7 +956,7 @@ class TestIf(BoaTest):
 
     def test_if_is_not_none(self):
         path, _ = self.get_deploy_file_paths('IfIsNotNone.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -974,7 +974,7 @@ class TestIf(BoaTest):
 
     def test_if_is_none_type_check(self):
         path, _ = self.get_deploy_file_paths('IfIsNoneTypeCheck.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_import.py
+++ b/boa3_test/tests/compiler_tests/test_import.py
@@ -4,7 +4,7 @@ from boa3.internal.exception import CompilerError
 from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestImport(BoaTest):
@@ -54,7 +54,7 @@ class TestImport(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -86,7 +86,7 @@ class TestImport(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -120,7 +120,7 @@ class TestImport(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -151,7 +151,7 @@ class TestImport(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -167,7 +167,7 @@ class TestImport(BoaTest):
 
     def test_variable_from_imported_module(self):
         path, _ = self.get_deploy_file_paths('variable_import', 'VariableFromImportedModule.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -186,7 +186,7 @@ class TestImport(BoaTest):
 
     def test_variable_access_from_imported_module(self):
         path, _ = self.get_deploy_file_paths('variable_import', 'VariableAccessFromImportedModule.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -260,7 +260,7 @@ class TestImport(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -300,7 +300,7 @@ class TestImport(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -337,7 +337,7 @@ class TestImport(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -355,7 +355,7 @@ class TestImport(BoaTest):
         path = self.get_contract_path('FromImportUserModuleFromRootAndFileDir.py')
         self.compile_and_save(path, root_folder=self.get_dir_path(self.test_root_dir))
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner()
+        runner = BoaTestRunner()
 
         invokes = []
         expected_results = []
@@ -378,7 +378,7 @@ class TestImport(BoaTest):
 
     def test_import_interop_with_alias(self):
         path, _ = self.get_deploy_file_paths('ImportInteropWithAlias.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -402,7 +402,7 @@ class TestImport(BoaTest):
 
     def test_import_user_module_with_not_imported_symbols(self):
         path, _ = self.get_deploy_file_paths('ImportUserModuleWithNotImportedSymbols.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -465,7 +465,7 @@ class TestImport(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -498,7 +498,7 @@ class TestImport(BoaTest):
 
     def test_incorrect_circular_import(self):
         path, _ = self.get_deploy_file_paths('incorrect_circular_import', 'IncorrectCircularImportDetection.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -514,7 +514,7 @@ class TestImport(BoaTest):
 
     def test_import_module_with_init(self):
         path, _ = self.get_deploy_file_paths('ImportModuleWithInit.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -533,7 +533,7 @@ class TestImport(BoaTest):
 
     def test_import_module_without_init(self):
         path, _ = self.get_deploy_file_paths('ImportModuleWithoutInit.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -553,7 +553,7 @@ class TestImport(BoaTest):
     def test_import_user_class_inner_files(self):
         inner_path, _ = self.get_deploy_file_paths('class_import', 'ImportUserClass.py')
         path, _ = self.get_deploy_file_paths('ImportUserClassInnerFiles.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_interop/test_blockchain.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_blockchain.py
@@ -9,9 +9,9 @@ from boa3.internal.neo.vm.type.String import String
 from boa3.internal.neo3.contracts import CallFlags
 from boa3.internal.neo3.core.types import UInt160, UInt256
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive import neoxp
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.test_classes.contract.neomanifeststruct import NeoManifestStruct
+from boa3_test.tests.test_drive import neoxp
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestBlockchainInterop(BoaTest):
@@ -19,7 +19,7 @@ class TestBlockchainInterop(BoaTest):
 
     def test_block_constructor(self):
         path, _ = self.get_deploy_file_paths('Block.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = runner.call_contract(path, 'main')
         runner.execute()
@@ -44,7 +44,7 @@ class TestBlockchainInterop(BoaTest):
 
     def test_get_contract(self):
         path, _ = self.get_deploy_file_paths('GetContract.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -76,7 +76,7 @@ class TestBlockchainInterop(BoaTest):
 
     def test_get_block_by_index(self):
         path, _ = self.get_deploy_file_paths('GetBlockByIndex.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         test_index_0 = 0
         test_index_10 = 10
@@ -106,7 +106,7 @@ class TestBlockchainInterop(BoaTest):
 
     def test_get_block_by_hash(self):
         path, _ = self.get_deploy_file_paths('GetBlockByHash.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         genesis_block = runner.get_genesis_block()
         expected_result_size = len(Interop.BlockType.variables)
@@ -136,7 +136,7 @@ class TestBlockchainInterop(BoaTest):
 
     def test_transaction_init(self):
         path, _ = self.get_deploy_file_paths('Transaction.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = runner.call_contract(path, 'main')
         runner.execute()
@@ -175,7 +175,7 @@ class TestBlockchainInterop(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         sender = neoxp.utils.get_default_account()
         contract_deploy = runner.deploy_contract(path)
@@ -230,7 +230,7 @@ class TestBlockchainInterop(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         sender = neoxp.utils.get_default_account()
         contract_deploy = runner.deploy_contract(path, account=sender)
@@ -284,7 +284,7 @@ class TestBlockchainInterop(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         runner.deploy_contract(path)  # to have a block with tx
         runner.update_contracts(export_checkpoint=True)
@@ -339,7 +339,7 @@ class TestBlockchainInterop(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -383,7 +383,7 @@ class TestBlockchainInterop(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         expected_block_index = 10
         blocks_to_mint = expected_block_index - 1  # mint blocks before running the tx to check
@@ -431,7 +431,7 @@ class TestBlockchainInterop(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         contract_deploy = runner.deploy_contract(path)
         runner.update_contracts(export_checkpoint=True)
@@ -451,7 +451,7 @@ class TestBlockchainInterop(BoaTest):
 
     def test_import_blockchain(self):
         path, _ = self.get_deploy_file_paths('ImportBlockchain.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -484,7 +484,7 @@ class TestBlockchainInterop(BoaTest):
 
     def test_import_interop_blockchain(self):
         path, _ = self.get_deploy_file_paths('ImportInteropBlockchain.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -516,7 +516,7 @@ class TestBlockchainInterop(BoaTest):
 
     def test_current_hash(self):
         path, _ = self.get_deploy_file_paths('CurrentHash.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = runner.call_contract(path, 'main', expected_result_type=bytes)
         runner.execute()
@@ -527,7 +527,7 @@ class TestBlockchainInterop(BoaTest):
 
     def test_current_index(self):
         path, _ = self.get_deploy_file_paths('CurrentIndex.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = runner.call_contract(path, 'main')
         runner.execute()

--- a/boa3_test/tests/compiler_tests/test_interop/test_contract.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_contract.py
@@ -9,8 +9,8 @@ from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo.vm.type.String import String
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.test_classes.contract.neomanifeststruct import NeoManifestStruct
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestContractInterop(BoaTest):
@@ -19,7 +19,7 @@ class TestContractInterop(BoaTest):
     def test_call_contract(self):
         path, _ = self.get_deploy_file_paths('CallScriptHash.py')
         call_contract_path, _ = self.get_deploy_file_paths('test_sc/arithmetic_test', 'Addition.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -52,7 +52,7 @@ class TestContractInterop(BoaTest):
     def test_call_contract_with_cast(self):
         path, _ = self.get_deploy_file_paths('CallScriptHashWithCast.py')
         call_contract_path, _ = self.get_deploy_file_paths('test_sc/arithmetic_test', 'Addition.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -79,7 +79,7 @@ class TestContractInterop(BoaTest):
     def test_call_contract_without_args(self):
         path, _ = self.get_deploy_file_paths('CallScriptHashWithoutArgs.py')
         call_contract_path, _ = self.get_deploy_file_paths('test_sc/list_test', 'IntList.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -108,7 +108,7 @@ class TestContractInterop(BoaTest):
     def test_call_contract_with_flags(self):
         path, _ = self.get_deploy_file_paths('CallScriptHashWithFlags.py')
         call_contract_path, _ = self.get_deploy_file_paths('CallFlagsUsage.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -198,7 +198,7 @@ class TestContractInterop(BoaTest):
         nef_file, manifest = self.get_bytes_output(call_contract_path)
         arg_manifest = String(json.dumps(manifest, separators=(',', ':'))).to_bytes()
 
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
         invoke = runner.call_contract(path, 'Main', nef_file, arg_manifest, None)
 
         runner.execute()
@@ -218,7 +218,7 @@ class TestContractInterop(BoaTest):
         nef_file, manifest = self.get_bytes_output(call_contract_path)
         arg_manifest = String(json.dumps(manifest, separators=(',', ':'))).to_bytes()
 
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
         runner.file_name = 'test_create_contract'
 
         data = 'some sort of data'
@@ -248,7 +248,7 @@ class TestContractInterop(BoaTest):
 
     def test_update_contract(self):
         path, _ = self.get_deploy_file_paths('UpdateContract.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
         runner.file_name = 'test_update_contract'
 
         invokes = []
@@ -278,7 +278,7 @@ class TestContractInterop(BoaTest):
 
     def test_update_contract_data_deploy(self):
         path, _ = self.get_deploy_file_paths('UpdateContract.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -317,7 +317,7 @@ class TestContractInterop(BoaTest):
 
     def test_destroy_contract(self):
         path, _ = self.get_deploy_file_paths('DestroyContract.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -358,7 +358,7 @@ class TestContractInterop(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -400,7 +400,7 @@ class TestContractInterop(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -430,7 +430,7 @@ class TestContractInterop(BoaTest):
 
     def test_call_flags_type(self):
         path, _ = self.get_deploy_file_paths('CallFlagsType.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -461,7 +461,7 @@ class TestContractInterop(BoaTest):
     def test_get_call_flags(self):
         path, _ = self.get_deploy_file_paths('CallScriptHashWithFlags.py')
         call_contract_path, _ = self.get_deploy_file_paths('GetCallFlags.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -504,7 +504,7 @@ class TestContractInterop(BoaTest):
     def test_import_contract(self):
         path, _ = self.get_deploy_file_paths('ImportContract.py')
         call_contract_path, _ = self.get_deploy_file_paths('test_sc/arithmetic_test', 'Addition.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -532,7 +532,7 @@ class TestContractInterop(BoaTest):
     def test_import_interop_contract(self):
         path, _ = self.get_deploy_file_paths('ImportInteropContract.py')
         call_contract_path, _ = self.get_deploy_file_paths('test_sc/arithmetic_test', 'Addition.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -596,7 +596,7 @@ class TestContractInterop(BoaTest):
 
     def test_get_minimum_deployment_fee(self):
         path, _ = self.get_deploy_file_paths('GetMinimumDeploymentFee.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_interop/test_crypto.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_crypto.py
@@ -11,7 +11,7 @@ from boa3.internal.neo.vm.type.String import String
 from boa3.internal.neo3.contracts.contracttypes import CallFlags
 from boa3.internal.neo3.contracts.namedcurve import NamedCurve
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestCryptoInterop(BoaTest):
@@ -33,7 +33,7 @@ class TestCryptoInterop(BoaTest):
 
     def test_ripemd160_str(self):
         path, _ = self.get_deploy_file_paths('Ripemd160Str.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -54,7 +54,7 @@ class TestCryptoInterop(BoaTest):
 
     def test_ripemd160_int(self):
         path, _ = self.get_deploy_file_paths('Ripemd160Int.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -71,7 +71,7 @@ class TestCryptoInterop(BoaTest):
 
     def test_ripemd160_bool(self):
         path, _ = self.get_deploy_file_paths('Ripemd160Bool.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -88,7 +88,7 @@ class TestCryptoInterop(BoaTest):
 
     def test_ripemd160_bytes(self):
         path, _ = self.get_deploy_file_paths('Ripemd160Bytes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -113,7 +113,7 @@ class TestCryptoInterop(BoaTest):
 
     def test_hash160_str(self):
         path, _ = self.get_deploy_file_paths('Hash160Str.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -130,7 +130,7 @@ class TestCryptoInterop(BoaTest):
 
     def test_hash160_int(self):
         path, _ = self.get_deploy_file_paths('Hash160Int.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -147,7 +147,7 @@ class TestCryptoInterop(BoaTest):
 
     def test_hash160_bool(self):
         path, _ = self.get_deploy_file_paths('Hash160Bool.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -164,7 +164,7 @@ class TestCryptoInterop(BoaTest):
 
     def test_hash160_bytes(self):
         path, _ = self.get_deploy_file_paths('Hash160Bytes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -181,7 +181,7 @@ class TestCryptoInterop(BoaTest):
 
     def test_sha256_str(self):
         path, _ = self.get_deploy_file_paths('Sha256Str.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -202,7 +202,7 @@ class TestCryptoInterop(BoaTest):
 
     def test_sha256_int(self):
         path, _ = self.get_deploy_file_paths('Sha256Int.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -219,7 +219,7 @@ class TestCryptoInterop(BoaTest):
 
     def test_sha256_bool(self):
         path, _ = self.get_deploy_file_paths('Sha256Bool.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -236,7 +236,7 @@ class TestCryptoInterop(BoaTest):
 
     def test_sha256_bytes(self):
         path, _ = self.get_deploy_file_paths('Sha256Bytes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -261,7 +261,7 @@ class TestCryptoInterop(BoaTest):
 
     def test_hash256_str(self):
         path, _ = self.get_deploy_file_paths('Hash256Str.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -278,7 +278,7 @@ class TestCryptoInterop(BoaTest):
 
     def test_hash256_int(self):
         path, _ = self.get_deploy_file_paths('Hash256Int.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -295,7 +295,7 @@ class TestCryptoInterop(BoaTest):
 
     def test_hash256_bool(self):
         path, _ = self.get_deploy_file_paths('Hash256Bool.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -312,7 +312,7 @@ class TestCryptoInterop(BoaTest):
 
     def test_hash256_bytes(self):
         path, _ = self.get_deploy_file_paths('Hash256Bytes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -358,7 +358,7 @@ class TestCryptoInterop(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -414,7 +414,7 @@ class TestCryptoInterop(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -497,7 +497,7 @@ class TestCryptoInterop(BoaTest):
 
     def test_import_crypto(self):
         path, _ = self.get_deploy_file_paths('ImportCrypto.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -514,7 +514,7 @@ class TestCryptoInterop(BoaTest):
 
     def test_import_interop_crypto(self):
         path, _ = self.get_deploy_file_paths('ImportInteropCrypto.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_interop/test_iterator.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_iterator.py
@@ -3,7 +3,7 @@ from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to 
 from boa3.internal.exception import CompilerError
 from boa3.internal.neo.vm.type.String import String
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestIteratorInterop(BoaTest):
@@ -15,7 +15,7 @@ class TestIteratorInterop(BoaTest):
 
     def test_iterator_next(self):
         path, _ = self.get_deploy_file_paths('IteratorNext.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -37,7 +37,7 @@ class TestIteratorInterop(BoaTest):
 
     def test_iterator_value(self):
         path, _ = self.get_deploy_file_paths('IteratorValue.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -64,7 +64,7 @@ class TestIteratorInterop(BoaTest):
 
     def test_import_iterator(self):
         path, _ = self.get_deploy_file_paths('ImportIterator.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -80,7 +80,7 @@ class TestIteratorInterop(BoaTest):
 
     def test_import_interop_iterator(self):
         path, _ = self.get_deploy_file_paths('ImportInteropIterator.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -96,7 +96,7 @@ class TestIteratorInterop(BoaTest):
 
     def test_iterator_implicit_typing(self):
         path, _ = self.get_deploy_file_paths('IteratorImplicitTyping.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -123,7 +123,7 @@ class TestIteratorInterop(BoaTest):
 
     def test_iterator_value_access(self):
         path, _ = self.get_deploy_file_paths('IteratorValueAccess.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_interop/test_json.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_json.py
@@ -4,7 +4,7 @@ from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to 
 
 from boa3.internal.neo.vm.type.String import String
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestJsonInterop(BoaTest):
@@ -12,7 +12,7 @@ class TestJsonInterop(BoaTest):
 
     def test_json_serialize(self):
         path, _ = self.get_deploy_file_paths('JsonSerialize.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -30,7 +30,7 @@ class TestJsonInterop(BoaTest):
 
     def test_json_serialize_int(self):
         path, _ = self.get_deploy_file_paths('JsonSerializeInt.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -47,7 +47,7 @@ class TestJsonInterop(BoaTest):
 
     def test_json_serialize_bool(self):
         path, _ = self.get_deploy_file_paths('JsonSerializeBool.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -64,7 +64,7 @@ class TestJsonInterop(BoaTest):
 
     def test_json_serialize_str(self):
         path, _ = self.get_deploy_file_paths('JsonSerializeStr.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -81,7 +81,7 @@ class TestJsonInterop(BoaTest):
 
     def test_json_serialize_bytes(self):
         path, _ = self.get_deploy_file_paths('JsonSerializeBytes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -100,7 +100,7 @@ class TestJsonInterop(BoaTest):
 
     def test_json_deserialize(self):
         path, _ = self.get_deploy_file_paths('JsonDeserialize.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -128,7 +128,7 @@ class TestJsonInterop(BoaTest):
 
     def test_import_json(self):
         path, _ = self.get_deploy_file_paths('ImportJson.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -149,7 +149,7 @@ class TestJsonInterop(BoaTest):
 
     def test_import_interop_json(self):
         path, _ = self.get_deploy_file_paths('ImportInteropJson.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_interop/test_policy.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_policy.py
@@ -2,7 +2,7 @@ from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to 
 
 from boa3.internal.exception import CompilerError
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestPolicyInterop(BoaTest):
@@ -10,7 +10,7 @@ class TestPolicyInterop(BoaTest):
 
     def test_get_exec_fee_factor(self):
         path, _ = self.get_deploy_file_paths('GetExecFeeFactor.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = runner.call_contract(path, 'main')
         runner.execute()
@@ -23,7 +23,7 @@ class TestPolicyInterop(BoaTest):
 
     def test_get_fee_per_byte(self):
         path, _ = self.get_deploy_file_paths('GetFeePerByte.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = runner.call_contract(path, 'main')
         runner.execute()
@@ -36,7 +36,7 @@ class TestPolicyInterop(BoaTest):
 
     def test_get_storage_price(self):
         path, _ = self.get_deploy_file_paths('GetStoragePrice.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = runner.call_contract(path, 'main')
         runner.execute()
@@ -49,7 +49,7 @@ class TestPolicyInterop(BoaTest):
 
     def test_is_blocked(self):
         path, _ = self.get_deploy_file_paths('IsBlocked.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -83,7 +83,7 @@ class TestPolicyInterop(BoaTest):
 
     def test_import_policy(self):
         path, _ = self.get_deploy_file_paths('ImportPolicy.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = runner.call_contract(path, 'main')
         runner.execute()
@@ -92,7 +92,7 @@ class TestPolicyInterop(BoaTest):
 
     def test_import_interop_policy(self):
         path, _ = self.get_deploy_file_paths('ImportInteropPolicy.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = runner.call_contract(path, 'main')
         runner.execute()

--- a/boa3_test/tests/compiler_tests/test_interop/test_runtime.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_runtime.py
@@ -8,8 +8,8 @@ from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo.vm.type.String import String
 from boa3.internal.neo3.contracts import TriggerType
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive import neoxp
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive import neoxp
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestRuntimeInterop(BoaTest):
@@ -19,7 +19,7 @@ class TestRuntimeInterop(BoaTest):
         path, _ = self.get_deploy_file_paths('CheckWitness.py')
         account = neoxp.utils.get_account_by_name('testAccount1')
         account_hash = account.script_hash.to_array()
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -44,7 +44,7 @@ class TestRuntimeInterop(BoaTest):
         call_contract_path, _ = self.get_deploy_file_paths('CheckWitness.py')
         account = neoxp.utils.get_account_by_name('testAccount1')
         account_hash = account.script_hash.to_array()
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -76,7 +76,7 @@ class TestRuntimeInterop(BoaTest):
         path, _ = self.get_deploy_file_paths('CheckWitnessImportedAs.py')
         account = neoxp.utils.get_account_by_name('testAccount1')
         account_hash = account.script_hash.to_array()
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -124,7 +124,7 @@ class TestRuntimeInterop(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -162,7 +162,7 @@ class TestRuntimeInterop(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -200,7 +200,7 @@ class TestRuntimeInterop(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -238,7 +238,7 @@ class TestRuntimeInterop(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -281,7 +281,7 @@ class TestRuntimeInterop(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -318,7 +318,7 @@ class TestRuntimeInterop(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -356,7 +356,7 @@ class TestRuntimeInterop(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -382,7 +382,7 @@ class TestRuntimeInterop(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -411,7 +411,7 @@ class TestRuntimeInterop(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -440,7 +440,7 @@ class TestRuntimeInterop(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -466,7 +466,7 @@ class TestRuntimeInterop(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         contract_call = runner.call_contract(path, 'Main',
                                              expected_result_type=bytes)
@@ -505,7 +505,7 @@ class TestRuntimeInterop(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         contract = runner.deploy_contract(path)
         invoke = runner.call_contract(path, 'Main')
@@ -530,7 +530,7 @@ class TestRuntimeInterop(BoaTest):
 
     def test_get_executing_script_hash_on_deploy(self):
         path, _ = self.get_deploy_file_paths('ExecutingScriptHashOnDeploy.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -558,7 +558,7 @@ class TestRuntimeInterop(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke_1 = runner.run_contract(path, 'Main')
         invoke_2 = runner.call_contract(path, 'Main')
@@ -604,7 +604,7 @@ class TestRuntimeInterop(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = runner.call_contract(path, 'Main')
         runner.execute()
@@ -637,7 +637,7 @@ class TestRuntimeInterop(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = runner.call_contract(path, 'Main')
         runner.execute()
@@ -660,7 +660,7 @@ class TestRuntimeInterop(BoaTest):
 
     def test_get_notifications(self):
         path, _ = self.get_deploy_file_paths('GetNotifications.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -708,7 +708,7 @@ class TestRuntimeInterop(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = runner.call_contract(path, 'main')
         runner.execute()
@@ -744,7 +744,7 @@ class TestRuntimeInterop(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -774,7 +774,7 @@ class TestRuntimeInterop(BoaTest):
 
     def test_burn_gas(self):
         path, _ = self.get_deploy_file_paths('BurnGas.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -808,7 +808,7 @@ class TestRuntimeInterop(BoaTest):
     def test_boa2_runtime_test(self):
         path, _ = self.get_deploy_file_paths('RuntimeBoa2Test.py')
         account = neoxp.utils.get_account_by_name('testAccount1').script_hash.to_array()
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -844,7 +844,7 @@ class TestRuntimeInterop(BoaTest):
 
     def test_boa2_trigger_type_test(self):
         path, _ = self.get_deploy_file_paths('TriggerTypeBoa2Test.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -870,7 +870,7 @@ class TestRuntimeInterop(BoaTest):
 
     def test_get_script_container(self):
         path, _ = self.get_deploy_file_paths('ScriptContainer.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = runner.call_contract(path, 'main')
         runner.execute()
@@ -879,7 +879,7 @@ class TestRuntimeInterop(BoaTest):
 
     def test_get_script_container_as_transaction(self):
         path, _ = self.get_deploy_file_paths('ScriptContainerAsTransaction.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = runner.call_contract(path, 'main')
         runner.execute()
@@ -904,7 +904,7 @@ class TestRuntimeInterop(BoaTest):
 
     def test_get_network(self):
         path, _ = self.get_deploy_file_paths('GetNetwork.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -924,7 +924,7 @@ class TestRuntimeInterop(BoaTest):
 
     def test_import_runtime(self):
         path, _ = self.get_deploy_file_paths('ImportRuntime.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = runner.call_contract(path, 'main')
         runner.execute()
@@ -933,7 +933,7 @@ class TestRuntimeInterop(BoaTest):
 
     def test_import_interop_runtime(self):
         path, _ = self.get_deploy_file_paths('ImportInteropRuntime.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = runner.call_contract(path, 'main')
         runner.execute()
@@ -942,7 +942,7 @@ class TestRuntimeInterop(BoaTest):
 
     def test_get_random(self):
         path, _ = self.get_deploy_file_paths('GetRandom.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = runner.call_contract(path, 'main')
         runner.execute()
@@ -955,7 +955,7 @@ class TestRuntimeInterop(BoaTest):
 
     def test_address_version(self):
         path, _ = self.get_deploy_file_paths('AddressVersion.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -975,7 +975,7 @@ class TestRuntimeInterop(BoaTest):
 
     def test_load_script(self):
         path, _ = self.get_deploy_file_paths('LoadScriptDynamicCall.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_interop/test_stdlib.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_stdlib.py
@@ -4,7 +4,7 @@ from boa3.internal.exception import CompilerError
 from boa3.internal.neo.vm.type.StackItem import StackItemType, serialize
 from boa3.internal.neo.vm.type.String import String
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestStdlibInterop(BoaTest):
@@ -13,7 +13,7 @@ class TestStdlibInterop(BoaTest):
     def test_base64_encode(self):
         import base64
         path, _ = self.get_deploy_file_paths('Base64Encode.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -54,7 +54,7 @@ class TestStdlibInterop(BoaTest):
     def test_base64_decode(self):
         import base64
         path, _ = self.get_deploy_file_paths('Base64Decode.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -95,7 +95,7 @@ class TestStdlibInterop(BoaTest):
     def test_base58_encode(self):
         import base58
         path, _ = self.get_deploy_file_paths('Base58Encode.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -136,7 +136,7 @@ class TestStdlibInterop(BoaTest):
     def test_base58_decode(self):
         import base58
         path, _ = self.get_deploy_file_paths('Base58Decode.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -174,7 +174,7 @@ class TestStdlibInterop(BoaTest):
     def test_base58_check_decode(self):
         import base58
         path, _ = self.get_deploy_file_paths('Base58CheckDecode.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -212,7 +212,7 @@ class TestStdlibInterop(BoaTest):
     def test_base58_check_encode(self):
         import base58
         path, _ = self.get_deploy_file_paths('Base58CheckEncode.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -252,7 +252,7 @@ class TestStdlibInterop(BoaTest):
 
     def test_serialize_int(self):
         path, _ = self.get_deploy_file_paths('SerializeInt.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -270,7 +270,7 @@ class TestStdlibInterop(BoaTest):
 
     def test_serialize_bool(self):
         path, _ = self.get_deploy_file_paths('SerializeBool.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -288,7 +288,7 @@ class TestStdlibInterop(BoaTest):
 
     def test_serialize_str(self):
         path, _ = self.get_deploy_file_paths('SerializeStr.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -306,7 +306,7 @@ class TestStdlibInterop(BoaTest):
 
     def test_serialize_sequence(self):
         path, _ = self.get_deploy_file_paths('SerializeSequence.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -324,7 +324,7 @@ class TestStdlibInterop(BoaTest):
 
     def test_serialize_dict(self):
         path, _ = self.get_deploy_file_paths('SerializeDict.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -342,7 +342,7 @@ class TestStdlibInterop(BoaTest):
 
     def test_deserialize(self):
         path, _ = self.get_deploy_file_paths('Deserialize.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -397,7 +397,7 @@ class TestStdlibInterop(BoaTest):
 
     def test_boa2_serialization_test1(self):
         path, _ = self.get_deploy_file_paths('SerializationBoa2Test.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -414,7 +414,7 @@ class TestStdlibInterop(BoaTest):
 
     def test_boa2_serialization_test2(self):
         path, _ = self.get_deploy_file_paths('SerializationBoa2Test.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -431,7 +431,7 @@ class TestStdlibInterop(BoaTest):
 
     def test_boa2_serialization_test3(self):
         path, _ = self.get_deploy_file_paths('SerializationBoa2Test.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -447,7 +447,7 @@ class TestStdlibInterop(BoaTest):
 
     def test_boa2_serialization_test4(self):
         path, _ = self.get_deploy_file_paths('SerializationBoa2Test.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -463,7 +463,7 @@ class TestStdlibInterop(BoaTest):
 
     def test_user_class_serialization(self):
         path, _ = self.get_deploy_file_paths('SerializationUserClass.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -498,7 +498,7 @@ class TestStdlibInterop(BoaTest):
 
     def test_atoi(self):
         path, _ = self.get_deploy_file_paths('Atoi.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -549,7 +549,7 @@ class TestStdlibInterop(BoaTest):
 
     def test_atoi_default(self):
         path, _ = self.get_deploy_file_paths('AtoiDefault.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -585,7 +585,7 @@ class TestStdlibInterop(BoaTest):
 
     def test_itoa(self):
         path, _ = self.get_deploy_file_paths('Itoa')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -614,7 +614,7 @@ class TestStdlibInterop(BoaTest):
 
     def test_itoa_default(self):
         path, _ = self.get_deploy_file_paths('ItoaDefault')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -644,7 +644,7 @@ class TestStdlibInterop(BoaTest):
 
     def test_import_stdlib(self):
         path, _ = self.get_deploy_file_paths('ImportStdlib')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -663,7 +663,7 @@ class TestStdlibInterop(BoaTest):
 
     def test_import_interop_binary(self):
         path, _ = self.get_deploy_file_paths('ImportInteropStdlib')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -682,7 +682,7 @@ class TestStdlibInterop(BoaTest):
 
     def test_memory_search(self):
         path, _ = self.get_deploy_file_paths('MemorySearch')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -730,7 +730,7 @@ class TestStdlibInterop(BoaTest):
 
     def test_memory_search_backward(self):
         path, _ = self.get_deploy_file_paths('MemorySearch')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -778,7 +778,7 @@ class TestStdlibInterop(BoaTest):
 
     def test_memory_search_start(self):
         path, _ = self.get_deploy_file_paths('MemorySearchStart')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -817,7 +817,7 @@ class TestStdlibInterop(BoaTest):
 
     def test_memory_search_default_values(self):
         path, _ = self.get_deploy_file_paths('MemorySearchDefault')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -866,7 +866,7 @@ class TestStdlibInterop(BoaTest):
 
     def test_memory_compare(self):
         path, _ = self.get_deploy_file_paths('MemoryCompare')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_interop/test_storage.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_storage.py
@@ -8,7 +8,7 @@ from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo.vm.type.String import String
 from boa3.internal.neo3.contracts import FindOptions
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestStorageInterop(BoaTest):
@@ -48,7 +48,7 @@ class TestStorageInterop(BoaTest):
 
     def test_storage_put_bytes_key_bytes_value(self):
         path, _ = self.get_deploy_file_paths('StoragePutBytesKeyBytesValue.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -101,7 +101,7 @@ class TestStorageInterop(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -158,7 +158,7 @@ class TestStorageInterop(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -227,7 +227,7 @@ class TestStorageInterop(BoaTest):
         self.assertStartsWith(output, expected_output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -270,7 +270,7 @@ class TestStorageInterop(BoaTest):
 
     def test_storage_find_bytes_prefix(self):
         path, _ = self.get_deploy_file_paths('StorageFindBytesPrefix.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -317,7 +317,7 @@ class TestStorageInterop(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -342,7 +342,7 @@ class TestStorageInterop(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -358,7 +358,7 @@ class TestStorageInterop(BoaTest):
 
     def test_storage_get_with_context(self):
         path, _ = self.get_deploy_file_paths('StorageGetWithContext.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -395,7 +395,7 @@ class TestStorageInterop(BoaTest):
 
     def test_storage_put_with_context(self):
         path, _ = self.get_deploy_file_paths('StoragePutWithContext.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -446,7 +446,7 @@ class TestStorageInterop(BoaTest):
         self.assertStartsWith(output, expected_output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -481,7 +481,7 @@ class TestStorageInterop(BoaTest):
 
     def test_storage_find_with_context(self):
         path, _ = self.get_deploy_file_paths('StorageFindWithContext.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -511,7 +511,7 @@ class TestStorageInterop(BoaTest):
 
     def test_storage_find_with_options(self):
         path, _ = self.get_deploy_file_paths('StorageFindWithOptions.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -542,7 +542,7 @@ class TestStorageInterop(BoaTest):
 
     def test_boa2_storage_test(self):
         path, _ = self.get_deploy_file_paths('StorageBoa2Test.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -577,7 +577,7 @@ class TestStorageInterop(BoaTest):
 
     def test_boa2_storage_test2(self):
         path, _ = self.get_deploy_file_paths('StorageBoa2Test.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -613,7 +613,7 @@ class TestStorageInterop(BoaTest):
     def test_storage_between_contracts(self):
         path1, _ = self.get_deploy_file_paths('StorageGetAndPut1.py')
         path2, _ = self.get_deploy_file_paths('StorageGetAndPut2.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -642,7 +642,7 @@ class TestStorageInterop(BoaTest):
 
     def test_create_map(self):
         path, _ = self.get_deploy_file_paths('StorageCreateMap.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -685,7 +685,7 @@ class TestStorageInterop(BoaTest):
 
     def test_import_storage(self):
         path, _ = self.get_deploy_file_paths('ImportStorage.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -736,7 +736,7 @@ class TestStorageInterop(BoaTest):
 
     def test_import_interop_storage(self):
         path, _ = self.get_deploy_file_paths('ImportInteropStorage.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -787,7 +787,7 @@ class TestStorageInterop(BoaTest):
 
     def test_as_read_only(self):
         path, _ = self.get_deploy_file_paths('StorageAsReadOnly.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -826,7 +826,7 @@ class TestStorageInterop(BoaTest):
 
     def test_find_options_values(self):
         path, _ = self.get_deploy_file_paths('FindOptionsValues.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_list.py
+++ b/boa3_test/tests/compiler_tests/test_list.py
@@ -6,7 +6,7 @@ from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo.vm.type.String import String
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestList(BoaTest):
@@ -133,7 +133,7 @@ class TestList(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -176,7 +176,7 @@ class TestList(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -231,7 +231,7 @@ class TestList(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -284,7 +284,7 @@ class TestList(BoaTest):
         self.assertCompilerNotLogs(CompilerWarning.NameShadowing, path)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -311,7 +311,7 @@ class TestList(BoaTest):
         self.assertCompilerNotLogs(CompilerWarning.NameShadowing, path)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -343,7 +343,7 @@ class TestList(BoaTest):
 
     def test_array_boa2_test1(self):
         path, _ = self.get_deploy_file_paths('ArrayBoa2Test1.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -359,7 +359,7 @@ class TestList(BoaTest):
 
     def test_boa2_array_test(self):
         path, _ = self.get_deploy_file_paths('ArrayBoa2Test.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -387,7 +387,7 @@ class TestList(BoaTest):
 
     def test_boa2_array_test2(self):
         path, _ = self.get_deploy_file_paths('ArrayBoa2Test2.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -403,7 +403,7 @@ class TestList(BoaTest):
 
     def test_boa2_array_test3(self):
         path, _ = self.get_deploy_file_paths('ArrayBoa2Test3.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -435,7 +435,7 @@ class TestList(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -457,7 +457,7 @@ class TestList(BoaTest):
 
     def test_boa2_demo1(self):
         path, _ = self.get_deploy_file_paths('Demo1Boa2.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -478,7 +478,7 @@ class TestList(BoaTest):
 
     def test_list_slicing(self):
         path, _ = self.get_deploy_file_paths('ListSlicingLiteralValues.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -494,7 +494,7 @@ class TestList(BoaTest):
 
     def test_list_slicing_start_larger_than_ending(self):
         path, _ = self.get_deploy_file_paths('ListSlicingStartLargerThanEnding.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -510,7 +510,7 @@ class TestList(BoaTest):
 
     def test_list_slicing_with_variables(self):
         path, _ = self.get_deploy_file_paths('ListSlicingVariableValues.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -526,7 +526,7 @@ class TestList(BoaTest):
 
     def test_list_slicing_negative_start(self):
         path, _ = self.get_deploy_file_paths('ListSlicingNegativeStart.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -542,7 +542,7 @@ class TestList(BoaTest):
 
     def test_list_slicing_negative_end(self):
         path, _ = self.get_deploy_file_paths('ListSlicingNegativeEnd.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -558,7 +558,7 @@ class TestList(BoaTest):
 
     def test_list_slicing_start_omitted(self):
         path, _ = self.get_deploy_file_paths('ListSlicingStartOmitted.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -574,7 +574,7 @@ class TestList(BoaTest):
 
     def test_list_slicing_omitted(self):
         path, _ = self.get_deploy_file_paths('ListSlicingOmitted.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -590,7 +590,7 @@ class TestList(BoaTest):
 
     def test_list_slicing_end_omitted(self):
         path, _ = self.get_deploy_file_paths('ListSlicingEndOmitted.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -810,7 +810,7 @@ class TestList(BoaTest):
 
     def test_list_slicing_with_stride(self):
         path, _ = self.get_deploy_file_paths('ListSlicingWithStride.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -880,7 +880,7 @@ class TestList(BoaTest):
 
     def test_list_slicing_with_negative_stride(self):
         path, _ = self.get_deploy_file_paths('ListSlicingWithNegativeStride.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -943,7 +943,7 @@ class TestList(BoaTest):
 
     def test_list_slicing_omitted_with_stride(self):
         path, _ = self.get_deploy_file_paths('ListSlicingOmittedWithStride.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1001,7 +1001,7 @@ class TestList(BoaTest):
 
     def test_list_slicing_omitted_with_negative_stride(self):
         path, _ = self.get_deploy_file_paths('ListSlicingOmittedWithNegativeStride.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1095,7 +1095,7 @@ class TestList(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1147,7 +1147,7 @@ class TestList(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1199,7 +1199,7 @@ class TestList(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1219,7 +1219,7 @@ class TestList(BoaTest):
 
     def test_boa2_list_append_test(self):
         path, _ = self.get_deploy_file_paths('AppendBoa2Test.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1235,7 +1235,7 @@ class TestList(BoaTest):
 
     def test_list_append_in_class_variable(self):
         path, _ = self.get_deploy_file_paths('AppendInClassVariable.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1312,7 +1312,7 @@ class TestList(BoaTest):
 
     def test_boa2_list_reverse_test(self):
         path, _ = self.get_deploy_file_paths('ReverseBoa2Test.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1332,7 +1332,7 @@ class TestList(BoaTest):
 
     def test_list_extend_tuple_value(self):
         path, _ = self.get_deploy_file_paths('ExtendTupleValue.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1348,7 +1348,7 @@ class TestList(BoaTest):
 
     def test_list_extend_any_value(self):
         path, _ = self.get_deploy_file_paths('ExtendAnyValue.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1372,7 +1372,7 @@ class TestList(BoaTest):
 
     def test_list_extend_with_builtin(self):
         path, _ = self.get_deploy_file_paths('ExtendWithBuiltin.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1432,7 +1432,7 @@ class TestList(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths('PopList.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = (runner.call_contract(path, 'pop_test'))
 
@@ -1479,7 +1479,7 @@ class TestList(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths('PopListWithoutAssignment.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = (runner.call_contract(path, 'pop_test'))
 
@@ -1528,7 +1528,7 @@ class TestList(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths('PopListLiteralArgument.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = (runner.call_contract(path, 'pop_test'))
 
@@ -1576,7 +1576,7 @@ class TestList(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths('PopListLiteralNegativeArgument.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = (runner.call_contract(path, 'pop_test'))
 
@@ -1623,7 +1623,7 @@ class TestList(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths('PopListVariableArgument.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1707,7 +1707,7 @@ class TestList(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1727,7 +1727,7 @@ class TestList(BoaTest):
 
     def test_boa2_list_remove_test(self):
         path, _ = self.get_deploy_file_paths('RemoveBoa2Test.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1747,7 +1747,7 @@ class TestList(BoaTest):
 
     def test_list_insert_int_value(self):
         path, _ = self.get_deploy_file_paths('InsertIntValue.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1763,7 +1763,7 @@ class TestList(BoaTest):
 
     def test_list_insert_any_value(self):
         path, _ = self.get_deploy_file_paths('InsertAnyValue.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1797,7 +1797,7 @@ class TestList(BoaTest):
 
     def test_list_insert_int_negative_index(self):
         path, _ = self.get_deploy_file_paths('InsertIntNegativeIndex.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1813,7 +1813,7 @@ class TestList(BoaTest):
 
     def test_list_insert_int_with_builtin(self):
         path, _ = self.get_deploy_file_paths('InsertIntWithBuiltin.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1833,7 +1833,7 @@ class TestList(BoaTest):
 
     def test_list_remove_value(self):
         path, _ = self.get_deploy_file_paths('RemoveValue.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1858,7 +1858,7 @@ class TestList(BoaTest):
 
     def test_list_remove_int_value(self):
         path, _ = self.get_deploy_file_paths('RemoveIntValue.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1874,7 +1874,7 @@ class TestList(BoaTest):
 
     def test_list_remove_int_with_builtin(self):
         path, _ = self.get_deploy_file_paths('RemoveIntWithBuiltin.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1894,7 +1894,7 @@ class TestList(BoaTest):
 
     def test_list_copy(self):
         path, _ = self.get_deploy_file_paths('Copy.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1931,7 +1931,7 @@ class TestList(BoaTest):
 
     def test_int_list_copy(self):
         path, _ = self.get_deploy_file_paths('CopyInt.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1948,7 +1948,7 @@ class TestList(BoaTest):
 
     def test_str_list_copy(self):
         path, _ = self.get_deploy_file_paths('CopyStr.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1966,7 +1966,7 @@ class TestList(BoaTest):
 
     def test_bool_list_copy(self):
         path, _ = self.get_deploy_file_paths('CopyBool.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1984,7 +1984,7 @@ class TestList(BoaTest):
 
     def test_list_copy_builtin_call(self):
         path, _ = self.get_deploy_file_paths('CopyListBuiltinCall.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -2014,7 +2014,7 @@ class TestList(BoaTest):
 
     def test_list_index(self):
         path, _ = self.get_deploy_file_paths('IndexList.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -2074,7 +2074,7 @@ class TestList(BoaTest):
 
     def test_list_index_end_default(self):
         path, _ = self.get_deploy_file_paths('IndexListEndDefault.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -2112,7 +2112,7 @@ class TestList(BoaTest):
 
     def test_list_index_defaults(self):
         path, _ = self.get_deploy_file_paths('IndexListDefaults.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -2135,7 +2135,7 @@ class TestList(BoaTest):
 
     def test_list_index_int(self):
         path, _ = self.get_deploy_file_paths('IndexListInt.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -2153,7 +2153,7 @@ class TestList(BoaTest):
 
     def test_list_index_str(self):
         path, _ = self.get_deploy_file_paths('IndexListStr.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -2171,7 +2171,7 @@ class TestList(BoaTest):
 
     def test_list_index_bool(self):
         path, _ = self.get_deploy_file_paths('IndexListBool.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_logical.py
+++ b/boa3_test/tests/compiler_tests/test_logical.py
@@ -4,7 +4,7 @@ from boa3.internal.exception import CompilerError
 from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3.internal.neo3.contracts import FindOptions
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestLogical(BoaTest):
@@ -28,7 +28,7 @@ class TestLogical(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -71,7 +71,7 @@ class TestLogical(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -111,7 +111,7 @@ class TestLogical(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -149,7 +149,7 @@ class TestLogical(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -189,7 +189,7 @@ class TestLogical(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -209,7 +209,7 @@ class TestLogical(BoaTest):
 
     def test_logic_left_shift_builtin_type(self):
         path, _ = self.get_deploy_file_paths('LogicLeftShiftBuiltinType.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -247,7 +247,7 @@ class TestLogical(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -281,7 +281,7 @@ class TestLogical(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -301,7 +301,7 @@ class TestLogical(BoaTest):
 
     def test_logic_and_builtin_type(self):
         path, _ = self.get_deploy_file_paths('LogicAndBuiltinType.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -338,7 +338,7 @@ class TestLogical(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -356,7 +356,7 @@ class TestLogical(BoaTest):
 
     def test_logic_not_builtin_type(self):
         path, _ = self.get_deploy_file_paths('LogicNotBuiltinType.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -385,7 +385,7 @@ class TestLogical(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -427,7 +427,7 @@ class TestLogical(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -461,7 +461,7 @@ class TestLogical(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -481,7 +481,7 @@ class TestLogical(BoaTest):
 
     def test_logic_or_builtin_type(self):
         path, _ = self.get_deploy_file_paths('LogicOrBuiltinType.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -536,7 +536,7 @@ class TestLogical(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -570,7 +570,7 @@ class TestLogical(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -590,7 +590,7 @@ class TestLogical(BoaTest):
 
     def test_logic_xor_builtin_type(self):
         path, _ = self.get_deploy_file_paths('LogicXorBuiltinType.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -614,7 +614,7 @@ class TestLogical(BoaTest):
 
     def test_logic_augmented_assignment(self):
         path, _ = self.get_deploy_file_paths('AugmentedAssignmentOperators.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -652,7 +652,7 @@ class TestLogical(BoaTest):
 
     def test_boa2_logic_test(self):
         path, _ = self.get_deploy_file_paths('BinOpBoa2Test.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -721,7 +721,7 @@ class TestLogical(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -743,7 +743,7 @@ class TestLogical(BoaTest):
 
     def test_logic_operation_with_return_and_stack_filled(self):
         path, _ = self.get_deploy_file_paths('LogicOperationWithReturnAndStackFilled.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -777,7 +777,7 @@ class TestLogical(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -797,7 +797,7 @@ class TestLogical(BoaTest):
 
     def test_logic_right_shift_builtin_type(self):
         path, _ = self.get_deploy_file_paths('LogicRightShiftBuiltinType.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_math.py
+++ b/boa3_test/tests/compiler_tests/test_math.py
@@ -2,7 +2,7 @@ from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to 
 
 from boa3.internal.exception import CompilerError
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestMath(BoaTest):
@@ -17,7 +17,7 @@ class TestMath(BoaTest):
 
     def test_pow_method(self):
         path, _ = self.get_deploy_file_paths('Pow.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -57,7 +57,7 @@ class TestMath(BoaTest):
 
     def test_pow_method_from_math(self):
         path, _ = self.get_deploy_file_paths('PowFromMath.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -81,7 +81,7 @@ class TestMath(BoaTest):
 
     def test_sqrt_method(self):
         path, _ = self.get_deploy_file_paths('Sqrt.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -130,7 +130,7 @@ class TestMath(BoaTest):
 
     def test_sqrt_method_from_math(self):
         path, _ = self.get_deploy_file_paths('SqrtFromMath.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_metadata.py
+++ b/boa3_test/tests/compiler_tests/test_metadata.py
@@ -6,8 +6,8 @@ from boa3.internal.exception import CompilerError, CompilerWarning
 from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3.internal.neo3.core.types import UInt160
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.test_classes.contract.neomanifeststruct import NeoManifestStruct
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestMetadata(BoaTest):
@@ -177,7 +177,7 @@ class TestMetadata(BoaTest):
         path, _ = self.get_deploy_file_paths(path)
         get_contract_path, _ = self.get_deploy_file_paths('test_sc/native_test/contractmanagement', 'GetContract.py')
 
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
         # verify using NeoManifestStruct
         contract = runner.deploy_contract(path)
         runner.update_contracts(export_checkpoint=True)
@@ -203,7 +203,7 @@ class TestMetadata(BoaTest):
         path, _ = self.get_deploy_file_paths(path)
         get_contract_path, _ = self.get_deploy_file_paths('test_sc/native_test/contractmanagement', 'GetContract.py')
 
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
         # verify using NeoManifestStruct
         contract = runner.deploy_contract(path)
         runner.update_contracts(export_checkpoint=True)
@@ -326,7 +326,7 @@ class TestMetadata(BoaTest):
         path, _ = self.get_deploy_file_paths(path)
         get_contract_path, _ = self.get_deploy_file_paths('test_sc/native_test/contractmanagement', 'GetContract.py')
 
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
         # verify using NeoManifestStruct
         contract = runner.deploy_contract(path)
         runner.update_contracts(export_checkpoint=True)
@@ -364,7 +364,7 @@ class TestMetadata(BoaTest):
         path, _ = self.get_deploy_file_paths(path)
         get_contract_path, _ = self.get_deploy_file_paths('test_sc/native_test/contractmanagement', 'GetContract.py')
 
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
         # verify using NeoManifestStruct
         contract = runner.deploy_contract(path)
         runner.update_contracts(export_checkpoint=True)
@@ -408,7 +408,7 @@ class TestMetadata(BoaTest):
         path, _ = self.get_deploy_file_paths(path)
         get_contract_path, _ = self.get_deploy_file_paths('test_sc/native_test/contractmanagement', 'GetContract.py')
 
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
         # verify using NeoManifestStruct
         contract = runner.deploy_contract(path)
         runner.update_contracts(export_checkpoint=True)
@@ -460,7 +460,7 @@ class TestMetadata(BoaTest):
         self.assertIn({"contract": "*", "methods": "*"}, manifest['permissions'])
 
         path, _ = self.get_deploy_file_paths_without_compiling(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = runner.call_contract(path, 'main')
 
@@ -495,7 +495,7 @@ class TestMetadata(BoaTest):
         self.assertIn(expected_permission, manifest['permissions'])
 
         path, _ = self.get_deploy_file_paths_without_compiling(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         runner.call_contract(path, 'main')
 
@@ -539,7 +539,7 @@ class TestMetadata(BoaTest):
         path, _ = self.get_deploy_file_paths(path)
         get_contract_path, _ = self.get_deploy_file_paths('test_sc/native_test/contractmanagement', 'GetContract.py')
 
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
         # verify using NeoManifestStruct
         contract_call = runner.call_contract(path, 'main')
         runner.execute()

--- a/boa3_test/tests/compiler_tests/test_multiple_expressions.py
+++ b/boa3_test/tests/compiler_tests/test_multiple_expressions.py
@@ -4,7 +4,7 @@ from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo.vm.type.String import String
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestMultipleExpressions(BoaTest):
@@ -32,7 +32,7 @@ class TestMultipleExpressions(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -75,7 +75,7 @@ class TestMultipleExpressions(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -124,7 +124,7 @@ class TestMultipleExpressions(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -183,7 +183,7 @@ class TestMultipleExpressions(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -235,7 +235,7 @@ class TestMultipleExpressions(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_native/test_contract_management.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_contract_management.py
@@ -6,8 +6,8 @@ from boa3.internal import constants
 from boa3.internal.exception import CompilerError
 from boa3.internal.neo.vm.type.String import String
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
 from boa3_test.tests.test_classes.contract.neomanifeststruct import NeoManifestStruct
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestContractManagementContract(BoaTest):
@@ -15,7 +15,7 @@ class TestContractManagementContract(BoaTest):
 
     def test_get_hash(self):
         path, _ = self.get_deploy_file_paths('GetHash.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -31,7 +31,7 @@ class TestContractManagementContract(BoaTest):
 
     def test_get_minimum_deployment_fee(self):
         path, _ = self.get_deploy_file_paths('GetMinimumDeploymentFee.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -52,7 +52,7 @@ class TestContractManagementContract(BoaTest):
 
     def test_get_contract(self):
         path, _ = self.get_deploy_file_paths('GetContract.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -84,7 +84,7 @@ class TestContractManagementContract(BoaTest):
 
     def test_has_method(self):
         path, _ = self.get_deploy_file_paths('HasMethod.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -116,7 +116,7 @@ class TestContractManagementContract(BoaTest):
         nef_file, manifest = self.get_bytes_output(call_contract_path)
         arg_manifest = String(json.dumps(manifest, separators=(',', ':'))).to_bytes()
 
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
         invoke = runner.call_contract(path, 'Main', nef_file, arg_manifest, None)
 
         runner.execute()
@@ -136,7 +136,7 @@ class TestContractManagementContract(BoaTest):
         nef_file, manifest = self.get_bytes_output(call_contract_path)
         arg_manifest = String(json.dumps(manifest, separators=(',', ':'))).to_bytes()
 
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
         runner.file_name = 'test_create_contract'
 
         data = 'some sort of data'
@@ -166,7 +166,7 @@ class TestContractManagementContract(BoaTest):
 
     def test_update_contract(self):
         path, _ = self.get_deploy_file_paths('UpdateContract.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -195,7 +195,7 @@ class TestContractManagementContract(BoaTest):
 
     def test_update_contract_data_deploy(self):
         path, _ = self.get_deploy_file_paths('UpdateContract.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -234,7 +234,7 @@ class TestContractManagementContract(BoaTest):
 
     def test_destroy_contract(self):
         path, _ = self.get_deploy_file_paths('DestroyContract.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_native/test_cryptolib.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_cryptolib.py
@@ -9,7 +9,7 @@ from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo3.contracts.namedcurve import NamedCurve
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestCryptoLibClass(BoaTest):
@@ -31,7 +31,7 @@ class TestCryptoLibClass(BoaTest):
 
     def test_get_hash(self):
         path, _ = self.get_deploy_file_paths('GetHash.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -47,7 +47,7 @@ class TestCryptoLibClass(BoaTest):
 
     def test_ripemd160_str(self):
         path, _ = self.get_deploy_file_paths('Ripemd160Str.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -68,7 +68,7 @@ class TestCryptoLibClass(BoaTest):
 
     def test_ripemd160_int(self):
         path, _ = self.get_deploy_file_paths('Ripemd160Int.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -85,7 +85,7 @@ class TestCryptoLibClass(BoaTest):
 
     def test_ripemd160_bool(self):
         path, _ = self.get_deploy_file_paths('Ripemd160Bool.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -102,7 +102,7 @@ class TestCryptoLibClass(BoaTest):
 
     def test_ripemd160_bytes(self):
         path, _ = self.get_deploy_file_paths('Ripemd160Bytes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -127,7 +127,7 @@ class TestCryptoLibClass(BoaTest):
 
     def test_sha256_str(self):
         path, _ = self.get_deploy_file_paths('Sha256Str.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -148,7 +148,7 @@ class TestCryptoLibClass(BoaTest):
 
     def test_sha256_int(self):
         path, _ = self.get_deploy_file_paths('Sha256Int.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -165,7 +165,7 @@ class TestCryptoLibClass(BoaTest):
 
     def test_sha256_bool(self):
         path, _ = self.get_deploy_file_paths('Sha256Bool.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -182,7 +182,7 @@ class TestCryptoLibClass(BoaTest):
 
     def test_sha256_bytes(self):
         path, _ = self.get_deploy_file_paths('Sha256Bytes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_native/test_gas.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_gas.py
@@ -3,8 +3,8 @@ from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to 
 from boa3.internal import constants
 from boa3.internal.exception import CompilerError
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive import neoxp
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive import neoxp
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestGasClass(BoaTest):
@@ -13,7 +13,7 @@ class TestGasClass(BoaTest):
 
     def test_get_hash(self):
         path, _ = self.get_deploy_file_paths('GetHash.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -29,7 +29,7 @@ class TestGasClass(BoaTest):
 
     def test_symbol(self):
         path, _ = self.get_deploy_file_paths('Symbol.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -49,7 +49,7 @@ class TestGasClass(BoaTest):
 
     def test_decimals(self):
         path, _ = self.get_deploy_file_paths('Decimals.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -69,7 +69,7 @@ class TestGasClass(BoaTest):
 
     def test_total_supply(self):
         path, _ = self.get_deploy_file_paths('TotalSupply.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         contract_call = runner.call_contract(path, 'main')
         runner.execute()
@@ -84,7 +84,7 @@ class TestGasClass(BoaTest):
         path, _ = self.get_deploy_file_paths('BalanceOf.py')
         test_account_1 = neoxp.utils.get_account_by_name('testAccount1').script_hash.to_array()
         test_account_2 = neoxp.utils.get_account_by_name('testAccount2').script_hash.to_array()
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -108,7 +108,7 @@ class TestGasClass(BoaTest):
 
     def test_transfer(self):
         path, _ = self.get_deploy_file_paths('Transfer.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -146,7 +146,7 @@ class TestGasClass(BoaTest):
 
     def test_transfer_data_default(self):
         path, _ = self.get_deploy_file_paths('TransferDataDefault.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -185,7 +185,7 @@ class TestGasClass(BoaTest):
 
     def test_import_with_alias(self):
         path, _ = self.get_deploy_file_paths('ImportWithAlias.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_native/test_ledger.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_ledger.py
@@ -9,8 +9,8 @@ from boa3.internal.neo.vm.type.String import String
 from boa3.internal.neo3.contracts import CallFlags
 from boa3.internal.neo3.core.types import UInt160, UInt256
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive import neoxp
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive import neoxp
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestLedgerContract(BoaTest):
@@ -18,7 +18,7 @@ class TestLedgerContract(BoaTest):
 
     def test_get_hash(self):
         path, _ = self.get_deploy_file_paths('GetHash.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -34,7 +34,7 @@ class TestLedgerContract(BoaTest):
 
     def test_get_block_by_hash(self):
         path, _ = self.get_deploy_file_paths('GetBlockByHash.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         genesis_block = runner.get_genesis_block()
         expected_result_size = len(Interop.BlockType.variables)
@@ -60,7 +60,7 @@ class TestLedgerContract(BoaTest):
 
     def test_get_block_by_index(self):
         path, _ = self.get_deploy_file_paths('GetBlockByIndex.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         test_index_0 = 0
         test_index_10 = 10
@@ -108,7 +108,7 @@ class TestLedgerContract(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         sender = neoxp.utils.get_default_account()
         contract_deploy = runner.deploy_contract(path)
@@ -163,7 +163,7 @@ class TestLedgerContract(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         sender = neoxp.utils.get_default_account()
         contract_deploy = runner.deploy_contract(path, account=sender)
@@ -217,7 +217,7 @@ class TestLedgerContract(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         runner.deploy_contract(path)  # to have a block with tx
         runner.update_contracts(export_checkpoint=True)
@@ -272,7 +272,7 @@ class TestLedgerContract(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -316,7 +316,7 @@ class TestLedgerContract(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         expected_block_index = 10
         blocks_to_mint = expected_block_index - 1  # mint blocks before running the tx to check
@@ -364,7 +364,7 @@ class TestLedgerContract(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         contract_deploy = runner.deploy_contract(path)
         runner.update_contracts(export_checkpoint=True)
@@ -384,7 +384,7 @@ class TestLedgerContract(BoaTest):
 
     def test_get_current_index(self):
         path, _ = self.get_deploy_file_paths('GetCurrentIndex.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_native/test_neo.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_neo.py
@@ -3,8 +3,8 @@ from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to 
 from boa3.internal import constants
 from boa3.internal.exception import CompilerError
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive import neoxp
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive import neoxp
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestNeoClass(BoaTest):
@@ -13,7 +13,7 @@ class TestNeoClass(BoaTest):
 
     def test_get_hash(self):
         path, _ = self.get_deploy_file_paths('GetHash.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -29,7 +29,7 @@ class TestNeoClass(BoaTest):
 
     def test_symbol(self):
         path, _ = self.get_deploy_file_paths('Symbol.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -49,7 +49,7 @@ class TestNeoClass(BoaTest):
 
     def test_decimals(self):
         path, _ = self.get_deploy_file_paths('Decimals.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -69,7 +69,7 @@ class TestNeoClass(BoaTest):
 
     def test_total_supply(self):
         path, _ = self.get_deploy_file_paths('TotalSupply.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -91,7 +91,7 @@ class TestNeoClass(BoaTest):
         path, _ = self.get_deploy_file_paths('BalanceOf.py')
         test_account_1 = neoxp.utils.get_account_by_name('testAccount1').script_hash.to_array()
         test_account_2 = neoxp.utils.get_account_by_name('testAccount2').script_hash.to_array()
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -115,7 +115,7 @@ class TestNeoClass(BoaTest):
 
     def test_transfer(self):
         path, _ = self.get_deploy_file_paths('Transfer.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -153,7 +153,7 @@ class TestNeoClass(BoaTest):
 
     def test_transfer_data_default(self):
         path, _ = self.get_deploy_file_paths('TransferDataDefault.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -192,7 +192,7 @@ class TestNeoClass(BoaTest):
 
     def test_get_gas_per_block(self):
         path, _ = self.get_deploy_file_paths('GetGasPerBlock.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -208,7 +208,7 @@ class TestNeoClass(BoaTest):
 
     def test_unclaimed_gas(self):
         path, _ = self.get_deploy_file_paths('UnclaimedGas.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         contract_call = runner.call_contract(path, 'main', bytes(20), 0)
         runner.execute()
@@ -217,7 +217,7 @@ class TestNeoClass(BoaTest):
 
     def test_register_candidate(self):
         path, _ = self.get_deploy_file_paths('RegisterCandidate.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -264,7 +264,7 @@ class TestNeoClass(BoaTest):
 
     def test_unregister_candidate(self):
         path, _ = self.get_deploy_file_paths('UnregisterCandidate.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -299,7 +299,7 @@ class TestNeoClass(BoaTest):
         path, _ = self.get_deploy_file_paths('Vote.py')
         path_get, _ = self.get_deploy_file_paths('GetCandidates.py')
 
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
         runner.deploy_contract(path_get)
 
         invokes = []
@@ -401,7 +401,7 @@ class TestNeoClass(BoaTest):
         self.compile_and_save(path)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         # no candidate was registered
         invoke = runner.call_contract(path, 'main')
@@ -433,7 +433,7 @@ class TestNeoClass(BoaTest):
 
     def test_get_candidates(self):
         path, _ = self.get_deploy_file_paths('GetCandidates.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -476,7 +476,7 @@ class TestNeoClass(BoaTest):
 
     def test_get_candidate_vote(self):
         path, _ = self.get_deploy_file_paths('GetCandidateVote.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -525,7 +525,7 @@ class TestNeoClass(BoaTest):
 
     def test_get_committee(self):
         path, _ = self.get_deploy_file_paths('GetCommittee.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         default_committee = neoxp.utils.get_account_by_name('node1')
         default_council = [
@@ -546,7 +546,7 @@ class TestNeoClass(BoaTest):
 
     def test_get_next_block_validators(self):
         path, _ = self.get_deploy_file_paths('GetNextBlockValidators.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         default_committee = neoxp.utils.get_account_by_name('node1')
         consensus_nodes = [
@@ -567,7 +567,7 @@ class TestNeoClass(BoaTest):
 
     def test_get_account_state(self):
         path, _ = self.get_deploy_file_paths('GetAccountState.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_native/test_oracle.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_oracle.py
@@ -6,7 +6,7 @@ from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo.vm.type.String import String
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 def _deep_scan(iterable: [dict, list], key: str, list_of_values: list):
@@ -37,7 +37,7 @@ class TestNativeContracts(BoaTest):
 
     def test_get_hash(self):
         path, _ = self.get_deploy_file_paths('GetHash.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -53,7 +53,7 @@ class TestNativeContracts(BoaTest):
 
     def test_oracle_request(self):
         path, _ = self.get_deploy_file_paths('OracleRequestCall.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -100,7 +100,7 @@ class TestNativeContracts(BoaTest):
 
     def test_oracle_response(self):
         path, _ = self.get_deploy_file_paths('OracleRequestCall.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -110,7 +110,7 @@ class TestNativeContracts(BoaTest):
         user_data = 'Any Data Here'
         gas_for_response = 1 * 10 ** 8
 
-        from boa3_test.test_drive import neoxp
+        from boa3_test.tests.test_drive import neoxp
         OWNER = neoxp.utils.get_account_by_name('owner')
 
         genesis = neoxp.utils.get_account_by_name('genesis')
@@ -164,7 +164,7 @@ class TestNativeContracts(BoaTest):
 
     def test_oracle_response_filter(self):
         path, _ = self.get_deploy_file_paths('OracleRequestCall.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -174,7 +174,7 @@ class TestNativeContracts(BoaTest):
         user_data = 'Any Data Here'
         gas_for_response = 1 * 10 ** 8
 
-        from boa3_test.test_drive import neoxp
+        from boa3_test.tests.test_drive import neoxp
         OWNER = neoxp.utils.get_account_by_name('owner')
         runner.add_gas(OWNER.address, 1000 * 10 ** 8)
 
@@ -233,7 +233,7 @@ class TestNativeContracts(BoaTest):
 
     def test_oracle_request_invalid_gas(self):
         path, _ = self.get_deploy_file_paths('OracleRequestCall.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         test_url = 'https://unittest.fake.url/api/0/'
         callback = 'callback_method'
@@ -241,7 +241,7 @@ class TestNativeContracts(BoaTest):
         filter = "$.store.*"
         gas_for_response = 9999999     # GAS can not be lower than 0.1 GAS
 
-        from boa3_test.test_drive import neoxp
+        from boa3_test.tests.test_drive import neoxp
         genesis = neoxp.utils.get_account_by_name('genesis')
         runner.oracle_enable(genesis)
 
@@ -253,14 +253,14 @@ class TestNativeContracts(BoaTest):
 
     def test_oracle_request_invalid_callback(self):
         path, _ = self.get_deploy_file_paths('OracleRequestCall.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         test_url = 'https://unittest.fake.url/api/0/'
         user_data = 'Any Data Here'
         filter = "$.store.*"
         gas_for_response = 1 * 10 ** 8
 
-        from boa3_test.test_drive import neoxp
+        from boa3_test.tests.test_drive import neoxp
         genesis = neoxp.utils.get_account_by_name('genesis')
         runner.oracle_enable(genesis)
 
@@ -280,14 +280,14 @@ class TestNativeContracts(BoaTest):
 
     def test_oracle_request_invalid_filter(self):
         path, _ = self.get_deploy_file_paths('OracleRequestCall.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         test_url = 'https://unittest.fake.url/api/0/'
         callback = 'callback_method'
         user_data = 'Any Data Here'
         gas_for_response = 1 * 10 ** 8
 
-        from boa3_test.test_drive import neoxp
+        from boa3_test.tests.test_drive import neoxp
         genesis = neoxp.utils.get_account_by_name('genesis')
         runner.oracle_enable(genesis)
 
@@ -316,7 +316,7 @@ class TestNativeContracts(BoaTest):
 
     def test_import_interop_oracle(self):
         path, _ = self.get_deploy_file_paths('ImportOracle.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -347,7 +347,7 @@ class TestNativeContracts(BoaTest):
 
     def test_import_interop_oracle_package(self):
         path, _ = self.get_deploy_file_paths('ImportInteropOracle.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -393,7 +393,7 @@ class TestNativeContracts(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = runner.call_contract(path, 'main')
         runner.execute()

--- a/boa3_test/tests/compiler_tests/test_native/test_policy.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_policy.py
@@ -3,7 +3,7 @@ from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to 
 from boa3.internal import constants
 from boa3.internal.exception import CompilerError
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestPolicyContract(BoaTest):
@@ -11,7 +11,7 @@ class TestPolicyContract(BoaTest):
 
     def test_get_hash(self):
         path, _ = self.get_deploy_file_paths('GetHash.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -27,7 +27,7 @@ class TestPolicyContract(BoaTest):
 
     def test_get_exec_fee_factor(self):
         path, _ = self.get_deploy_file_paths('GetExecFeeFactor.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = runner.call_contract(path, 'main')
         runner.execute()
@@ -40,7 +40,7 @@ class TestPolicyContract(BoaTest):
 
     def test_get_fee_per_byte(self):
         path, _ = self.get_deploy_file_paths('GetFeePerByte.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = runner.call_contract(path, 'main')
         runner.execute()
@@ -53,7 +53,7 @@ class TestPolicyContract(BoaTest):
 
     def test_get_storage_price(self):
         path, _ = self.get_deploy_file_paths('GetStoragePrice.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = runner.call_contract(path, 'main')
         runner.execute()
@@ -66,7 +66,7 @@ class TestPolicyContract(BoaTest):
 
     def test_is_blocked(self):
         path, _ = self.get_deploy_file_paths('IsBlocked.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_native/test_rolemanagement.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_rolemanagement.py
@@ -8,7 +8,7 @@ from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo.vm.type.String import String
 from boa3.internal.neo3.contracts import CallFlags
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestRoleManagementClass(BoaTest):
@@ -16,7 +16,7 @@ class TestRoleManagementClass(BoaTest):
 
     def test_get_hash(self):
         path, _ = self.get_deploy_file_paths('GetHash.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_native/test_stdlib.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_stdlib.py
@@ -7,7 +7,7 @@ from boa3.internal.exception import CompilerError
 from boa3.internal.neo.vm.type.StackItem import StackItemType, serialize
 from boa3.internal.neo.vm.type.String import String
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestStdlibClass(BoaTest):
@@ -15,7 +15,7 @@ class TestStdlibClass(BoaTest):
 
     def test_get_hash(self):
         path, _ = self.get_deploy_file_paths('GetHash.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -32,7 +32,7 @@ class TestStdlibClass(BoaTest):
     def test_base64_encode(self):
         import base64
         path, _ = self.get_deploy_file_paths('Base64Encode.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -73,7 +73,7 @@ class TestStdlibClass(BoaTest):
     def test_base64_decode(self):
         import base64
         path, _ = self.get_deploy_file_paths('Base64Decode.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -114,7 +114,7 @@ class TestStdlibClass(BoaTest):
     def test_base58_encode(self):
         import base58
         path, _ = self.get_deploy_file_paths('Base58Encode.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -155,7 +155,7 @@ class TestStdlibClass(BoaTest):
     def test_base58_decode(self):
         import base58
         path, _ = self.get_deploy_file_paths('Base58Decode.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -193,7 +193,7 @@ class TestStdlibClass(BoaTest):
     def test_base58_check_decode(self):
         import base58
         path, _ = self.get_deploy_file_paths('Base58CheckDecode.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -231,7 +231,7 @@ class TestStdlibClass(BoaTest):
     def test_base58_check_encode(self):
         import base58
         path, _ = self.get_deploy_file_paths('Base58CheckEncode.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -271,7 +271,7 @@ class TestStdlibClass(BoaTest):
 
     def test_serialize_int(self):
         path, _ = self.get_deploy_file_paths('SerializeInt.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -289,7 +289,7 @@ class TestStdlibClass(BoaTest):
 
     def test_serialize_bool(self):
         path, _ = self.get_deploy_file_paths('SerializeBool.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -307,7 +307,7 @@ class TestStdlibClass(BoaTest):
 
     def test_serialize_str(self):
         path, _ = self.get_deploy_file_paths('SerializeStr.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -325,7 +325,7 @@ class TestStdlibClass(BoaTest):
 
     def test_serialize_sequence(self):
         path, _ = self.get_deploy_file_paths('SerializeSequence.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -343,7 +343,7 @@ class TestStdlibClass(BoaTest):
 
     def test_serialize_dict(self):
         path, _ = self.get_deploy_file_paths('SerializeDict.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -361,7 +361,7 @@ class TestStdlibClass(BoaTest):
 
     def test_deserialize(self):
         path, _ = self.get_deploy_file_paths('Deserialize.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -416,7 +416,7 @@ class TestStdlibClass(BoaTest):
 
     def test_json_serialize(self):
         path, _ = self.get_deploy_file_paths('JsonSerialize.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -434,7 +434,7 @@ class TestStdlibClass(BoaTest):
 
     def test_json_serialize_int(self):
         path, _ = self.get_deploy_file_paths('JsonSerializeInt.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -451,7 +451,7 @@ class TestStdlibClass(BoaTest):
 
     def test_json_serialize_bool(self):
         path, _ = self.get_deploy_file_paths('JsonSerializeBool.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -468,7 +468,7 @@ class TestStdlibClass(BoaTest):
 
     def test_json_serialize_str(self):
         path, _ = self.get_deploy_file_paths('JsonSerializeStr.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -485,7 +485,7 @@ class TestStdlibClass(BoaTest):
 
     def test_json_serialize_bytes(self):
         path, _ = self.get_deploy_file_paths('JsonSerializeBytes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -504,7 +504,7 @@ class TestStdlibClass(BoaTest):
 
     def test_json_deserialize(self):
         path, _ = self.get_deploy_file_paths('JsonDeserialize.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -532,7 +532,7 @@ class TestStdlibClass(BoaTest):
 
     def test_boa2_serialization_test1(self):
         path, _ = self.get_deploy_file_paths('SerializationBoa2Test.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -549,7 +549,7 @@ class TestStdlibClass(BoaTest):
 
     def test_boa2_serialization_test2(self):
         path, _ = self.get_deploy_file_paths('SerializationBoa2Test.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -566,7 +566,7 @@ class TestStdlibClass(BoaTest):
 
     def test_boa2_serialization_test3(self):
         path, _ = self.get_deploy_file_paths('SerializationBoa2Test.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -582,7 +582,7 @@ class TestStdlibClass(BoaTest):
 
     def test_boa2_serialization_test4(self):
         path, _ = self.get_deploy_file_paths('SerializationBoa2Test.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -598,7 +598,7 @@ class TestStdlibClass(BoaTest):
 
     def test_atoi(self):
         path, _ = self.get_deploy_file_paths('Atoi.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -649,7 +649,7 @@ class TestStdlibClass(BoaTest):
 
     def test_atoi_default(self):
         path, _ = self.get_deploy_file_paths('AtoiDefault.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -685,7 +685,7 @@ class TestStdlibClass(BoaTest):
 
     def test_itoa(self):
         path, _ = self.get_deploy_file_paths('Itoa')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -714,7 +714,7 @@ class TestStdlibClass(BoaTest):
 
     def test_itoa_default(self):
         path, _ = self.get_deploy_file_paths('ItoaDefault')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -744,7 +744,7 @@ class TestStdlibClass(BoaTest):
 
     def test_memory_search(self):
         path, _ = self.get_deploy_file_paths('MemorySearch')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -792,7 +792,7 @@ class TestStdlibClass(BoaTest):
 
     def test_memory_search_backward(self):
         path, _ = self.get_deploy_file_paths('MemorySearch')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -840,7 +840,7 @@ class TestStdlibClass(BoaTest):
 
     def test_memory_search_start(self):
         path, _ = self.get_deploy_file_paths('MemorySearchStart')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -879,7 +879,7 @@ class TestStdlibClass(BoaTest):
 
     def test_memory_search_default_values(self):
         path, _ = self.get_deploy_file_paths('MemorySearchDefault')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -928,7 +928,7 @@ class TestStdlibClass(BoaTest):
 
     def test_memory_compare(self):
         path, _ = self.get_deploy_file_paths('MemoryCompare')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_neo_types.py
+++ b/boa3_test/tests/compiler_tests/test_neo_types.py
@@ -3,7 +3,7 @@ from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to 
 from boa3.internal.exception import CompilerError, CompilerWarning
 from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestNeoTypes(BoaTest):
@@ -13,7 +13,7 @@ class TestNeoTypes(BoaTest):
 
     def test_uint160_call_bytes(self):
         path, _ = self.get_deploy_file_paths('uint160', 'UInt160CallBytes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -48,7 +48,7 @@ class TestNeoTypes(BoaTest):
 
     def test_uint160_call_int(self):
         path, _ = self.get_deploy_file_paths('uint160', 'UInt160CallInt.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -82,7 +82,7 @@ class TestNeoTypes(BoaTest):
 
     def test_uint160_call_without_args(self):
         path, _ = self.get_deploy_file_paths('uint160', 'UInt160CallWithoutArgs.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -99,7 +99,7 @@ class TestNeoTypes(BoaTest):
 
     def test_uint160_return_bytes(self):
         path, _ = self.get_deploy_file_paths('uint160', 'UInt160ReturnBytes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -134,7 +134,7 @@ class TestNeoTypes(BoaTest):
 
     def test_uint160_concat_with_bytes(self):
         path, _ = self.get_deploy_file_paths('uint160', 'UInt160ConcatWithBytes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -165,7 +165,7 @@ class TestNeoTypes(BoaTest):
 
     def test_uint256_call_bytes(self):
         path, _ = self.get_deploy_file_paths('uint256', 'UInt256CallBytes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -200,7 +200,7 @@ class TestNeoTypes(BoaTest):
 
     def test_uint256_call_int(self):
         path, _ = self.get_deploy_file_paths('uint256', 'UInt256CallInt.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -234,7 +234,7 @@ class TestNeoTypes(BoaTest):
 
     def test_uint256_call_without_args(self):
         path, _ = self.get_deploy_file_paths('uint256', 'UInt256CallWithoutArgs.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -251,7 +251,7 @@ class TestNeoTypes(BoaTest):
 
     def test_uint256_return_bytes(self):
         path, _ = self.get_deploy_file_paths('uint256', 'UInt256ReturnBytes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -286,7 +286,7 @@ class TestNeoTypes(BoaTest):
 
     def test_uint256_concat_with_bytes(self):
         path, _ = self.get_deploy_file_paths('uint256', 'UInt256ConcatWithBytes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -317,7 +317,7 @@ class TestNeoTypes(BoaTest):
 
     def test_ecpoint_call_bytes(self):
         path, _ = self.get_deploy_file_paths('ecpoint', 'ECPointCallBytes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -356,7 +356,7 @@ class TestNeoTypes(BoaTest):
 
     def test_ecpoint_return_bytes(self):
         path, _ = self.get_deploy_file_paths('ecpoint', 'ECPointReturnBytes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -391,7 +391,7 @@ class TestNeoTypes(BoaTest):
 
     def test_ecpoint_concat_with_bytes(self):
         path, _ = self.get_deploy_file_paths('ecpoint', 'ECPointConcatWithBytes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -418,7 +418,7 @@ class TestNeoTypes(BoaTest):
 
     def test_ecpoint_script_hash(self):
         path, _ = self.get_deploy_file_paths('ecpoint', 'ECPointScriptHash.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -438,7 +438,7 @@ class TestNeoTypes(BoaTest):
 
     def test_ecpoint_script_hash_from_builtin(self):
         path, _ = self.get_deploy_file_paths('ecpoint', 'ECPointScriptHashBuiltinCall.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -485,7 +485,7 @@ class TestNeoTypes(BoaTest):
     def test_opcode_concat(self):
         from boa3.internal.neo.vm.opcode.Opcode import Opcode
         path, _ = self.get_deploy_file_paths('opcode', 'ConcatWithOpcode.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -503,7 +503,7 @@ class TestNeoTypes(BoaTest):
     def test_opcode_concat_with_bytes(self):
         from boa3.internal.neo.vm.opcode.Opcode import Opcode
         path, _ = self.get_deploy_file_paths('opcode', 'ConcatWithBytes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -537,7 +537,7 @@ class TestNeoTypes(BoaTest):
     def test_opcode_multiplication(self):
         from boa3.internal.neo.vm.opcode.Opcode import Opcode
         path, _ = self.get_deploy_file_paths('opcode', 'OpcodeMultiplication.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -564,7 +564,7 @@ class TestNeoTypes(BoaTest):
 
     def test_isinstance_contract(self):
         path, _ = self.get_deploy_file_paths('IsInstanceContract.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -589,7 +589,7 @@ class TestNeoTypes(BoaTest):
 
     def test_isinstance_block(self):
         path, _ = self.get_deploy_file_paths('IsInstanceBlock.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -626,7 +626,7 @@ class TestNeoTypes(BoaTest):
 
     def test_isinstance_transaction(self):
         path, _ = self.get_deploy_file_paths('IsInstanceTransaction.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -654,7 +654,7 @@ class TestNeoTypes(BoaTest):
 
     def test_isinstance_notification(self):
         path, _ = self.get_deploy_file_paths('IsInstanceNotification.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -678,7 +678,7 @@ class TestNeoTypes(BoaTest):
 
     def test_isinstance_storage_context(self):
         path, _ = self.get_deploy_file_paths('IsInstanceStorageContext.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -702,7 +702,7 @@ class TestNeoTypes(BoaTest):
 
     def test_isinstance_storage_map(self):
         path, _ = self.get_deploy_file_paths('IsInstanceStorageMap.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -726,7 +726,7 @@ class TestNeoTypes(BoaTest):
 
     def test_isinstance_iterator(self):
         path, _ = self.get_deploy_file_paths('IsInstanceIterator.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -750,7 +750,7 @@ class TestNeoTypes(BoaTest):
 
     def test_isinstance_ecpoint(self):
         path, _ = self.get_deploy_file_paths('IsInstanceECPoint.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_none.py
+++ b/boa3_test/tests/compiler_tests/test_none.py
@@ -3,7 +3,7 @@ from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to 
 from boa3.internal.exception import CompilerError
 from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestNone(BoaTest):
@@ -56,7 +56,7 @@ class TestNone(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -90,7 +90,7 @@ class TestNone(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -135,7 +135,7 @@ class TestNone(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -167,7 +167,7 @@ class TestNone(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_optional.py
+++ b/boa3_test/tests/compiler_tests/test_optional.py
@@ -2,7 +2,7 @@ from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to 
 
 from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestOptional(BoaTest):
@@ -10,7 +10,7 @@ class TestOptional(BoaTest):
 
     def test_optional_return(self):
         path, _ = self.get_deploy_file_paths('OptionalReturn.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -57,7 +57,7 @@ class TestOptional(BoaTest):
 
     def test_optional_variable_argument(self):
         path, _ = self.get_deploy_file_paths('OptionalVariableArgument.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -84,7 +84,7 @@ class TestOptional(BoaTest):
 
     def test_optional_isinstance_validation(self):
         path, _ = self.get_deploy_file_paths('OptionalIsInstanceValidation.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -123,7 +123,7 @@ class TestOptional(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_python_operation.py
+++ b/boa3_test/tests/compiler_tests/test_python_operation.py
@@ -3,7 +3,7 @@ from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to 
 from boa3.internal.exception import CompilerError
 from boa3.internal.neo3.contracts import FindOptions
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestPythonOperation(BoaTest):
@@ -13,7 +13,7 @@ class TestPythonOperation(BoaTest):
 
     def test_in_bytes(self):
         path, _ = self.get_deploy_file_paths('BytesIn.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -39,7 +39,7 @@ class TestPythonOperation(BoaTest):
 
     def test_int_in_bytes(self):
         path, _ = self.get_deploy_file_paths('BytesMembershipWithInt.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -58,7 +58,7 @@ class TestPythonOperation(BoaTest):
 
     def test_in_dict(self):
         path, _ = self.get_deploy_file_paths('DictIn.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -87,7 +87,7 @@ class TestPythonOperation(BoaTest):
 
     def test_in_list(self):
         path, _ = self.get_deploy_file_paths('ListIn.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -113,7 +113,7 @@ class TestPythonOperation(BoaTest):
 
     def test_in_str(self):
         path, _ = self.get_deploy_file_paths('StringIn.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -136,7 +136,7 @@ class TestPythonOperation(BoaTest):
 
     def test_in_tuple(self):
         path, _ = self.get_deploy_file_paths('TupleIn.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -162,7 +162,7 @@ class TestPythonOperation(BoaTest):
 
     def test_in_typed_dict_builtin_type(self):
         path, _ = self.get_deploy_file_paths('TypedDictBuiltinTypeIn.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -185,7 +185,7 @@ class TestPythonOperation(BoaTest):
 
     def test_in_typed_dict(self):
         path, _ = self.get_deploy_file_paths('TypedDictIn.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -204,7 +204,7 @@ class TestPythonOperation(BoaTest):
 
     def test_in_typed_list_builtin_type(self):
         path, _ = self.get_deploy_file_paths('TypedListBuiltinTypeIn.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -227,7 +227,7 @@ class TestPythonOperation(BoaTest):
 
     def test_in_typed_list(self):
         path, _ = self.get_deploy_file_paths('TypedListIn.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -246,7 +246,7 @@ class TestPythonOperation(BoaTest):
 
     def test_in_typed_tuple_builtin_type(self):
         path, _ = self.get_deploy_file_paths('TypedTupleBuiltinTypeIn.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -269,7 +269,7 @@ class TestPythonOperation(BoaTest):
 
     def test_in_typed_tuple(self):
         path, _ = self.get_deploy_file_paths('TypedTupleIn.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -292,7 +292,7 @@ class TestPythonOperation(BoaTest):
 
     def test_not_in_bytes(self):
         path, _ = self.get_deploy_file_paths('BytesNotIn.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -311,7 +311,7 @@ class TestPythonOperation(BoaTest):
 
     def test_not_in_dict(self):
         path, _ = self.get_deploy_file_paths('DictNotIn.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -336,7 +336,7 @@ class TestPythonOperation(BoaTest):
 
     def test_not_in_list(self):
         path, _ = self.get_deploy_file_paths('ListNotIn.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -358,7 +358,7 @@ class TestPythonOperation(BoaTest):
 
     def test_not_in_str(self):
         path, _ = self.get_deploy_file_paths('StringNotIn.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -377,7 +377,7 @@ class TestPythonOperation(BoaTest):
 
     def test_not_in_tuple(self):
         path, _ = self.get_deploy_file_paths('TupleNotIn.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -399,7 +399,7 @@ class TestPythonOperation(BoaTest):
 
     def test_not_in_typed_dict_builtin_type(self):
         path, _ = self.get_deploy_file_paths('TypedDictBuiltinTypeNotIn.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -422,7 +422,7 @@ class TestPythonOperation(BoaTest):
 
     def test_not_in_typed_dict(self):
         path, _ = self.get_deploy_file_paths('TypedDictNotIn.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -441,7 +441,7 @@ class TestPythonOperation(BoaTest):
 
     def test_not_in_typed_list_builtin_type(self):
         path, _ = self.get_deploy_file_paths('TypedListBuiltinTypeNotIn.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -464,7 +464,7 @@ class TestPythonOperation(BoaTest):
 
     def test_not_in_typed_list(self):
         path, _ = self.get_deploy_file_paths('TypedListNotIn.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -483,7 +483,7 @@ class TestPythonOperation(BoaTest):
 
     def test_not_in_typed_tuple_builtin_type(self):
         path, _ = self.get_deploy_file_paths('TypedTupleBuiltinTypeNotIn.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -506,7 +506,7 @@ class TestPythonOperation(BoaTest):
 
     def test_not_in_typed_tuple(self):
         path, _ = self.get_deploy_file_paths('TypedTupleNotIn.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_range.py
+++ b/boa3_test/tests/compiler_tests/test_range.py
@@ -5,7 +5,7 @@ from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo.vm.type.String import String
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestRange(BoaTest):
@@ -67,7 +67,7 @@ class TestRange(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -139,7 +139,7 @@ class TestRange(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -209,7 +209,7 @@ class TestRange(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -283,7 +283,7 @@ class TestRange(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -327,7 +327,7 @@ class TestRange(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -354,7 +354,7 @@ class TestRange(BoaTest):
 
     def test_range_slicing(self):
         path, _ = self.get_deploy_file_paths('RangeSlicingLiteralValues.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -370,7 +370,7 @@ class TestRange(BoaTest):
 
     def test_range_slicing_start_larger_than_ending(self):
         path, _ = self.get_deploy_file_paths('RangeSlicingStartLargerThanEnding.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -386,7 +386,7 @@ class TestRange(BoaTest):
 
     def test_range_slicing_with_variables(self):
         path, _ = self.get_deploy_file_paths('RangeSlicingVariableValues.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -402,7 +402,7 @@ class TestRange(BoaTest):
 
     def test_range_slicing_negative_start(self):
         path, _ = self.get_deploy_file_paths('RangeSlicingNegativeStart.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -418,7 +418,7 @@ class TestRange(BoaTest):
 
     def test_range_slicing_negative_end(self):
         path, _ = self.get_deploy_file_paths('RangeSlicingNegativeEnd.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -434,7 +434,7 @@ class TestRange(BoaTest):
 
     def test_range_slicing_start_omitted(self):
         path, _ = self.get_deploy_file_paths('RangeSlicingStartOmitted.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -450,7 +450,7 @@ class TestRange(BoaTest):
 
     def test_range_slicing_omitted(self):
         path, _ = self.get_deploy_file_paths('RangeSlicingOmitted.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -466,7 +466,7 @@ class TestRange(BoaTest):
 
     def test_range_slicing_end_omitted(self):
         path, _ = self.get_deploy_file_paths('RangeSlicingEndOmitted.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -482,7 +482,7 @@ class TestRange(BoaTest):
 
     def test_range_slicing_with_stride(self):
         path, _ = self.get_deploy_file_paths('RangeSlicingWithStride.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -550,7 +550,7 @@ class TestRange(BoaTest):
 
     def test_range_slicing_with_negative_stride(self):
         path, _ = self.get_deploy_file_paths('RangeSlicingWithNegativeStride.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -613,7 +613,7 @@ class TestRange(BoaTest):
 
     def test_range_slicing_omitted_with_stride(self):
         path, _ = self.get_deploy_file_paths('RangeSlicingOmittedWithStride.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -671,7 +671,7 @@ class TestRange(BoaTest):
 
     def test_range_slicing_omitted_with_negative_stride(self):
         path, _ = self.get_deploy_file_paths('RangeSlicingOmittedWithNegativeStride.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -729,7 +729,7 @@ class TestRange(BoaTest):
 
     def test_boa2_range_test(self):
         path, _ = self.get_deploy_file_paths('RangeBoa2Test.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_relational.py
+++ b/boa3_test/tests/compiler_tests/test_relational.py
@@ -5,7 +5,7 @@ from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo3.contracts import FindOptions
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestRelational(BoaTest):
@@ -15,7 +15,7 @@ class TestRelational(BoaTest):
 
     def test_builtin_type_greater_than_operation(self):
         path, _ = self.get_deploy_file_paths('BuiltinTypeGreaterThan.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -49,7 +49,7 @@ class TestRelational(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -83,7 +83,7 @@ class TestRelational(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -107,7 +107,7 @@ class TestRelational(BoaTest):
 
     def test_builtin_type_greater_than_or_equal_operation(self):
         path, _ = self.get_deploy_file_paths('BuiltinTypeGreaterThanOrEqual.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -141,7 +141,7 @@ class TestRelational(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -175,7 +175,7 @@ class TestRelational(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -199,7 +199,7 @@ class TestRelational(BoaTest):
 
     def test_boolean_identity_operation(self):
         path, _ = self.get_deploy_file_paths('BoolIdentity.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -227,7 +227,7 @@ class TestRelational(BoaTest):
 
     def test_list_identity(self):
         path, _ = self.get_deploy_file_paths('ListIdentity.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -250,7 +250,7 @@ class TestRelational(BoaTest):
 
     def test_mixed_identity(self):
         path, _ = self.get_deploy_file_paths('MixedIdentity.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -267,7 +267,7 @@ class TestRelational(BoaTest):
 
     def test_none_identity_operation(self):
         path, _ = self.get_deploy_file_paths('NoneIdentity.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -295,7 +295,7 @@ class TestRelational(BoaTest):
 
     def test_number_identity_operation(self):
         path, _ = self.get_deploy_file_paths('NumIdentity.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -323,7 +323,7 @@ class TestRelational(BoaTest):
 
     def test_string_identity_operation(self):
         path, _ = self.get_deploy_file_paths('StrIdentity.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -351,7 +351,7 @@ class TestRelational(BoaTest):
 
     def test_tuple_identity(self):
         path, _ = self.get_deploy_file_paths('TupleIdentity.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -378,7 +378,7 @@ class TestRelational(BoaTest):
 
     def test_builtin_type_less_than_operation(self):
         path, _ = self.get_deploy_file_paths('BuiltinTypeLessThan.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -412,7 +412,7 @@ class TestRelational(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -446,7 +446,7 @@ class TestRelational(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -470,7 +470,7 @@ class TestRelational(BoaTest):
 
     def test_builtin_type_less_than_or_equal_operation(self):
         path, _ = self.get_deploy_file_paths('BuiltinTypeLessThanOrEqual.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -504,7 +504,7 @@ class TestRelational(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -538,7 +538,7 @@ class TestRelational(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -576,7 +576,7 @@ class TestRelational(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -596,7 +596,7 @@ class TestRelational(BoaTest):
 
     def test_boa2_equality_test2(self):
         path, _ = self.get_deploy_file_paths('Equality2Boa2Test.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -648,7 +648,7 @@ class TestRelational(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -672,7 +672,7 @@ class TestRelational(BoaTest):
 
     def test_boolean_not_identity_operation(self):
         path, _ = self.get_deploy_file_paths('BoolNotIdentity.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -700,7 +700,7 @@ class TestRelational(BoaTest):
 
     def test_list_not_identity(self):
         path, _ = self.get_deploy_file_paths('ListNotIdentity.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -723,7 +723,7 @@ class TestRelational(BoaTest):
 
     def test_none_not_identity_operation(self):
         path, _ = self.get_deploy_file_paths('NoneNotIdentity.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -751,7 +751,7 @@ class TestRelational(BoaTest):
 
     def test_number_not_identity_operation(self):
         path, _ = self.get_deploy_file_paths('NumNotIdentity.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -779,7 +779,7 @@ class TestRelational(BoaTest):
 
     def test_string_not_identity_operation(self):
         path, _ = self.get_deploy_file_paths('StrNotIdentity.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -807,7 +807,7 @@ class TestRelational(BoaTest):
 
     def test_tuple_not_identity(self):
         path, _ = self.get_deploy_file_paths('TupleNotIdentity.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -848,7 +848,7 @@ class TestRelational(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -866,7 +866,7 @@ class TestRelational(BoaTest):
 
     def test_builtin_equality_operation(self):
         path, _ = self.get_deploy_file_paths('BuiltinTypeEquality.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -900,7 +900,7 @@ class TestRelational(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -936,7 +936,7 @@ class TestRelational(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -972,7 +972,7 @@ class TestRelational(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -990,7 +990,7 @@ class TestRelational(BoaTest):
 
     def test_builtin_inequality_operation(self):
         path, _ = self.get_deploy_file_paths('BuiltinTypeInequality.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1020,7 +1020,7 @@ class TestRelational(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1048,7 +1048,7 @@ class TestRelational(BoaTest):
 
     def test_compare_same_value_argument(self):
         path, _ = self.get_deploy_file_paths('CompareSameValueArgument.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1064,7 +1064,7 @@ class TestRelational(BoaTest):
 
     def test_compare_same_value_hard_coded(self):
         path, _ = self.get_deploy_file_paths('CompareSameValueHardCoded.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1080,7 +1080,7 @@ class TestRelational(BoaTest):
 
     def test_compare_string(self):
         path, _ = self.get_deploy_file_paths('CompareString.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1105,7 +1105,7 @@ class TestRelational(BoaTest):
 
     def test_list_equality_with_slice(self):
         path, _ = self.get_deploy_file_paths('ListEqualityWithSlice.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1143,7 +1143,7 @@ class TestRelational(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1179,7 +1179,7 @@ class TestRelational(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_reversed.py
+++ b/boa3_test/tests/compiler_tests/test_reversed.py
@@ -3,7 +3,7 @@ from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to 
 from boa3.internal.exception import CompilerError
 from boa3.internal.neo.vm.type.String import String
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestReversed(BoaTest):
@@ -11,7 +11,7 @@ class TestReversed(BoaTest):
 
     def test_reversed_list_bool(self):
         path, _ = self.get_deploy_file_paths('ReversedListBool.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -30,7 +30,7 @@ class TestReversed(BoaTest):
 
     def test_reversed_list_bytes(self):
         path, _ = self.get_deploy_file_paths('ReversedListBytes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -49,7 +49,7 @@ class TestReversed(BoaTest):
 
     def test_reversed_list_int(self):
         path, _ = self.get_deploy_file_paths('ReversedListInt.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -68,7 +68,7 @@ class TestReversed(BoaTest):
 
     def test_reversed_list_str(self):
         path, _ = self.get_deploy_file_paths('ReversedListStr.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -87,7 +87,7 @@ class TestReversed(BoaTest):
 
     def test_reversed_list(self):
         path, _ = self.get_deploy_file_paths('ReversedList.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -106,7 +106,7 @@ class TestReversed(BoaTest):
 
     def test_reversed_string(self):
         path, _ = self.get_deploy_file_paths('ReversedString.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -125,7 +125,7 @@ class TestReversed(BoaTest):
 
     def test_reversed_bytes(self):
         path, _ = self.get_deploy_file_paths('ReversedBytes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -144,7 +144,7 @@ class TestReversed(BoaTest):
 
     def test_reversed_range(self):
         path, _ = self.get_deploy_file_paths('ReversedRange.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -162,7 +162,7 @@ class TestReversed(BoaTest):
 
     def test_reversed_tuple(self):
         path, _ = self.get_deploy_file_paths('ReversedTuple.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_string.py
+++ b/boa3_test/tests/compiler_tests/test_string.py
@@ -6,7 +6,7 @@ from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo.vm.type.StackItem import StackItemType
 from boa3.internal.neo.vm.type.String import String
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestString(BoaTest):
@@ -31,7 +31,7 @@ class TestString(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -75,7 +75,7 @@ class TestString(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -135,7 +135,7 @@ class TestString(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -153,7 +153,7 @@ class TestString(BoaTest):
 
     def test_string_get_value_to_variable(self):
         path, _ = self.get_deploy_file_paths('GetValueToVariable.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -181,7 +181,7 @@ class TestString(BoaTest):
 
     def test_string_slicing(self):
         path, _ = self.get_deploy_file_paths('StringSlicingLiteralValues.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -197,7 +197,7 @@ class TestString(BoaTest):
 
     def test_string_slicing_start_larger_than_ending(self):
         path, _ = self.get_deploy_file_paths('StringSlicingStartLargerThanEnding.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -213,7 +213,7 @@ class TestString(BoaTest):
 
     def test_string_slicing_with_variables(self):
         path, _ = self.get_deploy_file_paths('StringSlicingVariableValues.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -229,7 +229,7 @@ class TestString(BoaTest):
 
     def test_string_slicing_negative_start(self):
         path, _ = self.get_deploy_file_paths('StringSlicingNegativeStartOmitted.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -246,7 +246,7 @@ class TestString(BoaTest):
 
     def test_string_slicing_negative_end_omitted(self):
         path, _ = self.get_deploy_file_paths('StringSlicingNegativeEndOmitted.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -262,7 +262,7 @@ class TestString(BoaTest):
 
     def test_string_slicing_start_omitted(self):
         path, _ = self.get_deploy_file_paths('StringSlicingStartOmitted.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -299,7 +299,7 @@ class TestString(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -315,7 +315,7 @@ class TestString(BoaTest):
 
     def test_string_slicing_end_omitted(self):
         path, _ = self.get_deploy_file_paths('StringSlicingEndOmitted.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -532,7 +532,7 @@ class TestString(BoaTest):
 
     def test_string_slicing_with_stride(self):
         path, _ = self.get_deploy_file_paths('StringSlicingWithStride.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -602,7 +602,7 @@ class TestString(BoaTest):
 
     def test_string_slicing_with_negative_stride(self):
         path, _ = self.get_deploy_file_paths('StringSlicingWithNegativeStride.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -665,7 +665,7 @@ class TestString(BoaTest):
 
     def test_string_slicing_omitted_with_stride(self):
         path, _ = self.get_deploy_file_paths('StringSlicingOmittedWithStride.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -723,7 +723,7 @@ class TestString(BoaTest):
 
     def test_string_slicing_omitted_with_negative_stride(self):
         path, _ = self.get_deploy_file_paths('StringSlicingOmittedWithNegativeStride.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -781,7 +781,7 @@ class TestString(BoaTest):
 
     def test_string_simple_concat(self):
         path, _ = self.get_deploy_file_paths('StringSimpleConcat.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -797,7 +797,7 @@ class TestString(BoaTest):
 
     def test_boa2_string_concat_test(self):
         path, _ = self.get_deploy_file_paths('ConcatBoa2Test.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -813,7 +813,7 @@ class TestString(BoaTest):
 
     def test_boa2_string_concat_test2(self):
         path, _ = self.get_deploy_file_paths('ConcatBoa2Test2.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -844,7 +844,7 @@ class TestString(BoaTest):
 
     def test_string_with_double_quotes(self):
         path, _ = self.get_deploy_file_paths('StringWithDoubleQuotes.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -866,7 +866,7 @@ class TestString(BoaTest):
 
     def test_string_upper(self):
         path, _ = self.get_deploy_file_paths('UpperStringMethod.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -897,7 +897,7 @@ class TestString(BoaTest):
 
     def test_string_lower(self):
         path, _ = self.get_deploy_file_paths('LowerStringMethod.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -928,7 +928,7 @@ class TestString(BoaTest):
 
     def test_string_startswith_method(self):
         path, _ = self.get_deploy_file_paths('StartswithStringMethod.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -997,7 +997,7 @@ class TestString(BoaTest):
 
     def test_string_startswith_method_default_end(self):
         path, _ = self.get_deploy_file_paths('StartswithStringMethodDefaultEnd.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1058,7 +1058,7 @@ class TestString(BoaTest):
 
     def test_string_startswith_method_defaults(self):
         path, _ = self.get_deploy_file_paths('StartswithStringMethodDefaults.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1096,7 +1096,7 @@ class TestString(BoaTest):
 
     def test_string_strip(self):
         path, _ = self.get_deploy_file_paths('StripStringMethod.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1124,7 +1124,7 @@ class TestString(BoaTest):
 
     def test_string_strip_default(self):
         path, _ = self.get_deploy_file_paths('StripStringMethodDefault.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1153,7 +1153,7 @@ class TestString(BoaTest):
 
     def test_isdigit_method(self):
         path, _ = self.get_deploy_file_paths('IsdigitMethod.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1188,7 +1188,7 @@ class TestString(BoaTest):
 
     def test_string_join_with_sequence(self):
         path, _ = self.get_deploy_file_paths('JoinStringMethodWithSequence.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1216,7 +1216,7 @@ class TestString(BoaTest):
 
     def test_string_join_with_dictionary(self):
         path, _ = self.get_deploy_file_paths('JoinStringMethodWithDictionary.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1244,7 +1244,7 @@ class TestString(BoaTest):
 
     def test_string_index(self):
         path, _ = self.get_deploy_file_paths('IndexString.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1303,7 +1303,7 @@ class TestString(BoaTest):
 
     def test_string_index_end_default(self):
         path, _ = self.get_deploy_file_paths('IndexStringEndDefault.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1360,7 +1360,7 @@ class TestString(BoaTest):
 
     def test_string_index_defaults(self):
         path, _ = self.get_deploy_file_paths('IndexStringDefaults.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1392,7 +1392,7 @@ class TestString(BoaTest):
 
     def test_string_property_slicing(self):
         path, _ = self.get_deploy_file_paths('StringPropertySlicing.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1421,7 +1421,7 @@ class TestString(BoaTest):
 
     def test_string_instance_variable_slicing(self):
         path, _ = self.get_deploy_file_paths('StringInstanceVariableSlicing.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -1450,7 +1450,7 @@ class TestString(BoaTest):
 
     def test_string_class_variable_slicing(self):
         path, _ = self.get_deploy_file_paths('StringClassVariableSlicing.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_tuple.py
+++ b/boa3_test/tests/compiler_tests/test_tuple.py
@@ -5,7 +5,7 @@ from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo.vm.type.String import String
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestTuple(BoaTest):
@@ -129,7 +129,7 @@ class TestTuple(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -185,7 +185,7 @@ class TestTuple(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -213,7 +213,7 @@ class TestTuple(BoaTest):
 
     def test_tuple_slicing(self):
         path, _ = self.get_deploy_file_paths('TupleSlicingLiteralValues.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -229,7 +229,7 @@ class TestTuple(BoaTest):
 
     def test_tuple_slicing_start_larger_than_ending(self):
         path, _ = self.get_deploy_file_paths('TupleSlicingStartLargerThanEnding.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -245,7 +245,7 @@ class TestTuple(BoaTest):
 
     def test_tuple_slicing_with_variables(self):
         path, _ = self.get_deploy_file_paths('TupleSlicingVariableValues.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -261,7 +261,7 @@ class TestTuple(BoaTest):
 
     def test_tuple_slicing_negative_start(self):
         path, _ = self.get_deploy_file_paths('TupleSlicingNegativeStart.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -277,7 +277,7 @@ class TestTuple(BoaTest):
 
     def test_tuple_slicing_negative_end(self):
         path, _ = self.get_deploy_file_paths('TupleSlicingNegativeEnd.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -293,7 +293,7 @@ class TestTuple(BoaTest):
 
     def test_tuple_slicing_start_omitted(self):
         path, _ = self.get_deploy_file_paths('TupleSlicingStartOmitted.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -331,7 +331,7 @@ class TestTuple(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -347,7 +347,7 @@ class TestTuple(BoaTest):
 
     def test_tuple_slicing_end_omitted(self):
         path, _ = self.get_deploy_file_paths('TupleSlicingEndOmitted.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -363,7 +363,7 @@ class TestTuple(BoaTest):
 
     def test_tuple_slicing_with_stride(self):
         path, _ = self.get_deploy_file_paths('TupleSlicingWithStride.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -436,7 +436,7 @@ class TestTuple(BoaTest):
 
     def test_tuple_slicing_with_negative_stride(self):
         path, _ = self.get_deploy_file_paths('TupleSlicingWithNegativeStride.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -509,7 +509,7 @@ class TestTuple(BoaTest):
 
     def test_tuple_slicing_omitted_with_stride(self):
         path, _ = self.get_deploy_file_paths('TupleSlicingOmittedWithStride.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -576,7 +576,7 @@ class TestTuple(BoaTest):
 
     def test_tuple_slicing_omitted_with_negative_stride(self):
         path, _ = self.get_deploy_file_paths('TupleSlicingOmittedWithNegativeStride.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -643,7 +643,7 @@ class TestTuple(BoaTest):
 
     def test_tuple_index(self):
         path, _ = self.get_deploy_file_paths('IndexTuple.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -703,7 +703,7 @@ class TestTuple(BoaTest):
 
     def test_tuple_index_end_default(self):
         path, _ = self.get_deploy_file_paths('IndexTupleEndDefault.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -741,7 +741,7 @@ class TestTuple(BoaTest):
 
     def test_tuple_index_defaults(self):
         path, _ = self.get_deploy_file_paths('IndexTupleDefaults.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_typing.py
+++ b/boa3_test/tests/compiler_tests/test_typing.py
@@ -5,7 +5,7 @@ from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo.vm.type.String import String
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestTyping(BoaTest):
@@ -117,7 +117,7 @@ class TestTyping(BoaTest):
         self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -150,7 +150,7 @@ class TestTyping(BoaTest):
 
     def test_cast_inside_if(self):
         path, _ = self.get_deploy_file_paths('CastInsideIf.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -166,7 +166,7 @@ class TestTyping(BoaTest):
 
     def test_cast_persisted_in_scope(self):
         path, _ = self.get_deploy_file_paths('CastPersistedInScope.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_union.py
+++ b/boa3_test/tests/compiler_tests/test_union.py
@@ -4,7 +4,7 @@ from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo.vm.type.String import String
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestUnion(BoaTest):
@@ -33,7 +33,7 @@ class TestUnion(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -75,7 +75,7 @@ class TestUnion(BoaTest):
 
     def test_union_variable_argument(self):
         path, _ = self.get_deploy_file_paths('UnionVariableArgument.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -94,7 +94,7 @@ class TestUnion(BoaTest):
 
     def test_union_isinstance_validation(self):
         path, _ = self.get_deploy_file_paths('UnionIsInstanceValidation.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -113,7 +113,7 @@ class TestUnion(BoaTest):
 
     def test_union_int_none(self):
         path, _ = self.get_deploy_file_paths('UnionIntNone.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_variable.py
+++ b/boa3_test/tests/compiler_tests/test_variable.py
@@ -11,7 +11,7 @@ from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo.vm.type.String import String
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestVariable(BoaTest):
@@ -261,7 +261,7 @@ class TestVariable(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -293,7 +293,7 @@ class TestVariable(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -325,7 +325,7 @@ class TestVariable(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -464,7 +464,7 @@ class TestVariable(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -497,7 +497,7 @@ class TestVariable(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -526,7 +526,7 @@ class TestVariable(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -546,7 +546,7 @@ class TestVariable(BoaTest):
 
     def test_global_chained_multiple_assignments(self):
         path, _ = self.get_deploy_file_paths('GlobalMultipleAssignments.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -608,7 +608,7 @@ class TestVariable(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -624,7 +624,7 @@ class TestVariable(BoaTest):
 
     def test_list_global_assignment(self):
         path, _ = self.get_deploy_file_paths('ListGlobalAssignment.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -664,7 +664,7 @@ class TestVariable(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -682,7 +682,7 @@ class TestVariable(BoaTest):
 
     def test_global_variable_in_class_method(self):
         path, _ = self.get_deploy_file_paths('GlobalVariableInClassMethod.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -737,7 +737,7 @@ class TestVariable(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -771,7 +771,7 @@ class TestVariable(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -789,7 +789,7 @@ class TestVariable(BoaTest):
 
     def test_assign_global_in_function_with_global_keyword(self):
         path, _ = self.get_deploy_file_paths('GlobalAssignmentInFunctionWithArgument.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -821,7 +821,7 @@ class TestVariable(BoaTest):
         self.assertIn(Opcode.NOP, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -837,7 +837,7 @@ class TestVariable(BoaTest):
 
     def test_anonymous_variable(self):
         path, _ = self.get_deploy_file_paths('AnonymousVariable')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -857,7 +857,7 @@ class TestVariable(BoaTest):
 
     def test_variables_in_different_scope_with_same_name(self):
         path, _ = self.get_deploy_file_paths('DifferentScopesWithSameName.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -873,7 +873,7 @@ class TestVariable(BoaTest):
 
     def test_instance_variable_and_variable_with_same_name(self):
         path, _ = self.get_deploy_file_paths('InstanceVariableAndVariableWithSameName.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -889,7 +889,7 @@ class TestVariable(BoaTest):
 
     def test_inner_object_variable_access(self):
         path, _ = self.get_deploy_file_paths('InnerObjectVariableAccess.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -906,7 +906,7 @@ class TestVariable(BoaTest):
 
     def test_variables_with_same_name_class_variable_and_local(self):
         path, _ = self.get_deploy_file_paths('VariablesWithSameNameClassVariableAndLocal.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -923,7 +923,7 @@ class TestVariable(BoaTest):
 
     def test_variables_with_same_name_instance_and_local(self):
         path, _ = self.get_deploy_file_paths('VariablesWithSameNameInstanceAndLocal.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -940,7 +940,7 @@ class TestVariable(BoaTest):
 
     def test_variables_with_same_name(self):
         path, _ = self.get_deploy_file_paths('VariablesWithSameName.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/compiler_tests/test_while.py
+++ b/boa3_test/tests/compiler_tests/test_while.py
@@ -6,7 +6,7 @@ from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo.vm.type.String import String
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestWhile(BoaTest):
@@ -40,7 +40,7 @@ class TestWhile(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -92,7 +92,7 @@ class TestWhile(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -121,7 +121,7 @@ class TestWhile(BoaTest):
 
     def test_nested_while(self):
         path, _ = self.get_deploy_file_paths('NestedWhile.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -167,7 +167,7 @@ class TestWhile(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -217,7 +217,7 @@ class TestWhile(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -271,7 +271,7 @@ class TestWhile(BoaTest):
         self.assertEqual(expected_output, output)
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -291,7 +291,7 @@ class TestWhile(BoaTest):
 
     def test_while_continue(self):
         path, _ = self.get_deploy_file_paths('WhileContinue.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -307,7 +307,7 @@ class TestWhile(BoaTest):
 
     def test_while_break(self):
         path, _ = self.get_deploy_file_paths('WhileBreak.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -323,7 +323,7 @@ class TestWhile(BoaTest):
 
     def test_boa2_while_test(self):
         path, _ = self.get_deploy_file_paths('WhileBoa2Test.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -339,7 +339,7 @@ class TestWhile(BoaTest):
 
     def test_boa2_while_test1(self):
         path, _ = self.get_deploy_file_paths('WhileBoa2Test1.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -355,7 +355,7 @@ class TestWhile(BoaTest):
 
     def test_boa2_while_test2(self):
         path, _ = self.get_deploy_file_paths('WhileBoa2Test2.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -371,7 +371,7 @@ class TestWhile(BoaTest):
 
     def test_while_interop_condition(self):
         path, _ = self.get_deploy_file_paths('WhileWithInteropCondition.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/examples_tests/test_amm.py
+++ b/boa3_test/tests/examples_tests/test_amm.py
@@ -3,8 +3,8 @@ from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to 
 from boa3.internal import constants
 from boa3.internal.neo.vm.type.String import String
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive import neoxp
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive import neoxp
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestAMMTemplate(BoaTest):
@@ -23,7 +23,7 @@ class TestAMMTemplate(BoaTest):
         path, _ = self.get_deploy_file_paths('amm.py')
         path_zneo, _ = self.get_deploy_file_paths('wrapped_neo.py')
         path_zgas, _ = self.get_deploy_file_paths('wrapped_gas.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -68,7 +68,7 @@ class TestAMMTemplate(BoaTest):
 
     def test_amm_symbol(self):
         path, _ = self.get_deploy_file_paths('amm.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = runner.call_contract(path, 'symbol')
         runner.execute()
@@ -78,7 +78,7 @@ class TestAMMTemplate(BoaTest):
 
     def test_amm_decimals(self):
         path, _ = self.get_deploy_file_paths('amm.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = runner.call_contract(path, 'decimals')
         runner.execute()
@@ -88,7 +88,7 @@ class TestAMMTemplate(BoaTest):
 
     def test_amm_total_supply(self):
         path, _ = self.get_deploy_file_paths('amm.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = runner.call_contract(path, 'totalSupply')
         runner.execute()
@@ -98,7 +98,7 @@ class TestAMMTemplate(BoaTest):
 
     def test_amm_total_balance_of(self):
         path, _ = self.get_deploy_file_paths('amm.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = runner.call_contract(path, 'balanceOf', self.OWNER.script_hash.to_array())
         runner.execute()
@@ -119,7 +119,7 @@ class TestAMMTemplate(BoaTest):
 
     def test_amm_quote(self):
         path, _ = self.get_deploy_file_paths('amm.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         amount_zneo = 1
         reserve_zneo = 100
@@ -137,7 +137,7 @@ class TestAMMTemplate(BoaTest):
         path, _ = self.get_deploy_file_paths('amm.py')
         path_zneo, _ = self.get_deploy_file_paths('wrapped_neo.py')
         path_zgas, _ = self.get_deploy_file_paths('wrapped_gas.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -192,7 +192,7 @@ class TestAMMTemplate(BoaTest):
         path, _ = self.get_deploy_file_paths('amm.py')
         path_zneo, _ = self.get_deploy_file_paths('wrapped_neo.py')
         path_zgas, _ = self.get_deploy_file_paths('wrapped_gas.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -395,7 +395,7 @@ class TestAMMTemplate(BoaTest):
         path, _ = self.get_deploy_file_paths('amm.py')
         path_zneo, _ = self.get_deploy_file_paths('wrapped_neo.py')
         path_zgas, _ = self.get_deploy_file_paths('wrapped_gas.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -535,7 +535,7 @@ class TestAMMTemplate(BoaTest):
         path, _ = self.get_deploy_file_paths('amm.py')
         path_zneo, _ = self.get_deploy_file_paths('wrapped_neo.py')
         path_zgas, _ = self.get_deploy_file_paths('wrapped_gas.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -681,7 +681,7 @@ class TestAMMTemplate(BoaTest):
         path, _ = self.get_deploy_file_paths('amm.py')
         path_zneo, _ = self.get_deploy_file_paths('wrapped_neo.py')
         path_zgas, _ = self.get_deploy_file_paths('wrapped_gas.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/examples_tests/test_hello_world.py
+++ b/boa3_test/tests/examples_tests/test_hello_world.py
@@ -1,7 +1,7 @@
 from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to avoid circular imports
 
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestTemplate(BoaTest):
@@ -13,7 +13,7 @@ class TestTemplate(BoaTest):
 
     def test_hello_world_main(self):
         path, _ = self.get_deploy_file_paths('hello_world.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = runner.call_contract(path, 'Main')
 

--- a/boa3_test/tests/examples_tests/test_htlc.py
+++ b/boa3_test/tests/examples_tests/test_htlc.py
@@ -7,9 +7,9 @@ from boa3.internal.neo.cryptography import hash160
 from boa3.internal.neo.smart_contract.notification import Notification
 from boa3.internal.neo3.core.types import UInt256
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive import neoxp
 from boa3_test.test_drive.model.network.payloads.testtransaction import TransactionExecution
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive import neoxp
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestHTLCTemplate(BoaTest):
@@ -21,7 +21,7 @@ class TestHTLCTemplate(BoaTest):
     GAS_TO_DEPLOY = 1000 * 10 ** 8
     REFUND_WAIT_TIME = 24 * 60 * 60     # smart contract constant in seconds
 
-    def _validate_execution_result(self, runner: NeoTestRunner, tx_id: UInt256, expected_result: Any) -> TransactionExecution:
+    def _validate_execution_result(self, runner: BoaTestRunner, tx_id: UInt256, expected_result: Any) -> TransactionExecution:
         # Test Runner isn't returning the runtime.time value correctly when using `call_contract`, so we have to get the
         # data from the transaction directly
         transactions_log = runner.get_transaction_result(tx_id)
@@ -39,7 +39,7 @@ class TestHTLCTemplate(BoaTest):
 
     def test_htlc_atomic_swap(self):
         path, _ = self.get_deploy_file_paths('htlc.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         runner.add_gas(self.OWNER.address, self.GAS_TO_DEPLOY)
         runner.deploy_contract(path, account=self.OWNER)
@@ -56,12 +56,12 @@ class TestHTLCTemplate(BoaTest):
 
         runner.update_contracts(export_checkpoint=True)
 
-        # The `atomic_swap` method uses runtime.time, but NeoTestRunner fails to get it
+        # The `atomic_swap` method uses runtime.time, but BoaTestRunner fails to get it
         self._validate_execution_result(runner, invoke.tx_id, expected_result=True)
 
     def test_htlc_on_nep17_payment(self):
         path, _ = self.get_deploy_file_paths('htlc.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         transferred_amount_neo = 10 * 10 ** 0
         transferred_amount_gas = 10000 * 10 ** 8
@@ -161,7 +161,7 @@ class TestHTLCTemplate(BoaTest):
 
     def test_htlc_withdraw(self):
         path, _ = self.get_deploy_file_paths('htlc.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         transferred_amount_neo = 10 * 10 ** 0
         transferred_amount_gas = 10000 * 10 ** 8
@@ -226,7 +226,7 @@ class TestHTLCTemplate(BoaTest):
         runner.execute()
         self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
-        # The `withdraw` method uses runtime.time, but NeoTestRunner fails to get it
+        # The `withdraw` method uses runtime.time, but BoaTestRunner fails to get it
         self._validate_execution_result(runner, invoke_withdraw_wrong1.tx_id, expected_result=False)
         self._validate_execution_result(runner, invoke_withdraw_wrong2.tx_id, expected_result=False)
         transaction_withdraw = self._validate_execution_result(runner, invoke_withdraw_right.tx_id, expected_result=True)
@@ -283,7 +283,7 @@ class TestHTLCTemplate(BoaTest):
 
     def test_htlc_refund_zero_transfers(self):
         path, _ = self.get_deploy_file_paths('htlc.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         transferred_amount_neo = 10 * 10 ** 0
         transferred_amount_gas = 10000 * 10 ** 8
@@ -322,10 +322,10 @@ class TestHTLCTemplate(BoaTest):
 
         runner.update_contracts(export_checkpoint=True)
 
-        # The `refund` method uses runtime.time, but NeoTestRunner fails to get it
+        # The `refund` method uses runtime.time, but BoaTestRunner fails to get it
         self._validate_execution_result(runner, invoke_refund_fail.tx_id, expected_result=False)
 
-        # The `refund` method uses runtime.time, but NeoTestRunner fails to get it
+        # The `refund` method uses runtime.time, but BoaTestRunner fails to get it
         self._validate_execution_result(runner, invoke_refund_success.tx_id, expected_result=True)
 
         transfer_events: List[Notification] = []
@@ -338,7 +338,7 @@ class TestHTLCTemplate(BoaTest):
 
     def test_htlc_refund_one_transfer(self):
         path, _ = self.get_deploy_file_paths('htlc.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         transferred_amount_neo = 10 * 10 ** 0
         transferred_amount_gas = 10000 * 10 ** 8
@@ -384,7 +384,7 @@ class TestHTLCTemplate(BoaTest):
 
         runner.update_contracts(export_checkpoint=True)
 
-        # The `refund` method uses runtime.time, but NeoTestRunner fails to get it
+        # The `refund` method uses runtime.time, but BoaTestRunner fails to get it
         transaction_refund = self._validate_execution_result(runner, invoke_refund_success.tx_id, expected_result=True)
 
         # person_a transferred cryptocurrency to the contract, so only he will be refunded
@@ -404,7 +404,7 @@ class TestHTLCTemplate(BoaTest):
 
     def test_htlc_refund_two_transfers(self):
         path, _ = self.get_deploy_file_paths('htlc.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         transferred_amount_neo = 10 * 10 ** 0
         transferred_amount_gas = 10000 * 10 ** 8
@@ -452,7 +452,7 @@ class TestHTLCTemplate(BoaTest):
 
         runner.update_contracts(export_checkpoint=True)
 
-        # The `refund` method uses runtime.time, but NeoTestRunner fails to get it
+        # The `refund` method uses runtime.time, but BoaTestRunner fails to get it
         transaction_refund = self._validate_execution_result(runner, invoke_refund_success.tx_id, expected_result=True)
 
         # person_a and person_b transferred cryptocurrency to the contract, so they both will be refunded

--- a/boa3_test/tests/examples_tests/test_ico.py
+++ b/boa3_test/tests/examples_tests/test_ico.py
@@ -2,8 +2,8 @@ from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to 
 
 from boa3.internal import constants
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive import neoxp
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive import neoxp
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestICOTemplate(BoaTest):
@@ -22,7 +22,7 @@ class TestICOTemplate(BoaTest):
 
     def test_ico_symbol(self):
         path, _ = self.get_deploy_file_paths('ico.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         runner.add_gas(self.OWNER.address, self.GAS_TO_DEPLOY)
         runner.deploy_contract(path, account=self.OWNER)
@@ -34,7 +34,7 @@ class TestICOTemplate(BoaTest):
 
     def test_ico_decimals(self):
         path, _ = self.get_deploy_file_paths('ico.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         runner.add_gas(self.OWNER.address, self.GAS_TO_DEPLOY)
         runner.deploy_contract(path, account=self.OWNER)
@@ -46,7 +46,7 @@ class TestICOTemplate(BoaTest):
 
     def test_ico_total_balance_of(self):
         path, _ = self.get_deploy_file_paths('ico.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         total_supply = 10_000_000 * 10 ** 8
         runner.add_gas(self.OWNER.address, self.GAS_TO_DEPLOY)
@@ -70,7 +70,7 @@ class TestICOTemplate(BoaTest):
 
     def test_ico_total_supply(self):
         path, _ = self.get_deploy_file_paths('ico.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         total_supply = 10_000_000 * 10 ** 8
         runner.add_gas(self.OWNER.address, self.GAS_TO_DEPLOY)
@@ -83,7 +83,7 @@ class TestICOTemplate(BoaTest):
 
     def test_ico_verify(self):
         path, _ = self.get_deploy_file_paths('ico.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -108,7 +108,7 @@ class TestICOTemplate(BoaTest):
 
     def test_ico_kyc_register(self):
         path, _ = self.get_deploy_file_paths('ico.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -150,7 +150,7 @@ class TestICOTemplate(BoaTest):
 
     def test_ico_kyc_remove(self):
         path, _ = self.get_deploy_file_paths('ico.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -192,7 +192,7 @@ class TestICOTemplate(BoaTest):
 
     def test_ico_approve(self):
         path, _ = self.get_deploy_file_paths('ico.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -257,7 +257,7 @@ class TestICOTemplate(BoaTest):
 
     def test_ico_allowance(self):
         path, _ = self.get_deploy_file_paths('ico.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -290,7 +290,7 @@ class TestICOTemplate(BoaTest):
 
     def test_ico_transfer_from(self):
         path, _ = self.get_deploy_file_paths('ico.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -428,7 +428,7 @@ class TestICOTemplate(BoaTest):
 
     def test_ico_mint(self):
         path, _ = self.get_deploy_file_paths('ico.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -472,7 +472,7 @@ class TestICOTemplate(BoaTest):
 
     def test_ico_refund(self):
         path, _ = self.get_deploy_file_paths('ico.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/examples_tests/test_nep11_non_divisible.py
+++ b/boa3_test/tests/examples_tests/test_nep11_non_divisible.py
@@ -4,8 +4,8 @@ from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to 
 
 from boa3.internal.neo.vm.type.String import String
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive import neoxp
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive import neoxp
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestNEP11Template(BoaTest):
@@ -36,7 +36,7 @@ class TestNEP11Template(BoaTest):
 
     def test_nep11_symbol(self):
         path, _ = self.get_deploy_file_paths('nep11_non_divisible.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         runner.add_gas(self.OWNER.address, self.GAS_TO_DEPLOY)
         runner.deploy_contract(path, account=self.OWNER)
@@ -49,7 +49,7 @@ class TestNEP11Template(BoaTest):
 
     def test_nep11_decimals(self):
         path, _ = self.get_deploy_file_paths('nep11_non_divisible.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         runner.add_gas(self.OWNER.address, self.GAS_TO_DEPLOY)
         runner.deploy_contract(path, account=self.OWNER)
@@ -62,7 +62,7 @@ class TestNEP11Template(BoaTest):
 
     def test_nep11_balance_of(self):
         path, _ = self.get_deploy_file_paths('nep11_non_divisible.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -105,7 +105,7 @@ class TestNEP11Template(BoaTest):
 
     def test_nep11_tokens_of(self):
         path, _ = self.get_deploy_file_paths('nep11_non_divisible.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -160,7 +160,7 @@ class TestNEP11Template(BoaTest):
 
     def test_nep11_total_supply(self):
         path, _ = self.get_deploy_file_paths('nep11_non_divisible.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         # smart contract deploys with zero tokens minted
         total_supply = 0
@@ -176,7 +176,7 @@ class TestNEP11Template(BoaTest):
 
     def test_nep11_transfer(self):
         path, _ = self.get_deploy_file_paths('nep11_non_divisible.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -230,7 +230,7 @@ class TestNEP11Template(BoaTest):
 
     def test_nep11_onNEP11Payment(self):
         path, _ = self.get_deploy_file_paths('nep11_non_divisible.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         runner.add_gas(self.OWNER.address, self.GAS_TO_DEPLOY)
         runner.deploy_contract(path, account=self.OWNER)
@@ -256,7 +256,7 @@ class TestNEP11Template(BoaTest):
 
     def test_nep11_deploy(self):
         path, _ = self.get_deploy_file_paths('nep11_non_divisible.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         runner.add_gas(self.OWNER.address, self.GAS_TO_DEPLOY)
         contract = runner.deploy_contract(path, account=self.OWNER)
@@ -279,7 +279,7 @@ class TestNEP11Template(BoaTest):
         arg_manifest = String(json.dumps(new_manifest, separators=(',', ':'))).to_bytes()
 
         path, _ = self.get_deploy_file_paths(path)
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         runner.add_gas(self.OWNER.address, self.GAS_TO_DEPLOY)
         runner.deploy_contract(path, account=self.OWNER)
@@ -294,7 +294,7 @@ class TestNEP11Template(BoaTest):
 
     def test_nep11_destroy(self):
         path, _ = self.get_deploy_file_paths('nep11_non_divisible.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         runner.add_gas(self.OWNER.address, self.GAS_TO_DEPLOY)
         runner.deploy_contract(path, account=self.OWNER)
@@ -316,7 +316,7 @@ class TestNEP11Template(BoaTest):
 
     def test_nep11_verify(self):
         path, _ = self.get_deploy_file_paths('nep11_non_divisible.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -354,7 +354,7 @@ class TestNEP11Template(BoaTest):
 
     def test_nep11_authorize(self):
         path, _ = self.get_deploy_file_paths('nep11_non_divisible.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         other_account_script_hash = self.OTHER_ACCOUNT_1.script_hash.to_array()
         runner.add_gas(self.OWNER.address, self.GAS_TO_DEPLOY)
@@ -384,7 +384,7 @@ class TestNEP11Template(BoaTest):
 
     def test_nep11_pause(self):
         path, _ = self.get_deploy_file_paths('nep11_non_divisible.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -436,7 +436,7 @@ class TestNEP11Template(BoaTest):
 
     def test_nep11_mint(self):
         path, _ = self.get_deploy_file_paths('nep11_non_divisible.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -485,7 +485,7 @@ class TestNEP11Template(BoaTest):
 
     def test_nep11_burn(self):
         path, _ = self.get_deploy_file_paths('nep11_non_divisible.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/examples_tests/test_nep17.py
+++ b/boa3_test/tests/examples_tests/test_nep17.py
@@ -2,8 +2,8 @@ from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to 
 
 from boa3.internal import constants
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive import neoxp
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive import neoxp
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestNEP17Template(BoaTest):
@@ -24,7 +24,7 @@ class TestNEP17Template(BoaTest):
 
     def test_nep17_symbol(self):
         path, _ = self.get_deploy_file_paths('nep17.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = runner.call_contract(path, 'symbol')
         runner.execute()
@@ -33,7 +33,7 @@ class TestNEP17Template(BoaTest):
 
     def test_nep17_decimals(self):
         path, _ = self.get_deploy_file_paths('nep17.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = runner.call_contract(path, 'decimals')
         runner.execute()
@@ -44,7 +44,7 @@ class TestNEP17Template(BoaTest):
         total_supply = 10_000_000 * 10 ** 8
 
         path, _ = self.get_deploy_file_paths('nep17.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = runner.call_contract(path, 'totalSupply')
         runner.execute()
@@ -55,7 +55,7 @@ class TestNEP17Template(BoaTest):
         total_supply = 10_000_000 * 10 ** 8
 
         path, _ = self.get_deploy_file_paths('nep17.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         runner.add_gas(self.OWNER.address, self.GAS_TO_DEPLOY)
         runner.deploy_contract(path, account=self.OWNER)
@@ -85,7 +85,7 @@ class TestNEP17Template(BoaTest):
         test_account_script_hash = self.OTHER_ACCOUNT.script_hash.to_array()
 
         path, _ = self.get_deploy_file_paths('nep17.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         runner.add_gas(self.OWNER.address, self.GAS_TO_DEPLOY)
         runner.deploy_contract(path, account=self.OWNER)
@@ -181,7 +181,7 @@ class TestNEP17Template(BoaTest):
         transferred_amount_gas = 10 * 10 ** 8   # 10 tokens
 
         path, _ = self.get_deploy_file_paths('nep17.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         runner.add_gas(self.OWNER.address, self.GAS_TO_DEPLOY)
         nep17_contract = runner.deploy_contract(path, account=self.OWNER)
@@ -290,7 +290,7 @@ class TestNEP17Template(BoaTest):
 
     def test_nep17_verify(self):
         path, _ = self.get_deploy_file_paths('nep17.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         runner.add_gas(self.OWNER.address, self.GAS_TO_DEPLOY)
         runner.deploy_contract(path, account=self.OWNER)

--- a/boa3_test/tests/examples_tests/test_simple_nep17.py
+++ b/boa3_test/tests/examples_tests/test_simple_nep17.py
@@ -1,8 +1,8 @@
 from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to avoid circular imports
 
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive import neoxp
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive import neoxp
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestSimpleNEP17Template(BoaTest):
@@ -26,7 +26,7 @@ class TestSimpleNEP17Template(BoaTest):
 
     def test_simple_nep17_symbol(self):
         path, _ = self.get_deploy_file_paths('simple_nep17.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = runner.call_contract(path, 'symbol')
         runner.execute()
@@ -35,7 +35,7 @@ class TestSimpleNEP17Template(BoaTest):
 
     def test_simple_nep17_decimals(self):
         path, _ = self.get_deploy_file_paths('simple_nep17.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = runner.call_contract(path, 'decimals')
         runner.execute()
@@ -44,7 +44,7 @@ class TestSimpleNEP17Template(BoaTest):
 
     def test_simple_nep17_total_supply(self):
         path, _ = self.get_deploy_file_paths('simple_nep17.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = runner.call_contract(path, 'totalSupply')
         runner.execute()
@@ -53,7 +53,7 @@ class TestSimpleNEP17Template(BoaTest):
 
     def test_simple_nep17_total_balance_of(self):
         path, _ = self.get_deploy_file_paths('simple_nep17.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         runner.add_gas(self.OWNER.address, self.GAS_TO_DEPLOY)
         runner.deploy_contract(path, account=self.OWNER)
@@ -83,7 +83,7 @@ class TestSimpleNEP17Template(BoaTest):
         test_account_script_hash = self.OTHER_ACCOUNT.script_hash.to_array()
 
         path, _ = self.get_deploy_file_paths('simple_nep17.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         runner.add_gas(self.OWNER.address, self.GAS_TO_DEPLOY)
         runner.deploy_contract(path, account=self.OWNER)
@@ -172,7 +172,7 @@ class TestSimpleNEP17Template(BoaTest):
 
     def test_simple_nep17_on_nep17_payment(self):
         path, _ = self.get_deploy_file_paths('simple_nep17.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         runner.add_gas(self.OWNER.address, self.GAS_TO_DEPLOY)
         runner.update_contracts(export_checkpoint=True)

--- a/boa3_test/tests/examples_tests/test_update_contract.py
+++ b/boa3_test/tests/examples_tests/test_update_contract.py
@@ -5,8 +5,8 @@ from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to 
 from boa3.internal import constants
 from boa3.internal.neo.vm.type.String import String
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive import neoxp
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive import neoxp
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestUpdateContractTemplate(BoaTest):
@@ -24,7 +24,7 @@ class TestUpdateContractTemplate(BoaTest):
 
     def test_update_contract(self):
         path, _ = self.get_deploy_file_paths('update_contract.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []

--- a/boa3_test/tests/examples_tests/test_wrapped_neo.py
+++ b/boa3_test/tests/examples_tests/test_wrapped_neo.py
@@ -2,8 +2,8 @@ from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to 
 
 from boa3.internal import constants
 from boa3.internal.neo3.vm import VMState
-from boa3_test.test_drive import neoxp
-from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive import neoxp
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestWrappedTokenTemplate(BoaTest):
@@ -21,7 +21,7 @@ class TestWrappedTokenTemplate(BoaTest):
 
     def test_wrapped_neo_symbol(self):
         path, _ = self.get_deploy_file_paths('wrapped_neo.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = runner.call_contract(path, 'symbol')
         runner.execute()
@@ -31,7 +31,7 @@ class TestWrappedTokenTemplate(BoaTest):
 
     def test_wrapped_neo_decimals(self):
         path, _ = self.get_deploy_file_paths('wrapped_neo.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = runner.call_contract(path, 'decimals')
         runner.execute()
@@ -43,7 +43,7 @@ class TestWrappedTokenTemplate(BoaTest):
         total_supply = 10_000_000
 
         path, _ = self.get_deploy_file_paths('wrapped_neo.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invoke = runner.call_contract(path, 'totalSupply')
         runner.execute()
@@ -55,7 +55,7 @@ class TestWrappedTokenTemplate(BoaTest):
         total_supply = 10_000_000
 
         path, _ = self.get_deploy_file_paths('wrapped_neo.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         runner.add_gas(self.OWNER.address, self.GAS_TO_DEPLOY)
         runner.deploy_contract(path, account=self.OWNER)
@@ -90,7 +90,7 @@ class TestWrappedTokenTemplate(BoaTest):
         expected_results = []
 
         path, _ = self.get_deploy_file_paths('wrapped_neo.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         runner.add_gas(self.OWNER.address, self.GAS_TO_DEPLOY)
         wrapped_neo_contract = runner.deploy_contract(path, account=self.OWNER)
@@ -185,7 +185,7 @@ class TestWrappedTokenTemplate(BoaTest):
 
     def test_wrapped_neo_burn(self):
         path, _ = self.get_deploy_file_paths('wrapped_neo.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         runner.add_gas(self.OWNER.address, self.GAS_TO_DEPLOY)
         wrapped_neo_contract = runner.deploy_contract(path, account=self.OWNER)
@@ -255,7 +255,7 @@ class TestWrappedTokenTemplate(BoaTest):
 
     def test_wrapped_neo_approve(self):
         path, _ = self.get_deploy_file_paths('wrapped_neo.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -309,7 +309,7 @@ class TestWrappedTokenTemplate(BoaTest):
 
     def test_wrapped_neo_allowance(self):
         path, _ = self.get_deploy_file_paths('wrapped_neo.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -355,7 +355,7 @@ class TestWrappedTokenTemplate(BoaTest):
 
     def test_wrapped_neo_transfer_from(self):
         path, _ = self.get_deploy_file_paths('wrapped_neo.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []
         expected_results = []
@@ -507,7 +507,7 @@ class TestWrappedTokenTemplate(BoaTest):
 
     def test_wrapped_neo_on_nep17_payment(self):
         path, _ = self.get_deploy_file_paths('wrapped_neo.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         minted_amount = 10
         test_account_1 = self.OTHER_ACCOUNT_1
@@ -570,7 +570,7 @@ class TestWrappedTokenTemplate(BoaTest):
 
     def test_wrapped_neo_verify(self):
         path, _ = self.get_deploy_file_paths('wrapped_neo.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = BoaTestRunner(runner_id=self.method_name())
 
         runner.add_gas(self.OWNER.address, self.GAS_TO_DEPLOY)
         runner.deploy_contract(path, account=self.OWNER)

--- a/boa3_test/tests/test_app_tests/test_test_runner.py
+++ b/boa3_test/tests/test_app_tests/test_test_runner.py
@@ -1,5 +1,8 @@
+import os.path
+
 from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to avoid circular imports
 
+from boa3.internal import env
 from boa3.internal.neo.vm.type.AbiType import AbiType
 from boa3.internal.neo.vm.type.String import String
 from boa3.internal.neo3.vm import VMState
@@ -12,7 +15,9 @@ class TestTestRunner(BoaTest):
 
     def test_run(self):
         path, _ = self.get_deploy_file_paths('test_sc/generation_test', 'GenerationWithDecorator.py')
-        runner = NeoTestRunner(runner_id=self.method_name())
+        runner = NeoTestRunner(os.path.join(env.NEO_EXPRESS_INSTANCE_DIRECTORY, 'default.neo-express'),
+                               runner_id=self.method_name()
+                               )
 
         invoke_result = runner.call_contract(path, 'Sub', 50, 20)
         self.assertEqual(invokeresult.NOT_EXECUTED, invoke_result.result)

--- a/boa3_test/tests/test_drive/neoxp/__init__.py
+++ b/boa3_test/tests/test_drive/neoxp/__init__.py
@@ -1,0 +1,5 @@
+__all__ = [
+    'utils'
+]
+
+from boa3_test.tests.test_drive.neoxp import utils

--- a/boa3_test/tests/test_drive/neoxp/utils.py
+++ b/boa3_test/tests/test_drive/neoxp/utils.py
@@ -1,0 +1,1 @@
+from boa3_test.test_drive.neoxp.utils import *

--- a/boa3_test/tests/test_drive/testrunner/__init__.py
+++ b/boa3_test/tests/test_drive/testrunner/__init__.py
@@ -1,0 +1,5 @@
+__all__ = [
+    'utils',
+]
+
+from boa3_test.test_drive.testrunner import utils

--- a/boa3_test/tests/test_drive/testrunner/boa_test_runner.py
+++ b/boa3_test/tests/test_drive/testrunner/boa_test_runner.py
@@ -1,0 +1,60 @@
+__all__ = [
+    'BoaTestRunner'
+]
+
+import os.path
+import threading
+from typing import Callable, List, Sequence, Tuple
+
+from boa3.internal import env
+from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+
+
+class BoaTestRunner(NeoTestRunner):
+
+    def __init__(self, neoxp_path: str = None, runner_id: str = None):
+        if not isinstance(neoxp_path, str):
+            neoxp_path = f'{env.NEO_EXPRESS_INSTANCE_DIRECTORY}{os.path.sep}default.neo-express'
+
+        super().__init__(neoxp_path, runner_id)
+
+        self._clear_files_when_destroyed = True
+
+    def _set_up_generate_file_names(self, file_name: str):
+        from boa3_test.test_drive import utils
+        runner_specific_id = utils.create_custom_id(file_name)
+        super()._set_up_generate_file_names(runner_specific_id)
+
+    def _internal_generate_files(self, methods_to_call: List[Tuple[Callable, Sequence]]):
+        worker_threads = []
+
+        if len(methods_to_call) > 0:
+            last_method, last_method_args = methods_to_call[-1]
+
+            for method, args in methods_to_call[:-1]:
+                work_thread = threading.Thread(target=method, args=args)
+                worker_threads.append(
+                    work_thread
+                )
+                work_thread.start()
+
+            last_method(*last_method_args)
+
+        for worker in worker_threads:
+            worker.join()
+
+    def __del__(self):
+        self.reset()
+        if self._clear_files_when_destroyed:
+            paths_to_delete = [
+                self.get_full_path(self._CHECKPOINT_FILE),
+                self.get_full_path(self._BATCH_FILE),
+                self.get_full_path(self._INVOKE_FILE)
+            ]
+            for path in paths_to_delete:
+                try:
+                    if os.path.exists(path):
+                        os.remove(path)
+                except BaseException as e:
+                    print(e)
+                    continue

--- a/boa3_test/tests/test_drive/testrunner/boa_test_runner.py
+++ b/boa3_test/tests/test_drive/testrunner/boa_test_runner.py
@@ -14,7 +14,7 @@ class BoaTestRunner(NeoTestRunner):
 
     def __init__(self, neoxp_path: str = None, runner_id: str = None):
         if not isinstance(neoxp_path, str):
-            neoxp_path = f'{env.NEO_EXPRESS_INSTANCE_DIRECTORY}{os.path.sep}default.neo-express'
+            neoxp_path = os.path.join(env.NEO_EXPRESS_INSTANCE_DIRECTORY, 'default.neo-express')
 
         super().__init__(neoxp_path, runner_id)
 


### PR DESCRIPTION
**Summary or solution description**
Part of refactoring to isolate neo3-boa specific logics from Neo TestRunner object.