### PR TITLE
Implement an interface for NEP-17 smart contracts

### DIFF
--- a/boa3/builtin/contract/Nep17Contract.py
+++ b/boa3/builtin/contract/Nep17Contract.py
@@ -1,0 +1,21 @@
+from typing import Any
+
+from boa3.builtin.interop.contract import Contract
+from boa3.builtin.type import UInt160
+
+
+class Nep17Contract(Contract):
+    def symbol(self) -> str:
+        pass
+
+    def decimals(self) -> int:
+        pass
+
+    def total_supply(self) -> int:
+        pass
+
+    def balance_of(self, account: UInt160) -> int:
+        pass
+
+    def transfer(self, from_address: UInt160, to_address: UInt160, amount: int, data: Any = None) -> bool:
+        pass

--- a/boa3/builtin/contract/__init__.py
+++ b/boa3/builtin/contract/__init__.py
@@ -1,6 +1,7 @@
 __all__ = [
     'Nep11TransferEvent',
     'Nep17TransferEvent',
+    'Nep17Contract',
     'NeoAccountState',
     'abort',
     'to_hex_str',
@@ -9,6 +10,7 @@ __all__ = [
 
 from typing import Any, Optional, Union
 
+from boa3.builtin.contract.Nep17Contract import Nep17Contract
 from boa3.builtin.compile_time import CreateNewEvent
 from boa3.builtin.type import ECPoint, UInt160, Event
 

--- a/boa3/internal/model/builtin/builtin.py
+++ b/boa3/internal/model/builtin/builtin.py
@@ -190,6 +190,9 @@ class Builtin:
     Nep11Transfer = Nep11TransferEvent()
     Nep17Transfer = Nep17TransferEvent()
 
+    # boa contract interfaces
+    Nep17Contract = Nep17ContractClass()
+
     # boa smart contract methods
     Abort = AbortMethod()
     Env = EnvProperty.build()
@@ -268,6 +271,7 @@ class Builtin:
                               NeoAccountState,
                               Nep11Transfer,
                               Nep17Transfer,
+                              Nep17Contract,
                               ScriptHashMethod_,
                               ToHexStr,
                               ],

--- a/boa3/internal/model/builtin/contract/__init__.py
+++ b/boa3/internal/model/builtin/contract/__init__.py
@@ -1,9 +1,11 @@
 __all__ = ['AbortMethod',
            'NeoAccountStateType',
            'Nep11TransferEvent',
-           'Nep17TransferEvent']
+           'Nep17TransferEvent',
+           'Nep17ContractClass']
 
 from boa3.internal.model.builtin.contract.abortmethod import AbortMethod
 from boa3.internal.model.builtin.contract.neoaccountstatetype import NeoAccountStateType
 from boa3.internal.model.builtin.contract.nep11transferevent import Nep11TransferEvent
+from boa3.internal.model.builtin.contract.nep17contract import Nep17ContractClass
 from boa3.internal.model.builtin.contract.nep17transferevent import Nep17TransferEvent

--- a/boa3/internal/model/builtin/contract/nep17_interface_methods/__init__.py
+++ b/boa3/internal/model/builtin/contract/nep17_interface_methods/__init__.py
@@ -1,0 +1,13 @@
+__all__ = [
+    'Nep17InterfaceBalanceOfMethod',
+    'Nep17InterfaceDecimalsMethod',
+    'Nep17InterfaceSymbolMethod',
+    'Nep17InterfaceTotalSupplyMethod',
+    'Nep17InterfaceTransferMethod',
+]
+
+from boa3.internal.model.builtin.contract.nep17_interface_methods.nep17interfacebalanceofmethod import Nep17InterfaceBalanceOfMethod
+from boa3.internal.model.builtin.contract.nep17_interface_methods.nep17interfacedecimalsmethod import Nep17InterfaceDecimalsMethod
+from boa3.internal.model.builtin.contract.nep17_interface_methods.nep17interfacesymbolmethod import Nep17InterfaceSymbolMethod
+from boa3.internal.model.builtin.contract.nep17_interface_methods.nep17interfacetotalsupplymethod import Nep17InterfaceTotalSupplyMethod
+from boa3.internal.model.builtin.contract.nep17_interface_methods.nep17interfacetransfermethod import Nep17InterfaceTransferMethod

