### PR TITLE
Create a bytes to hextring converter so it can be printed on log

### DIFF
--- a/boa3/builtin/contract/__init__.py
+++ b/boa3/builtin/contract/__init__.py
@@ -1,8 +1,9 @@
 __all__ = [
     'Nep11TransferEvent',
     'Nep17TransferEvent',
-    'abort',
     'NeoAccountState',
+    'abort',
+    'to_hex_str',
     'to_script_hash',
 ]
 
@@ -120,5 +121,24 @@ def to_script_hash(data_bytes: Any) -> bytes:
     :type data_bytes: Any
     :return: the script hash of the data
     :rtype: bytes
+    """
+    pass
+
+
+def to_hex_str(data: bytes) -> str:
+    """
+    Converts bytes into its string hex representation.
+
+    >>> to_hex_str(ECPoint(bytes(range(33))))
+    '201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100'
+
+    >>> to_hex_str(b'1234567891')
+    '31393837363534333231'
+
+    :param data: data to represent as hex.
+    :type data: bytearray or bytes
+
+    :return: the hex representation of the data
+    :rtype: str
     """
     pass

--- a/boa3/internal/compiler/codegenerator/codegenerator.py
+++ b/boa3/internal/compiler/codegenerator/codegenerator.py
@@ -1211,7 +1211,7 @@ class CodeGenerator:
                 new_stack_item = Type.any
             self._stack_append(new_stack_item)
 
-    def convert_get_substring(self, *, is_internal: bool = False):
+    def convert_get_substring(self, *, is_internal: bool = False, fix_result_type: bool = True):
         """
         Converts the end of get a substring
 
@@ -1236,7 +1236,8 @@ class CodeGenerator:
         if not is_internal:
             self._update_jump(jmp_address, self.last_code_start_address)
         self._stack_append(BufferType)  # substr returns a buffer instead of a bytestring
