### PR TITLE
Implement NEP-11 standard validator for divisible NFTs

### DIFF
--- a/boa3/internal/analyser/supportedstandard/__init__.py
+++ b/boa3/internal/analyser/supportedstandard/__init__.py
@@ -1,10 +1,11 @@
 """
 Use Upper Kebab Case to name the standards in this dictionary
 """
-from boa3.internal.model.standards.nep11standard import Nep11Standard
+from boa3.internal.model.standards.nep11nondivisiblestandard import Nep11NonDivisibleStandard
+from boa3.internal.model.standards.nep11divisiblestandard import Nep11DivisibleStandard
 from boa3.internal.model.standards.nep17standard import Nep17Standard
 
 neo_standards = {
-    'NEP-11': Nep11Standard(),
-    'NEP-17': Nep17Standard()
+    'NEP-11': [Nep11NonDivisibleStandard(), Nep11DivisibleStandard()],
+    'NEP-17': [Nep17Standard()]
 }

--- a/boa3/internal/analyser/supportedstandard/standardanalyser.py
+++ b/boa3/internal/analyser/supportedstandard/standardanalyser.py
@@ -69,61 +69,85 @@ class StandardAnalyser(IAstAnalyser):
         try:
             for standard in self.standards:
                 if standard in supportedstandard.neo_standards:
-                    current_standard = supportedstandard.neo_standards[standard]
+                    standard_is_correct = False
+                    errors = []
 
-                    # validate standard's methods
-                    for standard_method in current_standard.methods:
-                        method_id = standard_method.external_name
-                        is_implemented = False
+                    for current_standard in supportedstandard.neo_standards[standard]:
+                        check_next_standard = False
 
-                        found_methods = self.get_methods_by_display_name(method_id)
-                        for method in found_methods:
-                            if isinstance(method, Method) and current_standard.match_definition(standard_method, method):
-                                is_implemented = True
+                        # validate standard's methods
+                        for standard_method in current_standard.methods:
+                            method_id = standard_method.external_name
+                            is_implemented = False
+
+                            found_methods = self.get_methods_by_display_name(method_id)
+                            for method in found_methods:
+                                if isinstance(method, Method) and current_standard.match_definition(standard_method, method):
+                                    is_implemented = True
+                                    break
+
+                            if not is_implemented:
+                                errors.append(CompilerError.MissingStandardDefinition(standard, method_id, standard_method))
+                                check_next_standard = True
                                 break
 
-                        if not is_implemented:
-                            self._log_error(
-                                CompilerError.MissingStandardDefinition(standard, method_id, standard_method)
-                            )
+                        if check_next_standard:
+                            continue
 
-                    # validate standard's events
-                    events = [symbol for symbol in self.symbols.values() if isinstance(symbol, Event)]
-                    # imported events should be included in the validation
-                    for import_ in self._analyser.get_imports():
-                        events.extend([event for event in import_.symbol_table.values()
-                                       if isinstance(event, Event) and event not in events])
+                        # validate standard's events
+                        events = [symbol for symbol in self.symbols.values() if isinstance(symbol, Event)]
+                        # imported events should be included in the validation
+                        for import_ in self._analyser.get_imports():
+                            events.extend([event for event in import_.symbol_table.values()
+                                           if isinstance(event, Event) and event not in events])
 
-                    for standard_event in current_standard.events:
-                        is_implemented = False
-                        for event in events:
-                            if (event.name == standard_event.name
-                                    and current_standard.match_definition(standard_event, event)):
-                                is_implemented = True
+                        for standard_event in current_standard.events:
+                            is_implemented = False
+                            for event in events:
+                                if (event.name == standard_event.name
+                                        and current_standard.match_definition(standard_event, event)):
+                                    is_implemented = True
+                                    break
+
+                            if not is_implemented:
+                                errors.append(
+                                    CompilerError.MissingStandardDefinition(standard,
+                                                                            standard_event.name,
+                                                                            standard_event)
+                                )
+                                check_next_standard = True
                                 break
 
-                        if not is_implemented:
-                            self._log_error(
-                                CompilerError.MissingStandardDefinition(standard,
-                                                                        standard_event.name,
-                                                                        standard_event)
-                            )
+                        if check_next_standard:
+                            continue
 
