### PR TITLE
Add support to List sort method

### DIFF
--- a/boa3/internal/analyser/typeanalyser.py
+++ b/boa3/internal/analyser/typeanalyser.py
@@ -1455,13 +1455,13 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
                 already_called_arg = call.keywords[index].value
             index += 1
 
-        if len_call_args > len(callable_target.args) or unexpected_kwarg is not None or already_called_arg is not None:
+        if len_call_args > len(callable_target.positional_args) or unexpected_kwarg is not None or already_called_arg is not None:
             if unexpected_kwarg is not None:
                 unexpected_arg = unexpected_kwarg
             elif already_called_arg is not None:
                 unexpected_arg = already_called_arg
             else:
-                unexpected_arg = call.args[len(callable_target.args) + ignore_first_argument]
+                unexpected_arg = call.args[len(callable_target.positional_args) + ignore_first_argument]
 
             from boa3.internal.model.builtin.method import SuperMethod
             if isinstance(callable_target, SuperMethod):

--- a/boa3/internal/model/builtin/builtin.py
+++ b/boa3/internal/model/builtin/builtin.py
@@ -93,6 +93,7 @@ class Builtin:
     CountSequencePrimitive = CountSequencePrimitiveMethod()
     CountStr = CountStrMethod()
     Copy = CopyListMethod()
+    ListSort = SortMethod()
     SequenceAppend = AppendMethod()
     SequenceClear = ClearMethod()
     SequenceExtend = ExtendMethod()
@@ -144,6 +145,7 @@ class Builtin:
                                                 Exit,
                                                 IsInstance,
                                                 Len,
+                                                ListSort,
                                                 Max,
                                                 Min,
                                                 Print,

