### PR TITLE
Change setup.py configuration to generate typing information

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -117,9 +117,9 @@ setup(
     # If there are data files included in your packages that need to be
     # installed, specify them here.  If using Python 2.6 or less, then these
     # have to be included in MANIFEST.in as well.
-    # package_data={
-    #    'sample': ['package_data.dat'],
-    # },
+    package_data={
+        'boa3': ['py.typed'],
+    },
 
     # Although 'package_data' is the preferred approach, in some case you may
     # need to place data files outside of your packages. See:


### PR DESCRIPTION
**Summary or solution description**
While testing the mypy extension for VSCode we found some problems with the mypy recognizing of boa3 packages.
Changed the package data on setup to fix those problems

**How to Reproduce**
Install [Mypy Type Checker](https://marketplace.visualstudio.com/items?itemName=ms-python.mypy-type-checker) for VSCode and write a smart contract script importing `boa3.builtin` packages

**Tests**
A clear and concise description of how you tested it.

**Screenshots**
how it was:
![image](https://github.com/CityOfZion/neo3-boa/assets/19419485/f2ef80a5-eb76-49ae-ba35-35cb73df6511)
after the change on setup:
![image](https://github.com/CityOfZion/neo3-boa/assets/19419485/bc6d13f6-c3be-41bb-9fb7-1efc5a23f209)

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7+

