### PR TITLE
CU-2ewf14b - Add support to String Interpolation (f-string)

### DIFF
--- a/boa3/internal/analyser/moduleanalyser.py
+++ b/boa3/internal/analyser/moduleanalyser.py
@@ -1466,6 +1466,17 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
         """
         return str.s
 
+    def visit_JoinedStr(self, joined_str: ast.JoinedStr):
+        """
+        Visitor of joined string node
+
+        :param joined_str:
+        :return: the value of the string
+
+        """
+        for node in joined_str.values:
+            self.visit(node)
+
     def visit_Bytes(self, btes: ast.Bytes) -> bytes:
         """
         Visitor of literal string node

--- a/boa3/internal/compiler/codegenerator/codegeneratorvisitor.py
+++ b/boa3/internal/compiler/codegenerator/codegeneratorvisitor.py
@@ -1183,6 +1183,48 @@ class VisitorCodeGenerator(IAstAnalyser):
 
         return self.build_data(dict_node, result_type=result_type, already_generated=True)
 
+    def visit_JoinedStr(self, fstring: ast.JoinedStr) -> GeneratorData:
+        """
+        Visitor of an f-string node
+
+        :param string: the python ast string node
+        """
+        result_type = Type.str
+        index = self.generator.bytecode_size
+        for index, value in enumerate(fstring.values):
+            self.visit_to_generate(value)
+            if index != 0:
+                self.generator.convert_operation(BinaryOp.Concat)
+                if index < len(fstring.values) - 1:
+                    self._remove_inserted_opcodes_since(self.generator.last_code_start_address)
+
+        return self.build_data(fstring, result_type=result_type, index=index, already_generated=True)
+
+    def visit_FormattedValue(self, formatted_value: ast.FormattedValue) -> GeneratorData:
+        """
+        Visitor of a formatted_value node
+
+        :param formatted_value: the python ast string node
+        """
+        generated_value = self.visit_to_generate(formatted_value.value)
+        if generated_value.type == Type.str:
+            return generated_value
+
+        else:
+            match generated_value.type:
+                case Type.bool:
+                    self.generator.convert_builtin_method_call(Builtin.StrBool)
+                case Type.int:
+                    self.generator.convert_builtin_method_call(Builtin.StrInt)
+                case Type.bytes:
+                    self.generator.convert_builtin_method_call(Builtin.StrBytes)
+                case x if Type.sequence.is_type_of(x):
+                    self.generator.convert_builtin_method_call(Builtin.StrSequence)
+                case x if isinstance(x, UserClass):
+                    self.generator.convert_builtin_method_call(Builtin.StrClass.build(x))
+
+            return self.build_data(formatted_value, result_type=Type.str, already_generated=True)
+
     def visit_Pass(self, pass_node: ast.Pass) -> GeneratorData:
         """
         Visitor of pass node

--- a/boa3/internal/model/builtin/builtin.py
+++ b/boa3/internal/model/builtin/builtin.py
@@ -75,7 +75,9 @@ class Builtin:
     Reversed = ReversedMethod()
     StrBool = StrBoolMethod()
     StrBytes = StrBytesMethod()
+    StrClass = StrClassMethod()
     StrInt = StrIntMethod()
+    StrSequence = StrSequenceMethod()
     Super = SuperMethod()
 
     # python class method

--- a/boa3/internal/model/builtin/method/__init__.py
+++ b/boa3/internal/model/builtin/method/__init__.py
@@ -25,7 +25,9 @@ __all__ = ['AbsMethod',
            'ScriptHashMethod',
            'StrBoolMethod',
            'StrBytesMethod',
+           'StrClassMethod',
            'StrIntMethod',
+           'StrSequenceMethod',
            'StrSplitMethod',
            'SumMethod',
            'SuperMethod',
@@ -62,6 +64,8 @@ from boa3.internal.model.builtin.method.reversedmethod import ReversedMethod
 from boa3.internal.model.builtin.method.strboolmethod import StrBoolMethod
 from boa3.internal.model.builtin.method.strbytestringmethod import StrBytesMethod
 from boa3.internal.model.builtin.method.strintmethod import StrIntMethod
+from boa3.internal.model.builtin.method.strclassmethod import StrClassMethod
+from boa3.internal.model.builtin.method.strsequencemethod import StrSequenceMethod
 from boa3.internal.model.builtin.method.strsplitmethod import StrSplitMethod
 from boa3.internal.model.builtin.method.summethod import SumMethod
 from boa3.internal.model.builtin.method.supermethod import SuperMethod

--- a/boa3/internal/model/builtin/method/printclassmethod.py
+++ b/boa3/internal/model/builtin/method/printclassmethod.py
@@ -1,7 +1,6 @@
 from boa3.internal.model.builtin.method.printmethod import PrintMethod
 from boa3.internal.model.type.classes.userclass import UserClass
 from boa3.internal.model.type.itype import IType
-from boa3.internal.neo.vm.opcode.Opcode import Opcode
 
 
 class PrintClassMethod(PrintMethod):
@@ -15,21 +14,5 @@ class PrintClassMethod(PrintMethod):
         self._arg_type = arg_value
 
     def _generate_print_opcodes(self, code_generator):
-        from boa3.internal.model.builtin.interop.interop import Interop
-        from boa3.internal.model.type.type import Type
-
-        # class to dict, then print as json
-        code_generator.insert_opcode(Opcode.UNPACK, add_to_stack=[Type.any, Type.int])
-        code_generator.remove_stack_top_item()
-        code_generator.convert_new_map(Type.dict)
-
-        # add each value to the dict
-        for variable_name in self._arg_type.instance_variables:
-            code_generator.insert_opcode(Opcode.TUCK, add_to_stack=[Type.any])
-            code_generator.convert_literal(variable_name)
-            item_address = code_generator.bytecode_size
-            code_generator.swap_reverse_stack_items(3, rotate=True)
-            code_generator.convert_set_item(item_address, index_inserted_internally=True)
-
-        # print as json
-        code_generator.convert_builtin_method_call(Interop.JsonSerialize, is_internal=True)
+        from boa3.internal.model.builtin.builtin import Builtin
+        code_generator.convert_builtin_method_call(Builtin.StrClass.build(self._arg_type), is_internal=True)

--- a/boa3/internal/model/builtin/method/printsequencemethod.py
+++ b/boa3/internal/model/builtin/method/printsequencemethod.py
@@ -13,6 +13,5 @@ class PrintSequenceMethod(PrintMethod):
         super().__init__(arg_value)
 
     def _generate_print_opcodes(self, code_generator):
-        from boa3.internal.model.builtin.interop.interop import Interop
-
-        code_generator.convert_builtin_method_call(Interop.JsonSerialize, is_internal=True)
+        from boa3.internal.model.builtin.builtin import Builtin
+        code_generator.convert_builtin_method_call(Builtin.StrSequence, is_internal=True)

--- a/boa3/internal/model/builtin/method/strclassmethod.py
+++ b/boa3/internal/model/builtin/method/strclassmethod.py
@@ -1,0 +1,57 @@
+from typing import Dict, Any, Optional
+
+from boa3.internal.model.builtin.method import IBuiltinMethod
+from boa3.internal.model.builtin.method.strmethod import StrMethod
+from boa3.internal.model.type.classes.userclass import UserClass
+from boa3.internal.model.type.itype import IType
+from boa3.internal.model.type.type import Type
+from boa3.internal.model.variable import Variable
+from boa3.internal.neo.vm.opcode.Opcode import Opcode
+
+
+class StrClassMethod(StrMethod):
+
+    def __init__(self, arg_value: Optional[IType] = None):
+        from boa3.internal.model.type.classes import userclass
+
+        if arg_value is None:
+            arg_value = userclass._EMPTY_CLASS
+
+        args: Dict[str, Variable] = {
+            'object': Variable(arg_value),
+        }
+
+        super().__init__(args)
+
+    @property
+    def arg_type(self) -> UserClass:
+        return self._arg_value.type
+
+    def build(self, value: Any) -> IBuiltinMethod:
+        if isinstance(value, UserClass):
+            if 'object' in self.args and value.is_type_of(self.args['object'].type):
+                return self
+
+            return StrClassMethod(value)
+
+        return super().build(value)
+
+    def generate_internal_opcodes(self, code_generator):
+        from boa3.internal.model.builtin.interop.interop import Interop
+        from boa3.internal.model.type.type import Type
+
+        # class to dict, then print as json
+        code_generator.insert_opcode(Opcode.UNPACK, add_to_stack=[Type.any, Type.int])
+        code_generator.remove_stack_top_item()
+        code_generator.convert_new_map(Type.dict)
+
+        # add each value to the dict
+        for variable_name in self.arg_type.instance_variables:
+            code_generator.insert_opcode(Opcode.TUCK, add_to_stack=[Type.any])
+            code_generator.convert_literal(variable_name)
+            item_address = code_generator.bytecode_size
+            code_generator.swap_reverse_stack_items(3, rotate=True)
+            code_generator.convert_set_item(item_address, index_inserted_internally=True)
+
+        # print as json
+        code_generator.convert_builtin_method_call(Interop.JsonSerialize, is_internal=True)

--- a/boa3/internal/model/builtin/method/strmethod.py
+++ b/boa3/internal/model/builtin/method/strmethod.py
@@ -26,6 +26,13 @@ class StrMethod(IBuiltinMethod):
         if self._arg_value.type is Type.int:
             return '-{0}_{1}'.format(self._identifier, Type.int.identifier)
 
+        if Type.sequence.is_type_of(self._arg_value.type):
+            return '-{0}_{1}'.format(self._identifier, Type.sequence.identifier)
+
+        from boa3.internal.model.type.classes.userclass import UserClass
+        if isinstance(self._arg_value.type, UserClass):
+            return '-{0}_{1}'.format(self._identifier, self._arg_value.type.raw_identifier)
+
         return self._identifier
 
     @property

--- a/boa3/internal/model/builtin/method/strsequencemethod.py
+++ b/boa3/internal/model/builtin/method/strsequencemethod.py
@@ -1,0 +1,34 @@
+from typing import Dict, Any, Optional
+
+from boa3.internal.model.builtin.method import IBuiltinMethod
+from boa3.internal.model.builtin.method.strmethod import StrMethod
+from boa3.internal.model.type.itype import IType
+from boa3.internal.model.type.type import Type
+from boa3.internal.model.variable import Variable
+
+
+class StrSequenceMethod(StrMethod):
+
+    def __init__(self, arg_value: Optional[IType] = None):
+        if arg_value is None:
+            arg_value = Type.sequence
+
+        args: Dict[str, Variable] = {
+            'object': Variable(arg_value),
+        }
+
+        super().__init__(args)
+
+    def build(self, value: Any) -> IBuiltinMethod:
+        if 'object' in self.args and self.args['object'].type is not Type.any:
+            return self
+
+        if Type.sequence.is_type_of(value):
+            return StrSequenceMethod(value)
+
+        return super().build(value)
+
+    def generate_internal_opcodes(self, code_generator):
+        from boa3.internal.model.builtin.interop.interop import Interop
+
+        code_generator.convert_builtin_method_call(Interop.JsonSerialize, is_internal=True)

--- a/boa3_test/test_sc/string_test/FStringAnyVar.py
+++ b/boa3_test/test_sc/string_test/FStringAnyVar.py
@@ -1,0 +1,9 @@
+from typing import Any
+
+from boa3.builtin.compile_time import public
+
+
+@public
+def main(a: Any) -> str:
+    fstring = f"F-string: {a}"
+    return fstring

--- a/boa3_test/test_sc/string_test/FStringBoolVar.py
+++ b/boa3_test/test_sc/string_test/FStringBoolVar.py
@@ -1,0 +1,7 @@
+from boa3.builtin.compile_time import public
+
+
+@public
+def main(a: bool) -> str:
+    fstring = f"F-string: {a}"
+    return fstring

--- a/boa3_test/test_sc/string_test/FStringBytesVar.py
+++ b/boa3_test/test_sc/string_test/FStringBytesVar.py
@@ -1,0 +1,7 @@
+from boa3.builtin.compile_time import public
+
+
+@public
+def main(a: bytes) -> str:
+    fstring = f"F-string: {a}"
+    return fstring

--- a/boa3_test/test_sc/string_test/FStringIntVar.py
+++ b/boa3_test/test_sc/string_test/FStringIntVar.py
@@ -1,0 +1,7 @@
+from boa3.builtin.compile_time import public
+
+
+@public
+def main(a: int) -> str:
+    fstring = f"F-string: {a}"
+    return fstring

--- a/boa3_test/test_sc/string_test/FStringLiteral.py
+++ b/boa3_test/test_sc/string_test/FStringLiteral.py
@@ -1,0 +1,6 @@
+from boa3.builtin.compile_time import public
+
+
+@public
+def main() -> str:
+    return f'unit {"test"}'

--- a/boa3_test/test_sc/string_test/FStringSequenceVar.py
+++ b/boa3_test/test_sc/string_test/FStringSequenceVar.py
@@ -1,0 +1,9 @@
+from typing import List
+
+from boa3.builtin.compile_time import public
+
+
+@public
+def main(a: List) -> str:
+    fstring = f"F-string: {a}"
+    return fstring

--- a/boa3_test/test_sc/string_test/FStringStringVar.py
+++ b/boa3_test/test_sc/string_test/FStringStringVar.py
@@ -1,0 +1,7 @@
+from boa3.builtin.compile_time import public
+
+
+@public
+def main(a: str) -> str:
+    fstring = f"F-string: {a}"
+    return fstring

--- a/boa3_test/test_sc/string_test/FStringUnionVar.py
+++ b/boa3_test/test_sc/string_test/FStringUnionVar.py
@@ -1,0 +1,9 @@
+from typing import Union
+
+from boa3.builtin.compile_time import public
+
+
+@public
+def main(a: Union[int, str]) -> str:
+    fstring = f"F-string: {a}"
+    return fstring

--- a/boa3_test/test_sc/string_test/FStringUserClassVar.py
+++ b/boa3_test/test_sc/string_test/FStringUserClassVar.py
@@ -1,0 +1,16 @@
+from typing import List
+
+from boa3.builtin.compile_time import public
+
+
+@public
+def main() -> str:
+    example_value = Example()
+    fstring = f"F-string: {example_value}"
+    return fstring
+
+
+class Example:
+    def __init__(self):
+        self.string = 'unit test'
+        self.number = 123

--- a/boa3_test/test_sc/string_test/FormattedStringLiteral.py
+++ b/boa3_test/test_sc/string_test/FormattedStringLiteral.py
@@ -1,3 +1,0 @@
-def main() -> str:
-    # f-strings are not supported
-    return f'unit {"test"}'

--- a/boa3_test/tests/compiler_tests/test_string.py
+++ b/boa3_test/tests/compiler_tests/test_string.py
@@ -1477,8 +1477,135 @@ class TestString(BoaTest):
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result, msg=x)
 
-    def test_formatted_string_literal(self):
-        path = self.get_contract_path('FormattedStringLiteral.py')
+    def test_f_string_literal(self):
+        path, _ = self.get_deploy_file_paths('FStringLiteral.py')
+        runner = BoaTestRunner(runner_id=self.method_name())
+
+        invoke = runner.call_contract(path, 'main')
+        expected_result = "unit test"
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        self.assertEqual(expected_result, invoke.result)
+
+    def test_f_string_string_var(self):
+        path, _ = self.get_deploy_file_paths('FStringStringVar.py')
+        runner = BoaTestRunner(runner_id=self.method_name())
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', "unit test"))
+        expected_results.append("F-string: unit test")
+
+        invokes.append(runner.call_contract(path, 'main', ""))
+        expected_results.append("F-string: ")
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result, msg=x)
+
+    def test_f_string_int_var(self):
+        path, _ = self.get_deploy_file_paths('FStringIntVar.py')
+        runner = BoaTestRunner(runner_id=self.method_name())
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', 123))
+        expected_results.append("F-string: 123")
+
+        invokes.append(runner.call_contract(path, 'main', -100))
+        expected_results.append("F-string: -100")
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result, msg=x)
+
+    def test_f_string_bool_var(self):
+        path, _ = self.get_deploy_file_paths('FStringBoolVar.py')
+        runner = BoaTestRunner(runner_id=self.method_name())
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', True))
+        expected_results.append("F-string: True")
+
+        invokes.append(runner.call_contract(path, 'main', False))
+        expected_results.append("F-string: False")
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result, msg=x)
+
+    def test_f_string_bytes_var(self):
+        path, _ = self.get_deploy_file_paths('FStringBytesVar.py')
+        runner = BoaTestRunner(runner_id=self.method_name())
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', b"unit test"))
+        expected_results.append("F-string: unit test")
+
+        invokes.append(runner.call_contract(path, 'main', ""))
+        expected_results.append("F-string: ")
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result, msg=x)
+
+    def test_f_string_sequence_var(self):
+        path, _ = self.get_deploy_file_paths('FStringSequenceVar.py')
+        runner = BoaTestRunner(runner_id=self.method_name())
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', [1, 2, 3]))
+        expected_results.append("F-string: [1,2,3]")
+
+        invokes.append(runner.call_contract(path, 'main', []))
+        expected_results.append("F-string: []")
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result, msg=x)
+
+    def test_f_string_user_class_var(self):
+        path, _ = self.get_deploy_file_paths('FStringUserClassVar.py')
+        runner = BoaTestRunner(runner_id=self.method_name())
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main'))
+        expected_results.append('F-string: {"string":"unit test","number":123}')
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result, msg=x)
+
+    def test_f_string_any_var(self):
+        path = self.get_contract_path('FStringAnyVar.py')
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+
+    def test_f_string_union_var(self):
+        path = self.get_contract_path('FStringUnionVar.py')
         self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
 
     def test_string_replace(self):


### PR DESCRIPTION
**Summary or solution description**
Added support to f-string using str, int, bool, bytes, list, and class type variables.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/967debd0f2d1101a49c3d32d60a42534f2614bd7/boa3_test/test_sc/string_test/FStringStringVar.py#L1-L7

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/967debd0f2d1101a49c3d32d60a42534f2614bd7/boa3_test/tests/compiler_tests/test_string.py#L1492-L1510

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.11

**(Optional) Additional context**
Other type verifications will be implemented on another issue