--- a/boa3/internal/model/builtin/classmethod/__init__.py
+++ b/boa3/internal/model/builtin/classmethod/__init__.py
@@ -21,6 +21,7 @@ __all__ = ['AppendMethod',
            'ReplaceMethod',
            'ReverseMethod',
            'StartsWithMethod',
+           'SortMethod',
            'StripMethod',
            'UpperMethod',
            'UpperMethod',
@@ -48,6 +49,7 @@ from boa3.internal.model.builtin.classmethod.popsequencemethod import PopSequenc
 from boa3.internal.model.builtin.classmethod.removemethod import RemoveMethod
 from boa3.internal.model.builtin.classmethod.replacemethod import ReplaceMethod
 from boa3.internal.model.builtin.classmethod.reversemethod import ReverseMethod
+from boa3.internal.model.builtin.classmethod.sortmethod import SortMethod
 from boa3.internal.model.builtin.classmethod.startswithmethod import StartsWithMethod
 from boa3.internal.model.builtin.classmethod.stripmethod import StripMethod
 from boa3.internal.model.builtin.classmethod.uppermethod import UpperMethod

--- a/boa3/internal/model/builtin/classmethod/sortmethod.py
+++ b/boa3/internal/model/builtin/classmethod/sortmethod.py
@@ -1,0 +1,182 @@
+import ast
+from typing import Any, Dict, Optional
+
+from boa3.internal.model.builtin.method import IBuiltinMethod
+from boa3.internal.model.operation.binaryop import BinaryOp
+from boa3.internal.model.type.itype import IType
+from boa3.internal.model.variable import Variable
+
+
+class SortMethod(IBuiltinMethod):
+
+    def __init__(self, arg_value: Optional[IType] = None):
+        from boa3.internal.model.type.type import Type
+
+        if not Type.list.is_type_of(arg_value):
+            arg_value = Type.list
+
+        identifier = 'sort'
+        args: Dict[str, Variable] = {
+            'self': Variable(arg_value),
+            'reverse': Variable(Type.bool)
+        }
+        # TODO: change this when keyword-only arguments are implemented #2ewewtz
+        kwargs = {
+            'reverse': Variable(Type.bool)
+        }
+        reverse_default = ast.parse(str(Type.bool.default_value)).body[0].value
+
+        super().__init__(identifier, args, kwargs=kwargs, defaults=[reverse_default])
+
+    @property
+    def identifier(self) -> str:
+        from boa3.internal.model.type.type import Type
+
+        if self._arg_self.type is Type.list:
+            return self._identifier
+
+        if Type.list.is_type_of(self._arg_self.type):
+            return '-{0}_{1}'.format(self._identifier, self._arg_self.type.identifier)
+
+        return self._identifier
+
+    @property
+    def is_supported(self) -> bool:
+        from boa3.internal.model.type.primitive.primitivetype import PrimitiveType
+        item_type: IType = self._arg_self.type.item_type
+        if isinstance(item_type, PrimitiveType):
+            return True
+
+        from boa3.internal.model.type.annotation.uniontype import UnionType
+        if (isinstance(item_type, UnionType) and
+                all(isinstance(union_type, PrimitiveType) for union_type in item_type.union_types)):
+            return True
+
+        return False
+
+    @property
+    def _arg_self(self) -> Variable:
+        return self.args['self']
+
+    def generate_internal_opcodes(self, code_generator):
+        from boa3.internal.model.builtin.builtin import Builtin
+        from boa3.internal.neo.vm.opcode.Opcode import Opcode
+
+        # code_generator.remove_stack_top_item()  # ignore key arg
+        # reverse, self // reverse -> top
+
+        # start_index = 0
+        # i = 1
+        # end_address = len(self)
+        code_generator.duplicate_stack_item(2)
+        code_generator.convert_builtin_method_call(Builtin.Len, is_internal=True)
+        code_generator.convert_literal(1)
+
+        # while i <= end_address
+        begin_i_while_address = code_generator.convert_begin_while()
+
+        code_generator.duplicate_stack_item(4)  # push array to the stack top
+        #   j = i
+        code_generator.duplicate_stack_item(2)
+
+        j_while_start_address = code_generator.convert_begin_while()
+        #   while j > start_index and arr[j] < arr[j - 1]:
+        #       arr[j], arr[j - 1] = arr[j - 1], arr[j]
+        code_generator.duplicate_stack_top_item()
+        code_generator.insert_opcode(Opcode.DEC)    # (j - 1), j, arr
+
+        arr_j_minus_one_address = code_generator.bytecode_size
+        code_generator.duplicate_stack_item(3)
+        code_generator.duplicate_stack_item(2)
+        code_generator.convert_get_item(index_inserted_internally=True)  # aux = arr[j - 1]
+
+        # arr[j - 1] / j - 1 / j
+        code_generator.swap_reverse_stack_items(3, rotate=True)  # j / arr[j - 1] / j - 1
+        arr_j_address = code_generator.bytecode_size
+        code_generator.duplicate_stack_item(4)
+        code_generator.duplicate_stack_item(2)
+        code_generator.convert_get_item(index_inserted_internally=True)  # arr[j]
+
+        # arr[j] / j / arr[j - 1] / j - 1 / arr
+        code_generator.duplicate_stack_item(4)
+        code_generator.duplicate_stack_item(6)
+        code_generator.swap_reverse_stack_items(3)
+        code_generator.convert_set_item(arr_j_address, index_inserted_internally=True)  # arr[j - 1] = arr[j]
+
+        # j / arr[j - 1] / j - 1 / arr
+        code_generator.duplicate_stack_item(4)
+        code_generator.swap_reverse_stack_items(3)
+        code_generator.convert_set_item(arr_j_minus_one_address, index_inserted_internally=True)  # arr[j] = arr[j - 1]
+
+        j_while_test_address = code_generator.bytecode_size
+        # j > start_index
+        code_generator.duplicate_stack_top_item()
+        code_generator.convert_literal(0)
+        code_generator.convert_operation(BinaryOp.Gt, is_internal=True)
+
+        code_generator.duplicate_stack_top_item()
+        if_j_positive = code_generator.convert_begin_if()
+
+        # arr[j] (> if reverse else <) arr[j - 1]
+        code_generator.duplicate_stack_item(3)
+        code_generator.duplicate_stack_item(3)
+        code_generator.convert_get_item(index_inserted_internally=True)
+        code_generator.duplicate_stack_item(4)
+        code_generator.duplicate_stack_item(4)
+        code_generator.insert_opcode(Opcode.DEC)
+        code_generator.convert_get_item(index_inserted_internally=True)
+
+        # "gt" if reverse else "lt"
+        code_generator.duplicate_stack_item(8)
+        if_is_reverse = code_generator.convert_begin_if()
+        code_generator.convert_operation(BinaryOp.Gt, is_internal=True)
+
+        else_is_reverse = code_generator.convert_begin_else(if_is_reverse, is_internal=True)
+        code_generator.convert_operation(BinaryOp.Lt, is_internal=True)
+
+        code_generator.convert_end_if(else_is_reverse, is_internal=True)
+
+        code_generator.convert_operation(BinaryOp.And, is_internal=True)
+
+        code_generator.convert_end_if(if_j_positive, is_internal=True)
+
+        code_generator.convert_end_while(j_while_start_address, j_while_test_address, is_internal=True)
+
+        code_generator.remove_stack_top_item()  # remove j from the stack
+        code_generator.remove_stack_top_item()  # remove array from the stack
+
+        #   i += 1
+        code_generator.insert_opcode(Opcode.INC)
+
+        condition_i_while_address = code_generator.bytecode_size
+        code_generator.duplicate_stack_top_item()
+        code_generator.duplicate_stack_item(3)
+        code_generator.convert_operation(BinaryOp.Lt, is_internal=True)
+        code_generator.convert_end_while(begin_i_while_address, condition_i_while_address, is_internal=True)
+
+        # clean stack
+        code_generator.remove_stack_top_item()
+        code_generator.remove_stack_top_item()
+        code_generator.remove_stack_top_item()
+        code_generator.remove_stack_top_item()
+
+    def push_self_first(self) -> bool:
+        return self.has_self_argument
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> Optional[str]:
+        return None
+
+    def build(self, value: Any) -> IBuiltinMethod:
+        if not isinstance(value, list):
+            value = [value]
+
+        from boa3.internal.model.type.type import Type
+        if len(value) > 0 and Type.list.is_type_of(value[0]):
+            return SortMethod(value[0])
+
+        return self

--- a/boa3/internal/model/callable.py
+++ b/boa3/internal/model/callable.py
@@ -115,6 +115,10 @@ class Callable(IExpression, ABC):
         return self.args
 
     @property
+    def positional_args(self) -> Dict[str, Variable]:
+        return {key: value for key, value in self.args.items() if key not in self._kwargs}
+
+    @property
     def has_cls_or_self(self) -> bool:
         return any(decorator.has_cls_or_self for decorator in self.decorators)
 

--- a/boa3/internal/model/type/collection/sequence/mutable/listtype.py
+++ b/boa3/internal/model/type/collection/sequence/mutable/listtype.py
@@ -27,7 +27,8 @@ class ListType(MutableSequenceType):
 
         from boa3.internal.model.builtin.builtin import Builtin
 
-        instance_methods = [Builtin.Copy
+        instance_methods = [Builtin.Copy,
+                            Builtin.ListSort
                             ]
 
         for instance_method in instance_methods:

--- a/boa3_test/test_sc/list_test/SortArgsList.py
+++ b/boa3_test/test_sc/list_test/SortArgsList.py
@@ -1,0 +1,4 @@
+def sort_test() -> list:
+    a = [1, 2, 3, 4, 5]
+    a.sort(False)
+    return a

--- a/boa3_test/test_sc/list_test/SortKeyList.py
+++ b/boa3_test/test_sc/list_test/SortKeyList.py
@@ -1,0 +1,8 @@
+def sort_test() -> list:
+    a = [1, 2, 3, 4, 5]
+    a.sort(key=key_order)
+    return a
+
+
+def key_order(n: int) -> int:
+    return n % 5

--- a/boa3_test/test_sc/list_test/SortList.py
+++ b/boa3_test/test_sc/list_test/SortList.py
@@ -1,0 +1,8 @@
+from boa3.builtin.compile_time import public
+
+
+@public
+def sort_test() -> list:
+    a = [5, 4, 3, 2, 6, 1]
+    a.sort()
+    return a

--- a/boa3_test/test_sc/list_test/SortListAny.py
+++ b/boa3_test/test_sc/list_test/SortListAny.py
@@ -1,0 +1,8 @@
+from boa3.builtin.compile_time import public
+
+
+@public
+def sort_test() -> list:
+    a = [None, "4", 3, 2, 6, True]
+    a.sort()
+    return a

--- a/boa3_test/test_sc/list_test/SortListOfList.py
+++ b/boa3_test/test_sc/list_test/SortListOfList.py
@@ -1,0 +1,8 @@
+from boa3.builtin.compile_time import public
+
+
+@public
+def sort_test() -> list:
+    a = [[5, 4], [3], [2, 6, 1]]
+    a.sort()
+    return a

--- a/boa3_test/test_sc/list_test/SortReverseFalseList.py
+++ b/boa3_test/test_sc/list_test/SortReverseFalseList.py
@@ -1,0 +1,8 @@
+from boa3.builtin.compile_time import public
+
+
+@public
+def sort_test() -> list:
+    a = [5, 4, 3, 2, 6, 1]
+    a.sort(reverse=False)
+    return a

--- a/boa3_test/test_sc/list_test/SortReverseTrueList.py
+++ b/boa3_test/test_sc/list_test/SortReverseTrueList.py
@@ -1,0 +1,8 @@
+from boa3.builtin.compile_time import public
+
+
+@public
+def sort_test() -> list:
+    a = [5, 4, 3, 2, 6, 1]
+    a.sort(reverse=True)
+    return a

--- a/boa3_test/tests/compiler_tests/test_list.py
+++ b/boa3_test/tests/compiler_tests/test_list.py
@@ -2193,6 +2193,86 @@ class TestList(BoaTest):
 
     # endregion
 
+    # region TestSort
+
+    def test_list_sort(self):
+        path = self.get_contract_path('SortList.py')
+        self.compile_and_save(path, debug=True)
+        path, _ = self.get_deploy_file_paths('SortList.py')
+
+        runner = BoaTestRunner(runner_id=self.method_name())
+
+        invokes = []
+        expected_results = []
+
+        sorted_list = [5, 4, 3, 2, 6, 1]
+        sorted_list.sort()
+        invokes.append(runner.call_contract(path, 'sort_test'))
+        expected_results.append(sorted_list)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+    def test_list_sort_with_args(self):
+        # list.sort arguments must be used as kwargs
+        path = self.get_contract_path('SortArgsList.py')
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+
+    def test_list_sort_reverse_true(self):
+        path, _ = self.get_deploy_file_paths('SortReverseTrueList.py')
+
+        runner = BoaTestRunner(runner_id=self.method_name())
+
+        invokes = []
+        expected_results = []
+
+        sorted_list = [5, 4, 3, 2, 6, 1]
+        sorted_list.sort(reverse=True)
+        invokes.append(runner.call_contract(path, 'sort_test'))
+        expected_results.append(sorted_list)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+    def test_list_sort_reverse_false(self):
+        path, _ = self.get_deploy_file_paths('SortReverseFalseList.py')
+
+        runner = BoaTestRunner(runner_id=self.method_name())
+
+        invokes = []
+        expected_results = []
+
+        sorted_list = [5, 4, 3, 2, 6, 1]
+        sorted_list.sort(reverse=False)
+        invokes.append(runner.call_contract(path, 'sort_test'))
+        expected_results.append(sorted_list)
+
+        runner.execute()
+        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+
+        for x in range(len(invokes)):
+            self.assertEqual(expected_results[x], invokes[x].result)
+
+    def test_list_sort_key(self):
+        path = self.get_contract_path('SortKeyList.py')
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+
+    def test_list_any_sort(self):
+        path = self.get_contract_path('SortListAny.py')
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+
+    def test_list_of_list_sort(self):
+        path = self.get_contract_path('SortListOfList.py')
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+
+    # endregion
+
     # region TestComprehension
 
     def test_list_comprehension_str(self):


### PR DESCRIPTION
**Summary or solution description**
Implemented `list.sort` method with insertion sort algorithm

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/923328ead94af0f5b828d0aeaa0c204024623d46/boa3_test/test_sc/list_test/SortList.py#L5-L8

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/923328ead94af0f5b828d0aeaa0c204024623d46/boa3_test/tests/compiler_tests/test_list.py#L2196-L2274

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.10+

**(Optional) Additional context**
Since `sort` has keyword-only arguments, which are not supported by boa yet, the code may be changed when we work on supporting it.
