### PR TITLE
test-runner deploy_contract should validate NEF exists

### DIFF
--- a/boa3_test/test_drive/testrunner/neo_test_runner.py
+++ b/boa3_test/test_drive/testrunner/neo_test_runner.py
@@ -226,6 +226,8 @@ class NeoTestRunner:
     def deploy_contract(self, nef_path: str, account: Account = None) -> TestContract:
         if not isinstance(nef_path, str) or not nef_path.endswith('.nef'):
             raise ValueError('Requires a .nef file to deploy a contract')
+        elif not os.path.exists(nef_path):
+            raise FileNotFoundError(f'Could not find file at: {nef_path}')
 
         if nef_path not in self._contracts:
             contract = self._batch.deploy_contract(nef_path, account)

--- a/boa3_test/tests/test_app_tests/test_test_runner.py
+++ b/boa3_test/tests/test_app_tests/test_test_runner.py
@@ -117,3 +117,29 @@ class TestTestRunner(BoaTest):
             b'b': False
         })
         self.assertEqual(expected_result, result)
+
+    def test_deploy_contract_wrong_file(self):
+        path = self.get_contract_path('test_sc/generation_test', 'GenerationWithDecorator.py')
+        runner = NeoTestRunner(os.path.join(env.NEO_EXPRESS_INSTANCE_DIRECTORY, 'default.neo-express'),
+                               runner_id=self.method_name()
+                               )
+
+        # path ends with .py, instead of .nef
+        with self.assertRaises(ValueError) as error:
+            runner.deploy_contract(path)
+        self.assertEqual('Requires a .nef file to deploy a contract', str(error.exception))
+
+        path.replace('.py', '')
+        with self.assertRaises(ValueError) as error:
+            runner.deploy_contract(path)
+        self.assertEqual('Requires a .nef file to deploy a contract', str(error.exception))
+
+    def test_deploy_contract_file_does_not_exist(self):
+        path = os.path.join(env.NEO_EXPRESS_INSTANCE_DIRECTORY, 'file_does_not_exist.nef')
+        runner = NeoTestRunner(os.path.join(env.NEO_EXPRESS_INSTANCE_DIRECTORY, 'default.neo-express'),
+                               runner_id=self.method_name()
+                               )
+
+        with self.assertRaises(FileNotFoundError) as error:
+            runner.deploy_contract(path)
+        self.assertEqual(f'Could not find file at: {path}', str(error.exception))


### PR DESCRIPTION
**Summary or solution description**
Added a validation on `deploy_contract` to throw a FileNotFoundError, if the `.nef` doesn't exist.

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/8ae79f919bc6c7bb753b34d99023d50745e69802/boa3_test/tests/test_app_tests/test_test_runner.py#L121-L145

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
