### PR TITLE
Add an error when using the del keyword

### DIFF
--- a/boa3/internal/analyser/moduleanalyser.py
+++ b/boa3/internal/analyser/moduleanalyser.py
@@ -1513,4 +1513,17 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
             return None
         return dictionary
 
+    def visit_Delete(self, node: ast.Delete) -> Any:
+        """
+        Visitor of delete statement node. Currently, it's not supported
+        """
+        self._log_error(
+            CompilerError.NotSupportedOperation(
+                node.lineno, node.col_offset,
+                symbol_id='del keyword'
+            )
+        )
+        self.generic_visit(node)
+        return node
+
     # endregion

--- a/boa3_test/test_sc/class_test/DelClass.py
+++ b/boa3_test/test_sc/class_test/DelClass.py
@@ -1,0 +1,12 @@
+class Example:
+    def __init__(self):
+        self.val1 = 1
+
+
+del Example
+
+
+def main() -> int:
+    a = 123
+
+    return 123

--- a/boa3_test/test_sc/dict_test/DelPair.py
+++ b/boa3_test/test_sc/dict_test/DelPair.py
@@ -1,0 +1,5 @@
+def main() -> bool:
+    a = {'unit': 1, 'test': True}
+    del a['unit']
+
+    return a['test']

--- a/boa3_test/test_sc/list_test/DelItem.py
+++ b/boa3_test/test_sc/list_test/DelItem.py
@@ -1,0 +1,5 @@
+def main() -> int:
+    a = [0, 1, 2, 3, 5, 6]
+    del a[0]
+
+    return a[0]

--- a/boa3_test/test_sc/variable_test/DelVariable.py
+++ b/boa3_test/test_sc/variable_test/DelVariable.py
@@ -1,0 +1,9 @@
+from boa3.builtin.compile_time import public
+
+
+@public
+def main() -> int:
+    a = 123
+    del a
+
+    return 123

--- a/boa3_test/tests/compiler_tests/test_class.py
+++ b/boa3_test/tests/compiler_tests/test_class.py
@@ -869,3 +869,7 @@ class TestClass(BoaTest):
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
+
+    def test_del_class(self):
+        path = self.get_contract_path('DelClass.py')
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)

--- a/boa3_test/tests/compiler_tests/test_dict.py
+++ b/boa3_test/tests/compiler_tests/test_dict.py
@@ -790,3 +790,7 @@ class TestDict(BoaTest):
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
+
+    def test_del_dict_pair(self):
+        path = self.get_contract_path('DelPair.py')
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)

--- a/boa3_test/tests/compiler_tests/test_list.py
+++ b/boa3_test/tests/compiler_tests/test_list.py
@@ -2196,3 +2196,11 @@ class TestList(BoaTest):
         self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
 
     # endregion
+
+    # region TestDel
+
+    def test_del_list_item(self):
+        path = self.get_contract_path('DelItem.py')
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+
+    # endregion

--- a/boa3_test/tests/compiler_tests/test_variable.py
+++ b/boa3_test/tests/compiler_tests/test_variable.py
@@ -954,3 +954,7 @@ class TestVariable(BoaTest):
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
+
+    def test_del_variable(self):
+        path = self.get_contract_path('DelVariable.py')
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)


### PR DESCRIPTION
**Summary or solution description**
The `del` keyword is not supported, but the smart contract would still be compiled when using it. Now it won't.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/582f702bc0e4969c7f84c209653793e65175db46/boa3_test/test_sc/variable_test/DelVariable.py#L1-L9

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/582f702bc0e4969c7f84c209653793e65175db46/boa3_test/tests/compiler_tests/test_variable.py#L958-L960

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
