### PR TITLE
Refactor test_any.py to use BoaTestConstructor

### DIFF
--- a/boa3_test/tests/compiler_tests/test_any.py
+++ b/boa3_test/tests/compiler_tests/test_any.py
@@ -1,18 +1,15 @@
-from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to avoid circular imports
-
 from boa3.internal.exception import CompilerError, CompilerWarning
 from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo.vm.type.String import String
+from boa3_test.tests import boatestcase
 
 
-class TestAny(BoaTest):
+class TestAny(boatestcase.BoaTestCase):
     default_folder: str = 'test_sc/any_test'
 
     def test_any_variable_assignments(self):
         two = String('2').to_bytes()
-        path = self.get_contract_path('AnyVariableAssignments.py')
-
         expected_output = (
             Opcode.INITSLOT     # function signature
             + b'\x01'
@@ -32,7 +29,8 @@ class TestAny(BoaTest):
             + Opcode.STLOC0
             + Opcode.RET        # return
         )
-        output = self.compile(path)
+
+        output, _ = self.assertCompile('AnyVariableAssignments.py')
         self.assertEqual(expected_output, output)
 
     def test_variable_assignment_with_any(self):
@@ -41,8 +39,6 @@ class TestAny(BoaTest):
 
     def test_any_list(self):
         ok = String('ok').to_bytes()
-        path = self.get_contract_path('AnyList.py')
-
         expected_output = (
             Opcode.INITSLOT     # function signature
             + b'\x01'
@@ -56,13 +52,12 @@ class TestAny(BoaTest):
             + Opcode.STLOC0
             + Opcode.RET        # return
         )
-        output = self.compile(path)
+
+        output, _ = self.assertCompile('AnyList.py')
         self.assertEqual(expected_output, output)
 
     def test_any_tuple(self):
         ok = String('ok').to_bytes()
-        path = self.get_contract_path('AnyTuple.py')
-
         expected_output = (
             Opcode.INITSLOT     # function signature
             + b'\x01'
@@ -76,7 +71,8 @@ class TestAny(BoaTest):
             + Opcode.STLOC0
             + Opcode.RET        # return
         )
-        output = self.compile(path)
+
+        output, _ = self.assertCompile('AnyTuple.py')
         self.assertEqual(expected_output, output)
 
     def test_any_operation(self):
@@ -86,7 +82,6 @@ class TestAny(BoaTest):
     def test_function_any_param(self):
         ok = String('ok').to_bytes()
         some_string = String('some_string').to_bytes()
-
         expected_output = (
             Opcode.INITSLOT   # Main
             + b'\x01'
@@ -136,14 +131,12 @@ class TestAny(BoaTest):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('FunctionAnyParam.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('FunctionAnyParam.py')
         self.assertEqual(expected_output, output)
 
     def test_any_sequence_assignments(self):
         ok = String('ok').to_bytes()
         some_string = String('some_string').to_bytes()
-
         expected_output = (
             Opcode.INITSLOT
             + b'\x05'
@@ -187,8 +180,7 @@ class TestAny(BoaTest):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('AnySequenceAssignments.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('AnySequenceAssignments.py')
         self.assertEqual(expected_output, output)
 
     def test_int_sequence_any_assignments(self):
@@ -209,8 +201,7 @@ class TestAny(BoaTest):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('IntSequenceAnyAssignment.py')
-        output = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+        output, _ = self.assertCompile('IntSequenceAnyAssignment.py')
         self.assertEqual(expected_output, output)
 
     def test_str_sequence_any_assignments(self):
@@ -231,13 +222,11 @@ class TestAny(BoaTest):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('StrSequenceAnyAssignment.py')
-        output = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+        output, _ = self.assertCompile('StrSequenceAnyAssignment.py')
         self.assertEqual(expected_output, output)
 
     def test_str_sequence_str_assignment(self):
         some_string = String('some_string').to_bytes()
-
         expected_output = (
             Opcode.INITSLOT
             + b'\x01'
@@ -248,13 +237,11 @@ class TestAny(BoaTest):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('StrSequenceStrAssignment.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('StrSequenceStrAssignment.py')
         self.assertEqual(expected_output, output)
 
     def test_sequence_of_any_sequence(self):
         ok = String('ok').to_bytes()
-
         expected_output = (
             Opcode.INITSLOT
             + b'\x05'
@@ -294,8 +281,7 @@ class TestAny(BoaTest):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('SequenceOfAnySequence.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('SequenceOfAnySequence.py')
         self.assertEqual(expected_output, output)
 
     def test_sequence_of_int_sequence_success(self):
@@ -323,8 +309,7 @@ class TestAny(BoaTest):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('SequenceOfIntSequence.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('SequenceOfIntSequence.py')
         self.assertEqual(expected_output, output)
 
     def test_sequence_of_int_sequence_fail(self):
@@ -362,5 +347,5 @@ class TestAny(BoaTest):
         )
 
         path = self.get_contract_path('SequenceOfAnyIntSequence.py')
-        output = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
         self.assertEqual(expected_output, output)


### PR DESCRIPTION
**Summary or solution description**
Refactored `test_any` file to use `boatestconstructor` in place of `TestRunner` for unit testing
