### PR TITLE
Incorrect value when using variables in different module with the same name

### DIFF
--- a/boa3/internal/compiler/codegenerator/codegenerator.py
+++ b/boa3/internal/compiler/codegenerator/codegenerator.py
@@ -341,15 +341,6 @@ class CodeGenerator:
             result_global_vars = result_global_vars + [classes for (class_id, classes) in class_with_class_variables]
             result = module_global_ids + class_with_variables_ids
 
-        original_ids = []
-        for value in result:
-            split = value.split(constants.VARIABLE_NAME_SEPARATOR)
-            if len(split) > 1:
-                new_index = split[-1]
-            else:
-                new_index = value
-            original_ids.append(new_index)
-
         if vars_map != result_map:
             if vars_map is None:
                 # save to keep the same order in future accesses
@@ -360,17 +351,39 @@ class CodeGenerator:
 
             else:
                 # reorder to keep the same order as the first access
-                pre_reordered_ids = [var_id for (var_id, var) in vars_map]
-                for index, (value, var) in enumerate(vars_map):
-                    if value not in result:
-                        if var in result_global_vars:
-                            var_index = result_global_vars.index(var)
-                            new_value = result_map[var_index]
+                if len(result_map) > len(vars_map):
+                    additional_items = []
+                    vars_list = [var for var_id, var in vars_map]
+                    for index, var in enumerate(result_global_vars):
+                        if var in vars_list:
+                            var_index = vars_list.index(var)
+                            vars_map[var_index] = result_map[index]
                         else:
-                            var_index = original_ids.index(value)
-                            new_value = result_map[var_index]
+                            additional_items.append(result_map[index])
+                    vars_map.extend(additional_items)
 
-                        vars_map[index] = new_value
+                    pre_reordered_ids = [var_id for (var_id, var) in vars_map]
+                else:
+                    original_ids = []
+                    for value in result:
+                        split = value.split(constants.VARIABLE_NAME_SEPARATOR)
+                        if len(split) > 1:
+                            new_index = split[-1]
+                        else:
+                            new_index = value
+                        original_ids.append(new_index)
+
+                    pre_reordered_ids = [var_id for (var_id, var) in vars_map]
+                    for index, (value, var) in enumerate(vars_map):
+                        if value not in result:
+                            if var in result_global_vars:
+                                var_index = result_global_vars.index(var)
+                                new_value = result_map[var_index]
+                            else:
+                                var_index = original_ids.index(value)
+                                new_value = result_map[var_index]
+
+                            vars_map[index] = new_value
 
                 # add new symbols at the end always
                 reordered_ids = [var_id for (var_id, var) in vars_map]

--- a/boa3/internal/compiler/codegenerator/codegeneratorvisitor.py
+++ b/boa3/internal/compiler/codegenerator/codegeneratorvisitor.py
@@ -236,6 +236,7 @@ class VisitorCodeGenerator(IAstAnalyser):
                             global_stmts.remove(cls_fun)
 
                         class_non_static_stmts.append(cls_fun)
+                    self.symbols = last_symbols  # don't use inner scopes to evaluate the other globals
 
             # to generate the 'initialize' method for Neo
             self._log_info(f"Compiling '{constants.INITIALIZE_METHOD_ID}' function")

--- a/boa3_test/test_sc/variable_test/GetGlobalSameIdFromImport.py
+++ b/boa3_test/test_sc/variable_test/GetGlobalSameIdFromImport.py
@@ -1,0 +1,16 @@
+from typing import Any
+
+from boa3.builtin.compile_time import public
+from boa3_test.test_sc.variable_test.ListGlobalAssignment import get_from_global
+
+a = 42  # same name of a variable in a imported package
+
+
+@public
+def value_from_import() -> Any:
+    return get_from_global()
+
+
+@public
+def value_from_script() -> Any:
+    return a

--- a/boa3_test/tests/compiler_tests/test_variable.py
+++ b/boa3_test/tests/compiler_tests/test_variable.py
@@ -700,9 +700,7 @@ class TestVariable(BoaTest):
             self.assertEqual(expected_results[x], invokes[x].result)
 
     def test_global_variable_same_id_different_scopes(self):
-        path = self.get_contract_path('GetGlobalSameIdFromImport.py')
-        self.compile_and_save(path, debug=True)
-        path, _ = self.get_deploy_file_paths(path)
+        path, _ = self.get_deploy_file_paths('GetGlobalSameIdFromImport.py')
         runner = BoaTestRunner(runner_id=self.method_name())
 
         invokes = []

--- a/boa3_test/tests/compiler_tests/test_variable.py
+++ b/boa3_test/tests/compiler_tests/test_variable.py
@@ -699,6 +699,27 @@ class TestVariable(BoaTest):
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
 
+    def test_global_variable_same_id_different_scopes(self):
+        path = self.get_contract_path('GetGlobalSameIdFromImport.py')
+        self.compile_and_save(path, debug=True)
+        path, _ = self.get_deploy_file_paths(path)
+        runner = BoaTestRunner(runner_id=self.method_name())
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'value_from_script'))
+        expected_results.append(42)
+
+        invokes.append(runner.call_contract(path, 'value_from_import'))
+        expected_results.append([1, 2, 3, 4])
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
     def test_get_global_variable_value_written_after(self):
         expected_output = (
             Opcode.LDSFLD + b'\x07'


### PR DESCRIPTION
**Summary or solution description**
There was an error in the code generator when using multiple files with variables having the same name, even when the variables weren't imported. When importing a package with a variable with the same name as another variable in the root file the generator incorrectly uses the same value as if they were the same variable.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/b901d246d44274a2fa79d1404c81ba2dd3b9cae8/boa3_test/test_sc/variable_test/GetGlobalSameIdFromImport.py#L4-L16
https://github.com/CityOfZion/neo3-boa/blob/b901d246d44274a2fa79d1404c81ba2dd3b9cae8/boa3_test/test_sc/variable_test/ListGlobalAssignment.py#L3-L21
It was using the value from the root file for the `a` variable in the above example, returning `42` instead of `[1, 2, 3, 4]` when trying to execute the imported method.

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/2b3eea05518f9b108b9d90e32e6757cbda824ba1/boa3_test/tests/compiler_tests/test_variable.py#L701-L720

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7+