### PR TITLE
boa3_test folder not included in distribution for python 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ install_cpm = 'boa3.cpm:main'
 exclude = ['boa3_test.tests.*_tests*']
 include = [
     'boa3', 'boa3.*',
+    'boa3_test',
     'boa3_test.tests', 'boa3_test.tests.*',
     'boa3_test.test_drive', 'boa3_test.test_drive.*'
 ]


### PR DESCRIPTION
**Summary or solution description**
`find_packages` did not detect `boa3_test` as a package including only its sub-packages `boa3_test.tests` and `boa3_test.test_drive`. Included it explicitly in the setup packages

**Additional context**
This PR will have conflicts when compared with #1141. It's better to wait for it to be merged before merging this one.
