### PR TITLE
Fix for loop generation when iterating Iterator class

### DIFF
--- a/boa3/builtin/interop/iterator/__init__.py
+++ b/boa3/builtin/interop/iterator/__init__.py
@@ -36,3 +36,11 @@ class Iterator:
         :rtype: bool
         """
         pass
+
+    def __next__(self):
+        if self.next():
+            return self.value
+        raise StopIteration
+
+    def __iter__(self):
+        return self

--- a/boa3/internal/compiler/codegenerator/codegeneratorvisitor.py
+++ b/boa3/internal/compiler/codegenerator/codegeneratorvisitor.py
@@ -11,7 +11,6 @@ from boa3.internal.compiler.codegenerator.variablegenerationdata import Variable
 from boa3.internal.compiler.codegenerator.vmcodemapping import VMCodeMapping
 from boa3.internal.constants import SYS_VERSION_INFO
 from boa3.internal.model.builtin.builtin import Builtin
-from boa3.internal.model.builtin.interop.interop import Interop
 from boa3.internal.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.internal.model.expression import IExpression
 from boa3.internal.model.imports.package import Package

--- a/boa3/internal/model/builtin/interop/interop.py
+++ b/boa3/internal/model/builtin/interop/interop.py
@@ -137,6 +137,8 @@ class Interop:
 
     # Iterator Interops
     IteratorCreate = IteratorMethod(Iterator)
+    IteratorNext = IteratorNextMethod()
+    IteratorValue = IteratorValueMethod(Iterator)
 
     # Json Interops
     JsonDeserialize = JsonDeserializeMethod()

--- a/boa3/internal/model/builtin/interop/iterator/__init__.py
+++ b/boa3/internal/model/builtin/interop/iterator/__init__.py
@@ -1,5 +1,9 @@
 __all__ = ['IteratorMethod',
-           'IteratorType']
+           'IteratorNextMethod',
+           'IteratorType',
+           'IteratorValueMethod']
 
+from boa3.internal.model.builtin.interop.iterator.getiteratorvalue import GetIteratorValue as IteratorValueMethod
 from boa3.internal.model.builtin.interop.iterator.iteratorinitmethod import IteratorMethod
+from boa3.internal.model.builtin.interop.iterator.iteratornextmethod import IteratorNextMethod
 from boa3.internal.model.builtin.interop.iterator.iteratortype import IteratorType

--- a/boa3_test/test_sc/for_test/IteratorCondition.py
+++ b/boa3_test/test_sc/for_test/IteratorCondition.py
@@ -1,0 +1,29 @@
+from typing import Any, cast
+
+from boa3.builtin.compile_time import public
+from boa3.builtin.interop import storage
+from boa3.builtin.interop.iterator import Iterator
+
+
+@public
+def Main() -> int:
+    value = get_iterator()
+    a: int = 0
+
+    for x in value:
+        a = a + cast(int, x)
+
+    return a
+
+
+@public
+def _deploy(data: Any, update: bool):
+    prefix = b'example'
+    storage.put(prefix + b'\x01', 1)
+    storage.put(prefix + b'\x02', 2)
+    storage.put(prefix + b'\x03', 3)
+
+
+def get_iterator() -> Iterator:
+    prefix = b'example'
+    return storage.find(prefix, options=storage.FindOptions.VALUES_ONLY)


### PR DESCRIPTION
**Summary or solution description**
The default `for` loop is generated by internally saving the current iterating index and using it to access the next value, but that's not how the value in an `Iterator` is accessed, which causes runtime exceptions. Fixed to properly access `Iterator` `value` and `next`.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/bc9fd9ce3507f7d003fb0c28a5b72cb11988c233/boa3_test/test_sc/for_test/IteratorCondition.py#L8-L16

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/bc9fd9ce3507f7d003fb0c28a5b72cb11988c233/boa3_test/tests/compiler_tests/test_for.py#L96-L159

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.7+