### PR TITLE
Add another error when using lambda functions

### DIFF
--- a/boa3/internal/analyser/typeanalyser.py
+++ b/boa3/internal/analyser/typeanalyser.py
@@ -1144,6 +1144,10 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
             callable_id: str = call.func.id
             is_internal = hasattr(call, 'is_internal_call') and call.is_internal_call
             callable_target = self.get_symbol(callable_id, is_internal)
+        elif isinstance(call.func, ast.Lambda):
+            self._log_error(
+                CompilerError.NotSupportedOperation(call.func.lineno, call.func.col_offset, 'lambda function')
+            )
         else:
             callable_id, callable_target = self.get_callable_and_update_args(call)  # type: str, ISymbol
 

--- a/boa3_test/test_sc/function_test/LambdaFunction.py
+++ b/boa3_test/test_sc/function_test/LambdaFunction.py
@@ -1,0 +1,3 @@
+def main() -> int:
+    # lambda function is not supported
+    return (lambda a, b: a + b)(1, 2)

--- a/boa3_test/tests/compiler_tests/test_function.py
+++ b/boa3_test/tests/compiler_tests/test_function.py
@@ -1661,3 +1661,7 @@ class TestFunction(BoaTest):
     def test_inner_function(self):
         path = self.get_contract_path('InnerFunction.py')
         self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+
+    def test_lambda_function(self):
+        path = self.get_contract_path('LambdaFunction.py')
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)


### PR DESCRIPTION
**Summary or solution description**
Added a NotSupportedOperation error when trying to use lambda functions.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/d92558e52338cc73aa6cb35e79e519289a25f984/boa3_test/test_sc/function_test/LambdaFunction.py#L1-L3

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/d92558e52338cc73aa6cb35e79e519289a25f984/boa3_test/tests/compiler_tests/test_function.py#L1665-L1667

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