--- a/boa3/internal/model/builtin/contract/nep17_interface_methods/nep17interfacebalanceofmethod.py
+++ b/boa3/internal/model/builtin/contract/nep17_interface_methods/nep17interfacebalanceofmethod.py
@@ -1,0 +1,18 @@
+from typing import Dict
+
+from boa3.internal.model.builtin.contract.nep17_interface_methods.nep17interfacemethod import Nep17InterfaceMethod
+from boa3.internal.model.builtin.interop.contract import ContractType
+from boa3.internal.model.variable import Variable
+
+
+class Nep17InterfaceBalanceOfMethod(Nep17InterfaceMethod):
+
+    def __init__(self, self_type: ContractType):
+        from boa3.internal.model.type.type import Type
+
+        from boa3.internal.model.type.collection.sequence.uint160type import UInt160Type
+        args: Dict[str, Variable] = {
+            'self': Variable(self_type),
+            'account': Variable(UInt160Type.build())
+        }
+        super().__init__(args, 'balance_of', 'balanceOf', return_type=Type.int)

--- a/boa3/internal/model/builtin/contract/nep17_interface_methods/nep17interfacebalanceofmethod.py
+++ b/boa3/internal/model/builtin/contract/nep17_interface_methods/nep17interfacebalanceofmethod.py
@@ -15,4 +15,4 @@ class Nep17InterfaceBalanceOfMethod(Nep17InterfaceMethod):
             'self': Variable(self_type),
             'account': Variable(UInt160Type.build())
         }
-        super().__init__(args, 'balance_of', 'balanceOf', return_type=Type.int)
+        super().__init__(args, 'balance_of', native_identifier='balanceOf', return_type=Type.int)

--- a/boa3/internal/model/builtin/contract/nep17_interface_methods/nep17interfacedecimalsmethod.py
+++ b/boa3/internal/model/builtin/contract/nep17_interface_methods/nep17interfacedecimalsmethod.py
@@ -1,0 +1,14 @@
+from typing import Dict
+
+from boa3.internal.model.builtin.contract.nep17_interface_methods.nep17interfacemethod import Nep17InterfaceMethod
+from boa3.internal.model.builtin.interop.contract import ContractType
+from boa3.internal.model.variable import Variable
+
+
+class Nep17InterfaceDecimalsMethod(Nep17InterfaceMethod):
+
+    def __init__(self, self_type: ContractType):
+        from boa3.internal.model.type.type import Type
+
+        args: Dict[str, Variable] = {'self': Variable(self_type)}
+        super().__init__(args, 'decimals', 'decimals', return_type=Type.int)

--- a/boa3/internal/model/builtin/contract/nep17_interface_methods/nep17interfacedecimalsmethod.py
+++ b/boa3/internal/model/builtin/contract/nep17_interface_methods/nep17interfacedecimalsmethod.py
@@ -11,4 +11,4 @@ class Nep17InterfaceDecimalsMethod(Nep17InterfaceMethod):
         from boa3.internal.model.type.type import Type
 
         args: Dict[str, Variable] = {'self': Variable(self_type)}
-        super().__init__(args, 'decimals', 'decimals', return_type=Type.int)
+        super().__init__(args, 'decimals', return_type=Type.int)

--- a/boa3/internal/model/builtin/contract/nep17_interface_methods/nep17interfacemethod.py
+++ b/boa3/internal/model/builtin/contract/nep17_interface_methods/nep17interfacemethod.py
@@ -1,8 +1,6 @@
 import ast
 from typing import Dict, Optional, List
 
-from boa3.internal.compiler.compiledmetadata import CompiledMetadata
-from boa3.internal.model.builtin.interop.contract import ContractType
 from boa3.internal.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.internal.model.type.itype import IType
 from boa3.internal.model.variable import Variable
@@ -11,9 +9,13 @@ from boa3.internal.model.variable import Variable
 class Nep17InterfaceMethod(IBuiltinMethod):
 
     def __init__(self, args: Dict[str, Variable], identifier: str,
-                 native_identifier: str, return_type: IType, defaults: List[ast.AST] = None):
+                 return_type: IType, defaults: List[ast.AST] = None,
+                 native_identifier: str = None):
         super().__init__(identifier, args, return_type=return_type, defaults=defaults)
