### PR TITLE
Add support to match-case (switch) with bool, int and str

### DIFF
--- a/boa3/internal/analyser/astoptimizer.py
+++ b/boa3/internal/analyser/astoptimizer.py
@@ -302,6 +302,25 @@ class AstOptimizer(IAstAnalyser, ast.NodeTransformer):
         except BaseException:
             return None
 
+    def visit_Match(self, match_node: ast.Match) -> ast.AST:
+        self.visit(match_node.subject)
+
+        case_scopes = []
+
+        match_scope = self.current_scope
+
+        for case in match_node.cases:
+            case_scopes.append(match_scope.new_scope())
+
+            self.current_scope = case_scopes[-1]
+            for stmt in case.body:
+                self.visit(stmt)
+
+        self.current_scope = match_scope
+        self.current_scope.update_values(*case_scopes)
+
+        return match_node
+
     def visit_If(self, node: ast.If) -> ast.AST:
         self.visit(node.test)
 

--- a/boa3/internal/analyser/moduleanalyser.py
+++ b/boa3/internal/analyser/moduleanalyser.py
@@ -1391,6 +1391,19 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
         # continue to walk through the tree
         self.generic_visit(for_node)
 
+    def visit_Match(self, match_node: ast.Match):
+        for case in match_node.cases:
+            if not (isinstance(case.pattern, (ast.MatchValue, ast.MatchSingleton)) or
+                    isinstance(case.pattern, ast.MatchAs) and case.pattern.pattern is None and case.guard is None
+            ):
+                self._log_error(
+                    CompilerError.NotSupportedOperation(
+                        case.pattern.lineno, case.pattern.col_offset,
+                        symbol_id='case pattern with guard'
+                    )
+                )
+        return super().generic_visit(match_node)
+
     def visit_ListComp(self, node: ast.ListComp):
         return self._visit_comprehension(node)
 

--- a/boa3_test/test_sc/match_case_test/AnyTypeMatchCase.py
+++ b/boa3_test/test_sc/match_case_test/AnyTypeMatchCase.py
@@ -1,0 +1,17 @@
+from typing import Any
+
+from boa3.builtin.compile_time import public
+
+
+@public
+def main(x: Any) -> str:
+    match x:
+        case True:
+            return "True"
+        case 1:
+            return "one"
+        case "2":
+            return "2 string"
+        case _:
+            # this is the default case, when all others are False
+            return "other"

--- a/boa3_test/test_sc/match_case_test/BoolTypeMatchCase.py
+++ b/boa3_test/test_sc/match_case_test/BoolTypeMatchCase.py
@@ -1,0 +1,12 @@
+from boa3.builtin.compile_time import public
+
+
+@public
+def main(x: bool) -> str:
+    match x:
+        case True:
+            return "True"
+        case False:
+            return "False"
+
+    return "bool not provided"

--- a/boa3_test/test_sc/match_case_test/IntTypeMatchCase.py
+++ b/boa3_test/test_sc/match_case_test/IntTypeMatchCase.py
@@ -1,0 +1,15 @@
+from boa3.builtin.compile_time import public
+
+
+@public
+def main(x: int) -> str:
+    match x:
+        case 10:
+            return "ten"
+        case -10:
+            return "minus ten"
+        case 0:
+            return "zero"
+        case _:
+            # this is the default case, when all others are False
+            return "other"

--- a/boa3_test/test_sc/match_case_test/OuterVariableInsideMatch.py
+++ b/boa3_test/test_sc/match_case_test/OuterVariableInsideMatch.py
@@ -1,0 +1,20 @@
+from typing import Any
+
+from boa3.builtin.compile_time import public
+
+
+@public
+def main(x: Any) -> str:
+    string = "String is: "
+    match x:
+        case True:
+            string += "True"
+        case 10:
+            string += "10"
+        case "2":
+            string += "2 string"
+        case _:
+            # this is the default case, when all others are False
+            string += "other"
+
+    return string

--- a/boa3_test/test_sc/match_case_test/StrTypeMatchCase.py
+++ b/boa3_test/test_sc/match_case_test/StrTypeMatchCase.py
@@ -1,0 +1,15 @@
+from boa3.builtin.compile_time import public
+
+
+@public
+def main(x: str) -> str:
+    match x:
+        case 'first':
+            return "1"
+        case 'second':
+            return "2"
+        case "third":
+            return "3"
+        case _:
+            # this is the default case, when all others are False
+            return "other"

--- a/boa3_test/test_sc/match_case_test/UnsupportedCase.py
+++ b/boa3_test/test_sc/match_case_test/UnsupportedCase.py
@@ -1,0 +1,15 @@
+from boa3.builtin.compile_time import public
+
+
+@public
+def main(x: str) -> str:
+    match x:
+        case string if len(string) > 10:
+            return "1"
+        case 'second':
+            return "2"
+        case "third":
+            return "3"
+        case _:
+            # this is the default case, when all others are False
+            return "other"

