### PR TITLE
Refactor test_types.py to use BoaTestConstructor

### DIFF
--- a/boa3_test/tests/compiler_tests/test_types.py
+++ b/boa3_test/tests/compiler_tests/test_types.py
@@ -1,16 +1,15 @@
 import ast
 
-from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to avoid circular imports
-
 from boa3.internal.analyser.analyser import Analyser
 from boa3.internal.analyser.typeanalyser import TypeAnalyser
 from boa3.internal.model.type.annotation.uniontype import UnionType
 from boa3.internal.model.type.collection.sequence.mutable.listtype import ListType
 from boa3.internal.model.type.collection.sequence.tupletype import TupleType
 from boa3.internal.model.type.type import Type
+from boa3_test.tests import boatestcase
 
 
-class TestTypes(BoaTest):
+class TestTypes(boatestcase.BoaTestCase):
 
     def test_small_integer_constant(self):
         input = 42


### PR DESCRIPTION
**Summary or solution description**
 Refactored `test_types` file to use `boatestconstructor` in place of TestRunner for unit testing.