-        self.convert_cast(original)
+        if fix_result_type:
+            self.convert_cast(original)
 
     def convert_get_array_slice(self, array: SequenceType):
         """

--- a/boa3/internal/model/builtin/builtin.py
+++ b/boa3/internal/model/builtin/builtin.py
@@ -58,6 +58,7 @@ class Builtin:
     ScriptHashMethod_ = ScriptHashMethod()
     StrSplit = StrSplitMethod()
     Sum = SumMethod()
+    ToHexStr = ToHexStrMethod()
 
     # python builtin class constructor
     Bool = BoolMethod()
@@ -267,7 +268,8 @@ class Builtin:
                               NeoAccountState,
                               Nep11Transfer,
                               Nep17Transfer,
-                              ScriptHashMethod_
+                              ScriptHashMethod_,
+                              ToHexStr,
                               ],
         BoaPackage.Interop: Interop.package_symbols,
         BoaPackage.Type: _builtin_type_package_symbols,

--- a/boa3/internal/model/builtin/method/__init__.py
+++ b/boa3/internal/model/builtin/method/__init__.py
@@ -31,6 +31,7 @@ __all__ = ['AbsMethod',
            'SuperMethod',
            'ToBoolMethod',
            'ToBytesMethod',
+           'ToHexStrMethod',
            'ToIntMethod',
            'ToStrMethod',
            ]
@@ -66,6 +67,7 @@ from boa3.internal.model.builtin.method.summethod import SumMethod
 from boa3.internal.model.builtin.method.supermethod import SuperMethod
 from boa3.internal.model.builtin.method.toboolmethod import ToBool as ToBoolMethod
 from boa3.internal.model.builtin.method.tobytesmethod import ToBytes as ToBytesMethod
+from boa3.internal.model.builtin.method.tohexstrmethod import ToHexStrMethod
 from boa3.internal.model.builtin.method.tointmethod import ToInt as ToIntMethod
 from boa3.internal.model.builtin.method.toscripthashmethod import ScriptHashMethod
 from boa3.internal.model.builtin.method.tostrmethod import ToStr as ToStrMethod

--- a/boa3/internal/model/builtin/method/minmethod.py
+++ b/boa3/internal/model/builtin/method/minmethod.py
@@ -27,6 +27,8 @@ class MinMethod(IBuiltinMethod):
         vararg = ('values', Variable(arg_value))
         super().__init__(identifier, args, return_type=arg_value, vararg=vararg)
 
+        self.internal_call_args = len(args)
+
     def _is_valid_type(self, arg_type: Optional[IType]) -> bool:
         return (isinstance(arg_type, IType) and
                 any(allowed_type.is_type_of(arg_type) for allowed_type in self._allowed_types))

--- a/boa3/internal/model/builtin/method/tohexstrmethod.py
+++ b/boa3/internal/model/builtin/method/tohexstrmethod.py
@@ -1,0 +1,115 @@
+from typing import Dict, Optional
+
+from boa3.internal.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.internal.model.variable import Variable
+
+
+class ToHexStrMethod(IBuiltinMethod):
+
+    def __init__(self):
+        from boa3.internal.model.type.type import Type
+        identifier = 'to_hex_str'
+        args: Dict[str, Variable] = {
+            'data': Variable(Type.bytes)
+        }
+        super().__init__(identifier, args, return_type=Type.str)
+
+    def generate_internal_opcodes(self, code_generator):
+        from boa3.internal import constants
+        from boa3.internal.model.builtin.builtin import Builtin
+        from boa3.internal.model.builtin.interop.interop import Interop
+        from boa3.internal.model.operation.binaryop import BinaryOp
+        from boa3.internal.model.type.type import Type
+        from boa3.internal.neo.vm.opcode.Opcode import Opcode
+
+        max_size_to_convert = constants.SIZE_OF_INT256
+        hex_base = 16
+
+        code_generator.duplicate_stack_top_item()
+        code_generator.convert_builtin_method_call(Builtin.Len, is_internal=True)
+        code_generator.convert_literal(0)
+        # if len(arg) == 0
+        is_empty = code_generator.convert_begin_if()
+        #   result = arg  # do nothing on script
+        # else
+        code_generator.change_jump(is_empty, Opcode.JMPEQ)
+
+        #   no_calls = len(arg) // max_size + 1
+        code_generator.duplicate_stack_top_item()
+        code_generator.convert_builtin_method_call(Builtin.Len, is_internal=True)
+        code_generator.convert_literal(max_size_to_convert)
+        code_generator.convert_operation(BinaryOp.IntDiv, is_internal=True)
+        code_generator.insert_opcode(Opcode.INC)
+        #   result = ''
+        code_generator.convert_literal('')
+        #   index = 0
+        code_generator.convert_literal(0)
+
+        #   while index < no_calls:
+        loop_start = code_generator.convert_begin_while()
+        code_generator.convert_literal(hex_base)
+
+        code_generator.duplicate_stack_item(5)
+        #       pos = index * max_size
+        code_generator.duplicate_stack_item(3)
+        code_generator.convert_literal(max_size_to_convert)
+        code_generator.convert_operation(BinaryOp.Mul)
+
+        #       subsize = min(len(arg) - pos, max_size)
+        code_generator.duplicate_stack_item(2)
+        code_generator.convert_builtin_method_call(Builtin.Len, is_internal=True)
+        code_generator.duplicate_stack_item(2)
+        code_generator.convert_operation(BinaryOp.Sub)
+        code_generator.convert_literal(max_size_to_convert)
+        code_generator.convert_builtin_method_call(Builtin.Min, is_internal=True)
+
+        code_generator.convert_get_substring(is_internal=True, fix_result_type=False)
+        #       aux = itoa(arg[pos: pos + max_size], hex_base)
+        code_generator.convert_cast(Type.int, is_internal=True)
+        code_generator.convert_builtin_method_call(Interop.Itoa, is_internal=True)
+
+        code_generator.duplicate_stack_top_item()
+        code_generator.convert_builtin_method_call(Builtin.Len, is_internal=True)
+        code_generator.convert_literal(2)
+        code_generator.convert_operation(BinaryOp.Mod, is_internal=True)
+        #       if len(aux) % 2:
+        is_odd = code_generator.convert_begin_if()
+
+        #           aux = '0' + aux
+        code_generator.convert_literal('0')
+        code_generator.swap_reverse_stack_items(2)
+        code_generator.convert_operation(BinaryOp.Concat, is_internal=True)
+
+        code_generator.convert_end_if(is_odd)
+
+        code_generator.swap_reverse_stack_items(3, rotate=True)
+        #       result += aux
+        code_generator.convert_operation(BinaryOp.Concat, is_internal=True)
+        code_generator.swap_reverse_stack_items(2)
+
+        #       index += 1
+        code_generator.insert_opcode(Opcode.INC)
+
+        loop_condition = code_generator.bytecode_size
+        code_generator.duplicate_stack_item(3)
+        code_generator.duplicate_stack_item(2)
+        code_generator.convert_operation(BinaryOp.Gt)
+
+        code_generator.convert_end_while(loop_start, loop_condition, is_internal=True)
+
+        # clear stack
+        code_generator.remove_stack_top_item()
+        code_generator.remove_stack_item(2)
+        code_generator.remove_stack_item(2)
+
+        code_generator.convert_cast(self.return_type)
+
+        code_generator.convert_end_if(is_empty)
+
+    @property
+    def _args_on_stack(self) -> int:
+        return 0
+
+    @property
+    def _body(self) -> Optional[str]:
+        return None

--- a/boa3_test/test_sc/built_in_methods_test/HexStr.py
+++ b/boa3_test/test_sc/built_in_methods_test/HexStr.py
@@ -1,0 +1,12 @@
+from boa3.builtin.compile_time import public
+from boa3.builtin.contract import to_hex_str
+
+
+@public
+def Main() -> str:
+    return to_hex_str(b'abcdefghijklmnopqrstuvwxyz0123456789')
+
+
+@public
+def Main2() -> str:
+    return to_hex_str(b'123')

--- a/boa3_test/test_sc/built_in_methods_test/HexStrMismatchedType.py
+++ b/boa3_test/test_sc/built_in_methods_test/HexStrMismatchedType.py
@@ -1,0 +1,5 @@
+from boa3.builtin.contract import to_hex_str
+
+
+def Main() -> str:
+    return to_hex_str(123)

--- a/boa3_test/test_sc/built_in_methods_test/HexStrTooFewParameters.py
+++ b/boa3_test/test_sc/built_in_methods_test/HexStrTooFewParameters.py
@@ -1,0 +1,5 @@
+from boa3.builtin.contract import to_hex_str
+
+
+def Main() -> str:
+    return to_hex_str()

--- a/boa3_test/test_sc/built_in_methods_test/HexStrTooManyParameters.py
+++ b/boa3_test/test_sc/built_in_methods_test/HexStrTooManyParameters.py
@@ -1,0 +1,5 @@
+from boa3.builtin.contract import to_hex_str
+
+
+def Main() -> str:
+    return to_hex_str(b'123', b'123')

--- a/boa3_test/test_sc/built_in_methods_test/HexStrVariable.py
+++ b/boa3_test/test_sc/built_in_methods_test/HexStrVariable.py
@@ -1,0 +1,7 @@
+from boa3.builtin.compile_time import public
+from boa3.builtin.contract import to_hex_str
+
+
+@public
+def Main(a: bytes) -> str:
+    return to_hex_str(a)


### PR DESCRIPTION
**Summary or solution description**

Logging bytes data has runtime errors when the data have non-printable bytes values. Included `to_hex_str` method to convert data objects to its readable hex string equivalent.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/659a244f5fec5f2bae6963129d3dca5e99e2f38a/boa3_test/test_sc/built_in_methods_test/HexStr.py#L2-L12

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/659a244f5fec5f2bae6963129d3dca5e99e2f38a/boa3_test/tests/compiler_tests/test_builtin_method.py#L609-L677

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7+
