### PR TITLE
Add an error when trying to attribute a function to a variable

### DIFF
--- a/boa3/internal/analyser/typeanalyser.py
+++ b/boa3/internal/analyser/typeanalyser.py
@@ -372,6 +372,16 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
             value = self.visit(value)
             if isinstance(value, ast.Name):
                 symbol: ISymbol = self.get_symbol(value.id)
+
+                # TODO: change when assign functions to variable is implemented
+                if isinstance(symbol, Method):
+                    self._log_error(
+                        CompilerError.NotSupportedOperation(
+                            node.lineno, node.col_offset,
+                            'Assigning a function to a variable'
+                        ))
+                    return False
+
                 if isinstance(symbol, IExpression):
                     value_type = symbol.type
                 elif isinstance(symbol, IType):

--- a/boa3_test/test_sc/variable_test/AssignFunction.py
+++ b/boa3_test/test_sc/variable_test/AssignFunction.py
@@ -1,0 +1,12 @@
+from boa3.builtin.compile_time import public
+
+
+@public
+def function() -> int:
+    return 123
+
+
+@public
+def main() -> int:
+    a = function
+    return a()

--- a/boa3_test/tests/compiler_tests/test_variable.py
+++ b/boa3_test/tests/compiler_tests/test_variable.py
@@ -958,3 +958,7 @@ class TestVariable(BoaTest):
     def test_del_variable(self):
         path = self.get_contract_path('DelVariable.py')
         self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+
+    def test_assign_function(self):
+        path = self.get_contract_path('AssignFunction.py')
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)


### PR DESCRIPTION
**Summary or solution description**
The compilation did not stop when you tried to attribute a function to a variable, only when you were trying to call it later.
Now you get a NotSupported error.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/fbbb3c7edfc163c87a01ad3489b096305c4b9231/boa3_test/test_sc/variable_test/AssignFunction.py#L1-L12

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/fbbb3c7edfc163c87a01ad3489b096305c4b9231/boa3_test/tests/compiler_tests/test_variable.py#L962-L964

**Platform:**
 - OS: Windows 11 x64
 - Python version: Python 3.7
