### PR TITLE
CU-86a1z3n56 - Deprecate the @metadata annotation - detect using return type instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Deprecated
+- Deprecated @metadata decorator to identify metadata function.
 
 
 ### Removed

--- a/boa3/builtin/compile_time/__init__.py
+++ b/boa3/builtin/compile_time/__init__.py
@@ -91,6 +91,8 @@ def metadata(*args):
     This decorator identifies the function that returns the metadata object of the smart contract.
     This can be used to only one function. Using this decorator in multiple functions will raise a compiler error.
 
+    Deprecated in 1.1.1. Will be removed in 1.2.0
+
     >>> @metadata   # this indicates that this function will have information about the smart contract
     ... def neo_metadata() -> NeoMetadata:      # needs to return a NeoMetadata
     ...     meta = NeoMetadata()
@@ -170,8 +172,7 @@ class NeoMetadata:
     Check out `Neo's Documentation <https://developers.neo.org/docs/n3/develop/write/manifest>`__ to learn more about
     the Manifest.
 
-    >>> @metadata
-    ... def neo_metadata() -> NeoMetadata:
+    >>> def neo_metadata() -> NeoMetadata:
     ...     meta = NeoMetadata()
     ...     meta.name = 'NewContractName'
     ...     meta.add_permission(methods=['onNEP17Payment'])

--- a/boa3/internal/exception/CompilerWarning.py
+++ b/boa3/internal/exception/CompilerWarning.py
@@ -28,6 +28,21 @@ class CompilerWarning(ABC, BaseException):
         return self.message == other.message
 
 
+class DeprecatedSymbol(CompilerWarning):
+    """
+    A warning raised when a deprecated symbol is used.
+    """
+
+    def __init__(self, line: int, col: int, symbol_id: str):
+        self.symbol_id: str = symbol_id
+        super().__init__(line, col)
+
+    @property
+    def _warning_message(self) -> Optional[str]:
+        if self.symbol_id is not None:
+            return f'Using deprecated feature: {self.symbol_id}'
+
+
 class InvalidArgument(CompilerWarning):
     """
     An warning raised when an attempt of method evaluation fails during optimization because an argument is invalid.

--- a/boa3_test/examples/amm.py
+++ b/boa3_test/examples/amm.py
@@ -1,6 +1,6 @@
 from typing import Any, List, Union
 
-from boa3.builtin.compile_time import NeoMetadata, metadata, public, CreateNewEvent
+from boa3.builtin.compile_time import CreateNewEvent, NeoMetadata, public
 from boa3.builtin.contract import Nep17TransferEvent, abort
 from boa3.builtin.interop import runtime, storage
 from boa3.builtin.interop.blockchain import Transaction
@@ -14,7 +14,6 @@ from boa3.builtin.type import UInt160, helper as type_helper
 # METADATA
 # -------------------------------------------
 
-@metadata
 def manifest_metadata() -> NeoMetadata:
     """
     Defines this smart contract's metadata information

--- a/boa3_test/examples/auxiliary_contracts/update_contract.py
+++ b/boa3_test/examples/auxiliary_contracts/update_contract.py
@@ -1,6 +1,6 @@
 from typing import Any, Union
 
-from boa3.builtin.compile_time import NeoMetadata, metadata, public, CreateNewEvent
+from boa3.builtin.compile_time import CreateNewEvent, NeoMetadata, public
 from boa3.builtin.interop import storage, runtime
 from boa3.builtin.interop.blockchain import Transaction
 from boa3.builtin.interop.runtime import check_witness
@@ -23,8 +23,6 @@ TOKEN_TOTAL_SUPPLY = 10_000_000 * 10 ** 8  # 10m total supply * 10^8 (decimals)
 # METADATA
 # -------------------------------------------
 
-
-@metadata
 def manifest_metadata() -> NeoMetadata:
     """
     Defines this smart contract's metadata information.

--- a/boa3_test/examples/hello_world.py
+++ b/boa3_test/examples/hello_world.py
@@ -1,4 +1,4 @@
-from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.compile_time import NeoMetadata, public
 from boa3.builtin.interop import storage
 
 
@@ -7,7 +7,6 @@ def Main():
     storage.put(b'hello', b'world')
 
 
-@metadata
 def manifest() -> NeoMetadata:
     meta = NeoMetadata()
 

--- a/boa3_test/examples/htlc.py
+++ b/boa3_test/examples/htlc.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.compile_time import NeoMetadata, public
 from boa3.builtin.contract import abort
 from boa3.builtin.interop import runtime, storage
 from boa3.builtin.interop.blockchain import Transaction
@@ -13,8 +13,6 @@ from boa3.builtin.type import UInt160, helper as type_helper
 # METADATA
 # -------------------------------------------
 
-
-@metadata
 def manifest_metadata() -> NeoMetadata:
     """
     Defines this smart contract's metadata information

