### PR TITLE
Test runner uses incorrect neo-express path resolving

### DIFF
--- a/boa3_test/test_drive/model/network/payloads/testblock.py
+++ b/boa3_test/test_drive/model/network/payloads/testblock.py
@@ -35,7 +35,7 @@ class TestBlock:
         return json_block
 
     @classmethod
-    def from_json(cls, json: Dict[str, Any]) -> TestBlock:
+    def from_json(cls, json: Dict[str, Any], *args, **kwargs) -> TestBlock:
         block = object.__new__(cls)
 
         if 'index' in json:

--- a/boa3_test/test_drive/model/network/payloads/testtransaction.py
+++ b/boa3_test/test_drive/model/network/payloads/testtransaction.py
@@ -44,7 +44,7 @@ class TestTransaction:
         }
 
     @classmethod
-    def from_json(cls, json: Dict[str, Any]) -> TestTransaction:
+    def from_json(cls, json: Dict[str, Any], *args, **kwargs) -> TestTransaction:
         import base64
 
         if 'hash' in json and isinstance(json['hash'], str):

--- a/boa3_test/test_drive/neoxp/batch.py
+++ b/boa3_test/test_drive/neoxp/batch.py
@@ -17,13 +17,14 @@ _NEOXP_BATCH_LOCK = threading.Lock()
 
 
 class NeoExpressBatch:
-    def __init__(self):
+    def __init__(self, neoxp_config):
         self._instructions: List[NeoExpressCommand] = []
         self._transaction_submissions: List[int] = []
         self._transaction_logs: List[str] = []
 
         self._tx_invokes: List[ITransactionObject] = []
         self._tx_invokes_pos: List[int] = []
+        self._neoxp_config = neoxp_config
 
     def is_empty(self) -> bool:
         return len(self._instructions) == 0
@@ -38,7 +39,7 @@ class NeoExpressBatch:
         if hasattr(deployer, 'name') and isinstance(deployer.name, str):
             deployer_id = deployer
         else:
-            deployer_id = utils.get_default_account()  # neo express default account
+            deployer_id = utils.get_default_account(self._neoxp_config)  # neo express default account
 
         tx_pos = len(self._instructions)
         deployed_contract = TestContract(nef_path, nef_path.replace('.nef', '.manifest.json'))
@@ -56,7 +57,7 @@ class NeoExpressBatch:
         if hasattr(invoke.invoker, 'name') and isinstance(invoke.invoker.name, str):
             invoker_id = invoke.invoker
         else:
-            invoker_id = utils.get_default_account()  # neo express default account
+            invoker_id = utils.get_default_account(self._neoxp_config)  # neo express default account
 
         tx_pos = len(self._instructions)
         batch_invoke = NeoBatchInvoke(invoke, tx_pos, expected_result_type=expected_result_type)
@@ -74,7 +75,7 @@ class NeoExpressBatch:
         if hasattr(account, 'name') and isinstance(account.name, str):
             invoker_id = account
         else:
-            invoker_id = utils.get_default_account()  # neo express default account
+            invoker_id = utils.get_default_account(self._neoxp_config)  # neo express default account
 
         if witness_scope != WitnessScope.CalledByEntry:
             # only CalledByEntry and Global are accepted as WitnessScopes in neo express

--- a/boa3_test/test_drive/testrunner/blockchain/transaction.py
+++ b/boa3_test/test_drive/testrunner/blockchain/transaction.py
@@ -66,14 +66,24 @@ class TestRunnerTransaction(TestTransaction):
         return self._witnesses.copy()
 
     @classmethod
-    def from_json(cls, json: Dict[str, Any]) -> TestRunnerTransaction:
+    def from_json(cls, json: Dict[str, Any], *args, **kwargs) -> TestRunnerTransaction:
         tx: TestRunnerTransaction = super().from_json(json)
