### PR TITLE
CU-86a1huqre - Refactor test_variable.py to use BoaTestConstructor

### DIFF
--- a/boa3_test/tests/boatestcase.py
+++ b/boa3_test/tests/boatestcase.py
@@ -15,7 +15,7 @@ from boaconstructor import SmartContractTestCase, AbortException, AssertExceptio
 from neo3.api import noderpc
 from neo3.api.wrappers import GenericContract
 from neo3.contracts import nef, manifest
-from neo3.core import types
+from neo3.core import types, cryptography
 from neo3.network.payloads.verification import Signer
 from neo3.wallet import account
 
@@ -162,10 +162,13 @@ class BoaTestCase(SmartContractTestCase):
             target_contract: Optional[types.UInt160] = None,
     ) -> tuple[T, list[noderpc.Notification]]:
 
-        if return_type is tuple:
+        return_type_class = return_type.__origin__ if hasattr(return_type, '__origin__') else return_type
+        expected_values = return_type.__args__ if hasattr(return_type, '__args__') else ()
+
+        if return_type_class is tuple:
             internal_return_type = list
         else:
-            internal_return_type = return_type
+            internal_return_type = return_type_class
 
         result, events = await super().call(method,
                                             args,
@@ -175,9 +178,9 @@ class BoaTestCase(SmartContractTestCase):
                                             target_contract=target_contract,
                                             )
 
-        if isinstance(result, list):
-            cls.unwrap_inner_values(result)
-        if return_type is tuple:
+        if isinstance(result, (list, dict)):
+            cls.unwrap_inner_values(result, *expected_values)
+        if return_type_class is tuple:
             result = tuple(result)
 
         return result, events
@@ -220,39 +223,58 @@ class BoaTestCase(SmartContractTestCase):
             return cls.deployed_contracts[_manifest.name]
 
     @classmethod
-    def unwrap_inner_values(cls, value: list | dict):
+    def unwrap_inner_values(cls, value: list | dict, *args: type):
         if isinstance(value, list):
+            list_type = args[0] if len(args) else None
             for index, item in enumerate(value):
                 if not isinstance(item, noderpc.StackItem):
                     continue
 
-                value[index] = cls._unwrap_stack_item(item)
+                value[index] = cls._unwrap_stack_item(item, list_type)
 
         elif isinstance(value, dict):
+            dict_key_type = args[0] if len(args) else None
+            dict_value_type = args[1] if len(args) > 1 else None
             aux = value.copy()
             value.clear()
             for key, item in aux.items():
-                dict_key = key if not isinstance(key, noderpc.StackItem) else cls._unwrap_stack_item(key)
-                dict_item = item if not isinstance(item, noderpc.StackItem) else cls._unwrap_stack_item(item)
+
+                if dict_key_type not in (None, bytes) and isinstance(key, bytes):
+                    key = noderpc.StackItem(
+                        noderpc.StackItemType.BYTE_STRING, key
+                    )
+                if dict_value_type not in (None, bytes) and isinstance(item, bytes):
+                    item = noderpc.StackItem(
+                        noderpc.StackItemType.BYTE_STRING, item
+                    )
+
+                dict_key = key if not isinstance(key, noderpc.StackItem) else cls._unwrap_stack_item(key, dict_key_type)
+                dict_item = item if not isinstance(item, noderpc.StackItem) else cls._unwrap_stack_item(item, dict_value_type)
                 if isinstance(dict_item, list):
                     if dict_item and isinstance(dict_item[0], tuple):
                         dict_item = cls._unwrap_stack_item(
-                            noderpc.MapStackItem(noderpc.StackItemType.MAP, dict_item)
+                            noderpc.MapStackItem(noderpc.StackItemType.MAP, dict_item),
+                            *args[:2]
                         )
                     else:
-                        cls.unwrap_inner_values(dict_item)
+                        cls.unwrap_inner_values(dict_item, *args[:2])
 
                 value[dict_key] = dict_item
 
     @classmethod
-    def _unwrap_stack_item(cls, stack_item: noderpc.StackItem) -> Any:
+    def _unwrap_stack_item(cls, stack_item: noderpc.StackItem, expected_type: type | None = None) -> Any:
         result = None
 
         if stack_item.type is noderpc.StackItemType.BYTE_STRING:
-            try:
+            if expected_type is str:
                 result = stack_item.as_str()
-            except:
+            elif expected_type is bytes:
                 result = stack_item.as_bytes()
+            else:
+                try:
+                    result = stack_item.as_str()
+                except:
+                    result = stack_item.as_bytes()
 
         elif stack_item.type is noderpc.StackItemType.INTEGER:
             result = stack_item.as_int()
@@ -261,27 +283,40 @@ class BoaTestCase(SmartContractTestCase):
             result = stack_item.as_bool()
 
         elif stack_item.type is noderpc.StackItemType.BUFFER:
-            try:
+            if expected_type is str:
+                result = stack_item.as_str()
+            elif expected_type is bytes:
+                result = stack_item.as_bytes()
+            elif expected_type is types.UInt160:
                 result = stack_item.as_uint160()
-            except ValueError:
+            elif expected_type is types.UInt256:
+                result = stack_item.as_uint256()
+            elif expected_type is cryptography.ECPoint:
+                result = stack_item.as_public_key()
+            else:
                 try:
-                    result = stack_item.as_uint256()
+                    result = stack_item.as_uint160()
                 except ValueError:
                     try:
-                        result = stack_item.as_public_key()
-                    except BaseException:
+                        result = stack_item.as_uint256()
+                    except ValueError:
                         try:
-                            result = stack_item.as_str()
+                            result = stack_item.as_public_key()
                         except BaseException:
-                            result = stack_item.as_bytes()
+                            try:
+                                result = stack_item.as_str()
+                            except BaseException:
+                                result = stack_item.as_bytes()
 
         elif stack_item.type is noderpc.StackItemType.ARRAY:
             result = stack_item.as_list()
-            cls.unwrap_inner_values(result)
+            inner_list_type = expected_type.__args__ if hasattr(expected_type, '__args__') else ()
+            cls.unwrap_inner_values(result, inner_list_type)
 
         elif stack_item.type is noderpc.StackItemType.MAP:
             result = stack_item.as_dict()
-            cls.unwrap_inner_values(result)
+            inner_dict_type = expected_type.__args__ if hasattr(expected_type, '__args__') else ()
+            cls.unwrap_inner_values(result, inner_dict_type)
 
         if result is None:
             result = stack_item.value

--- a/boa3_test/tests/boatestcase.py
+++ b/boa3_test/tests/boatestcase.py
@@ -20,6 +20,8 @@ from neo3.network.payloads.verification import Signer
 from neo3.wallet import account
 
 from boa3.internal import env, constants
+from boa3.internal.analyser.analyser import Analyser
+from boa3.internal.compiler.compiler import Compiler
 from boa3.internal.exception.CompilerError import CompilerError
 from boa3.internal.exception.CompilerWarning import CompilerWarning
 from boa3_test.tests.boa_test import (USE_UNIQUE_NAME,  # move theses to this module when refactoring is done
@@ -322,7 +324,7 @@ class BoaTestCase(SmartContractTestCase):
             py_abs_path,
             root_folder=root_folder,
             fail_fast=fail_fast,
-            kwargs=kwargs
+            **kwargs
         )
 
         return result, {}
@@ -663,3 +665,6 @@ class BoaTestCase(SmartContractTestCase):
                 manifest = json.loads(manifest_output.read())
 
         return output, manifest
+
+    def get_compiler_analyser(self, compiler: Compiler) -> Analyser:
+        return compiler._analyser

--- a/boa3_test/tests/compiler_tests/test_variable.py
+++ b/boa3_test/tests/compiler_tests/test_variable.py
@@ -1,7 +1,5 @@
 from typing import Dict
 
-from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to avoid circular imports
-
 from boa3.internal.compiler.compiler import Compiler
 from boa3.internal.exception import CompilerError, CompilerWarning
 from boa3.internal.model.method import Method
@@ -10,11 +8,10 @@ from boa3.internal.model.variable import Variable
 from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo.vm.type.String import String
-from boa3.internal.neo3.vm import VMState
-from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
+from boa3_test.tests import boatestcase
 
 
-class TestVariable(BoaTest):
+class TestVariable(boatestcase.BoaTestCase):
     default_folder: str = 'test_sc/variable_test'
 
     def test_declaration_with_type(self):
