### PR TITLE
CU-86a1qdpd2 - Change how an Optional is generated on events of the m…

### DIFF
--- a/boa3/internal/neo/vm/type/AbiType.py
+++ b/boa3/internal/neo/vm/type/AbiType.py
@@ -27,6 +27,11 @@ class AbiType(str, Enum):
         if len(abi_types) == 1:
             return abi_types[0]
 
+        if AbiType.Void in abi_types:
+            abi_types.remove(AbiType.Void)
+            if len(abi_types) == 1:
+                return abi_types[0]
+
         abis = abi_types[:1]
         for abi in abi_types[1:]:
             if abi not in abis:

--- a/boa3_test/test_sc/generation_test/ManifestOptionalUnionEvent.py
+++ b/boa3_test/test_sc/generation_test/ManifestOptionalUnionEvent.py
@@ -1,0 +1,16 @@
+from typing import Optional, Union
+
+from boa3.builtin.compile_time import public, CreateNewEvent
+
+event = CreateNewEvent(
+    [
+        ('optional', Optional[str]),
+        ('union', Union[int, None]),
+    ],
+    'event'
+)
+
+
+@public
+def main():
+    event('foo', 1)

--- a/boa3_test/tests/compiler_tests/test_file_generation.py
+++ b/boa3_test/tests/compiler_tests/test_file_generation.py
@@ -1174,3 +1174,14 @@ class TestFileGeneration(BoaTest):
 
         self.assertTrue(len(manifest['abi']['events']) > 0)
         self.assertEqual('notify', manifest['abi']['events'][0]['name'])
+
+    def test_manifest_optional_union_eventsd(self):
+        path = self.get_contract_path('test_sc/generation_test', 'ManifestOptionalUnionEvent.py')
+        nef_output, expected_manifest_output = self.get_deploy_file_paths_without_compiling(path)
+        compiler = Compiler()
+        with LOCK:
+            compiler.compile_and_save(path, nef_output)
+            _, manifest = self.get_output(nef_output)
+
+        self.assertEqual(manifest['abi']['events'][0]['parameters'][0]['type'], 'String')
+        self.assertEqual(manifest['abi']['events'][0]['parameters'][1]['type'], 'Integer')


### PR DESCRIPTION
**Summary or solution description**
Abi type for Optional[T] and Union[T, None] is now considering the type of the argument T for manifest generation