--- a/boa3_test/examples/ico.py
+++ b/boa3_test/examples/ico.py
@@ -1,6 +1,6 @@
 from typing import Any, List, Union
 
-from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.compile_time import NeoMetadata, public
 from boa3.builtin.contract import Nep17TransferEvent, abort
 from boa3.builtin.interop import runtime, storage
 from boa3.builtin.interop.blockchain import Transaction
@@ -15,8 +15,6 @@ from boa3.builtin.type import UInt160, helper as type_helper
 # METADATA
 # -------------------------------------------
 
-
-@metadata
 def manifest_metadata() -> NeoMetadata:
     """
     Defines this smart contract's metadata information

--- a/boa3_test/examples/nep11_non_divisible.py
+++ b/boa3_test/examples/nep11_non_divisible.py
@@ -5,9 +5,9 @@
 
 from typing import Any, Dict, List, Union, cast
 
-from boa3.builtin.compile_time import metadata, public, CreateNewEvent, NeoMetadata
+from boa3.builtin.compile_time import CreateNewEvent, NeoMetadata, public
 from boa3.builtin.contract import abort
-from boa3.builtin.interop.blockchain import get_contract, Transaction
+from boa3.builtin.interop.blockchain import Transaction, get_contract
 from boa3.builtin.interop.contract import CallFlags, call_contract, destroy_contract, get_call_flags, update_contract
 from boa3.builtin.interop.iterator import Iterator
 from boa3.builtin.interop.json import json_deserialize
@@ -21,7 +21,7 @@ from boa3.builtin.type import UInt160, helper as type_helper
 # -------------------------------------------
 # METADATA
 # -------------------------------------------
-@metadata
+
 def gm_manifest() -> NeoMetadata:
     """
     Defines this smart contract's metadata information

--- a/boa3_test/examples/nep17.py
+++ b/boa3_test/examples/nep17.py
@@ -1,6 +1,6 @@
 from typing import Any, Union, cast
 
-from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.compile_time import NeoMetadata, public
 from boa3.builtin.contract import Nep17TransferEvent, abort
 from boa3.builtin.interop import runtime, storage
 from boa3.builtin.interop.blockchain import Transaction
@@ -13,7 +13,6 @@ from boa3.builtin.type import UInt160, helper as type_helper
 # METADATA
 # -------------------------------------------
 
-@metadata
 def manifest_metadata() -> NeoMetadata:
     """
     Defines this smart contract's metadata information

--- a/boa3_test/examples/simple_nep17.py
+++ b/boa3_test/examples/simple_nep17.py
@@ -1,6 +1,6 @@
 from typing import Any, Union
 
-from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.compile_time import NeoMetadata, public
 from boa3.builtin.contract import Nep17TransferEvent, abort
 from boa3.builtin.interop import runtime, storage
 from boa3.builtin.interop.blockchain import Transaction
@@ -13,8 +13,6 @@ from boa3.builtin.type import UInt160, helper as type_helper
 # METADATA
 # -------------------------------------------
 
-
-@metadata
 def manifest_metadata() -> NeoMetadata:
     """
     Defines this smart contract's metadata information

--- a/boa3_test/examples/update_contract.py
+++ b/boa3_test/examples/update_contract.py
@@ -1,6 +1,6 @@
 from typing import Any, Union
 
-from boa3.builtin.compile_time import NeoMetadata, metadata, public, CreateNewEvent
+from boa3.builtin.compile_time import CreateNewEvent, NeoMetadata, public
 from boa3.builtin.interop import storage, runtime
 from boa3.builtin.interop.blockchain import Transaction
 from boa3.builtin.interop.runtime import check_witness
@@ -23,8 +23,6 @@ TOKEN_TOTAL_SUPPLY = 10_000_000 * 10 ** 8  # 10m total supply * 10^8 (decimals)
 # METADATA
 # -------------------------------------------
 
-
-@metadata
 def manifest_metadata() -> NeoMetadata:
     """
     Defines this smart contract's metadata information.

--- a/boa3_test/examples/wrapped_gas.py
+++ b/boa3_test/examples/wrapped_gas.py
@@ -1,6 +1,6 @@
 from typing import Any, Union
 
-from boa3.builtin.compile_time import NeoMetadata, metadata, public, CreateNewEvent
+from boa3.builtin.compile_time import CreateNewEvent, NeoMetadata, public
 from boa3.builtin.contract import Nep17TransferEvent, abort
 from boa3.builtin.interop import runtime, storage
 from boa3.builtin.interop.contract import GAS as GAS_SCRIPT, call_contract
@@ -13,8 +13,6 @@ from boa3.builtin.type import UInt160, helper as type_helper
 # METADATA
 # -------------------------------------------
 
-
-@metadata
 def manifest_metadata() -> NeoMetadata:
     """
     Defines this smart contract's metadata information

--- a/boa3_test/examples/wrapped_neo.py
+++ b/boa3_test/examples/wrapped_neo.py
@@ -1,6 +1,6 @@
 from typing import Any, Union
 
