### PR TITLE
Add more information on the error when calling an instance method from a class

### DIFF
--- a/boa3/internal/analyser/typeanalyser.py
+++ b/boa3/internal/analyser/typeanalyser.py
@@ -1287,7 +1287,8 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
                 and callable_id in attribute_symbol.instance_methods:
             callable_complete_id = f'{attribute_type.identifier}.{callable_id}'
             self._log_error(
-                CompilerError.NotSupportedOperation(call.func.lineno, call.func.col_offset, callable_complete_id)
+                CompilerError.NotSupportedOperation(call.func.lineno, call.func.col_offset,
+                                                    "Calling instance method from class: " + callable_complete_id)
             )
         elif is_from_type_name and callable_id not in attribute_type.class_symbols:
             # the current symbol doesn't exist in the class scope

--- a/boa3_test/test_sc/class_test/UserClassWithInstanceMethodFromClass.py
+++ b/boa3_test/test_sc/class_test/UserClassWithInstanceMethodFromClass.py
@@ -1,0 +1,12 @@
+from boa3.builtin.compile_time import public
+
+
+class Example:
+    def some_method(self) -> int:
+        return 42
+
+
+@public
+def call_by_class_name() -> int:
+    example_obj = Example()
+    return Example.some_method(example_obj)

--- a/boa3_test/tests/compiler_tests/test_class.py
+++ b/boa3_test/tests/compiler_tests/test_class.py
@@ -473,6 +473,10 @@ class TestClass(BoaTest):
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
 
+    def test_user_class_with_instance_method_from_class(self):
+        path = self.get_contract_path('UserClassWithInstanceMethodFromClass.py')
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+
     def test_user_class_with_instance_variable_from_class(self):
         path = self.get_contract_path('UserClassWithInstanceVariableFromClass.py')
         self.assertCompilerLogs(CompilerError.UnresolvedReference, path)


### PR DESCRIPTION
**Summary or solution description**
The error was `The following operation is not supported: 'Example.some_method'`, now it is `The following operation is not supported: Calling instance method from class: 'Example.some_method'`

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/6687308eadbb2cf20caef508da8d357b978da5a8/boa3_test/test_sc/class_test/UserClassWithInstanceMethodFromClass.py#L1-L12

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/6687308eadbb2cf20caef508da8d357b978da5a8/boa3_test/tests/compiler_tests/test_class.py#L476-L479

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