-        self.native_identifier = native_identifier
+        if native_identifier is None:
+            self.native_identifier = identifier
+        else:
+            self.native_identifier = native_identifier
 
     @property
     def _args_on_stack(self) -> int:

--- a/boa3/internal/model/builtin/contract/nep17_interface_methods/nep17interfacemethod.py
+++ b/boa3/internal/model/builtin/contract/nep17_interface_methods/nep17interfacemethod.py
@@ -1,0 +1,45 @@
+import ast
+from typing import Dict, Optional, List
+
+from boa3.internal.compiler.compiledmetadata import CompiledMetadata
+from boa3.internal.model.builtin.interop.contract import ContractType
+from boa3.internal.model.builtin.method.builtinmethod import IBuiltinMethod
+from boa3.internal.model.type.itype import IType
+from boa3.internal.model.variable import Variable
+
+
+class Nep17InterfaceMethod(IBuiltinMethod):
+
+    def __init__(self, args: Dict[str, Variable], identifier: str,
+                 native_identifier: str, return_type: IType, defaults: List[ast.AST] = None):
+        super().__init__(identifier, args, return_type=return_type, defaults=defaults)
+        self.native_identifier = native_identifier
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> Optional[str]:
+        return None
+
+    def generate_internal_opcodes(self, code_generator):
+        from boa3.internal.model.builtin.interop.interop import Interop
+        from boa3.internal.model.type.type import Type
+        from boa3.builtin.interop.contract import CallFlags
+
+        if len(self.args) != 1:
+            code_generator.swap_reverse_stack_items(len(self.args))
+            code_generator.swap_reverse_stack_items(len(self.args) - 1)
+
+        code_generator.convert_new_array(len(self.args) - 1)
+        code_generator.convert_literal(CallFlags.ALL)
+        code_generator.convert_literal(self.native_identifier)
+        code_generator.duplicate_stack_item(4)
+        code_generator.convert_literal(2)   # Nep17Contract script hash
+        code_generator.convert_get_item(index_inserted_internally=True, index_is_positive=True, test_is_negative_index=False)
+        code_generator.convert_builtin_method_call(Interop.CallContract, is_internal=True)
+        code_generator.remove_stack_item(2)
+
+        if self.return_type is Type.none:
+            code_generator.remove_stack_top_item()

--- a/boa3/internal/model/builtin/contract/nep17_interface_methods/nep17interfacesymbolmethod.py
+++ b/boa3/internal/model/builtin/contract/nep17_interface_methods/nep17interfacesymbolmethod.py
@@ -11,4 +11,4 @@ class Nep17InterfaceSymbolMethod(Nep17InterfaceMethod):
         from boa3.internal.model.type.type import Type
 
         args: Dict[str, Variable] = {'self': Variable(self_type)}
-        super().__init__(args, 'symbol', 'symbol', return_type=Type.str)
+        super().__init__(args, 'symbol', return_type=Type.str)

--- a/boa3/internal/model/builtin/contract/nep17_interface_methods/nep17interfacesymbolmethod.py
+++ b/boa3/internal/model/builtin/contract/nep17_interface_methods/nep17interfacesymbolmethod.py
@@ -1,0 +1,14 @@
+from typing import Dict
+
+from boa3.internal.model.builtin.contract.nep17_interface_methods.nep17interfacemethod import Nep17InterfaceMethod
+from boa3.internal.model.builtin.interop.contract import ContractType
+from boa3.internal.model.variable import Variable
+
+
+class Nep17InterfaceSymbolMethod(Nep17InterfaceMethod):
+
+    def __init__(self, self_type: ContractType):
+        from boa3.internal.model.type.type import Type
+
+        args: Dict[str, Variable] = {'self': Variable(self_type)}
+        super().__init__(args, 'symbol', 'symbol', return_type=Type.str)

--- a/boa3/internal/model/builtin/contract/nep17_interface_methods/nep17interfacetotalsupplymethod.py
+++ b/boa3/internal/model/builtin/contract/nep17_interface_methods/nep17interfacetotalsupplymethod.py
@@ -11,4 +11,4 @@ class Nep17InterfaceTotalSupplyMethod(Nep17InterfaceMethod):
         from boa3.internal.model.type.type import Type
 
         args: Dict[str, Variable] = {'self': Variable(self_type)}