--- a/boa3_test/test_sc/match_case_test/VarExistingInAllCases.py
+++ b/boa3_test/test_sc/match_case_test/VarExistingInAllCases.py
@@ -1,0 +1,19 @@
+from typing import Any
+
+from boa3.builtin.compile_time import public
+
+
+@public
+def main(x: Any) -> str:
+    match x:
+        case True:
+            string = "True"
+        case 10:
+            string = "10"
+        case "2":
+            string = "2 string"
+        case _:
+            # this is the default case, when all others are False
+            string = "other"
+
+    return string

--- a/boa3_test/tests/compiler_tests/test_match_case.py
+++ b/boa3_test/tests/compiler_tests/test_match_case.py
@@ -1,0 +1,165 @@
+from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to avoid circular imports
+
+from boa3.internal.exception import CompilerError
+from boa3.internal.neo3.vm import VMState
+from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
+
+
+class TestMatchCase(BoaTest):
+    default_folder: str = 'test_sc/match_case_test'
+
+    def test_any_type_match_case(self):
+        path, _ = self.get_deploy_file_paths('AnyTypeMatchCase.py')
+        runner = BoaTestRunner(runner_id=self.method_name())
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', True))
+        expected_results.append("True")
+
+        invokes.append(runner.call_contract(path, 'main', 1))
+        expected_results.append("one")
+
+        invokes.append(runner.call_contract(path, 'main', "2"))
+        expected_results.append("2 string")
+
+        invokes.append(runner.call_contract(path, 'main', 'other value'))
+        expected_results.append("other")
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+    def test_bool_type_match_case(self):
+        path, _ = self.get_deploy_file_paths('BoolTypeMatchCase.py')
+        runner = BoaTestRunner(runner_id=self.method_name())
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', True))
+        expected_results.append("True")
+
+        invokes.append(runner.call_contract(path, 'main', False))
+        expected_results.append("False")
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+    def test_int_type_match_case(self):
+        path, _ = self.get_deploy_file_paths('IntTypeMatchCase.py')
+        runner = BoaTestRunner(runner_id=self.method_name())
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', 10))
+        expected_results.append("ten")
+
+        invokes.append(runner.call_contract(path, 'main', -10))
+        expected_results.append("minus ten")
+
+        invokes.append(runner.call_contract(path, 'main', 0))
+        expected_results.append("zero")
+
+        invokes.append(runner.call_contract(path, 'main', 123))
+        expected_results.append("other")
+        invokes.append(runner.call_contract(path, 'main', -999))
+        expected_results.append("other")
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+    def test_str_type_match_case(self):
+        path, _ = self.get_deploy_file_paths('StrTypeMatchCase.py')
+        runner = BoaTestRunner(runner_id=self.method_name())
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', 'first'))
+        expected_results.append("1")
+
+        invokes.append(runner.call_contract(path, 'main', 'second'))
+        expected_results.append("2")
+
+        invokes.append(runner.call_contract(path, 'main', 'third'))
+        expected_results.append("3")
+
+        invokes.append(runner.call_contract(path, 'main', 'another value'))
+        expected_results.append("other")
+        invokes.append(runner.call_contract(path, 'main', 'unit test'))
+        expected_results.append("other")
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+    def test_outer_var_inside_match(self):
+        path, _ = self.get_deploy_file_paths('OuterVariableInsideMatch.py')
+        runner = BoaTestRunner(runner_id=self.method_name())
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', True))
+        expected_results.append("String is: True")
+
+        invokes.append(runner.call_contract(path, 'main', 10))
+        expected_results.append("String is: 10")
+
+        invokes.append(runner.call_contract(path, 'main', "2"))
+        expected_results.append("String is: 2 string")
+
+        invokes.append(runner.call_contract(path, 'main', 'another value'))
+        expected_results.append("String is: other")
+        invokes.append(runner.call_contract(path, 'main', 'unit test'))
+        expected_results.append("String is: other")
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+    def test_var_existing_in_all_cases(self):
+        path, _ = self.get_deploy_file_paths('VarExistingInAllCases.py')
+        runner = BoaTestRunner(runner_id=self.method_name())
+
+        invokes = []
+        expected_results = []
+
+        invokes.append(runner.call_contract(path, 'main', True))
+        expected_results.append("True")
+
+        invokes.append(runner.call_contract(path, 'main', 10))
+        expected_results.append("10")
+
+        invokes.append(runner.call_contract(path, 'main', "2"))
+        expected_results.append("2 string")
+
+        invokes.append(runner.call_contract(path, 'main', 'another value'))
+        expected_results.append("other")
+        invokes.append(runner.call_contract(path, 'main', 'unit test'))
+        expected_results.append("other")
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+    def test_unsupported_case(self):
+        path = self.get_contract_path('UnsupportedCase.py')
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)


### PR DESCRIPTION
**Summary or solution description**
Added support to basic match-case operations

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/5acaf9c75f4c35e14b559bd12882d4f6632b1e5e/boa3_test/test_sc/match_case_test/VarExistingInAllCases.py#L1-L19

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/5acaf9c75f4c35e14b559bd12882d4f6632b1e5e/boa3_test/tests/compiler_tests/test_match_case.py#L11-L35

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.10
