### PR TITLE
Change the error when trying to use super with args

### DIFF
--- a/boa3/internal/analyser/typeanalyser.py
+++ b/boa3/internal/analyser/typeanalyser.py
@@ -1412,9 +1412,16 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
                 unexpected_arg = already_called_arg
             else:
                 unexpected_arg = call.args[len(callable_target.args) + ignore_first_argument]
-            self._log_error(
-                CompilerError.UnexpectedArgument(unexpected_arg.lineno, unexpected_arg.col_offset)
-            )
+
+            from boa3.internal.model.builtin.method import SuperMethod
+            if isinstance(callable_target, SuperMethod):
+                self._log_error(
+                    CompilerError.NotSupportedOperation(unexpected_arg.lineno, unexpected_arg.col_offset, 'super with arguments')
+                )
+            else:
+                self._log_error(
+                    CompilerError.UnexpectedArgument(unexpected_arg.lineno, unexpected_arg.col_offset)
+                )
             return False
         elif len_call_args + len_call_keywords < callable_required_args or not all_required_arg_have_values:
             missed_arg = list(callable_target.args)[len(call.args) + ignore_first_argument]

--- a/boa3_test/tests/compiler_tests/test_builtin_method.py
+++ b/boa3_test/tests/compiler_tests/test_builtin_method.py
@@ -2204,7 +2204,7 @@ class TestBuiltinMethod(BoaTest):
     def test_super_with_args(self):
         # TODO: Change when super with args is implemented
         path = self.get_contract_path('SuperWithArgs.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
 
     def test_super_call_method(self):
         path, _ = self.get_deploy_file_paths('SuperCallMethod.py')


### PR DESCRIPTION
**Summary or solution description**
Changed the UnexpectedArgument error into a NotSupported error to make the error more clear

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/e76a8526abded28d0ce69389d35e7bf6d601505a/boa3_test/tests/compiler_tests/test_builtin_method.py#L2204-L2207

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