-        super().__init__(args, 'total_supply', 'totalSupply', return_type=Type.int)
+        super().__init__(args, 'total_supply', native_identifier='totalSupply', return_type=Type.int)

--- a/boa3/internal/model/builtin/contract/nep17_interface_methods/nep17interfacetotalsupplymethod.py
+++ b/boa3/internal/model/builtin/contract/nep17_interface_methods/nep17interfacetotalsupplymethod.py
@@ -1,0 +1,14 @@
+from typing import Dict
+
+from boa3.internal.model.builtin.contract.nep17_interface_methods.nep17interfacemethod import Nep17InterfaceMethod
+from boa3.internal.model.builtin.interop.contract import ContractType
+from boa3.internal.model.variable import Variable
+
+
+class Nep17InterfaceTotalSupplyMethod(Nep17InterfaceMethod):
+
+    def __init__(self, self_type: ContractType):
+        from boa3.internal.model.type.type import Type
+
+        args: Dict[str, Variable] = {'self': Variable(self_type)}
+        super().__init__(args, 'total_supply', 'totalSupply', return_type=Type.int)

--- a/boa3/internal/model/builtin/contract/nep17_interface_methods/nep17interfacetransfermethod.py
+++ b/boa3/internal/model/builtin/contract/nep17_interface_methods/nep17interfacetransfermethod.py
@@ -23,4 +23,4 @@ class Nep17InterfaceTransferMethod(Nep17InterfaceMethod):
         data_default = ast.parse("{0}".format(Type.any.default_value)
                                  ).body[0].value
 
-        super().__init__(args, 'transfer', 'transfer', return_type=Type.bool, defaults=[data_default])
+        super().__init__(args, 'transfer', return_type=Type.bool, defaults=[data_default])

--- a/boa3/internal/model/builtin/contract/nep17_interface_methods/nep17interfacetransfermethod.py
+++ b/boa3/internal/model/builtin/contract/nep17_interface_methods/nep17interfacetransfermethod.py
@@ -1,0 +1,26 @@
+import ast
+from typing import Dict
+
+from boa3.internal.model.builtin.contract.nep17_interface_methods.nep17interfacemethod import Nep17InterfaceMethod
+from boa3.internal.model.builtin.interop.contract import ContractType
+from boa3.internal.model.variable import Variable
+
+
+class Nep17InterfaceTransferMethod(Nep17InterfaceMethod):
+
+    def __init__(self, self_type: ContractType):
+        from boa3.internal.model.type.type import Type
+        from boa3.internal.model.type.collection.sequence.uint160type import UInt160Type
+
+        args: Dict[str, Variable] = {
+            'self': Variable(self_type),
+            'from_address': Variable(UInt160Type.build()),
+            'to_address': Variable(UInt160Type.build()),
+            'amount': Variable(Type.int),
+            'data': Variable(Type.any),
+        }
+
+        data_default = ast.parse("{0}".format(Type.any.default_value)
+                                 ).body[0].value
+
+        super().__init__(args, 'transfer', 'transfer', return_type=Type.bool, defaults=[data_default])

--- a/boa3/internal/model/builtin/contract/nep17contract.py
+++ b/boa3/internal/model/builtin/contract/nep17contract.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, List
 
 from boa3.internal.model.builtin.interop.contract import ContractType
 
@@ -19,13 +19,20 @@ class Nep17ContractClass(ContractType):
             Nep17InterfaceTransferMethod,
         )
 
-        self._instance_methods: Dict[str, Method] = {
-            'balance_of': Nep17InterfaceBalanceOfMethod(self),
-            'decimals': Nep17InterfaceDecimalsMethod(self),
-            'symbol': Nep17InterfaceSymbolMethod(self),
-            'total_supply': Nep17InterfaceTotalSupplyMethod(self),
-            'transfer': Nep17InterfaceTransferMethod(self),
-        }
+        nep17_methods: List = [
+            Nep17InterfaceBalanceOfMethod,
+            Nep17InterfaceDecimalsMethod,
+            Nep17InterfaceSymbolMethod,
+            Nep17InterfaceTotalSupplyMethod,
+            Nep17InterfaceTransferMethod,
+        ]
+
+        instance_methods: Dict[str, Method] = {}
+        for nep17_method in nep17_methods:
+            nep17_method_obj = nep17_method(self)
+            instance_methods[nep17_method_obj.identifier] = nep17_method_obj
+
+        self._instance_methods: Dict[str, Method] = instance_methods
 
     @property
     def instance_methods(self) -> Dict[str, Method]:

