### PR TITLE
No module name 'filelock' error raised when trying to use NeoTestRunner interface

### DIFF
--- a/boa3_test/test_drive/neoxp/batch.py
+++ b/boa3_test/test_drive/neoxp/batch.py
@@ -135,12 +135,15 @@ class NeoExpressBatch:
     def execute(self, neoxp_path: str, batch_file_path: str, reset: bool = False, check_point_file: str = None) -> str:
         with _NEOXP_BATCH_LOCK:
             self.write(batch_file_path)
-            log = utils.run_batch(neoxp_path, batch_file_path, reset=reset, check_point_file=check_point_file)
+            log = self._run_batch(neoxp_path, batch_file_path, reset=reset, check_point_file=check_point_file)
 
         self._transaction_logs.clear()
         self._update_logs(log)
         self._remove_commands_until_checkpoint(check_point_file)
         return log
+
+    def _run_batch(self, neoxp_path: str, batch_file_path: str, reset: bool = False, check_point_file: str = None):
+        return utils.run_batch(neoxp_path, batch_file_path, reset=reset, check_point_file=check_point_file)
 
     def _update_logs(self, log: str):
         import re

--- a/boa3_test/test_drive/neoxp/executor.py
+++ b/boa3_test/test_drive/neoxp/executor.py
@@ -1,0 +1,187 @@
+__all__ = [
+    'NeoExpressWrapper',
+    '_NEOXP_CONFIG_LOCK'
+]
+
+import os.path
+import re
+import subprocess
+import threading
+from typing import Tuple, List, Union
+
+from boa3.internal.neo3.core.types import UInt256
+from boa3_test.test_drive.neoxp.command import neoexpresscommand as neoxp
+from boa3_test.test_drive.neoxp.model.neoxpconfig import NeoExpressConfig
+from boa3_test.test_drive.testrunner.blockchain.block import TestRunnerBlock as Block
+from boa3_test.test_drive.testrunner.blockchain.contract import TestRunnerContract as Contract
+from boa3_test.test_drive.testrunner.blockchain.transaction import TestRunnerTransaction as Transaction
+from boa3_test.test_drive.testrunner.blockchain.transactionlog import TestRunnerTransactionLog as TransactionLog
+
+_NEOXP_CONFIG_LOCK = threading.Lock()
+
+
+class NeoExpressWrapper:
+    @classmethod
+    def run_neo_express_cli(cls, command: neoxp.NeoExpressCommand) -> Tuple[str, str]:
+        neoxp_args = ['neoxp']
+        neoxp_args.extend(command.cli_command().split())
+
+        cli_result = cls._run_cli(*neoxp_args)
+        return cli_result
+
+    @classmethod
+    def _run_cli(cls, *neoxp_args: str):
+        process = subprocess.Popen(neoxp_args,
+                                   stdout=subprocess.PIPE,
+                                   stderr=subprocess.STDOUT,
+                                   text=True)
+        return process.communicate()
+
+    @staticmethod
+    def get_config_data(neoxp_path: str) -> NeoExpressConfig:
+        return NeoExpressConfig(neoxp_path)
+
+    @classmethod
+    def create_neo_express_instance(cls, neoxp_path: str) -> str:
+        command = neoxp.create.CreateCommand(config_output=neoxp_path,
+                                             node_count=1,
+                                             force=True)
+        with _NEOXP_CONFIG_LOCK:
+            stdout, stderr = cls.run_neo_express_cli(command)
+
+        return stdout
+
+    @classmethod
+    def reset_neo_express_instance(cls, neoxp_path: str, check_point_file: str = None) -> str:
+        if isinstance(check_point_file, str) and os.path.isfile(check_point_file):
+            command = neoxp.checkpoint.CheckpointRestoreCommand(neo_express_data_file=neoxp_path,
+                                                                file_name=check_point_file,
+                                                                force=True)
+        else:
+            command = neoxp.reset.ResetCommand(neo_express_data_file=neoxp_path,
+                                               force=True)
+        stdout, stderr = cls.run_neo_express_cli(command)
+        return stdout
+
+    @classmethod
+    def get_deployed_contracts(cls, neoxp_path: str, check_point_file: str = None) -> List[Contract]:
+        command = neoxp.contract.ContractListCommand(neo_express_data_file=neoxp_path)
+        with _NEOXP_CONFIG_LOCK:
+            cls.reset_neo_express_instance(neoxp_path, check_point_file)
+            stdout, stderr = cls.run_neo_express_cli(command)
+
+        contracts = []
+        for line in stdout.splitlines():
+            try:
+                groups = re.match(r'(?P<name>.*?) \((?P<scripthash>0x\w+)\)', line).groupdict()
+                contract_name = groups['name']
+                contract_hash = groups['scripthash']
+                found_contract = Contract(contract_name, contract_hash)
+                contracts.append(found_contract)
+            except:
+                # don't break if some line doesn't match the regex
+                continue
+        return contracts
+
+    @classmethod
+    def _get_transaction_raw(cls, neoxp_path: str, tx_hash: UInt256, check_point_file: str = None) -> str:
+        command = neoxp.show.ShowTransactionCommand(tx_hash.to_array(), neo_express_data_file=neoxp_path)
+        with _NEOXP_CONFIG_LOCK:
+            if isinstance(check_point_file, str):
+                cls.reset_neo_express_instance(neoxp_path, check_point_file)
+            stdout, stderr = cls.run_neo_express_cli(command)
+
+        return stdout
+
+    @classmethod
+    def get_transaction(cls, neoxp_path: str, tx_hash: UInt256, check_point_file: str = None) -> Transaction:
+        raw_result = cls._get_transaction_raw(neoxp_path, tx_hash, check_point_file)
+
+        tx: Transaction
+        try:
+            import json
+            result_json = json.loads(raw_result)
+            tx = Transaction.from_json(result_json['transaction'], neoxp_config=cls.get_config_data(neoxp_path))
+        except:
+            tx = None
+
+        return tx
+
+    @classmethod
+    def get_transaction_log(cls, neoxp_path: str, tx_hash: UInt256, check_point_file: str = None, contract_collection=None) -> TransactionLog:
+        raw_result = cls._get_transaction_raw(neoxp_path, tx_hash, check_point_file)
+
+        tx_log: TransactionLog
+        try:
+            import json
+            result_json = json.loads(raw_result)
+            tx_log = TransactionLog.from_json(result_json['application-log'], contract_collection)
+            tx_log._tx_id = tx_hash
+        except:
+            tx_log = None
+
+        return tx_log
+
+    @classmethod
+    def get_latest_block(cls, neoxp_path: str, check_point_file: str = None) -> Block:
+        return cls.get_block(neoxp_path, check_point_file=check_point_file)
+
+    @classmethod
+    def get_block(cls, neoxp_path: str, block_hash_or_index: Union[UInt256, int] = None,
+                  check_point_file: str = None) -> Block:
+        if isinstance(block_hash_or_index, (UInt256, int)):
+            if isinstance(block_hash_or_index, int):
+                if block_hash_or_index < 0:
+                    block_hash_or_index = 0
+            else:
+                block_hash_or_index = block_hash_or_index.to_array()
+
+            command = neoxp.show.ShowBlockCommand(block_hash_or_index,
+                                                  neo_express_data_file=neoxp_path)
+        else:
+            command = neoxp.show.ShowBlockCommand(neo_express_data_file=neoxp_path)
+
+        with _NEOXP_CONFIG_LOCK:
+            if isinstance(check_point_file, str):
+                cls.reset_neo_express_instance(neoxp_path, check_point_file)
+            stdout, stderr = cls.run_neo_express_cli(command)
+
+        block: Block
+        try:
+            import json
+            result_json = json.loads(stdout)
+            block = Block.from_json(result_json, neoxp_config=cls.get_config_data(neoxp_path))
+        except:
+            block = None
+
+        return block
+
+    @classmethod
+    def run_batch(cls, neoxp_path: str, batch_path: str, reset: bool = False, check_point_file: str = None) -> str:
+        if isinstance(check_point_file, str) and not os.path.isfile(check_point_file):
+            check_point_file = None
+        command = neoxp.batch.BatchCommand(batch_path,
+                                           neo_express_data_file=neoxp_path,
+                                           check_point_file=check_point_file,
+                                           reset=reset)
+        with _NEOXP_CONFIG_LOCK:
+            stdout, stderr = cls.run_neo_express_cli(command)
+
+        return stdout
+
+    @classmethod
+    def oracle_response(cls, neoxp_path: str, url: str, response_path: str, request_id: int = None,
+                        check_point_file: str = None) -> List[UInt256]:
+        command = neoxp.oracle.OracleResponseCommand(url, response_path, request_id, neo_express_data_file=neoxp_path)
+
+        with _NEOXP_CONFIG_LOCK:
+            if isinstance(check_point_file, str):
+                cls.reset_neo_express_instance(neoxp_path, check_point_file)
+            stdout, stderr = cls.run_neo_express_cli(command)
+
+        import re
+        from boa3.internal.neo import from_hex_str
+
+        oracle_response_submitted = re.findall(r"0x\w{64}", stdout)
+
+        return [UInt256(from_hex_str(tx)) for tx in oracle_response_submitted]