-                    # validate optional methods
-                    for optional_method in current_standard.optionals:
-                        method_id = optional_method.external_name
-                        is_implemented = False
+                        # validate optional methods
+                        for optional_method in current_standard.optionals:
+                            method_id = optional_method.external_name
+                            is_implemented = False
 
-                        found_methods = self.get_methods_by_display_name(method_id)
-                        for method in found_methods:
-                            if isinstance(method, Method) and current_standard.match_definition(optional_method, method):
-                                is_implemented = True
+                            found_methods = self.get_methods_by_display_name(method_id)
+                            for method in found_methods:
+                                if isinstance(method, Method) and current_standard.match_definition(optional_method, method):
+                                    is_implemented = True
+                                    break
+
+                            if found_methods and not is_implemented:
+                                errors.append(
+                                    CompilerError.MissingStandardDefinition(standard, method_id, optional_method)
+                                )
+                                check_next_standard = True
                                 break
 
-                        if found_methods and not is_implemented:
-                            self._log_error(
-                                CompilerError.MissingStandardDefinition(standard, method_id, optional_method)
-                            )
+                        if check_next_standard:
+                            continue
+
+                        standard_is_correct = True
+
+                    if not standard_is_correct:
+                        for error in errors:
+                            self._log_error(error)
+
         except CompilerError.CompilerError:
             # stops the analyser if fail fast is activated
             pass
@@ -142,39 +166,40 @@ class StandardAnalyser(IAstAnalyser):
 
         # verify if the methods and events that were implemented corresponds to a standard
         for standard in other_standards:
+            for current_standard in other_standards[standard]:
+                # verify the methods
+                methods_implemented = True
+                standard_methods = current_standard.methods
+                index = 0
 
-            # verify the methods
-            methods_implemented = True
-            standard_methods = other_standards[standard].methods
-            index = 0
+                while methods_implemented and index < len(standard_methods):
+                    standard_method = standard_methods[index]
+                    method_id = standard_method.external_name
+                    found_methods = self.get_methods_by_display_name(method_id)
 
-            while methods_implemented and index < len(standard_methods):
-                standard_method = standard_methods[index]
-                method_id = standard_method.external_name
-                found_methods = self.get_methods_by_display_name(method_id)
+                    methods_implemented = any(
+                        current_standard.match_definition(standard_method, method) for method in found_methods
+                    )
+                    index += 1
 
-                methods_implemented = any(
-                    other_standards[standard].match_definition(standard_method, method) for method in found_methods
-                )
-                index += 1
+                if not methods_implemented:
+                    continue    # if even one of the methods was not implemented, then check the next standard
 
-            if not methods_implemented:
-                continue    # if even one of the methods was not implemented, then check the next standard
+                # verify the events
+                events_implemented = True
+                standard_events = current_standard.events
+                index = 0
 
-            # verify the events
-            events_implemented = True
-            standard_events = other_standards[standard].events
-            index = 0
+                while events_implemented and index < len(standard_events):
+                    standard_event = standard_events[index]
+                    events_implemented = any(
+                        (event.name == standard_event.name and
+                         current_standard.match_definition(standard_event, event)) for event in events
+                    )
+                    index += 1
 
-            while events_implemented and index < len(standard_events):
-                standard_event = standard_events[index]
-                events_implemented = any(
-                    (event.name == standard_event.name and
-                     other_standards[standard].match_definition(standard_event, event)) for event in events
-                )
-                index += 1
+                if not events_implemented:
+                    continue    # if even one of the events was not implemented, then check the next standard
 
-            if not events_implemented:
-                continue    # if even one of the events was not implemented, then check the next standard
-
-            self.standards.append(standard)
+                self.standards.append(standard)
+                break

--- a/boa3/internal/model/standards/nep11divisiblestandard.py
+++ b/boa3/internal/model/standards/nep11divisiblestandard.py
@@ -6,7 +6,7 @@ from boa3.internal.model.type.collection.sequence.uint160type import UInt160Type
 from boa3.internal.model.type.type import Type
 
 
