### PR TITLE
Add an error when trying to use decorators with functions other than the builtin ones

### DIFF
--- a/boa3/internal/analyser/moduleanalyser.py
+++ b/boa3/internal/analyser/moduleanalyser.py
@@ -737,8 +737,25 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
         valid_decorators: List[IDecorator] = []
         for decorator in fun_decorators:
             if isinstance(decorator, IDecorator):
+                if not decorator.is_function_decorator:
+                    self._log_error(
+                        CompilerError.NotSupportedOperation(
+                            function.lineno, function.col_offset,
+                            symbol_id=f'"{decorator.identifier}" decorator with function'
+                        )
+                    )
+
                 decorator.update_args(function.args, self._current_scope)
                 valid_decorators.append(decorator)
+
+            # TODO: remove when user-created decorators are implemented
+            elif isinstance(decorator, Method):
+                self._log_error(
+                    CompilerError.NotSupportedOperation(
+                        function.lineno, function.col_offset,
+                        symbol_id='user-created decorators'
+                    )
+                )
 
         is_static_method = (isinstance(self._current_scope, ClassType)
                             and Builtin.StaticMethodDecorator in valid_decorators)

--- a/boa3/internal/model/builtin/decorator/displaynamedecorator.py
+++ b/boa3/internal/model/builtin/decorator/displaynamedecorator.py
@@ -92,8 +92,8 @@ class DisplayNameDecorator(IBuiltinDecorator):
 
     @property
     def is_function_decorator(self) -> bool:
-        return False
+        return True
 
     @property
     def is_class_decorator(self) -> bool:
-        return True
+        return False

--- a/boa3_test/test_sc/function_test/BuiltinContractDecoratorWithFunction.py
+++ b/boa3_test/test_sc/function_test/BuiltinContractDecoratorWithFunction.py
@@ -1,0 +1,8 @@
+from typing import Any
+
+from boa3.builtin.compile_time import contract
+
+
+@contract('0x1234567890123456789012345678901234567890')
+def main() -> Any:
+    return 'unit test'

--- a/boa3_test/test_sc/function_test/CustomDecoratorWithGlobalFunction.py
+++ b/boa3_test/test_sc/function_test/CustomDecoratorWithGlobalFunction.py
@@ -1,0 +1,11 @@
+from typing import Any
+
+
+def decorator_method(func: Any):
+    a = 123
+    return func
+
+
+@decorator_method
+def main() -> Any:
+    return []

--- a/boa3_test/tests/compiler_tests/test_function.py
+++ b/boa3_test/tests/compiler_tests/test_function.py
@@ -1665,3 +1665,11 @@ class TestFunction(BoaTest):
     def test_lambda_function(self):
         path = self.get_contract_path('LambdaFunction.py')
         self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+
+    def test_function_custom_decorator_with_global_function(self):
+        path = self.get_contract_path('CustomDecoratorWithGlobalFunction.py')
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+
+    def test_function_builtin_function_decorators_with_class(self):
+        path = self.get_contract_path('BuiltinContractDecoratorWithFunction.py')
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)


### PR DESCRIPTION
**Summary or solution description**
Added an error when a user tries to use a function they created as a decorator, and another error when using `contract` decorator on a function

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/c4efb526cbfd394c79f27c1b365990129b93d54d/boa3_test/test_sc/function_test/CustomDecoratorWithGlobalFunction.py#L1-L11
https://github.com/CityOfZion/neo3-boa/blob/c4efb526cbfd394c79f27c1b365990129b93d54d/boa3_test/test_sc/function_test/BuiltinContractDecoratorWithFunction.py#L1-L8

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/c4efb526cbfd394c79f27c1b365990129b93d54d/boa3_test/tests/compiler_tests/test_function.py#L1661-L1667

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