--- a/boa3_test/test_drive/neoxp/utils.py
+++ b/boa3_test/test_drive/neoxp/utils.py
@@ -1,30 +1,43 @@
-import logging
-import os.path
-import re
-import subprocess
-import threading
-from typing import Tuple, List, Union
+__all__ = [
+    'get_config_data',
+    'get_account_by_name',
+    'get_account_by_address',
+    'get_account_by_identifier',
+    'get_default_account',
+    'get_genesis_block',
+    'get_account_from_script_hash_or_id',
+    'create_neo_express_instance',
+    'reset_neo_express_instance',
+    'get_deployed_contracts',
+    'get_transaction',
+    'get_transaction_log',
+    'get_latest_block',
+    'get_block',
+    'run_batch',
+    'oracle_response',
+    'Account',
+    'Block',
+    'Contract',
+    'NeoExpressConfig',
+    'Transaction',
+    'TransactionLog'
+]
 
-from filelock import FileLock
+from typing import List, Union
 
-from boa3.internal import env
 from boa3.internal.neo3.core.types import UInt256
 from boa3_test.test_drive.model.wallet import utils as wallet_utils
 from boa3_test.test_drive.model.wallet.account import Account
-from boa3_test.test_drive.neoxp.command import neoexpresscommand as neoxp
+from boa3_test.test_drive.neoxp.executor import NeoExpressWrapper
 from boa3_test.test_drive.neoxp.model.neoxpconfig import NeoExpressConfig
 from boa3_test.test_drive.testrunner.blockchain.block import TestRunnerBlock as Block
 from boa3_test.test_drive.testrunner.blockchain.contract import TestRunnerContract as Contract
 from boa3_test.test_drive.testrunner.blockchain.transaction import TestRunnerTransaction as Transaction
 from boa3_test.test_drive.testrunner.blockchain.transactionlog import TestRunnerTransactionLog as TransactionLog
 