-from boa3.builtin.compile_time import NeoMetadata, metadata, public, CreateNewEvent
+from boa3.builtin.compile_time import CreateNewEvent, NeoMetadata, public
 from boa3.builtin.contract import Nep17TransferEvent, abort
 from boa3.builtin.interop import runtime, storage
 from boa3.builtin.interop.blockchain import Transaction
@@ -14,7 +14,6 @@ from boa3.builtin.type import UInt160, helper as type_helper
 # METADATA
 # -------------------------------------------
 
-@metadata
 def manifest_metadata() -> NeoMetadata:
     """
     Defines this smart contract's metadata information

--- a/boa3_test/test_sc/contract_interface_test/ContractInterfaceGetHashOnMetadata.py
+++ b/boa3_test/test_sc/contract_interface_test/ContractInterfaceGetHashOnMetadata.py
@@ -1,4 +1,4 @@
-from boa3.builtin.compile_time import contract, public, metadata, NeoMetadata
+from boa3.builtin.compile_time import NeoMetadata, contract, public
 from boa3.builtin.type import UInt160
 
 
@@ -11,7 +11,6 @@ class ContractInterface:
         pass
 
 
-@metadata
 def contract_metadata() -> NeoMetadata:
     obj = NeoMetadata()
     obj.add_permission(contract=ContractInterface.hash)

--- a/boa3_test/test_sc/interop_test/contract/CallScriptHash.py
+++ b/boa3_test/test_sc/interop_test/contract/CallScriptHash.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from boa3.builtin.compile_time import metadata, NeoMetadata, public
+from boa3.builtin.compile_time import NeoMetadata, public
 from boa3.builtin.interop.contract import call_contract
 from boa3.builtin.type import UInt160
 
@@ -10,7 +10,6 @@ def Main(scripthash: UInt160, method: str, args: list) -> Any:
     return call_contract(scripthash, method, args)
 
 
-@metadata
 def manifest_metadata() -> NeoMetadata:
     # since this smart contract will call another, it needs to have permission to do so on the manifest
     meta = NeoMetadata()

--- a/boa3_test/test_sc/interop_test/contract/CallScriptHashWithCast.py
+++ b/boa3_test/test_sc/interop_test/contract/CallScriptHashWithCast.py
@@ -1,6 +1,6 @@
 from typing import cast
 
-from boa3.builtin.compile_time import metadata, NeoMetadata, public
+from boa3.builtin.compile_time import NeoMetadata, public
 from boa3.builtin.interop.contract import call_contract
 from boa3.builtin.type import UInt160
 
@@ -11,7 +11,6 @@ def Main(scripthash: bytes, method: str, args: list) -> bool:
     return True
 
 
-@metadata
 def manifest_metadata() -> NeoMetadata:
     # since this smart contract will call another, it needs to have permission to do so on the manifest
     meta = NeoMetadata()

--- a/boa3_test/test_sc/interop_test/contract/CallScriptHashWithFlags.py
+++ b/boa3_test/test_sc/interop_test/contract/CallScriptHashWithFlags.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from boa3.builtin.compile_time import metadata, NeoMetadata, public
+from boa3.builtin.compile_time import NeoMetadata, public
 from boa3.builtin.interop.contract import CallFlags, call_contract
 from boa3.builtin.type import UInt160
 
@@ -10,7 +10,6 @@ def Main(scripthash: UInt160, method: str, args: list, flags: CallFlags) -> Any:
     return call_contract(scripthash, method, args, flags)
 
 
-@metadata
 def manifest_metadata() -> NeoMetadata:
     # since this smart contract will call another, it needs to have permission to do so on the manifest
     meta = NeoMetadata()

--- a/boa3_test/test_sc/interop_test/contract/CallScriptHashWithoutArgs.py
+++ b/boa3_test/test_sc/interop_test/contract/CallScriptHashWithoutArgs.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from boa3.builtin.compile_time import metadata, NeoMetadata, public
+from boa3.builtin.compile_time import NeoMetadata, public
 from boa3.builtin.interop.contract import call_contract
 from boa3.builtin.type import UInt160
 
@@ -10,7 +10,6 @@ def Main(scripthash: UInt160, method: str) -> Any:
     return call_contract(scripthash, method)
 
 
-@metadata
 def manifest_metadata() -> NeoMetadata:
     # since this smart contract will call another, it needs to have permission to do so on the manifest
     meta = NeoMetadata()

--- a/boa3_test/test_sc/interop_test/contract/ImportContract.py
+++ b/boa3_test/test_sc/interop_test/contract/ImportContract.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from boa3.builtin.compile_time import metadata, NeoMetadata, public
+from boa3.builtin.compile_time import NeoMetadata, public
 from boa3.builtin.interop import contract
 from boa3.builtin.type import UInt160
 
@@ -15,7 +15,6 @@ def main(scripthash: UInt160, method: str, args: list) -> Any:
     return contract.call_contract(scripthash, method, args)
 
 
-@metadata
 def manifest_metadata() -> NeoMetadata:
     # since this smart contract will call another, it needs to have permission to do so on the manifest
     meta = NeoMetadata()

--- a/boa3_test/test_sc/interop_test/contract/ImportInteropContract.py
+++ b/boa3_test/test_sc/interop_test/contract/ImportInteropContract.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from boa3.builtin import interop, type
-from boa3.builtin.compile_time import metadata, NeoMetadata, public
+from boa3.builtin.compile_time import NeoMetadata, public
 
 
 @public
@@ -14,7 +14,6 @@ def main(scripthash: type.UInt160, method: str, args: list) -> Any:
     return interop.contract.call_contract(scripthash, method, args)
 
 
-@metadata
 def manifest_metadata() -> NeoMetadata:
     # since this smart contract will call another, it needs to have permission to do so on the manifest
     meta = NeoMetadata()

--- a/boa3_test/test_sc/metadata_test/MetadataImportingExternalContractBeforeMetadataMethod.py
+++ b/boa3_test/test_sc/metadata_test/MetadataImportingExternalContractBeforeMetadataMethod.py
@@ -1,8 +1,7 @@
-from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.compile_time import NeoMetadata, public
 from boa3_test.test_sc.metadata_test.aux_package.internal_package.external_contract import ExternalContract
 
 
-@metadata
 def standards_manifest() -> NeoMetadata:
     meta = NeoMetadata()
     meta.description = 'Test importing a external contract before declaring the metadata'

--- a/boa3_test/test_sc/metadata_test/MetadataInfoAuthor.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoAuthor.py
@@ -1,4 +1,4 @@
-from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.compile_time import NeoMetadata, public
 
 
 @public
@@ -6,7 +6,6 @@ def Main() -> int:
     return 5
 
 
-@metadata
 def author_manifest() -> NeoMetadata:
     meta = NeoMetadata()
     meta.author = 'Test'

--- a/boa3_test/test_sc/metadata_test/MetadataInfoAuthorMismatchedType.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoAuthorMismatchedType.py
@@ -1,11 +1,10 @@
-from boa3.builtin.compile_time import NeoMetadata, metadata
+from boa3.builtin.compile_time import NeoMetadata
 
 
 def Main() -> int:
     return 5
 
 
-@metadata
 def author_manifest() -> NeoMetadata:
     meta = NeoMetadata()
     meta.author = 98

--- a/boa3_test/test_sc/metadata_test/MetadataInfoDefault.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoDefault.py
@@ -1,4 +1,4 @@
-from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.compile_time import NeoMetadata, public
 
 
 @public
@@ -6,7 +6,6 @@ def main() -> int:
     return 5
 
 
-@metadata
 def permissions_manifest() -> NeoMetadata:
     meta = NeoMetadata()
     return meta

--- a/boa3_test/test_sc/metadata_test/MetadataInfoDescription.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoDescription.py
@@ -1,4 +1,4 @@
-from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.compile_time import NeoMetadata, public
 
 
 @public
@@ -6,7 +6,6 @@ def Main() -> int:
     return 5
 
 
-@metadata
 def description_manifest() -> NeoMetadata:
     meta = NeoMetadata()
     meta.description = 'This is an example'

--- a/boa3_test/test_sc/metadata_test/MetadataInfoDescriptionMismatchedType.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoDescriptionMismatchedType.py
@@ -1,11 +1,10 @@
-from boa3.builtin.compile_time import NeoMetadata, metadata
+from boa3.builtin.compile_time import NeoMetadata
 
 
 def Main() -> int:
     return 5
 
 
-@metadata
 def description_manifest() -> NeoMetadata:
     meta = NeoMetadata()
     meta.description = [0, 4, 8, 12]

--- a/boa3_test/test_sc/metadata_test/MetadataInfoEmail.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoEmail.py
@@ -1,4 +1,4 @@
-from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.compile_time import NeoMetadata, public
 
 
 @public
@@ -6,7 +6,6 @@ def Main() -> int:
     return 5
 
 
-@metadata
 def email_manifest() -> NeoMetadata:
     meta = NeoMetadata()
     meta.email = 'test@test.com'

--- a/boa3_test/test_sc/metadata_test/MetadataInfoEmailMismatchedType.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoEmailMismatchedType.py
@@ -1,11 +1,10 @@
-from boa3.builtin.compile_time import NeoMetadata, metadata
+from boa3.builtin.compile_time import NeoMetadata
 
 
 def Main() -> int:
     return 5
 
 
-@metadata
 def email_manifest() -> NeoMetadata:
     meta = NeoMetadata()
     meta.email = False

--- a/boa3_test/test_sc/metadata_test/MetadataInfoExtras.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoExtras.py
@@ -1,4 +1,4 @@
-from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.compile_time import NeoMetadata, public
 
 
 @public
@@ -6,7 +6,6 @@ def Main() -> int:
     return 5
 
 
-@metadata
 def extras_manifest() -> NeoMetadata:
     meta = NeoMetadata()
     meta.author = 'Test'

--- a/boa3_test/test_sc/metadata_test/MetadataInfoGroups.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoGroups.py
@@ -1,4 +1,4 @@
-from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.compile_time import NeoMetadata, public
 
 
 @public
@@ -6,7 +6,6 @@ def main() -> int:
     return 5
 
 
-@metadata
 def permissions_manifest() -> NeoMetadata:
     meta = NeoMetadata()
 

--- a/boa3_test/test_sc/metadata_test/MetadataInfoMethodNoReturn.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoMethodNoReturn.py
@@ -1,10 +1,9 @@
-from boa3.builtin.compile_time import NeoMetadata, metadata
+from boa3.builtin.compile_time import NeoMetadata
 
 
 def Main() -> int:
     return 5
 
 
-@metadata
 def manifest() -> NeoMetadata:
     "Missing metadata object return"

--- a/boa3_test/test_sc/metadata_test/MetadataInfoMultipleMethod.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoMultipleMethod.py
@@ -1,4 +1,4 @@
-from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.compile_time import NeoMetadata, public
 
 
 @public
@@ -6,7 +6,6 @@ def Main() -> int:
     return 5
 
 
-@metadata
 def manifest_func1() -> NeoMetadata:
     from boa3.builtin.compile_time import NeoMetadata
     meta = NeoMetadata()
@@ -14,7 +13,7 @@ def manifest_func1() -> NeoMetadata:
     return meta
 
 
-@metadata  # this decorator can be applied to one function only
+# this function will be ignored by the compiler
 def manifest_func2() -> NeoMetadata:
     from boa3.builtin.compile_time import NeoMetadata
     meta = NeoMetadata()

--- a/boa3_test/test_sc/metadata_test/MetadataInfoName.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoName.py
@@ -1,4 +1,4 @@
-from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.compile_time import NeoMetadata, public
 
 
 @public
@@ -6,7 +6,6 @@ def Main() -> int:
     return 5
 
 
-@metadata
 def name_manifest() -> NeoMetadata:
     meta = NeoMetadata()
 

--- a/boa3_test/test_sc/metadata_test/MetadataInfoNameMismatchedType.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoNameMismatchedType.py
@@ -1,11 +1,10 @@
-from boa3.builtin.compile_time import NeoMetadata, metadata
+from boa3.builtin.compile_time import NeoMetadata
 
 
 def Main() -> int:
     return 5
 
 
-@metadata
 def name_manifest() -> NeoMetadata:
     meta = NeoMetadata()
 

--- a/boa3_test/test_sc/metadata_test/MetadataInfoNewExtras.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoNewExtras.py
@@ -1,4 +1,4 @@
-from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.compile_time import NeoMetadata, public
 
 
 @public
@@ -6,7 +6,6 @@ def Main() -> int:
     return 5
 
 
-@metadata
 def extras_manifest() -> NeoMetadata:
     meta = NeoMetadata()
 

--- a/boa3_test/test_sc/metadata_test/MetadataInfoPermissions.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoPermissions.py
@@ -1,4 +1,4 @@
-from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.compile_time import NeoMetadata, public
 
 
 @public
@@ -6,7 +6,6 @@ def Main() -> int:
     return 5
 
 
-@metadata
 def permissions_manifest() -> NeoMetadata:
     meta = NeoMetadata()
 

--- a/boa3_test/test_sc/metadata_test/MetadataInfoPermissionsInvalidCall.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoPermissionsInvalidCall.py
@@ -1,10 +1,9 @@
 from typing import Any
 
-from boa3.builtin.compile_time import NeoMetadata, metadata, public
-from boa3.builtin.interop.contract import call_contract, NEO
+from boa3.builtin.compile_time import NeoMetadata, public
+from boa3.builtin.interop.contract import NEO, call_contract
 
 
-@metadata
 def permissions_manifest() -> NeoMetadata:
     meta = NeoMetadata()
 

--- a/boa3_test/test_sc/metadata_test/MetadataInfoPermissionsMismatchedType.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoPermissionsMismatchedType.py
@@ -1,4 +1,4 @@
-from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.compile_time import NeoMetadata, public
 
 
 @public
@@ -6,7 +6,6 @@ def Main() -> int:
     return 5
 
 
-@metadata
 def permissions_manifest() -> NeoMetadata:
     meta = NeoMetadata()
 

--- a/boa3_test/test_sc/metadata_test/MetadataInfoPermissionsNativeContract.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoPermissionsNativeContract.py
@@ -1,8 +1,7 @@
-from boa3.builtin.compile_time import metadata, public, NeoMetadata
+from boa3.builtin.compile_time import NeoMetadata, public
 from boa3.builtin.nativecontract.contractmanagement import ContractManagement
 
 
-@metadata
 def permissions_manifest() -> NeoMetadata:
     meta = NeoMetadata()
     # permission to call 'update' and 'destroy' from ContractManagement should be included by the compiler

--- a/boa3_test/test_sc/metadata_test/MetadataInfoPermissionsWildcard.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoPermissionsWildcard.py
@@ -1,4 +1,4 @@
-from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.compile_time import NeoMetadata, public
 from boa3.builtin.nativecontract.neo import NEO
 
 
@@ -7,7 +7,6 @@ def main() -> int:
     return NEO.totalSupply()
 
 
-@metadata
 def permissions_manifest() -> NeoMetadata:
     meta = NeoMetadata()
 

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSource.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSource.py
@@ -1,4 +1,4 @@
-from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.compile_time import NeoMetadata, public
 
 
 @public
@@ -6,7 +6,6 @@ def Main() -> int:
     return 5
 
 
-@metadata
 def email_manifest() -> NeoMetadata:
     meta = NeoMetadata()
     meta.source = 'https://github.com/CityOfZion/neo3-boa'

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSourceMismatchedType.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSourceMismatchedType.py
@@ -1,11 +1,10 @@
-from boa3.builtin.compile_time import NeoMetadata, metadata
+from boa3.builtin.compile_time import NeoMetadata
 
 
 def Main() -> int:
     return 5
 
 
-@metadata
 def name_manifest() -> NeoMetadata:
     meta = NeoMetadata()
 

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandards.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandards.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.compile_time import NeoMetadata, public
 from boa3.builtin.contract import Nep17TransferEvent
 from boa3.builtin.type import UInt160
 
@@ -12,7 +12,6 @@ def Main() -> int:
     return 5
 
 
-@metadata
 def standards_manifest() -> NeoMetadata:
     meta = NeoMetadata()
     meta.supported_standards = ['NEP-17']

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsByteStringAsBytes.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsByteStringAsBytes.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Union
 
-from boa3.builtin.compile_time import NeoMetadata, metadata, public, CreateNewEvent
+from boa3.builtin.compile_time import CreateNewEvent, NeoMetadata, public
 from boa3.builtin.interop.iterator import Iterator
 from boa3.builtin.type import UInt160
 
@@ -16,7 +16,6 @@ on_transfer = CreateNewEvent(
 )
 
 
-@metadata
 def standards_manifest() -> NeoMetadata:
     meta = NeoMetadata()
     meta.supported_standards = ['NEP-11']

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsByteStringAsStr.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsByteStringAsStr.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Union
 
-from boa3.builtin.compile_time import NeoMetadata, metadata, public, CreateNewEvent
+from boa3.builtin.compile_time import CreateNewEvent, NeoMetadata, public
 from boa3.builtin.interop.iterator import Iterator
 from boa3.builtin.type import UInt160
 
@@ -16,7 +16,6 @@ on_transfer = CreateNewEvent(
 )
 
 
-@metadata
 def standards_manifest() -> NeoMetadata:
     meta = NeoMetadata()
     meta.supported_standards = ['NEP-11']

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsEventFromPackage.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsEventFromPackage.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.compile_time import NeoMetadata, public
 from boa3.builtin.type import UInt160
 from boa3_test.test_sc.metadata_test.aux_package import internal_package
 
@@ -10,7 +10,6 @@ def Main() -> int:
     return 5
 
 
-@metadata
 def standards_manifest() -> NeoMetadata:
     meta = NeoMetadata()
     meta.supported_standards = ['NEP-17']

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsFilter.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsFilter.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.compile_time import NeoMetadata, public
 from boa3.builtin.contract import Nep17TransferEvent
 from boa3.builtin.type import UInt160
 
@@ -12,7 +12,6 @@ def Main() -> int:
     return 5
 
 
-@metadata
 def standards_manifest() -> NeoMetadata:
     meta = NeoMetadata()
     meta.supported_standards = [

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsImportedEvent.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsImportedEvent.py
@@ -1,11 +1,10 @@
 from typing import Any
 
 import boa3_test.examples.nep17 as nep17
-from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.compile_time import NeoMetadata, public
 from boa3.builtin.type import UInt160
 
 
-@metadata
 def standards_manifest() -> NeoMetadata:
     meta = NeoMetadata()
     meta.supported_standards = ['NEP-17']

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsMismatchedType.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsMismatchedType.py
@@ -1,11 +1,10 @@
-from boa3.builtin.compile_time import NeoMetadata, metadata
+from boa3.builtin.compile_time import NeoMetadata
 
 
 def Main() -> int:
     return 5
 
 
-@metadata
 def standards_manifest() -> NeoMetadata:
     meta = NeoMetadata()
     meta.supported_standards = 'NEP-11'

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsMissingEventNEP11.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsMissingEventNEP11.py
@@ -1,11 +1,10 @@
 from typing import Any
 
-from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.compile_time import NeoMetadata, public
 from boa3.builtin.interop.iterator import Iterator
 from boa3.builtin.type import UInt160
 
 
-@metadata
 def standards_manifest() -> NeoMetadata:
     meta = NeoMetadata()
     meta.supported_standards = ['NEP-11']  # for nep11, boa checks if the standard is implemented

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsMissingImplementationNEP11.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsMissingImplementationNEP11.py
@@ -1,11 +1,10 @@
-from boa3.builtin.compile_time import NeoMetadata, metadata
+from boa3.builtin.compile_time import NeoMetadata
 
 
 def Main() -> int:
     return 5
 
 
-@metadata
 def standards_manifest() -> NeoMetadata:
     meta = NeoMetadata()
     meta.supported_standards = ['NEP-11']  # for nep11, boa checks if the standard is implemented

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsMissingImplementationNEP11Divisible.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsMissingImplementationNEP11Divisible.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.compile_time import NeoMetadata, public
 from boa3.builtin.contract import Nep11TransferEvent
 from boa3.builtin.interop.iterator import Iterator
 from boa3.builtin.type import UInt160
@@ -8,7 +8,6 @@ from boa3.builtin.type import UInt160
 on_transfer = Nep11TransferEvent
 
 
-@metadata
 def standards_manifest() -> NeoMetadata:
     meta = NeoMetadata()
     meta.supported_standards = ['NEP-11']  # for nep11, boa checks if the standard is implemented

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsMissingImplementationNEP11OptionalMethods.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsMissingImplementationNEP11OptionalMethods.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict
 
-from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.compile_time import NeoMetadata, public
 from boa3.builtin.contract import Nep11TransferEvent
 from boa3.builtin.interop.iterator import Iterator
 from boa3.builtin.type import UInt160
@@ -8,7 +8,6 @@ from boa3.builtin.type import UInt160
 on_transfer = Nep11TransferEvent
 
 
-@metadata
 def standards_manifest() -> NeoMetadata:
     meta = NeoMetadata()
     meta.supported_standards = ['NEP-11']  # for nep11, boa checks if the standard is implemented

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsMissingImplementationNEP17.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsMissingImplementationNEP17.py
@@ -1,11 +1,10 @@
-from boa3.builtin.compile_time import NeoMetadata, metadata
+from boa3.builtin.compile_time import NeoMetadata
 
 
 def Main() -> int:
     return 5
 
 
-@metadata
 def standards_manifest() -> NeoMetadata:
     meta = NeoMetadata()
     meta.supported_standards = ['NEP-17']  # for nep17, boa checks if the standard is implemented

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsNEP11Divisible.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsNEP11Divisible.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.compile_time import NeoMetadata, public
 from boa3.builtin.contract import Nep11TransferEvent
 from boa3.builtin.interop.iterator import Iterator
 from boa3.builtin.type import UInt160
@@ -8,7 +8,6 @@ from boa3.builtin.type import UInt160
 on_transfer = Nep11TransferEvent
 
 
-@metadata
 def standards_manifest() -> NeoMetadata:
     meta = NeoMetadata()
     meta.supported_standards = ['NEP-11']  # for nep11, boa checks if the standard is implemented

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsNEP11DivisibleOptionalMethods.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsNEP11DivisibleOptionalMethods.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict
 
-from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.compile_time import NeoMetadata, public
 from boa3.builtin.contract import Nep11TransferEvent
 from boa3.builtin.interop.iterator import Iterator
 from boa3.builtin.type import UInt160
@@ -8,7 +8,6 @@ from boa3.builtin.type import UInt160
 on_transfer = Nep11TransferEvent
 
 
-@metadata
 def standards_manifest() -> NeoMetadata:
     meta = NeoMetadata()
     meta.supported_standards = ['NEP-11']  # for nep11, boa checks if the standard is implemented

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsNEP11NonDivisible.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsNEP11NonDivisible.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.compile_time import NeoMetadata, public
 from boa3.builtin.contract import Nep11TransferEvent
 from boa3.builtin.interop.iterator import Iterator
 from boa3.builtin.type import UInt160
@@ -8,7 +8,6 @@ from boa3.builtin.type import UInt160
 on_transfer = Nep11TransferEvent
 
 
-@metadata
 def standards_manifest() -> NeoMetadata:
     meta = NeoMetadata()
     meta.supported_standards = ['NEP-11']  # for nep11, boa checks if the standard is implemented

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsNEP11NonDivisibleOptionalMethods.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsNEP11NonDivisibleOptionalMethods.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict
 
-from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.compile_time import NeoMetadata, public
 from boa3.builtin.contract import Nep11TransferEvent
 from boa3.builtin.interop.iterator import Iterator
 from boa3.builtin.type import UInt160
@@ -8,7 +8,6 @@ from boa3.builtin.type import UInt160
 on_transfer = Nep11TransferEvent
 
 
-@metadata
 def standards_manifest() -> NeoMetadata:
     meta = NeoMetadata()
     meta.supported_standards = ['NEP-11']  # for nep11, boa checks if the standard is implemented

--- a/boa3_test/test_sc/metadata_test/MetadataInfoTrusts.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoTrusts.py
@@ -1,4 +1,4 @@
-from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.compile_time import NeoMetadata, public
 
 
 @public
@@ -6,7 +6,6 @@ def Main() -> int:
     return 5
 
 
-@metadata
 def trusts_manifest() -> NeoMetadata:
     meta = NeoMetadata()
 

--- a/boa3_test/test_sc/metadata_test/MetadataInfoTrustsMismatchedTypes.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoTrustsMismatchedTypes.py
@@ -1,4 +1,4 @@
-from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.compile_time import NeoMetadata, public
 
 
 @public
@@ -6,7 +6,6 @@ def Main() -> int:
     return 5
 
 
-@metadata
 def trusts_manifest() -> NeoMetadata:
     meta = NeoMetadata()
 

--- a/boa3_test/test_sc/metadata_test/MetadataInfoTrustsWildcard.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoTrustsWildcard.py
@@ -1,4 +1,4 @@
-from boa3.builtin.compile_time import NeoMetadata, metadata, public
+from boa3.builtin.compile_time import NeoMetadata, public
 
 
 @public
@@ -6,7 +6,6 @@ def Main() -> int:
     return 5
 
 
-@metadata
 def trusts_manifest() -> NeoMetadata:
     meta = NeoMetadata()
 

--- a/boa3_test/test_sc/metadata_test/MetadataInfoWithDecorator.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoWithDecorator.py
@@ -1,4 +1,4 @@
-from boa3.builtin.compile_time import NeoMetadata, public
+from boa3.builtin.compile_time import NeoMetadata, metadata, public
 
 
 @public
@@ -6,6 +6,7 @@ def Main() -> int:
     return 5
 
 
+@metadata
 def manifest() -> NeoMetadata:
     from boa3.builtin.compile_time import NeoMetadata
     return NeoMetadata()

--- a/boa3_test/test_sc/metadata_test/MetadataMethodCalledByUserMethod.py
+++ b/boa3_test/test_sc/metadata_test/MetadataMethodCalledByUserMethod.py
@@ -1,4 +1,4 @@
-from boa3.builtin.compile_time import NeoMetadata, metadata
+from boa3.builtin.compile_time import NeoMetadata
 
 
 def Main() -> int:
@@ -6,7 +6,6 @@ def Main() -> int:
     return 5
 
 
-@metadata
 def example() -> NeoMetadata:
     # this function won't exist in the scope of the smart contract, so it can't be called by other functions
     meta = NeoMetadata()

--- a/boa3_test/test_sc/metadata_test/MetadataMethodWithArgs.py
+++ b/boa3_test/test_sc/metadata_test/MetadataMethodWithArgs.py
@@ -1,11 +1,10 @@
-from boa3.builtin.compile_time import NeoMetadata, metadata
+from boa3.builtin.compile_time import NeoMetadata
 
 
 def Main() -> int:
     return 5
 
 
-@metadata
 def example(arg0: int, arg1: str) -> NeoMetadata:
     # this function doesn't allow arguments
     return NeoMetadata()

--- a/boa3_test/tests/compiler_tests/test_metadata.py
+++ b/boa3_test/tests/compiler_tests/test_metadata.py
@@ -27,6 +27,16 @@ class TestMetadata(BoaTest):
         self.assertIn('extra', manifest)
         self.assertIsNone(manifest['extra'])
 
+    def test_metadata_info_method_with_decorator(self):
+        expected_output = (
+            Opcode.PUSH5  # return 5
+            + Opcode.RET
+        )
+
+        path = self.get_contract_path('MetadataInfoWithDecorator.py')
+        output = self.assertCompilerLogs(CompilerWarning.DeprecatedSymbol, path)
+        self.assertEqual(expected_output, output)
+
     def test_metadata_info_method_mismatched_type(self):
         path = self.get_contract_path('MetadataInfoMethodMismatchedReturn.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)

--- a/docs/source/calling-smart-contracts.md
+++ b/docs/source/calling-smart-contracts.md
@@ -43,7 +43,7 @@ Use the `contract` decorator from `boa3.builtin.compile_time` using the script h
 same methods you want call.
 ```python
 # calling_with_interface.py
-from boa3.builtin.compile_time import public, contract
+from boa3.builtin.compile_time import contract, public
 from boa3.builtin.type import UInt160
 
 @public


### PR DESCRIPTION
**Summary or solution description**
`@metadata` decorator is not necessary to identify which method is the one that defines metadata information because the return type can be used instead.
Deprecated it in this issue, but didn't remove it yet.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/3ac7c5df316d18e81acfbc6e4d3e188dc7110a0f/boa3_test/test_sc/metadata_test/MetadataInfoDefault.py#L4-L11

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/3ac7c5df316d18e81acfbc6e4d3e188dc7110a0f/boa3_test/tests/compiler_tests/test_metadata.py#L16-L38

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.10