### PR TITLE
Change the error when trying to use f-string

### DIFF
--- a/boa3/internal/analyser/typeanalyser.py
+++ b/boa3/internal/analyser/typeanalyser.py
@@ -1896,3 +1896,16 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
         :return: the object with the index value information
         """
         return slice_node.lower, slice_node.upper, slice_node.step
+
+    def visit_JoinedStr(self, fstring_node: ast.JoinedStr) -> str:
+        """
+        Visitor of an f-string node
+
+        :param fstring_node:
+        :return: the object with the index value information
+        """
+        self._log_error(
+            CompilerError.NotSupportedOperation(fstring_node.lineno, fstring_node.col_offset, 'f-string')
+        )
+
+        return self.generic_visit(fstring_node)

--- a/boa3_test/test_sc/string_test/FormattedStringLiteral.py
+++ b/boa3_test/test_sc/string_test/FormattedStringLiteral.py
@@ -1,0 +1,3 @@
+def main() -> str:
+    # f-strings are not supported
+    return f'unit {"test"}'

--- a/boa3_test/tests/compiler_tests/test_string.py
+++ b/boa3_test/tests/compiler_tests/test_string.py
@@ -1476,3 +1476,7 @@ class TestString(BoaTest):
 
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result, msg=x)
+
+    def test_formatted_string_literal(self):
+        path = self.get_contract_path('FormattedStringLiteral.py')
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)


### PR DESCRIPTION
**Summary or solution description**
The previous error was: `Expected type 'str', got 'none' instead`, now it's a NotSupported error.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/81bf9754420d61b4bd2d317b8c14b19aedd080fe/boa3_test/test_sc/string_test/FormattedStringLiteral.py#L1-L3

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/81bf9754420d61b4bd2d317b8c14b19aedd080fe/boa3_test/tests/compiler_tests/test_string.py#L1480-L1482

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