-_NEOXP_CONFIG_LOCK = threading.Lock()
-_NEOXP_FILE_LOCK = FileLock(f'{env.TEST_RUNNER_DIRECTORY}/test-runner.lock')
-logging.getLogger("filelock").setLevel(logging.INFO)
-
 
 def get_config_data(neoxp_path: str) -> NeoExpressConfig:
-    return NeoExpressConfig(neoxp_path)
+    return NeoExpressWrapper.get_config_data(neoxp_path)
 
 
 def get_account_by_name(neoxp_config: NeoExpressConfig, account_name) -> Account:
@@ -71,158 +84,38 @@ def get_account_from_script_hash_or_id(neoxp_config: NeoExpressConfig, script_ha
 
 
 def create_neo_express_instance(neoxp_path: str) -> str:
-    command = neoxp.create.CreateCommand(config_output=neoxp_path,
-                                         node_count=1,
-                                         force=True)
-    with _NEOXP_CONFIG_LOCK:
-        stdout, stderr = run_neo_express_cli(command)
-
-    return stdout
+    return NeoExpressWrapper.create_neo_express_instance(neoxp_path)
 
 
 def reset_neo_express_instance(neoxp_path: str, check_point_file: str = None) -> str:
-    if isinstance(check_point_file, str) and os.path.isfile(check_point_file):
-        command = neoxp.checkpoint.CheckpointRestoreCommand(neo_express_data_file=neoxp_path,
-                                                            file_name=check_point_file,
-                                                            force=True)
-    else:
-        command = neoxp.reset.ResetCommand(neo_express_data_file=neoxp_path,
-                                           force=True)
-    stdout, stderr = run_neo_express_cli(command)
-    return stdout
+    return NeoExpressWrapper.reset_neo_express_instance(neoxp_path, check_point_file)
 
 
 def get_deployed_contracts(neoxp_path: str, check_point_file: str = None) -> List[Contract]:
-    command = neoxp.contract.ContractListCommand(neo_express_data_file=neoxp_path)
-    with _NEOXP_CONFIG_LOCK:
-        reset_neo_express_instance(neoxp_path, check_point_file)
-        stdout, stderr = run_neo_express_cli(command)
-
-    contracts = []
-    for line in stdout.splitlines():
-        try:
-            groups = re.match(r'(?P<name>.*?) \((?P<scripthash>0x\w+)\)', line).groupdict()
-            contract_name = groups['name']
-            contract_hash = groups['scripthash']
-            found_contract = Contract(contract_name, contract_hash)
-            contracts.append(found_contract)
-        except:
-            # don't break if some line doesn't match the regex
-            continue
-    return contracts
-
-
-def _get_transaction_raw(neoxp_path: str, tx_hash: UInt256, check_point_file: str = None) -> str:
-    command = neoxp.show.ShowTransactionCommand(tx_hash.to_array(), neo_express_data_file=neoxp_path)
-    with _NEOXP_CONFIG_LOCK:
-        if isinstance(check_point_file, str):
-            reset_neo_express_instance(neoxp_path, check_point_file)
-        stdout, stderr = run_neo_express_cli(command)
-
-    return stdout
+    return NeoExpressWrapper.get_deployed_contracts(neoxp_path, check_point_file)
 
 
 def get_transaction(neoxp_path: str, tx_hash: UInt256, check_point_file: str = None) -> Transaction:
-    raw_result = _get_transaction_raw(neoxp_path, tx_hash, check_point_file)
-
-    tx: Transaction
-    try:
-        import json
-        result_json = json.loads(raw_result)
-        tx = Transaction.from_json(result_json['transaction'], neoxp_config=get_config_data(neoxp_path))
-    except:
-        tx = None
-
-    return tx
+    return NeoExpressWrapper.get_transaction(neoxp_path, tx_hash, check_point_file)
 
 
 def get_transaction_log(neoxp_path: str, tx_hash: UInt256, check_point_file: str = None, contract_collection=None) -> TransactionLog:
-    raw_result = _get_transaction_raw(neoxp_path, tx_hash, check_point_file)
-
-    tx_log: TransactionLog
-    try:
-        import json
-        result_json = json.loads(raw_result)
-        tx_log = TransactionLog.from_json(result_json['application-log'], contract_collection)
-        tx_log._tx_id = tx_hash
-    except:
-        tx_log = None
-
-    return tx_log
+    return NeoExpressWrapper.get_transaction_log(neoxp_path, tx_hash, check_point_file, contract_collection)
 
 
 def get_latest_block(neoxp_path: str, check_point_file: str = None) -> Block:
-    return get_block(neoxp_path, check_point_file=check_point_file)
+    return NeoExpressWrapper.get_latest_block(neoxp_path, check_point_file)
 
 
 def get_block(neoxp_path: str, block_hash_or_index: Union[UInt256, int] = None,
               check_point_file: str = None) -> Block:
-    if isinstance(block_hash_or_index, (UInt256, int)):
-        if isinstance(block_hash_or_index, int):
-            if block_hash_or_index < 0:
-                block_hash_or_index = 0
-        else:
-            block_hash_or_index = block_hash_or_index.to_array()
-
-        command = neoxp.show.ShowBlockCommand(block_hash_or_index,
-                                              neo_express_data_file=neoxp_path)
-    else:
-        command = neoxp.show.ShowBlockCommand(neo_express_data_file=neoxp_path)
-
-    with _NEOXP_CONFIG_LOCK:
-        if isinstance(check_point_file, str):
-            reset_neo_express_instance(neoxp_path, check_point_file)
-        stdout, stderr = run_neo_express_cli(command)
-
-    block: Block
-    try:
-        import json
-        result_json = json.loads(stdout)
-        block = Block.from_json(result_json, neoxp_config=get_config_data(neoxp_path))
-    except:
-        block = None
-
-    return block
+    return NeoExpressWrapper.get_block(neoxp_path, block_hash_or_index, check_point_file)
 
 
 def run_batch(neoxp_path: str, batch_path: str, reset: bool = False, check_point_file: str = None) -> str:
-    if isinstance(check_point_file, str) and not os.path.isfile(check_point_file):
-        check_point_file = None
-    command = neoxp.batch.BatchCommand(batch_path,
-                                       neo_express_data_file=neoxp_path,
-                                       check_point_file=check_point_file,
-                                       reset=reset)
-    with _NEOXP_CONFIG_LOCK:
-        stdout, stderr = run_neo_express_cli(command)
-
-    return stdout
-
-
-def run_neo_express_cli(command: neoxp.NeoExpressCommand) -> Tuple[str, str]:
-    neoxp_args = ['neoxp']
-    neoxp_args.extend(command.cli_command().split())
-
-    with _NEOXP_FILE_LOCK:
-        process = subprocess.Popen(neoxp_args,
-                                   stdout=subprocess.PIPE,
-                                   stderr=subprocess.STDOUT,
-                                   text=True)
-        cli_result = process.communicate()
-    return cli_result
+    return NeoExpressWrapper.run_batch(neoxp_path, batch_path, reset, check_point_file)
 
 
 def oracle_response(neoxp_path: str, url: str, response_path: str, request_id: int = None,
                     check_point_file: str = None) -> List[UInt256]:
-    command = neoxp.oracle.OracleResponseCommand(url, response_path, request_id, neo_express_data_file=neoxp_path)
-
-    with _NEOXP_CONFIG_LOCK:
-        if isinstance(check_point_file, str):
-            reset_neo_express_instance(neoxp_path, check_point_file)
-        stdout, stderr = run_neo_express_cli(command)
-
-    import re
-    from boa3.internal.neo import from_hex_str
-
-    oracle_response_submitted = re.findall(r"0x\w{64}", stdout)
-
-    return [UInt256(from_hex_str(tx)) for tx in oracle_response_submitted]
+    return NeoExpressWrapper.oracle_response(neoxp_path, url, response_path, request_id, check_point_file)

--- a/boa3_test/tests/test_drive/neoxp/utils.py
+++ b/boa3_test/tests/test_drive/neoxp/utils.py
@@ -1,7 +1,41 @@
+__all__ = [
+    'get_account_by_name',
+    'get_account_by_address',
+    'get_account_by_identifier',
+    'get_default_account',
+    'get_genesis_block',
+    'get_account_from_script_hash_or_id',
+    'reset_neo_express_instance',
+    'get_deployed_contracts',
+    'get_transaction',
+    'get_transaction_log',
+    'get_latest_block',
+    'get_block',
+    'run_batch',
+    'oracle_response'
+]
+
+
+import logging
+from typing import List, Union
+
+from filelock import FileLock
+
+from boa3.internal import env
+from boa3.internal.neo3.core.types import UInt256
 from boa3_test.test_drive.neoxp import utils as neoxp_utils
-from boa3_test.test_drive.neoxp.utils import *
+from boa3_test.test_drive.neoxp.executor import NeoExpressWrapper
+from boa3_test.test_drive.neoxp.model.neoxpconfig import NeoExpressConfig
+from boa3_test.test_drive.neoxp.utils import (Account,
+                                              Block,
+                                              Contract,
+                                              Transaction,
+                                              TransactionLog,
+                                              )
 
 _NEOXP_CONFIG = NeoExpressConfig(f'{env.NEO_EXPRESS_INSTANCE_DIRECTORY}/default.neo-express')
+_NEOXP_FILE_LOCK = FileLock(f'{env.TEST_RUNNER_DIRECTORY}/test-runner.lock')
+logging.getLogger("filelock").setLevel(logging.INFO)
 
 
 def get_account_by_name(account_name) -> Account:
@@ -14,6 +48,10 @@ def get_account_by_address(account_address: str) -> Account:
 
 def get_account_by_identifier(account_identifier: str) -> Account:
     return neoxp_utils.get_account_by_identifier(_NEOXP_CONFIG, account_identifier)
+
+
+def get_account_from_script_hash_or_id(script_hash_or_address: Union[bytes, str]) -> Account:
+    return neoxp_utils.get_account_from_script_hash_or_id(_NEOXP_CONFIG, script_hash_or_address)
 
 
 def get_default_account() -> Account:
@@ -30,3 +68,45 @@ def get_magic() -> int:
 
 def get_genesis_block() -> Block:
     return _NEOXP_CONFIG.genesis_block
+
+
+class _BoaNeoExpressWrapper(NeoExpressWrapper):
+    @classmethod
+    def _run_cli(cls, *neoxp_args: str):
+        with _NEOXP_FILE_LOCK:
+            cli_result = super()._run_cli(*neoxp_args)
+        return cli_result
+
+
+def reset_neo_express_instance(neoxp_path: str, check_point_file: str = None) -> str:
+    return _BoaNeoExpressWrapper.reset_neo_express_instance(neoxp_path, check_point_file)
+
+
+def get_deployed_contracts(neoxp_path: str, check_point_file: str = None) -> List[Contract]:
+    return _BoaNeoExpressWrapper.get_deployed_contracts(neoxp_path, check_point_file)
+
+
+def get_transaction(neoxp_path: str, tx_hash: UInt256, check_point_file: str = None) -> Transaction:
+    return _BoaNeoExpressWrapper.get_transaction(neoxp_path, tx_hash, check_point_file)
+
+
+def get_transaction_log(neoxp_path: str, tx_hash: UInt256, check_point_file: str = None, contract_collection=None) -> TransactionLog:
+    return _BoaNeoExpressWrapper.get_transaction_log(neoxp_path, tx_hash, check_point_file, contract_collection)
+
+
+def get_latest_block(neoxp_path: str, check_point_file: str = None) -> Block:
+    return _BoaNeoExpressWrapper.get_latest_block(neoxp_path, check_point_file)
+
+
+def get_block(neoxp_path: str, block_hash_or_index: Union[UInt256, int] = None,
+              check_point_file: str = None) -> Block:
+    return _BoaNeoExpressWrapper.get_block(neoxp_path, block_hash_or_index, check_point_file)
+
+
+def run_batch(neoxp_path: str, batch_path: str, reset: bool = False, check_point_file: str = None) -> str:
+    return _BoaNeoExpressWrapper.run_batch(neoxp_path, batch_path, reset, check_point_file)
+
+
+def oracle_response(neoxp_path: str, url: str, response_path: str, request_id: int = None,
+                    check_point_file: str = None) -> List[UInt256]:
+    return _BoaNeoExpressWrapper.oracle_response(neoxp_path, url, response_path, request_id, check_point_file)

--- a/boa3_test/tests/test_drive/testrunner/boa_neoxp_batch.py
+++ b/boa3_test/tests/test_drive/testrunner/boa_neoxp_batch.py
@@ -1,0 +1,12 @@
+__all__ = [
+    'BoaNeoExpressBatch'
+]
+
+
+from boa3_test.test_drive.neoxp.batch import NeoExpressBatch
+from boa3_test.tests.test_drive.neoxp import utils as boa_neoxp_utils
+
+
+class BoaNeoExpressBatch(NeoExpressBatch):
+    def _run_batch(self, neoxp_path: str, batch_file_path: str, reset: bool = False, check_point_file: str = None):
+        return boa_neoxp_utils.run_batch(neoxp_path, batch_file_path, reset=reset, check_point_file=check_point_file)

--- a/boa3_test/tests/test_drive/testrunner/boa_test_runner.py
+++ b/boa3_test/tests/test_drive/testrunner/boa_test_runner.py
@@ -4,27 +4,32 @@ __all__ = [
 
 import os.path
 import threading
-from typing import Callable, List, Sequence, Tuple
+from typing import Callable, List, Sequence, Optional, Tuple, Union
 
 from boa3.internal import env
+from boa3.internal.neo3.core.types import UInt256
+from boa3_test.test_drive.model.smart_contract.contractcollection import ContractCollection
 from boa3_test.test_drive.neoxp.model.neoxpconfig import NeoExpressConfig
+from boa3_test.test_drive.testrunner.blockchain.block import TestRunnerBlock as Block
 from boa3_test.test_drive.testrunner.neo_test_runner import NeoTestRunner
-from boa3_test.tests.test_drive.neoxp import utils as neoxp_utils
+from boa3_test.tests.test_drive.neoxp import utils as boa_neoxp_utils
+from boa3_test.tests.test_drive.testrunner.boa_neoxp_batch import BoaNeoExpressBatch
 
 
 class BoaTestRunner(NeoTestRunner):
-    _DEFAULT_ACCOUNT = neoxp_utils.get_default_account()
+    _DEFAULT_ACCOUNT = boa_neoxp_utils.get_default_account()
 
     def __init__(self, neoxp_path: str = None, runner_id: str = None, cleanup_files: bool = True):
         if not isinstance(neoxp_path, str):
             neoxp_path = os.path.join(env.NEO_EXPRESS_INSTANCE_DIRECTORY, 'default.neo-express')
 
         super().__init__(neoxp_path, runner_id)
+        self._batch = BoaNeoExpressBatch(self._neoxp_config)
 
         self._clear_files_when_destroyed = cleanup_files
 
     def _set_up_neoxp_config(self) -> NeoExpressConfig:
-        default_config = neoxp_utils._NEOXP_CONFIG
+        default_config = boa_neoxp_utils._NEOXP_CONFIG
         if self._neoxp_abs_path == os.path.abspath(default_config.config_path):
             return default_config
         return super()._set_up_neoxp_config()
@@ -33,6 +38,19 @@ class BoaTestRunner(NeoTestRunner):
         from boa3_test.test_drive import utils
         runner_specific_id = utils.create_custom_id(file_name)
         super()._set_up_generate_file_names(runner_specific_id)
+
+    def add_neo(self, script_hash_or_address: Union[bytes, str], amount: int):
+        address = boa_neoxp_utils.get_account_from_script_hash_or_id(script_hash_or_address)
+        self._batch.transfer_assets(sender=self._DEFAULT_ACCOUNT, receiver=address,
+                                    quantity=amount,
+                                    asset='NEO')
+
+    def add_gas(self, script_hash_or_address: Union[bytes, str], amount: int):
+        address = boa_neoxp_utils.get_account_from_script_hash_or_id(script_hash_or_address)
+        gas_decimals = 8
+        self._batch.transfer_assets(sender=self._DEFAULT_ACCOUNT, receiver=address,
+                                    asset='GAS', decimals=gas_decimals,
+                                    quantity=(amount / (10 ** gas_decimals)))
 
     def _internal_generate_files(self, methods_to_call: List[Tuple[Callable, Sequence]]):
         worker_threads = []
@@ -51,6 +69,30 @@ class BoaTestRunner(NeoTestRunner):
 
         for worker in worker_threads:
             worker.join()
+
+    def _get_genesis_block(self) -> Optional[Block]:
+        return boa_neoxp_utils.get_genesis_block()
+
+    def _get_block(self, block_hash_or_index) -> Optional[Block]:
+        check_point_path = self.get_full_path(self._CHECKPOINT_FILE)
+        return boa_neoxp_utils.get_block(self._neoxp_abs_path, block_hash_or_index,
+                                         check_point_file=check_point_path)
+
+    def _get_tx(self, tx_hash: UInt256):
+        check_point_path = self.get_full_path(self._CHECKPOINT_FILE)
+        return boa_neoxp_utils.get_transaction(self._neoxp_abs_path, tx_hash,
+                                               check_point_file=check_point_path)
+
+    def _get_tx_log(self, tx_hash: UInt256, contract_collection: ContractCollection):
+        check_point_path = self.get_full_path(self._CHECKPOINT_FILE)
+        return boa_neoxp_utils.get_transaction_log(self._neoxp_abs_path, tx_hash,
+                                                   check_point_file=check_point_path,
+                                                   contract_collection=contract_collection)
+
+    def _get_oracle_resp(self, url: str, response_path: str, request_id: int = None) -> List[UInt256]:
+        check_point_path = self.get_full_path(self._CHECKPOINT_FILE)
+        return boa_neoxp_utils.oracle_response(self._neoxp_abs_path, url, response_path, request_id,
+                                               check_point_file=check_point_path)
 
     def __del__(self):
         self.reset()


### PR DESCRIPTION
**Summary or solution description**
`filelock` package is used to speed up boa3 unit test by running them parallelly, but this shouldn't be required to use NeoTestRunner.
Removed all code that uses filelock in its logic from `boa3_test.test_drive` packages and moved to the packaged related to boa3 unit tests

