### PR TITLE
Add an error when implicitly using Sets

### DIFF
--- a/boa3/internal/analyser/typeanalyser.py
+++ b/boa3/internal/analyser/typeanalyser.py
@@ -1821,6 +1821,17 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
                 dictionary[key] = value
         return dictionary
 
+    def visit_Set(self, node: ast.Set) -> Set[Any]:
+        """
+        Visitor of literal set node. Currently, is not supported
+        """
+
+        self._log_error(
+            CompilerError.InvalidType(node.lineno, node.col_offset, 'Set')
+        )
+
+        return self.generic_visit(node)
+
     def visit_NameConstant(self, constant: ast.NameConstant) -> Any:
         """
         Visitor of constant names node

--- a/boa3_test/test_sc/set_test/SetConstructor.py
+++ b/boa3_test/test_sc/set_test/SetConstructor.py
@@ -1,0 +1,9 @@
+from typing import Any
+
+from boa3.builtin.compile_time import public
+
+
+@public
+def main() -> Any:
+    a = ('unit', 'test')
+    return set(a)

--- a/boa3_test/test_sc/set_test/SetLiteral.py
+++ b/boa3_test/test_sc/set_test/SetLiteral.py
@@ -1,0 +1,8 @@
+from typing import Any
+
+from boa3.builtin.compile_time import public
+
+
+@public
+def main() -> Any:
+    return {'unit', 'test'}

--- a/boa3_test/test_sc/set_test/SetTyping.py
+++ b/boa3_test/test_sc/set_test/SetTyping.py
@@ -1,0 +1,8 @@
+from typing import Set
+
+from boa3.builtin.compile_time import public
+
+
+@public
+def main() -> Set:
+    return {'unit', 'test'}

--- a/boa3_test/tests/compiler_tests/test_set.py
+++ b/boa3_test/tests/compiler_tests/test_set.py
@@ -1,0 +1,19 @@
+from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to avoid circular imports
+
+from boa3.internal.exception import CompilerError
+
+
+class TestSet(BoaTest):
+    default_folder: str = 'test_sc/set_test'
+
+    def test_set_from_typing(self):
+        path = self.get_contract_path('SetTyping.py')
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+
+    def test_set_literal(self):
+        path = self.get_contract_path('SetLiteral.py')
+        self.assertCompilerLogs(CompilerError.InvalidType, path)
+
+    def test_set_from_constructor(self):
+        path = self.get_contract_path('SetConstructor.py')
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)


### PR DESCRIPTION
**Summary or solution description**
Importing Set from typing or using the `set` keyword throws an error, but implicitly using a Set was not throwing. Not it does throw an error.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/1033863af5f3a5eabbb08962c734bb55f8f214a7/boa3_test/test_sc/set_test/SetLiteral.py#L1-L8

**Tests**
Created tests for other circumstances that would already throw an error
https://github.com/CityOfZion/neo3-boa/blob/1033863af5f3a5eabbb08962c734bb55f8f214a7/boa3_test/tests/compiler_tests/test_set.py#L1-L19

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
