### PR TITLE
Property and parameter with same name error

### DIFF
--- a/boa3/internal/compiler/codegenerator/codegenerator.py
+++ b/boa3/internal/compiler/codegenerator/codegenerator.py
@@ -1494,9 +1494,6 @@ class CodeGenerator:
         :param symbol_id: the symbol identifier
         :param params_addresses: a list with each function arguments' first addresses
         """
-        if class_type is None and len(self._stack) > 0 and isinstance(self._stack[-1], UserClass):
-            class_type = self._stack[-1]
-
         another_symbol_id, symbol = self.get_symbol(symbol_id, is_internal=is_internal)
 
         if class_type is not None and symbol_id in class_type.symbols:

--- a/boa3/internal/compiler/codegenerator/codegeneratorvisitor.py
+++ b/boa3/internal/compiler/codegenerator/codegeneratorvisitor.py
@@ -134,7 +134,7 @@ class VisitorCodeGenerator(IAstAnalyser):
                 else:
                     # TODO: validate function calls
                     is_internal = hasattr(node, 'is_internal_call') and node.is_internal_call
-                    class_type = result.type
+                    class_type = result.type if isinstance(node, ast.Attribute) else None
 
                     if (self.is_implemented_class_type(result.type)
                             and len(result.symbol_id.split(constants.ATTRIBUTE_NAME_SEPARATOR)) > 1):
@@ -146,7 +146,7 @@ class VisitorCodeGenerator(IAstAnalyser):
                     elif isinstance(result.index, Package):
                         class_type = None
 
-                    self.generator.convert_load_symbol(result.symbol_id, is_internal=is_internal, class_type=class_type if self.current_method is None else None)
+                    self.generator.convert_load_symbol(result.symbol_id, is_internal=is_internal, class_type=class_type)
 
                 result.already_generated = True
 
@@ -856,11 +856,14 @@ class VisitorCodeGenerator(IAstAnalyser):
                 VMCodeMapping.instance().bytecode_size
             )
             self.visit_to_generate(arg)
+
+        class_type = None
         if has_cls_or_self_argument:
             num_args = len(args_addresses)
             if self.generator.stack_size > num_args:
                 value = self.generator._stack_pop(-num_args - 1)
                 self.generator._stack_append(value)
+                class_type = value if isinstance(value, UserClass) else None
             end_address = VMCodeMapping.instance().move_to_end(last_address, args_begin_address)
             if not symbol.is_init:
                 args_addresses.append(end_address)
@@ -873,7 +876,8 @@ class VisitorCodeGenerator(IAstAnalyser):
         elif isinstance(symbol, IBuiltinMethod):
             self.generator.convert_builtin_method_call(symbol, args_addresses)
         else:
-            self.generator.convert_load_symbol(function_id, args_addresses)
+            self.generator.convert_load_symbol(function_id, args_addresses,
+                                               class_type=class_type)
 
         return self.build_data(call, symbol=symbol, symbol_id=function_id,
                                result_type=symbol.type if isinstance(symbol, IExpression) else symbol,
@@ -1068,6 +1072,7 @@ class VisitorCodeGenerator(IAstAnalyser):
                 return self.build_data(attribute,
                                        symbol_id=symbol_id, symbol=symbol,
                                        result_type=result_type, index=symbol_index,
+                                       origin_object_type=value_type,
                                        already_generated=generated)
 
         if value_data is not None and value_symbol is None:

--- a/boa3_test/test_sc/class_test/ClassPropertyAndParameterWithSameName.py
+++ b/boa3_test/test_sc/class_test/ClassPropertyAndParameterWithSameName.py
@@ -1,0 +1,16 @@
+from boa3.builtin.compile_time import public
+
+
+class Example:
+    def __init__(self, arg: str):
+        self._internal_value = arg
+
+    @property
+    def same_name(self) -> str:
+        return self._internal_value
+
+
+@public
+def main(same_name: str) -> str:
+    obj = Example(same_name)
+    return obj.same_name

--- a/boa3_test/tests/compiler_tests/test_class.py
+++ b/boa3_test/tests/compiler_tests/test_class.py
@@ -873,3 +873,19 @@ class TestClass(BoaTest):
     def test_del_class(self):
         path = self.get_contract_path('DelClass.py')
         self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+
+    def test_class_property_and_parameter_with_same_name(self):
+        path, _ = self.get_deploy_file_paths('ClassPropertyAndParameterWithSameName.py')
+        runner = BoaTestRunner(runner_id=self.method_name())
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', 'unit test'))
+        expected_results.append('unit test')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)


### PR DESCRIPTION
**Summary or solution description**
There was an internal problem when creating a class property and a parameter with the same names.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/e81de1c65e84bb11a74d3a917cd134b9d7de06ff/boa3_test/test_sc/class_test/ClassPropertyAndParameterWithSameName.py#L1-L16

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/e81de1c65e84bb11a74d3a917cd134b9d7de06ff/boa3_test/tests/compiler_tests/test_class.py#L877-L891

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