-class Nep11Standard(INeoStandard):
+class Nep11DivisibleStandard(INeoStandard):
     def __init__(self):
         type_uint160 = UInt160Type.build()
         type_iterator = IteratorType.build()
@@ -34,9 +34,23 @@ class Nep11Standard(INeoStandard):
                                  'data': Type.any},
                            return_type=Type.bool,
                            literal_implementation=False),
+            # exclusive divisible methods below
+            StandardMethod('transfer',
+                           args={'from': type_uint160,
+                                 'to': type_uint160,
+                                 'amount': Type.int,
+                                 'tokenId': type_token_id,
+                                 'data': Type.any},
+                           return_type=Type.bool,
+                           literal_implementation=False),
             StandardMethod('ownerOf', safe=True,
                            args={'tokenId': type_token_id},
-                           return_type=type_uint160,
+                           return_type=type_iterator,
+                           literal_implementation=False),
+            StandardMethod('balanceOf', safe=True,
+                           args={'owner': type_uint160,
+                                 'tokenId': type_token_id},
+                           return_type=Type.int,
                            literal_implementation=False),
         ]
 

--- a/boa3/internal/model/standards/nep11nondivisiblestandard.py
+++ b/boa3/internal/model/standards/nep11nondivisiblestandard.py
@@ -1,0 +1,60 @@
+from boa3.internal.model.builtin.builtin import Builtin
+from boa3.internal.model.builtin.interop.iterator import IteratorType
+from boa3.internal.model.standards.neostandard import INeoStandard
+from boa3.internal.model.standards.standardmethod import StandardMethod
+from boa3.internal.model.type.collection.sequence.uint160type import UInt160Type
+from boa3.internal.model.type.type import Type
+
+
+class Nep11NonDivisibleStandard(INeoStandard):
+    def __init__(self):
+        type_uint160 = UInt160Type.build()
+        type_iterator = IteratorType.build()
+        type_token_id = Type.union.build([Type.str, Type.bytes])
+
+        methods = [
+            StandardMethod('symbol', safe=True,
+                           args={},
+                           return_type=Type.str),
+            StandardMethod('decimals', safe=True,
+                           args={},
+                           return_type=Type.int),
+            StandardMethod('totalSupply', safe=True,
+                           args={},
+                           return_type=Type.int),
+            StandardMethod('balanceOf', safe=True,
+                           args={'owner': type_uint160},
+                           return_type=Type.int),
+            StandardMethod('tokensOf', safe=True,
+                           args={'owner': type_uint160},
+                           return_type=type_iterator),
+            StandardMethod('transfer',
+                           args={'to': type_uint160,
+                                 'tokenId': type_token_id,
+                                 'data': Type.any},
+                           return_type=Type.bool,
+                           literal_implementation=False),
+            # exclusive non-divisible methods below
+            StandardMethod('ownerOf', safe=True,
+                           args={'tokenId': type_token_id},
+                           return_type=type_uint160,
+                           literal_implementation=False),
+        ]
+
+        optionals = [
+            StandardMethod('tokens', safe=True,
+                           args={},
+                           return_type=type_iterator),
+            StandardMethod('properties', safe=True,
+                           args={
+                               'tokenId': type_token_id,
+                           },
+                           return_type=Type.dict,
+                           literal_implementation=False),
+        ]
+
+        events = [
+            Builtin.Nep11Transfer
+        ]
+
+        super().__init__(methods, events, optionals)

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsMissingEventNEP11.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsMissingEventNEP11.py
@@ -1,0 +1,47 @@
+from typing import Any
+
+from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.interop.iterator import Iterator
+from boa3.builtin.type import UInt160
+
+
+@metadata
+def standards_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+    meta.supported_standards = ['NEP-11']  # for nep11, boa checks if the standard is implemented
+    return meta
+
+
+@public(safe=True)
+def symbol() -> str:
+    pass
+
+
+@public(safe=True)
+def decimals() -> int:
+    pass
+
+
+@public(name='totalSupply', safe=True)
+def total_supply() -> int:
+    pass
+
+
+@public(name='balanceOf', safe=True)
+def balance_of(owner_address: UInt160) -> int:
+    pass
+
+
+@public(name='tokensOf', safe=True)
+def tokens_of(owner: UInt160) -> Iterator:
+    pass
+
+
+@public(name='ownerOf', safe=True)
+def owner_of(token_id: bytes) -> UInt160:
+    pass
+
+
+@public
+def transfer(to_address: UInt160, token_id: bytes, data: Any) -> bool:
+    pass

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsMissingImplementationNEP11Divisible.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsMissingImplementationNEP11Divisible.py
@@ -1,0 +1,51 @@
+from typing import Any
+
+from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.contract import Nep11TransferEvent
+from boa3.builtin.interop.iterator import Iterator
+from boa3.builtin.type import UInt160
+
+on_transfer = Nep11TransferEvent
+
+
+@metadata
+def standards_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+    meta.supported_standards = ['NEP-11']  # for nep11, boa checks if the standard is implemented
+    return meta
+
+
+# only the ownerOf method of the NEP-11 divisible standard is implemented, so an error should be logged
+@public(name='ownerOf', safe=True)
+def owner_of(token_id: bytes) -> Iterator:
+    pass
+
+
+@public(safe=True)
+def symbol() -> str:
+    pass
+
+
+@public(safe=True)
+def decimals() -> int:
+    pass
+
+
+@public(name='totalSupply', safe=True)
+def total_supply() -> int:
+    pass
+
+
+@public(name='balanceOf', safe=True)
+def balance_of(owner_address: UInt160) -> int:
+    pass
+
+
+@public(name='tokensOf', safe=True)
+def tokens_of(owner: UInt160) -> Iterator:
+    pass
+
+
+@public
+def transfer(to_address: UInt160, token_id: bytes, data: Any) -> bool:
+    pass

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsNEP11Divisible.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsNEP11Divisible.py
@@ -1,0 +1,60 @@
+from typing import Any, Dict
+
+from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.contract import Nep11TransferEvent
+from boa3.builtin.interop.iterator import Iterator
+from boa3.builtin.type import UInt160
+
+on_transfer = Nep11TransferEvent
+
+
+@metadata
+def standards_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+    meta.supported_standards = ['NEP-11']  # for nep11, boa checks if the standard is implemented
+    return meta
+
+
+@public(safe=True)
+def symbol() -> str:
+    pass
+
+
+@public(safe=True)
+def decimals() -> int:
+    pass
+
+
+@public(name='totalSupply', safe=True)
+def total_supply() -> int:
+    pass
+
+
+@public(name='balanceOf', safe=True)
+def balance_of(owner_address: UInt160) -> int:
+    pass
+
+
+@public(name='tokensOf', safe=True)
+def tokens_of(owner: UInt160) -> Iterator:
+    pass
+
+
+@public
+def transfer(to_address: UInt160, token_id: bytes, data: Any) -> bool:
+    pass
+
+
+@public(name='transfer')
+def transfer_divisible(from_address: UInt160, to_address: UInt160, amount: int, token_id: bytes, data: Any) -> bool:
+    pass
+
+
+@public(name='ownerOf', safe=True)
+def owner_of_divisible(token_id: bytes) -> Iterator:
+    pass
+
+
+@public(name='balanceOf', safe=True)
+def balance_of_divisible(owner_address: UInt160, token_id: bytes) -> int:
+    pass

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsNEP11DivisibleOptionalMethods.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsNEP11DivisibleOptionalMethods.py
@@ -1,0 +1,70 @@
+from typing import Any, Dict
+
+from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.contract import Nep11TransferEvent
+from boa3.builtin.interop.iterator import Iterator
+from boa3.builtin.type import UInt160
+
+on_transfer = Nep11TransferEvent
+
+
+@metadata
+def standards_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+    meta.supported_standards = ['NEP-11']  # for nep11, boa checks if the standard is implemented
+    return meta
+
+
+@public(safe=True)
+def symbol() -> str:
+    pass
+
+
+@public(safe=True)
+def decimals() -> int:
+    pass
+
+
+@public(name='totalSupply', safe=True)
+def total_supply() -> int:
+    pass
+
+
+@public(name='balanceOf', safe=True)
+def balance_of(owner_address: UInt160) -> int:
+    pass
+
+
+@public(name='tokensOf', safe=True)
+def tokens_of(owner: UInt160) -> Iterator:
+    pass
+
+
+@public
+def transfer(to_address: UInt160, token_id: bytes, data: Any) -> bool:
+    pass
+
+
+@public(name='transfer')
+def transfer_divisible(from_address: UInt160, to_address: UInt160, amount: int, token_id: bytes, data: Any) -> bool:
+    pass
+
+
+@public(name='ownerOf', safe=True)
+def owner_of_divisible(token_id: bytes) -> Iterator:
+    pass
+
+
+@public(name='balanceOf', safe=True)
+def balance_of_divisible(owner_address: UInt160, token_id: bytes) -> int:
+    pass
+
+
+@public(safe=True)
+def tokens() -> Iterator:
+    pass
+
+
+@public(safe=True)
+def properties(token_id: bytes) -> Dict[Any, Any]:
+    pass

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsNEP11NonDivisible.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsNEP11NonDivisible.py
@@ -1,0 +1,50 @@
+from typing import Any, Dict
+
+from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.contract import Nep11TransferEvent
+from boa3.builtin.interop.iterator import Iterator
+from boa3.builtin.type import UInt160
+
+on_transfer = Nep11TransferEvent
+
+
+@metadata
+def standards_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+    meta.supported_standards = ['NEP-11']  # for nep11, boa checks if the standard is implemented
+    return meta
+
+
+@public(safe=True)
+def symbol() -> str:
+    pass
+
+
+@public(safe=True)
+def decimals() -> int:
+    pass
+
+
+@public(name='totalSupply', safe=True)
+def total_supply() -> int:
+    pass
+
+
+@public(name='balanceOf', safe=True)
+def balance_of(owner_address: UInt160) -> int:
+    pass
+
+
+@public(name='tokensOf', safe=True)
+def tokens_of(owner: UInt160) -> Iterator:
+    pass
+
+
+@public
+def transfer(to_address: UInt160, token_id: bytes, data: Any) -> bool:
+    pass
+
+
+@public(name='ownerOf', safe=True)
+def owner_of_non_divisible(token_id: bytes) -> UInt160:
+    pass

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsNEP11NonDivisibleOptionalMethods.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsNEP11NonDivisibleOptionalMethods.py
@@ -1,0 +1,60 @@
+from typing import Any, Dict
+
+from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.contract import Nep11TransferEvent
+from boa3.builtin.interop.iterator import Iterator
+from boa3.builtin.type import UInt160
+
+on_transfer = Nep11TransferEvent
+
+
+@metadata
+def standards_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+    meta.supported_standards = ['NEP-11']  # for nep11, boa checks if the standard is implemented
+    return meta
+
+
+@public(safe=True)
+def symbol() -> str:
+    pass
+
+
+@public(safe=True)
+def decimals() -> int:
+    pass
+
+
+@public(name='totalSupply', safe=True)
+def total_supply() -> int:
+    pass
+
+
+@public(name='balanceOf', safe=True)
+def balance_of(owner_address: UInt160) -> int:
+    pass
+
+
+@public(name='tokensOf', safe=True)
+def tokens_of(owner: UInt160) -> Iterator:
+    pass
+
+
+@public
+def transfer(to_address: UInt160, token_id: bytes, data: Any) -> bool:
+    pass
+
+
+@public(name='ownerOf', safe=True)
+def owner_of_non_divisible(token_id: bytes) -> UInt160:
+    pass
+
+
+@public(safe=True)
+def tokens() -> Iterator:
+    pass
+
+
+@public(safe=True)
+def properties(token_id: bytes) -> Dict[Any, Any]:
+    pass