--- a/boa3/internal/model/builtin/contract/nep17contract.py
+++ b/boa3/internal/model/builtin/contract/nep17contract.py
@@ -1,0 +1,32 @@
+from typing import Dict
+
+from boa3.internal.model.builtin.interop.contract import ContractType
+
+from boa3.internal.model.method import Method
+
+
+class Nep17ContractClass(ContractType):
+    def __init__(self):
+        super().__init__()
+        
+        self._identifier = 'Nep17Contract'
+        
+        from boa3.internal.model.builtin.contract.nep17_interface_methods import (
+            Nep17InterfaceBalanceOfMethod,
+            Nep17InterfaceDecimalsMethod,
+            Nep17InterfaceSymbolMethod,
+            Nep17InterfaceTotalSupplyMethod,
+            Nep17InterfaceTransferMethod,
+        )
+
+        self._instance_methods: Dict[str, Method] = {
+            'balance_of': Nep17InterfaceBalanceOfMethod(self),
+            'decimals': Nep17InterfaceDecimalsMethod(self),
+            'symbol': Nep17InterfaceSymbolMethod(self),
+            'total_supply': Nep17InterfaceTotalSupplyMethod(self),
+            'transfer': Nep17InterfaceTransferMethod(self),
+        }
+
+    @property
+    def instance_methods(self) -> Dict[str, Method]:
+        return self._instance_methods.copy()

--- a/boa3_test/test_sc/nep17_contract_interface_test/Nep17BalanceOf.py
+++ b/boa3_test/test_sc/nep17_contract_interface_test/Nep17BalanceOf.py
@@ -1,0 +1,12 @@
+from boa3.builtin.compile_time import public
+from boa3.builtin.contract import Nep17Contract
+from boa3.builtin.interop.blockchain import get_contract
+from boa3.builtin.interop.contract import NEO
+from boa3.builtin.type import UInt160
+
+
+@public
+def main(account: UInt160) -> int:
+    nep_17_contract: Nep17Contract = get_contract(NEO)
+    contract_balance_of = nep_17_contract.balance_of(account)
+    return contract_balance_of

--- a/boa3_test/test_sc/nep17_contract_interface_test/Nep17Decimals.py
+++ b/boa3_test/test_sc/nep17_contract_interface_test/Nep17Decimals.py
@@ -1,0 +1,11 @@
+from boa3.builtin.compile_time import public
+from boa3.builtin.contract import Nep17Contract
+from boa3.builtin.interop.blockchain import get_contract
+from boa3.builtin.interop.contract import NEO
+
+
+@public
+def main() -> int:
+    nep_17_contract: Nep17Contract = get_contract(NEO)
+    contract_decimals = nep_17_contract.decimals()
+    return contract_decimals

--- a/boa3_test/test_sc/nep17_contract_interface_test/Nep17Symbol.py
+++ b/boa3_test/test_sc/nep17_contract_interface_test/Nep17Symbol.py
@@ -1,0 +1,11 @@
+from boa3.builtin.compile_time import public
+from boa3.builtin.contract import Nep17Contract
+from boa3.builtin.interop.blockchain import get_contract
+from boa3.builtin.interop.contract import NEO
+
+
+@public
+def main() -> str:
+    nep_17_contract: Nep17Contract = get_contract(NEO)
+    contract_symbol = nep_17_contract.symbol()
+    return contract_symbol

--- a/boa3_test/test_sc/nep17_contract_interface_test/Nep17TotalSupply.py
+++ b/boa3_test/test_sc/nep17_contract_interface_test/Nep17TotalSupply.py
@@ -1,0 +1,11 @@
+from boa3.builtin.compile_time import public
+from boa3.builtin.contract import Nep17Contract
+from boa3.builtin.interop.blockchain import get_contract
+from boa3.builtin.interop.contract import NEO
+
+
+@public
+def main() -> int:
+    nep_17_contract: Nep17Contract = get_contract(NEO)
+    contract_total_supply = nep_17_contract.total_supply()
+    return contract_total_supply