+
+        if 'neoxp_config' in kwargs:
+            neoxp_config = kwargs['neoxp_config']
+        elif len(args) > 0:
+            neoxp_config = args[0]
+        else:
+            neoxp_config = None
 
         tx._size = json['size']
         tx._version = json['version']
         tx._nonce = json['nonce']
         sender_account = json['sender']
-        tx._sender = utils.get_account_from_script_hash_or_id(sender_account)
+        tx._sender = (utils.get_account_from_script_hash_or_id(neoxp_config, sender_account)
+                      if neoxp_config is not None
+                      else sender_account
+                      )
         tx._system_fee = int(json['sysfee'])
         tx._network_fee = int(json['netfee'])
         tx._valid_until_block = json['validuntilblock']

--- a/boa3_test/tests/test_drive/neoxp/utils.py
+++ b/boa3_test/tests/test_drive/neoxp/utils.py
@@ -1,1 +1,32 @@
+from boa3_test.test_drive.neoxp import utils as neoxp_utils
 from boa3_test.test_drive.neoxp.utils import *
+
+_NEOXP_CONFIG = NeoExpressConfig(f'{env.NEO_EXPRESS_INSTANCE_DIRECTORY}/default.neo-express')
+
+
+def get_account_by_name(account_name) -> Account:
+    return neoxp_utils.get_account_by_name(_NEOXP_CONFIG, account_name)
+
+
+def get_account_by_address(account_address: str) -> Account:
+    return neoxp_utils.get_account_by_address(_NEOXP_CONFIG, account_address)
+
+
+def get_account_by_identifier(account_identifier: str) -> Account:
+    return neoxp_utils.get_account_by_identifier(_NEOXP_CONFIG, account_identifier)
+
+
+def get_default_account() -> Account:
+    return _NEOXP_CONFIG.default_account
+
+
+def get_address_version() -> int:
+    return _NEOXP_CONFIG.version
+
+
+def get_magic() -> int:
+    return _NEOXP_CONFIG.magic
+
+
+def get_genesis_block() -> Block:
+    return _NEOXP_CONFIG.genesis_block

--- a/boa3_test/tests/test_drive/testrunner/boa_test_runner.py
+++ b/boa3_test/tests/test_drive/testrunner/boa_test_runner.py
@@ -7,18 +7,27 @@ import threading
 from typing import Callable, List, Sequence, Tuple
 
 from boa3.internal import env
+from boa3_test.test_drive.neoxp.model.neoxpconfig import NeoExpressConfig
 from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
+from boa3_test.tests.test_drive.neoxp import utils as neoxp_utils
 
 
 class BoaTestRunner(NeoTestRunner):
+    _DEFAULT_ACCOUNT = neoxp_utils.get_default_account()
 
-    def __init__(self, neoxp_path: str = None, runner_id: str = None):
+    def __init__(self, neoxp_path: str = None, runner_id: str = None, cleanup_files: bool = True):
         if not isinstance(neoxp_path, str):
             neoxp_path = os.path.join(env.NEO_EXPRESS_INSTANCE_DIRECTORY, 'default.neo-express')
 
         super().__init__(neoxp_path, runner_id)
 
-        self._clear_files_when_destroyed = True
+        self._clear_files_when_destroyed = cleanup_files
+
+    def _set_up_neoxp_config(self) -> NeoExpressConfig:
+        default_config = neoxp_utils._NEOXP_CONFIG
+        if self._neoxp_abs_path == os.path.abspath(default_config.config_path):
+            return default_config
+        return super()._set_up_neoxp_config()
 
     def _set_up_generate_file_names(self, file_name: str):
         from boa3_test.test_drive import utils


### PR DESCRIPTION
**Related issue**
Fix #1100 

**Summary or solution description**
`neoxp.utils` package had a `NEOXP_CONFIG` object that was created using the neo express config from boa3 unit tests by default, but this file is not included in the boa3 package install and the object wasn't updated when other neo express config files were used to initialize the TestRunner.

Moved this default config object to the boa3 unit test specific package.

**How to Reproduce**
Use NeoTestRunner with a neo express config file different from boa3's