--- a/boa3_test/tests/compiler_tests/test_metadata.py
+++ b/boa3_test/tests/compiler_tests/test_metadata.py
@@ -280,12 +280,56 @@ class TestMetadata(BoaTest):
         path = self.get_contract_path('MetadataInfoSupportedStandardsMissingImplementationNEP17.py')
         self.assertCompilerLogs(CompilerError.MissingStandardDefinition, path)
 
+    def test_metadata_info_supported_standards_nep11_divisible(self):
+        path = self.get_contract_path('MetadataInfoSupportedStandardsNEP11Divisible.py')
+        output, manifest = self.compile_and_save(path)
+
+        self.assertIn('supportedstandards', manifest)
+        self.assertIsInstance(manifest['supportedstandards'], list)
+        self.assertGreater(len(manifest['supportedstandards']), 0)
+        self.assertIn('NEP-11', manifest['supportedstandards'])
+
+    def test_metadata_info_supported_standards_nep11_divisible_optional_methods(self):
+        path = self.get_contract_path('MetadataInfoSupportedStandardsNEP11DivisibleOptionalMethods.py')
+        output, manifest = self.compile_and_save(path)
+
+        self.assertIn('supportedstandards', manifest)
+        self.assertIsInstance(manifest['supportedstandards'], list)
+        self.assertGreater(len(manifest['supportedstandards']), 0)
+        self.assertIn('NEP-11', manifest['supportedstandards'])
+
+    def test_metadata_info_supported_standards_nep11_non_divisible(self):
+        path = self.get_contract_path('MetadataInfoSupportedStandardsNEP11NonDivisible.py')
+        output, manifest = self.compile_and_save(path)
+
+        self.assertIn('supportedstandards', manifest)
+        self.assertIsInstance(manifest['supportedstandards'], list)
+        self.assertGreater(len(manifest['supportedstandards']), 0)
+        self.assertIn('NEP-11', manifest['supportedstandards'])
+
+    def test_metadata_info_supported_standards_nep11_non_divisible_optional_methods(self):
+        path = self.get_contract_path('MetadataInfoSupportedStandardsNEP11NonDivisibleOptionalMethods.py')
+        output, manifest = self.compile_and_save(path)
+
+        self.assertIn('supportedstandards', manifest)
+        self.assertIsInstance(manifest['supportedstandards'], list)
+        self.assertGreater(len(manifest['supportedstandards']), 0)
+        self.assertIn('NEP-11', manifest['supportedstandards'])
+
     def test_metadata_info_supported_standards_missing_implementations_nep11(self):
         path = self.get_contract_path('MetadataInfoSupportedStandardsMissingImplementationNEP11.py')
         self.assertCompilerLogs(CompilerError.MissingStandardDefinition, path)
 