--- a/boa3_test/test_sc/nep17_contract_interface_test/Nep17Transfer.py
+++ b/boa3_test/test_sc/nep17_contract_interface_test/Nep17Transfer.py
@@ -1,0 +1,12 @@
+from boa3.builtin.compile_time import public
+from boa3.builtin.contract import Nep17Contract
+from boa3.builtin.interop.blockchain import get_contract
+from boa3.builtin.interop.contract import NEO
+from boa3.builtin.type import UInt160
+
+
+@public
+def main(from_address: UInt160, to_address: UInt160, amount: int) -> bool:
+    nep_17_contract: Nep17Contract = get_contract(NEO)
+    contract_transfer = nep_17_contract.transfer(from_address, to_address, amount)
+    return contract_transfer

--- a/boa3_test/tests/compiler_tests/test_nep17_contract_interface.py
+++ b/boa3_test/tests/compiler_tests/test_nep17_contract_interface.py
@@ -1,0 +1,62 @@
+from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to avoid circular imports
+
+from boa3.internal.neo3.vm import VMState
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
+
+
+class TestContractInterface(BoaTest):
+    default_folder: str = 'test_sc/nep17_contract_interface_test'
+
+    def test_balance_of(self):
+        path, _ = self.get_deploy_file_paths('Nep17BalanceOf.py')
+        runner = BoaTestRunner(runner_id=self.method_name())
+
+        from boa3_test.tests.test_drive import neoxp
+        genesis = neoxp.utils.get_account_by_name('genesis')
+
+        invoke_balance_of = runner.call_contract(path, 'main', genesis.script_hash.to_array())
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        self.assertEqual(10 ** 8, invoke_balance_of.result)
+
+    def test_decimals(self):
+        path, _ = self.get_deploy_file_paths('Nep17Decimals.py')
+        runner = BoaTestRunner(runner_id=self.method_name())
+
+        invoke_decimals = runner.call_contract(path, 'main')
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        self.assertEqual(0, invoke_decimals.result)
+
+    def test_symbol(self):
+        path, _ = self.get_deploy_file_paths('Nep17Symbol.py')
+        runner = BoaTestRunner(runner_id=self.method_name())
+
+        invoke_symbol = runner.call_contract(path, 'main')
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        self.assertEqual('NEO', invoke_symbol.result)
+
+    def test_total_supply(self):
+        path, _ = self.get_deploy_file_paths('Nep17TotalSupply.py')
+        runner = BoaTestRunner(runner_id=self.method_name())
+
+        invoke_total_supply = runner.call_contract(path, 'main')
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        self.assertEqual(10 ** 8, invoke_total_supply.result)
+
+    def test_transfer(self):
+        path, _ = self.get_deploy_file_paths('Nep17Transfer.py')
+        runner = BoaTestRunner(runner_id=self.method_name())
+
+        from boa3_test.tests.test_drive import neoxp
+        genesis = neoxp.utils.get_account_by_name('genesis')
+
+        # TODO: Methods and contract hash are not being added to the contract permissions yet
+        with self.assertRaises(AssertionError):
+            invoke_test_transfer = runner.call_contract(path, 'main',
+                                                        genesis.script_hash.to_array(), genesis.script_hash.to_array(), -1)
+            runner.execute()
+            self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+            self.assertEqual(False, invoke_test_transfer.result)


### PR DESCRIPTION
**Summary or solution description**
Added a class that has the NEP-17 methods that can be called be the user.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/b23d1c18862b7664bb6bdaedd5dd58585fe9c7b7/boa3_test/test_sc/nep17_contract_interface_test/Nep17BalanceOf.py#L1-L12

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/b23d1c18862b7664bb6bdaedd5dd58585fe9c7b7/boa3_test/tests/compiler_tests/test_nep17_contract_interface.py#L10-L21

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.10

**(Optional) Additional context**
The contract hash and methods name were not added to the permission field on the manifest.json in this issue.
