### PR TITLE
Add a new error when trying to create inner function

### DIFF
--- a/boa3/internal/analyser/typeanalyser.py
+++ b/boa3/internal/analyser/typeanalyser.py
@@ -191,6 +191,11 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
             method = method.getter
 
         if isinstance(method, Method):
+            if self._current_method is not None:
+                self._log_error(
+                    CompilerError.NotSupportedOperation(line=function.lineno, col=function.col_offset,
+                                                        symbol_id="Inner function")
+                )
             self._current_method = method
             self.new_local_scope({var_id: var for var_id, var in method.symbols.items()
                                   if isinstance(var, Variable) and var.type is not UndefinedType})

--- a/boa3_test/test_sc/function_test/InnerFunction.py
+++ b/boa3_test/test_sc/function_test/InnerFunction.py
@@ -1,0 +1,7 @@
+# Inner Functions are currently not allowed in smart contracts
+def main() -> str:
+
+    def inner_function() -> str:
+        return 'unit test'
+
+    return inner_function()

--- a/boa3_test/tests/compiler_tests/test_function.py
+++ b/boa3_test/tests/compiler_tests/test_function.py
@@ -1657,3 +1657,7 @@ class TestFunction(BoaTest):
         self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
 
         self.assertEqual(invoke.result, None)
+
+    def test_inner_function(self):
+        path = self.get_contract_path('InnerFunction.py')
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)


### PR DESCRIPTION
**Summary or solution description**
You'll get a Not Supported error when you try to create inner functions.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/f8f849c53ac2b301c8fb4de32ce587b4f382d20c/boa3_test/test_sc/function_test/InnerFunction.py#L1-L7

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/f8f849c53ac2b301c8fb4de32ce587b4f382d20c/boa3_test/tests/compiler_tests/test_function.py#L1661-L1663

**Platform:**
 - OS: Windows 10 x64
 - Python version:  Python 3.7