+    def test_metadata_info_supported_standards_missing_implementations_nep11_divisible(self):
+        path = self.get_contract_path('MetadataInfoSupportedStandardsMissingImplementationNEP11Divisible.py')
+        self.assertCompilerLogs(CompilerError.MissingStandardDefinition, path)
+
     def test_metadata_info_supported_standards_missing_implementations_nep11_optional_method(self):
         path = self.get_contract_path('MetadataInfoSupportedStandardsMissingImplementationNEP11OptionalMethods.py')
+        self.assertCompilerLogs(CompilerError.MissingStandardDefinition, path)
+
+    def test_metadata_info_supported_standards_missing_event_nep11(self):
+        path = self.get_contract_path('MetadataInfoSupportedStandardsMissingEventNEP11.py')
         self.assertCompilerLogs(CompilerError.MissingStandardDefinition, path)
 
     def test_metadata_info_supported_standards_mismatched_type(self):


### PR DESCRIPTION
**Summary or solution description**
Previously, only non-divisible NEP-11 tokens were being validated (if it were a divisible it would raise an error), now there is a divisible NEP-11 validator too.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/cf775d7d1c949244c1c2f9f697f7d8b28ab57b87/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsNEP11Divisible.py#L1-L60
https://github.com/CityOfZion/neo3-boa/blob/cf775d7d1c949244c1c2f9f697f7d8b28ab57b87/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsNEP11NonDivisible.py#L1-L50

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/cf775d7d1c949244c1c2f9f697f7d8b28ab57b87/boa3_test/tests/compiler_tests/test_metadata.py#L283-L291
https://github.com/CityOfZion/neo3-boa/blob/cf775d7d1c949244c1c2f9f697f7d8b28ab57b87/boa3_test/tests/compiler_tests/test_metadata.py#L301-L308

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7
