### PR TITLE
Add an error when using the list slice assignment

### DIFF
--- a/boa3/internal/analyser/moduleanalyser.py
+++ b/boa3/internal/analyser/moduleanalyser.py
@@ -1048,6 +1048,11 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
                 CompilerError.NotSupportedOperation(assign.lineno, assign.col_offset, 'Multiple variable assignments')
             )
 
+        elif isinstance(assign.targets[0], ast.Subscript) and isinstance(assign.targets[0].slice, ast.Slice):
+            self._log_error(
+                CompilerError.NotSupportedOperation(assign.lineno, assign.col_offset, 'Assigning a value into a slice')
+            )
+
         else:
             var_type = self.visit_type(assign.value)
 

--- a/boa3_test/test_sc/list_test/SetListIntoListSlice.py
+++ b/boa3_test/test_sc/list_test/SetListIntoListSlice.py
@@ -1,0 +1,10 @@
+from typing import List
+
+from boa3.builtin.compile_time import public
+
+
+@public
+def main() -> List[int]:
+    a = [1, 2, 3, 4, 5, 6]
+    a[:3] = [10]
+    return a

--- a/boa3_test/tests/compiler_tests/test_list.py
+++ b/boa3_test/tests/compiler_tests/test_list.py
@@ -279,6 +279,10 @@ class TestList(BoaTest):
         output = self.compile(path)
         self.assertEqual(expected_output, output)
 
+    def test_list_set_into_list_slice(self):
+        path = self.get_contract_path('SetListIntoListSlice.py')
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+
     def test_list_set_value(self):
         path = self.get_contract_path('SetValue.py')
         self.assertCompilerNotLogs(CompilerWarning.NameShadowing, path)


### PR DESCRIPTION
**Summary or solution description**
When doing a slice attribution, the compiler would not stop compiling. Now it does

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/11772837c5ab8ede350574722bcb35c809277366/boa3_test/test_sc/list_test/SetListIntoListSlice.py#L1-L10

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/11772837c5ab8ede350574722bcb35c809277366/boa3_test/tests/compiler_tests/test_list.py#L282-L284

**Platform:**
 - OS:  Windows 10 x64
 - Python version: Python 3.7