@@ -67,8 +64,7 @@ class TestVariable(BoaTest):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('AssignmentWithType.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('AssignmentWithType.py')
         self.assertEqual(expected_output, output)
 
     def test_assignment_without_type(self):
@@ -81,8 +77,7 @@ class TestVariable(BoaTest):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('AssignmentWithoutType.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('AssignmentWithoutType.py')
         self.assertEqual(expected_output, output)
 
     def test_argument_assignment(self):
@@ -99,8 +94,7 @@ class TestVariable(BoaTest):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('ArgumentAssignment.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('ArgumentAssignment.py')
         self.assertEqual(expected_output, output)
 
     def test_multiple_assignments(self):
@@ -117,8 +111,7 @@ class TestVariable(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = self.get_contract_path('MultipleAssignments.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('MultipleAssignments.py')
         self.assertEqual(expected_output, output)
 
     def test_multiple_assignments_set_sequence(self):
@@ -152,8 +145,7 @@ class TestVariable(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = self.get_contract_path('MultipleAssignmentsSetSequence.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('MultipleAssignmentsSetSequence.py')
         self.assertEqual(expected_output, output)
 
     def test_multiple_assignments_set_sequence_last(self):
@@ -187,8 +179,7 @@ class TestVariable(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = self.get_contract_path('MultipleAssignmentsSetSequenceLast.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('MultipleAssignmentsSetSequenceLast.py')
         self.assertEqual(expected_output, output)
 
     def test_multiple_assignments_mismatched_type(self):
@@ -210,8 +201,7 @@ class TestVariable(BoaTest):
             + Opcode.RET        # return
         )
 
-        path = self.get_contract_path('MismatchedTypeMultipleAssignments.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('MismatchedTypeMultipleAssignments.py')
         self.assertEqual(expected_output, output)
 
     def test_tuple_multiple_assignments(self):
@@ -243,11 +233,10 @@ class TestVariable(BoaTest):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('ManyAssignments.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('ManyAssignments.py')
         self.assertEqual(expected_output, output)
 
-    def test_return_arg_value(self):
+    def test_return_arg_value_compile(self):
         expected_output = (
             Opcode.INITSLOT     # function signature
             + b'\x00'
@@ -256,28 +245,18 @@ class TestVariable(BoaTest):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('ReturnArgument.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('ReturnArgument.py')
         self.assertEqual(expected_output, output)
 
-        path, _ = self.get_deploy_file_paths(path)
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_return_arg_value(self):
+        await self.set_up_contract('ReturnArgument.py')
 
-        invokes = []
-        expected_results = []
+        result, _ = await self.call('Main', [10], return_type=int)
+        self.assertEqual(10, result)
+        result, _ = await self.call('Main', [-140], return_type=int)
+        self.assertEqual(-140, result)
 
-        invokes.append(runner.call_contract(path, 'Main', 10))
-        expected_results.append(10)
-        invokes.append(runner.call_contract(path, 'Main', -140))
-        expected_results.append(-140)
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_return_local_var_value(self):
+    def test_return_local_var_value_compile(self):
         expected_output = (
             Opcode.INITSLOT     # function signature
             + b'\x01'
@@ -288,28 +267,18 @@ class TestVariable(BoaTest):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('ReturnLocalVariable.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('ReturnLocalVariable.py')
         self.assertEqual(expected_output, output)
 
-        path, _ = self.get_deploy_file_paths(path)
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_return_local_var_value(self):
+        await self.set_up_contract('ReturnLocalVariable.py')
 
-        invokes = []
-        expected_results = []
+        result, _ = await self.call('Main', [10], return_type=int)
+        self.assertEqual(1, result)
+        result, _ = await self.call('Main', [-140], return_type=int)
+        self.assertEqual(1, result)
 
-        invokes.append(runner.call_contract(path, 'Main', 10))
-        expected_results.append(1)
-        invokes.append(runner.call_contract(path, 'Main', -140))
-        expected_results.append(1)
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_assign_local_with_arg_value(self):
+    def test_assign_local_with_arg_value_compile(self):
         expected_output = (
             Opcode.INITSLOT     # function signature
             + b'\x01'
@@ -320,26 +289,16 @@ class TestVariable(BoaTest):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('AssignLocalWithArgument.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('AssignLocalWithArgument.py')
         self.assertEqual(expected_output, output)
 
-        path, _ = self.get_deploy_file_paths(path)
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_assign_local_with_arg_value(self):
+        await self.set_up_contract('AssignLocalWithArgument.py')
 
-        invokes = []
-        expected_results = []
-
-        invokes.append(runner.call_contract(path, 'Main', 10))
-        expected_results.append(10)
-        invokes.append(runner.call_contract(path, 'Main', -140))
-        expected_results.append(-140)
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        result, _ = await self.call('Main', [10], return_type=int)
+        self.assertEqual(10, result)
+        result, _ = await self.call('Main', [-140], return_type=int)
+        self.assertEqual(-140, result)
 
     def test_using_undeclared_variable(self):
         path = self.get_contract_path('UsingUndeclaredVariable.py')
@@ -365,7 +324,7 @@ class TestVariable(BoaTest):
         )
 
         path = self.get_contract_path('MismatchedTypeAssignValue.py')
-        output = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
         self.assertEqual(expected_output, output)
 
     def test_assign_binary_operation_mismatched_type(self):
@@ -379,7 +338,7 @@ class TestVariable(BoaTest):
         )
 
         path = self.get_contract_path('MismatchedTypeAssignBinOp.py')
-        output = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
         self.assertEqual(expected_output, output)
 
     def test_assign_unary_operation_mismatched_type(self):
@@ -394,7 +353,7 @@ class TestVariable(BoaTest):
         )
 
         path = self.get_contract_path('MismatchedTypeAssignUnOp.py')
-        output = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
         self.assertEqual(expected_output, output)
 
     def test_assign_mixed_operations_mismatched_type(self):
@@ -418,7 +377,7 @@ class TestVariable(BoaTest):
         )
 
         path = self.get_contract_path('MismatchedTypeAssignMixedOp.py')
-        output = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
         self.assertEqual(expected_output, output)
 
     def test_assign_sequence_get_mismatched_type(self):
@@ -434,7 +393,7 @@ class TestVariable(BoaTest):
         )
 
         path = self.get_contract_path('MismatchedTypeAssignSequenceGet.py')
-        output = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
         self.assertEqual(expected_output, output)
 
     def test_assign_sequence_set_mismatched_type(self):
@@ -449,7 +408,7 @@ class TestVariable(BoaTest):
         path = self.get_contract_path('MismatchedTypeInvalidTypeFormat.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
-    def test_global_declaration_with_assignment(self):
+    def test_global_declaration_with_assignment_compile(self):
         expected_output = (
             Opcode.LDSFLD0
             + Opcode.RET
@@ -459,35 +418,30 @@ class TestVariable(BoaTest):
             + Opcode.STSFLD0    # a = 10
             + Opcode.RET
         )
-        path = self.get_contract_path('GlobalDeclarationWithArgumentWrittenAfter.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('GlobalDeclarationWithArgumentWrittenAfter.py')
         self.assertEqual(expected_output, output)
 
-        path, _ = self.get_deploy_file_paths(path)
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_global_declaration_with_assignment(self):
+        await self.set_up_contract('GlobalDeclarationWithArgumentWrittenAfter.py')
 
-        invokes = []
-        expected_results = []
-
-        invokes.append(runner.call_contract(path, 'Main'))
-        expected_results.append(10)
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        result, _ = await self.call('Main', [], return_type=int)
+        self.assertEqual(10, result)
 
     def test_global_declaration_without_assignment(self):
         path = self.get_contract_path('GlobalDeclarationWithoutAssignment.py')
         self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
 
-    def test_global_assignment_with_type(self):
+    def test_global_assignment_with_type_compile(self):
         expected_output = (
             Opcode.PUSH10
             + Opcode.RET
         )
-        expected_output_no_optimization = (
+
+        output, _ = self.assertCompile('GlobalAssignmentWithType.py')
+        self.assertEqual(expected_output, output)
+
+    def test_global_assignment_with_type_compile_no_optimization(self):
+        expected_output = (
             Opcode.LDSFLD0
             + Opcode.RET
             + Opcode.INITSSLOT  # global variables
@@ -496,34 +450,27 @@ class TestVariable(BoaTest):
             + Opcode.STSFLD0    # a = 10
             + Opcode.RET
         )
-        path = self.get_contract_path('GlobalAssignmentWithType.py')
-        output = self.compile(path)
+
+        output, _ = self.assertCompile('GlobalAssignmentWithType.py', optimize=False)
         self.assertEqual(expected_output, output)
 
-        output = self.compile(path, optimize=False)
-        self.assertEqual(expected_output_no_optimization, output)
+    async def test_global_assignment_with_type(self):
+        await self.set_up_contract('GlobalAssignmentWithType.py')
 
-        path, _ = self.get_deploy_file_paths(path)
-        runner = BoaTestRunner(runner_id=self.method_name())
+        result, _ = await self.call('Main', [], return_type=int)
+        self.assertEqual(10, result)
 
-        invokes = []
-        expected_results = []
-
-        invokes.append(runner.call_contract(path, 'Main'))
-        expected_results.append(10)
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_global_assignment_without_type(self):
+    def test_global_assignment_without_type_compile(self):
         expected_output = (
             Opcode.PUSH10
             + Opcode.RET
         )
-        expected_output_no_optimization = (
+
+        output, _ = self.assertCompile('GlobalAssignmentWithoutType.py')
+        self.assertEqual(expected_output, output)
+
+    def test_global_assignment_without_type_compile_no_optimization(self):
+        expected_output = (
             Opcode.LDSFLD0
             + Opcode.RET
             + Opcode.INITSSLOT  # global variables
@@ -532,33 +479,39 @@ class TestVariable(BoaTest):
             + Opcode.STSFLD0    # a = 10
             + Opcode.RET
         )
-        path = self.get_contract_path('GlobalAssignmentWithoutType.py')
-        output = self.compile(path)
+
+        output, _ = self.assertCompile('GlobalAssignmentWithoutType.py', optimize=False)
         self.assertEqual(expected_output, output)
 
-        output = self.compile(path, optimize=False)
-        self.assertEqual(expected_output_no_optimization, output)
+    async def test_global_assignment_without_type(self):
+        await self.set_up_contract('GlobalAssignmentWithoutType.py')
 
-        path, _ = self.get_deploy_file_paths(path)
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
-
-        invokes.append(runner.call_contract(path, 'Main'))
-        expected_results.append(10)
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        result, _ = await self.call('Main', [], return_type=int)
+        self.assertEqual(10, result)
 
     def test_global_tuple_multiple_assignments(self):
         path = self.get_contract_path('GlobalAssignmentWithTuples.py')
         self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
 
+    # TODO: Storage is not working properly, to be fixed by #86a1z5xy9
+    # async def test_global_chained_multiple_assignments(self):
+    #     await self.set_up_contract('GlobalMultipleAssignments.py', compile_if_found=True)
+    #
+    #     result, _ = await self.call('get_a', [], return_type=int)
+    #     self.assertEqual(10, result)
+    #
+    #     result, _ = await self.call('get_c', [], return_type=int)
+    #     self.assertEqual(15, result)
+    #
+    #     result, _ = await self.call('set_a', [100], return_type=None)
+    #     self.assertEqual(None, result)
+    #
+    #     result, _ = await self.call('get_a', [], return_type=int)
+    #     self.assertEqual(100, result)
     def test_global_chained_multiple_assignments(self):
+        from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
+        from boa3.internal.neo3.vm import VMState
+
         path, _ = self.get_deploy_file_paths('GlobalMultipleAssignments.py', compile_if_found=True)
         runner = BoaTestRunner(runner_id=self.method_name())
 
@@ -583,7 +536,7 @@ class TestVariable(BoaTest):
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
 
-    def test_many_global_assignments(self):
+    def test_many_global_assignments_compile(self):
         expected_output = (
             Opcode.PUSH7
             + Opcode.PUSH6
@@ -597,7 +550,12 @@ class TestVariable(BoaTest):
             + Opcode.PACK       # return [a, b, c, d, e, f, g, h]
             + Opcode.RET
         )
-        expected_output_no_optimization = (
+
+        output, _ = self.assertCompile('ManyGlobalAssignments.py')
+        self.assertEqual(expected_output, output)
+
+    def test_many_global_assignments_compile_no_optimization(self):
+        expected_output = (
             Opcode.LDSFLD + b'\x07'
             + Opcode.LDSFLD6    # [a, b, c, d, e, f, g, h]
             + Opcode.LDSFLD5
@@ -629,60 +587,41 @@ class TestVariable(BoaTest):
             + Opcode.STSFLD + b'\x07'   # variable index greater than 6 uses another opcode
             + Opcode.RET
         )
-
-        path = self.get_contract_path('ManyGlobalAssignments.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('ManyGlobalAssignments.py', optimize=False)
         self.assertEqual(expected_output, output)
 
-        output = self.compile(path, optimize=False)
-        self.assertEqual(expected_output_no_optimization, output)
+    async def test_many_global_assignments(self):
+        await self.set_up_contract('ManyGlobalAssignments.py')
 
-        path, _ = self.get_deploy_file_paths(path)
-        runner = BoaTestRunner(runner_id=self.method_name())
+        result, _ = await self.call('Main', [], return_type=list)
+        self.assertEqual([0, 1, 2, 3, 4, 5, 6, 7], result)
 
-        invokes = []
-        expected_results = []
-
-        invokes.append(runner.call_contract(path, 'Main'))
-        expected_results.append([0, 1, 2, 3, 4, 5, 6, 7])
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_list_global_assignment(self):
-        path, _ = self.get_deploy_file_paths('ListGlobalAssignment.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_list_global_assignment(self):
+        await self.set_up_contract('ListGlobalAssignment.py')
 
         expected_value = [1, 2, 3, 4]
-        invokes.append(runner.call_contract(path, 'get_from_global'))
-        expected_results.append(expected_value)
+        result, _ = await self.call('get_from_global', [], return_type=list)
+        self.assertEqual(expected_value, result)
 
-        invokes.append(runner.call_contract(path, 'get_from_class'))
-        expected_results.append(expected_value)
+        result, _ = await self.call('get_from_class', [], return_type=list)
+        self.assertEqual(expected_value, result)
 
-        invokes.append(runner.call_contract(path, 'get_from_class_without_assigning'))
-        expected_results.append([])
+        result, _ = await self.call('get_from_class_without_assigning', [], return_type=list)
+        self.assertEqual([], result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_global_assignment_between_functions(self):
+    def test_global_assignment_between_functions_compile(self):
         expected_output = (
             Opcode.PUSH10
             + Opcode.RET
             + Opcode.PUSH5
             + Opcode.RET
         )
-        expected_output_no_optimization = (
+
+        output, _ = self.assertCompile('GlobalAssignmentBetweenFunctions.py')
+        self.assertEqual(expected_output, output)
+
+    def test_global_assignment_between_functions_compile_no_optimization(self):
+        expected_output = (
             Opcode.LDSFLD0
             + Opcode.RET
             + Opcode.LDSFLD1
@@ -695,69 +634,37 @@ class TestVariable(BoaTest):
             + Opcode.STSFLD1
             + Opcode.RET
         )
-        path = self.get_contract_path('GlobalAssignmentBetweenFunctions.py')
-        output = self.compile(path)
+
+        output, _ = self.assertCompile('GlobalAssignmentBetweenFunctions.py', optimize=False)
         self.assertEqual(expected_output, output)
 
-        output = self.compile(path, optimize=False)
-        self.assertEqual(expected_output_no_optimization, output)
+    async def test_global_assignment_between_functions(self):
+        await self.set_up_contract('GlobalAssignmentBetweenFunctions.py')
 
-        path, _ = self.get_deploy_file_paths(path)
-        runner = BoaTestRunner(runner_id=self.method_name())
+        result, _ = await self.call('Main', [], return_type=int)
+        self.assertEqual(10, result)
+        result, _ = await self.call('example', [], return_type=int)
+        self.assertEqual(5, result)
 
-        invokes = []
-        expected_results = []
+    async def test_global_variable_in_class_method(self):
+        await self.set_up_contract('GlobalVariableInClassMethod.py', compile_if_found=True)
 
-        invokes.append(runner.call_contract(path, 'Main'))
-        expected_results.append(10)
-        invokes.append(runner.call_contract(path, 'example'))
-        expected_results.append(5)
+        result, _ = await self.call('use_variable_in_func', [], return_type=int)
+        self.assertEqual(42, result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        result, _ = await self.call('use_variable_in_map', [], return_type=dict)
+        self.assertEqual({b'val1': 1, b'val2': 2, b'bar': 42}, result)
 
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+    async def test_global_variable_same_id_different_scopes(self):
+        await self.set_up_contract('GetGlobalSameIdFromImport.py')
 
-    def test_global_variable_in_class_method(self):
-        path, _ = self.get_deploy_file_paths('GlobalVariableInClassMethod.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
+        result, _ = await self.call('value_from_script', [], return_type=int)
+        self.assertEqual(42, result)
 
-        invokes = []
-        expected_results = []
+        result, _ = await self.call('value_from_import', [], return_type=list)
+        self.assertEqual([1, 2, 3, 4], result)
 
-        invokes.append(runner.call_contract(path, 'use_variable_in_func'))
-        expected_results.append(42)
-
-        invokes.append(runner.call_contract(path, 'use_variable_in_map'))
-        expected_results.append({'val1': 1, 'val2': 2, 'bar': 42})
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_global_variable_same_id_different_scopes(self):
-        path, _ = self.get_deploy_file_paths('GetGlobalSameIdFromImport.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
-
-        invokes.append(runner.call_contract(path, 'value_from_script'))
-        expected_results.append(42)
-
-        invokes.append(runner.call_contract(path, 'value_from_import'))
-        expected_results.append([1, 2, 3, 4])
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_get_global_variable_value_written_after(self):
+    def test_get_global_variable_value_written_after_compile(self):
         expected_output = (
             Opcode.PUSH7
             + Opcode.PUSH6    # [a, b, c, d, e, f, g, h]
@@ -771,6 +678,11 @@ class TestVariable(BoaTest):
             + Opcode.PACK       # return [a, b, c, d, e, f, g, h]
             + Opcode.RET
         )
+
+        output, _ = self.assertCompile('GetGlobalValueWrittenAfter.py')
+        self.assertEqual(expected_output, output)
+
+    def test_get_global_variable_value_written_after_compile_no_optimization(self):
         expected_output_no_optimization = (
             Opcode.LDSFLD + b'\x07'
             + Opcode.LDSFLD6    # [a, b, c, d, e, f, g, h]
@@ -803,29 +715,17 @@ class TestVariable(BoaTest):
             + Opcode.STSFLD + b'\x07'   # variable index greater than 6 uses another opcode
             + Opcode.RET
         )
-        path = self.get_contract_path('GetGlobalValueWrittenAfter.py')
-        output = self.compile(path)
-        self.assertEqual(expected_output, output)
 
-        output = self.compile(path, optimize=False)
+        output, _ = self.assertCompile('GetGlobalValueWrittenAfter.py', optimize=False)
         self.assertEqual(expected_output_no_optimization, output)
 
-        path, _ = self.get_deploy_file_paths(path)
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_get_global_variable_value_written_after(self):
+        await self.set_up_contract('GetGlobalValueWrittenAfter.py')
 
-        invokes = []
-        expected_results = []
+        result, _ = await self.call('Main', [], return_type=list)
+        self.assertEqual([0, 1, 2, 3, 4, 5, 6, 7], result)
 
-        invokes.append(runner.call_contract(path, 'Main'))
-        expected_results.append([0, 1, 2, 3, 4, 5, 6, 7])
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_assign_local_shadowing_global_with_arg_value(self):
+    def test_assign_local_shadowing_global_with_arg_value_compile(self):
         expected_output = (
             Opcode.INITSLOT     # function signature
             + b'\x01'
@@ -835,39 +735,60 @@ class TestVariable(BoaTest):
             + Opcode.LDLOC0     # variable address
             + Opcode.RET
         )
-        expected_output_no_optimization = (
-            expected_output
+
+        path = self.get_contract_path('AssignLocalWithArgumentShadowingGlobal.py')
+        output, _ = self.assertCompilerLogs(CompilerWarning.NameShadowing, path)
+        self.assertEqual(expected_output, output)
+
+    def test_assign_local_shadowing_global_with_arg_value_compile_no_optimization(self):
+        expected_output = (
+            Opcode.INITSLOT  # function signature
+            + b'\x01'
+            + b'\x01'
+            + Opcode.LDARG0  # b = a  // this b is not the global b
+            + Opcode.STLOC0
+            + Opcode.LDLOC0  # variable address
+            + Opcode.RET
             + Opcode.INITSSLOT  # global variables
             + b'\x01'           # number of globals
             + Opcode.PUSH0      # b = 0
             + Opcode.STSFLD0
             + Opcode.RET
         )
-        path = self.get_contract_path('AssignLocalWithArgumentShadowingGlobal.py')
-        output = self.assertCompilerLogs(CompilerWarning.NameShadowing, path)
+
+        output, _ = self.assertCompile('AssignLocalWithArgumentShadowingGlobal.py', optimize=False)
         self.assertEqual(expected_output, output)
 
-        output = self.compile(path, optimize=False)
-        self.assertEqual(expected_output_no_optimization, output)
+    async def test_assign_local_shadowing_global_with_arg_value(self):
+        await self.set_up_contract('AssignLocalWithArgumentShadowingGlobal.py')
 
-        path, _ = self.get_deploy_file_paths(path)
-        runner = BoaTestRunner(runner_id=self.method_name())
+        result, _ = await self.call('Main', [10], return_type=int)
+        self.assertEqual(10, result)
+        result, _ = await self.call('Main', [-140], return_type=int)
+        self.assertEqual(-140, result)
 
-        invokes = []
-        expected_results = []
-
-        invokes.append(runner.call_contract(path, 'Main', 10))
-        expected_results.append(10)
-        invokes.append(runner.call_contract(path, 'Main', -140))
-        expected_results.append(-140)
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
+    # TODO: Storage is not working properly, to be fixed by #86a1z5xy9
+    # async def test_assign_global_in_function_with_global_keyword(self):
+    #     await self.set_up_contract('GlobalAssignmentInFunctionWithArgument.py', compile_if_found=True)
+    #
+    #     result, _ = await self.call('get_b', [], return_type=int)
+    #     self.assertEqual(0, result)
+    #
+    #     result, _ = await self.call('Main', [10], return_type=int)
+    #     self.assertEqual(10, result)
+    #
+    #     result, _ = await self.call('get_b', [], return_type=int)
+    #     self.assertEqual(10, result)
+    #
+    #     result, _ = await self.call('Main', [-140], return_type=int)
+    #     self.assertEqual(-140, result)
+    #
+    #     result, _ = await self.call('get_b', [], return_type=int)
+    #     self.assertEqual(-140, result)
     def test_assign_global_in_function_with_global_keyword(self):
+        from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
+        from boa3.internal.neo3.vm import VMState
+
         path, _ = self.get_deploy_file_paths('GlobalAssignmentInFunctionWithArgument.py')
         runner = BoaTestRunner(runner_id=self.method_name())
 
@@ -895,145 +816,65 @@ class TestVariable(BoaTest):
         for x in range(len(invokes)):
             self.assertEqual(expected_results[x], invokes[x].result)
 
-    def test_assign_void_function_call(self):
-        path = self.get_contract_path('AssignVoidFunctionCall.py')
-        output = self.compile(path)
+    def test_assign_void_function_call_compile(self):
+        output, _ = self.assertCompile('AssignVoidFunctionCall.py')
         self.assertIn(Opcode.NOP, output)
 
-        path, _ = self.get_deploy_file_paths(path)
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_assign_void_function_call(self):
+        await self.set_up_contract('AssignVoidFunctionCall.py')
 
-        invokes = []
-        expected_results = []
+        result, _ = await self.call('Main', [], return_type=None)
+        self.assertEqual(None, result)
 
-        invokes.append(runner.call_contract(path, 'Main'))
-        expected_results.append(None)
+    async def test_anonymous_variable(self):
+        await self.set_up_contract('AnonymousVariable')
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_anonymous_variable(self):
-        path, _ = self.get_deploy_file_paths('AnonymousVariable')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
-
-        invokes.append(runner.call_contract(path, 'Main'))
-        expected_results.append(400)
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        result, _ = await self.call('Main', [], return_type=int)
+        self.assertEqual(400, result)
 
     def test_assign_starred_variable(self):
         path = self.get_contract_path('AssignStarredVariable.py')
         self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
 
-    def test_variables_in_different_scope_with_same_name(self):
-        path, _ = self.get_deploy_file_paths('DifferentScopesWithSameName.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_variables_in_different_scope_with_same_name(self):
+        await self.set_up_contract('DifferentScopesWithSameName.py')
 
-        invokes = []
-        expected_results = []
+        result, _ = await self.call('test', [], return_type=int)
+        self.assertEqual(1_000, result)
 
-        invokes.append(runner.call_contract(path, 'test'))
-        expected_results.append(1_000)
+    async def test_instance_variable_and_variable_with_same_name(self):
+        await self.set_up_contract('InstanceVariableAndVariableWithSameName.py')
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        result, _ = await self.call('test', [], return_type=list)
+        self.assertEqual([10], result)
 
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_instance_variable_and_variable_with_same_name(self):
-        path, _ = self.get_deploy_file_paths('InstanceVariableAndVariableWithSameName.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
-
-        invokes.append(runner.call_contract(path, 'test'))
-        expected_results.append([10])
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_inner_object_variable_access(self):
-        path, _ = self.get_deploy_file_paths('InnerObjectVariableAccess.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_inner_object_variable_access(self):
+        await self.set_up_contract('InnerObjectVariableAccess.py')
 
         expected_return = 'InnerObjectVariableAccess'
-        invokes.append(runner.call_contract(path, 'main'))
-        expected_results.append(expected_return)
+        result, _ = await self.call('main', [], return_type=str)
+        self.assertEqual(expected_return, result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_variables_with_same_name_class_variable_and_local(self):
-        path, _ = self.get_deploy_file_paths('VariablesWithSameNameClassVariableAndLocal.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_variables_with_same_name_class_variable_and_local(self):
+        await self.set_up_contract('VariablesWithSameNameClassVariableAndLocal.py')
 
         expected_return = 'example'
-        invokes.append(runner.call_contract(path, 'main'))
-        expected_results.append(expected_return)
+        result, _ = await self.call('main', [], return_type=str)
+        self.assertEqual(expected_return, result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_variables_with_same_name_instance_and_local(self):
-        path, _ = self.get_deploy_file_paths('VariablesWithSameNameInstanceAndLocal.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_variables_with_same_name_instance_and_local(self):
+        await self.set_up_contract('VariablesWithSameNameInstanceAndLocal.py')
 
         expected_return = 'example'
-        invokes.append(runner.call_contract(path, 'main'))
-        expected_results.append(expected_return)
+        result, _ = await self.call('main', [], return_type=str)
+        self.assertEqual(expected_return, result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_variables_with_same_name(self):
-        path, _ = self.get_deploy_file_paths('VariablesWithSameName.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_variables_with_same_name(self):
+        await self.set_up_contract('VariablesWithSameName.py')
 
         expected_return = 'example'
-        invokes.append(runner.call_contract(path, 'main'))
-        expected_results.append(expected_return)
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        result, _ = await self.call('main', [], return_type=str)
+        self.assertEqual(expected_return, result)
 
     def test_del_variable(self):
         path = self.get_contract_path('DelVariable.py')
@@ -1043,130 +884,70 @@ class TestVariable(BoaTest):
         path = self.get_contract_path('AssignFunction.py')
         self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
 
-    def test_elvis_operator_any_param(self):
-        path, _ = self.get_deploy_file_paths('ElvisOperatorAnyParam.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_elvis_operator_any_param(self):
+        await self.set_up_contract('ElvisOperatorAnyParam.py')
 
-        invokes = []
-        expected_results = []
+        result, _ = await self.call('main', ['not empty string'], return_type=str)
+        self.assertEqual('not empty string', result)
 
-        invokes.append(runner.call_contract(path, 'main', 'not empty string'))
-        expected_results.append('not empty string')
+        result, _ = await self.call('main', [123456], return_type=int)
+        self.assertEqual(123456, result)
 
-        invokes.append(runner.call_contract(path, 'main', 123456))
-        expected_results.append(123456)
+        result, _ = await self.call('main', [True], return_type=bool)
+        self.assertEqual(True, result)
 
-        invokes.append(runner.call_contract(path, 'main', True))
-        expected_results.append(True)
+        result, _ = await self.call('main', [None], return_type=str)
+        self.assertEqual('some default value', result)
+        result, _ = await self.call('main', [''], return_type=str)
+        self.assertEqual('some default value', result)
+        result, _ = await self.call('main', [0], return_type=str)
+        self.assertEqual('some default value', result)
+        result, _ = await self.call('main', [False], return_type=str)
+        self.assertEqual('some default value', result)
 
-        invokes.append(runner.call_contract(path, 'main', None))
-        expected_results.append('some default value')
-        invokes.append(runner.call_contract(path, 'main', ''))
-        expected_results.append('some default value')
-        invokes.append(runner.call_contract(path, 'main', 0))
-        expected_results.append('some default value')
-        invokes.append(runner.call_contract(path, 'main', False))
-        expected_results.append('some default value')
+    async def test_elvis_operator_bytes_param(self):
+        await self.set_up_contract('ElvisOperatorBytesParam.py')
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        result, _ = await self.call('main', [b'not empty string'], return_type=bytes)
+        self.assertEqual(b'not empty string', result)
 
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        result, _ = await self.call('main', [b''], return_type=bytes)
+        self.assertEqual(b'some default value', result)
 
-    def test_elvis_operator_bytes_param(self):
-        path, _ = self.get_deploy_file_paths('ElvisOperatorBytesParam.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_elvis_operator_str_param(self):
+        await self.set_up_contract('ElvisOperatorStrParam.py')
 
-        invokes = []
-        expected_results = []
+        result, _ = await self.call('main', ['not empty string'], return_type=str)
+        self.assertEqual('not empty string', result)
 
-        invokes.append(runner.call_contract(path, 'main', b'not empty string', expected_result_type=bytes))
-        expected_results.append(b'not empty string')
+        result, _ = await self.call('main', [''], return_type=str)
+        self.assertEqual('some default value', result)
 
-        invokes.append(runner.call_contract(path, 'main', b'', expected_result_type=bytes))
-        expected_results.append(b'some default value')
+    async def test_elvis_operator_int_param(self):
+        await self.set_up_contract('ElvisOperatorIntParam.py')
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        result, _ = await self.call('main', [100], return_type=int)
+        self.assertEqual(100, result)
 
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        result, _ = await self.call('main', [0], return_type=int)
+        self.assertEqual(123456, result)
 
-    def test_elvis_operator_str_param(self):
-        path, _ = self.get_deploy_file_paths('ElvisOperatorStrParam.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_elvis_operator_bool_param(self):
+        await self.set_up_contract('ElvisOperatorBoolParam.py')
 
-        invokes = []
-        expected_results = []
+        result, _ = await self.call('main', [True], return_type=bool)
+        self.assertEqual(True, result)
 
-        invokes.append(runner.call_contract(path, 'main', 'not empty string'))
-        expected_results.append('not empty string')
+        result, _ = await self.call('main', [False], return_type=bool)
+        self.assertEqual(True, result)
 
-        invokes.append(runner.call_contract(path, 'main', ''))
-        expected_results.append('some default value')
+    async def test_elvis_operator_optional_param(self):
+        await self.set_up_contract('ElvisOperatorOptionalParam.py')
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        result, _ = await self.call('main', ['unit test'], return_type=str)
+        self.assertEqual('unit test', result)
 
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_elvis_operator_int_param(self):
-        path, _ = self.get_deploy_file_paths('ElvisOperatorIntParam.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
-
-        invokes.append(runner.call_contract(path, 'main', 100))
-        expected_results.append(100)
-
-        invokes.append(runner.call_contract(path, 'main', 0))
-        expected_results.append(123456)
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_elvis_operator_bool_param(self):
-        path, _ = self.get_deploy_file_paths('ElvisOperatorBoolParam.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
-
-        invokes.append(runner.call_contract(path, 'main', True))
-        expected_results.append(True)
-
-        invokes.append(runner.call_contract(path, 'main', False))
-        expected_results.append(True)
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_elvis_operator_optional_param(self):
-        path, _ = self.get_deploy_file_paths('ElvisOperatorOptionalParam.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
-
-        invokes.append(runner.call_contract(path, 'main', 'unit test'))
-        expected_results.append('unit test')
-
-        invokes.append(runner.call_contract(path, 'main', ''))
-        expected_results.append('some default value')
-        invokes.append(runner.call_contract(path, 'main', None))
-        expected_results.append('some default value')
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        result, _ = await self.call('main', [''], return_type=str)
+        self.assertEqual('some default value', result)
+        result, _ = await self.call('main', [None], return_type=str)
+        self.assertEqual('some default value', result)

--- a/boa3_test/tests/compiler_tests/test_variable.py
+++ b/boa3_test/tests/compiler_tests/test_variable.py
@@ -652,8 +652,8 @@ class TestVariable(boatestcase.BoaTestCase):
         result, _ = await self.call('use_variable_in_func', [], return_type=int)
         self.assertEqual(42, result)
 
-        result, _ = await self.call('use_variable_in_map', [], return_type=dict)
-        self.assertEqual({b'val1': 1, b'val2': 2, b'bar': 42}, result)
+        result, _ = await self.call('use_variable_in_map', [], return_type=dict[str, int])
+        self.assertEqual({'val1': 1, 'val2': 2, 'bar': 42}, result)
 
     async def test_global_variable_same_id_different_scopes(self):
         await self.set_up_contract('GetGlobalSameIdFromImport.py')


### PR DESCRIPTION
**Summary or solution description**
Refactored `test_variable` file to use `boatestconstructor` in place of `TestRunner` for unit testing.

**(Optional) Additional context**
Some refactored tests were left commented and the original left as is, because the storage isn't working properly, but they are mapped to be fixed by #86a1z5xy9
