### PR TITLE
CU-86a1hur7f - Refactor test_relational.py to use BoaTestConstructor

### DIFF
--- a/boa3/internal/model/operation/binary/relational/__init__.py
+++ b/boa3/internal/model/operation/binary/relational/__init__.py
@@ -7,7 +7,11 @@ __all__ = ['LessThan',
            'NumericEquality',
            'NumericInequality',
            'ObjectEquality',
-           'ObjectInequality'
+           'ObjectInequality',
+           'StrBytesGreaterThan',
+           'StrBytesGreaterThanOrEqual',
+           'StrBytesLessThan',
+           'StrBytesLessThanOrEqual',
            ]
 
 from boa3.internal.model.operation.binary.relational.greaterthan import GreaterThan
@@ -20,3 +24,7 @@ from boa3.internal.model.operation.binary.relational.numericequality import Nume
 from boa3.internal.model.operation.binary.relational.numericinequality import NumericInequality
 from boa3.internal.model.operation.binary.relational.objectequality import ObjectEquality
 from boa3.internal.model.operation.binary.relational.objectinequality import ObjectInequality
+from boa3.internal.model.operation.binary.relational.strbytesgreaterthan import StrBytesGreaterThan
+from boa3.internal.model.operation.binary.relational.strbytesgreaterthanorequal import StrBytesGreaterThanOrEqual
+from boa3.internal.model.operation.binary.relational.strbyteslessthan import StrBytesLessThan
+from boa3.internal.model.operation.binary.relational.strbyteslessthanorequal import StrBytesLessThanOrEqual

--- a/boa3/internal/model/operation/binary/relational/greaterthan.py
+++ b/boa3/internal/model/operation/binary/relational/greaterthan.py
@@ -15,7 +15,7 @@ class GreaterThan(BinaryOperation):
     :ivar right: the left operand type. Inherited from :class:`BinaryOperation`
     :ivar result: the result type of the operation.  Inherited from :class:`IOperation`
     """
-    _valid_types: List[IType] = [Type.int, Type.str]
+    _valid_types: List[IType] = [Type.int]
 
     def __init__(self, left: IType = Type.int, right: IType = None):
         self.operator: Operator = Operator.Gt

--- a/boa3/internal/model/operation/binary/relational/greaterthanorequal.py
+++ b/boa3/internal/model/operation/binary/relational/greaterthanorequal.py
@@ -15,7 +15,7 @@ class GreaterThanOrEqual(BinaryOperation):
     :ivar right: the left operand type. Inherited from :class:`BinaryOperation`
     :ivar result: the result type of the operation.  Inherited from :class:`IOperation`
     """
-    _valid_types: List[IType] = [Type.int, Type.str]
+    _valid_types: List[IType] = [Type.int]
 
     def __init__(self, left: IType = Type.int, right: IType = None):
         self.operator: Operator = Operator.GtE

--- a/boa3/internal/model/operation/binary/relational/lessthan.py
+++ b/boa3/internal/model/operation/binary/relational/lessthan.py
@@ -15,7 +15,7 @@ class LessThan(BinaryOperation):
     :ivar right: the left operand type. Inherited from :class:`BinaryOperation`
     :ivar result: the result type of the operation.  Inherited from :class:`IOperation`
     """
-    _valid_types: List[IType] = [Type.int, Type.str]
+    _valid_types: List[IType] = [Type.int]
 
     def __init__(self, left: IType = Type.int, right: IType = None):
         self.operator: Operator = Operator.Lt

--- a/boa3/internal/model/operation/binary/relational/lessthanorequal.py
+++ b/boa3/internal/model/operation/binary/relational/lessthanorequal.py
@@ -15,7 +15,7 @@ class LessThanOrEqual(BinaryOperation):
     :ivar right: the left operand type. Inherited from :class:`BinaryOperation`
     :ivar result: the result type of the operation.  Inherited from :class:`IOperation`
     """
-    _valid_types: List[IType] = [Type.int, Type.str]
+    _valid_types: List[IType] = [Type.int]
 
     def __init__(self, left: IType = Type.int, right: IType = None):
         self.operator: Operator = Operator.LtE

--- a/boa3/internal/model/operation/binary/relational/strbytesgreaterthan.py
+++ b/boa3/internal/model/operation/binary/relational/strbytesgreaterthan.py
@@ -4,7 +4,6 @@ from boa3.internal.model.builtin.interop.interop import Interop
 from boa3.internal.model.operation.binary.binaryoperation import BinaryOperation
 from boa3.internal.model.operation.operator import Operator
 from boa3.internal.model.type.type import IType, Type
-from boa3.internal.neo.vm.opcode.Opcode import Opcode
 
 
 class StrBytesGreaterThan(BinaryOperation):
@@ -37,6 +36,8 @@ class StrBytesGreaterThan(BinaryOperation):
             return Type.none
 
     def generate_internal_opcodes(self, code_generator):
+        from boa3.internal.model.operation.binaryop import BinaryOp
+
         # comparing strings, on the stack the first string is the right one and the second is the left one
         Interop.MemoryCompare.generate_internal_opcodes(code_generator)
         # -1 means the left string is greater than the right string
@@ -45,11 +46,5 @@ class StrBytesGreaterThan(BinaryOperation):
 
         # if comparison equals -1 (the left string is greater than the right string), then return True
         code_generator.convert_literal(-1)
-        if_comparison_equals_m1 = code_generator.convert_begin_if()
-        code_generator.change_jump(if_comparison_equals_m1, Opcode.JMPNE)
-        code_generator.convert_literal(True)
-
+        code_generator.convert_operation(BinaryOp.NumEq)
         # else, return False
-        if_comparison_not_equals_m1 = code_generator.convert_begin_else(if_comparison_equals_m1)
-        code_generator.convert_literal(False)
-        code_generator.convert_end_if(if_comparison_not_equals_m1)

--- a/boa3/internal/model/operation/binary/relational/strbytesgreaterthan.py
+++ b/boa3/internal/model/operation/binary/relational/strbytesgreaterthan.py
@@ -1,0 +1,55 @@
+from typing import List
+
+from boa3.internal.model.builtin.interop.interop import Interop
+from boa3.internal.model.operation.binary.binaryoperation import BinaryOperation
+from boa3.internal.model.operation.operator import Operator
+from boa3.internal.model.type.type import IType, Type
+from boa3.internal.neo.vm.opcode.Opcode import Opcode
+
+
+class StrBytesGreaterThan(BinaryOperation):
+    """
+    A class used to represent a string/bytes greater than comparison
+
+    :ivar operator: the operator of the operation. Inherited from :class:`IOperation`
+    :ivar left: the left operand type. Inherited from :class:`BinaryOperation`
+    :ivar right: the left operand type. Inherited from :class:`BinaryOperation`
+    :ivar result: the result type of the operation.  Inherited from :class:`IOperation`
+    """
+    _valid_types: List[IType] = [Type.bytes, Type.str]
+
+    def __init__(self, left: IType = Type.str, right: IType = None):
+        self.operator: Operator = Operator.Gt
+        super().__init__(left, right)
+
+    def validate_type(self, *types: IType) -> bool:
+        if len(types) != self.number_of_operands:
+            return False
+        left: IType = types[0]
+        right: IType = types[1]
+
+        return left == right and any(_type.is_type_of(left) for _type in self._valid_types)
+
+    def _get_result(self, left: IType, right: IType) -> IType:
+        if self.validate_type(left, right):
+            return Type.bool
+        else:
+            return Type.none
+
+    def generate_internal_opcodes(self, code_generator):
+        # comparing strings, on the stack the first string is the right one and the second is the left one
+        Interop.MemoryCompare.generate_internal_opcodes(code_generator)
+        # -1 means the left string is greater than the right string
+        # 1 means the left string is less than the right string
+        # 0 means the right string is equals to the left string
+
+        # if comparison equals -1 (the left string is greater than the right string), then return True
+        code_generator.convert_literal(-1)
+        if_comparison_equals_m1 = code_generator.convert_begin_if()
+        code_generator.change_jump(if_comparison_equals_m1, Opcode.JMPNE)
+        code_generator.convert_literal(True)
+
+        # else, return False
+        if_comparison_not_equals_m1 = code_generator.convert_begin_else(if_comparison_equals_m1)
+        code_generator.convert_literal(False)
+        code_generator.convert_end_if(if_comparison_not_equals_m1)

--- a/boa3/internal/model/operation/binary/relational/strbytesgreaterthanorequal.py
+++ b/boa3/internal/model/operation/binary/relational/strbytesgreaterthanorequal.py
@@ -1,0 +1,55 @@
+from typing import List
+
+from boa3.internal.model.builtin.interop.interop import Interop
+from boa3.internal.model.operation.binary.binaryoperation import BinaryOperation
+from boa3.internal.model.operation.operator import Operator
+from boa3.internal.model.type.type import IType, Type
+from boa3.internal.neo.vm.opcode.Opcode import Opcode
+
+
+class StrBytesGreaterThanOrEqual(BinaryOperation):
+    """
+    A class used to represent a string/bytes greater than or equal comparison
+
+    :ivar operator: the operator of the operation. Inherited from :class:`IOperation`
+    :ivar left: the left operand type. Inherited from :class:`BinaryOperation`
+    :ivar right: the left operand type. Inherited from :class:`BinaryOperation`
+    :ivar result: the result type of the operation.  Inherited from :class:`IOperation`
+    """
+    _valid_types: List[IType] = [Type.bytes, Type.str]
+
+    def __init__(self, left: IType = Type.str, right: IType = None):
+        self.operator: Operator = Operator.GtE
+        super().__init__(left, right)
+
+    def validate_type(self, *types: IType) -> bool:
+        if len(types) != self.number_of_operands:
+            return False
+        left: IType = types[0]
+        right: IType = types[1]
+
+        return left == right and any(_type.is_type_of(left) for _type in self._valid_types)
+
+    def _get_result(self, left: IType, right: IType) -> IType:
+        if self.validate_type(left, right):
+            return Type.bool
+        else:
+            return Type.none
+
+    def generate_internal_opcodes(self, code_generator):
+        # comparing strings, on the stack the first string is the right one and the second is the left one
+        Interop.MemoryCompare.generate_internal_opcodes(code_generator)
+        # -1 means the left string is greater than the right string
+        # 1 means the left string is less than the right string
+        # 0 means the right string is equals to the left string
+
+        # if comparison equals 1 (the left string is less than the right string), then return False
+        code_generator.convert_literal(1)
+        if_comparison_equals_1 = code_generator.convert_begin_if()
+        code_generator.change_jump(if_comparison_equals_1, Opcode.JMPNE)
+        code_generator.convert_literal(False)
+
+        # else, return True
+        if_comparison_not_equals_1 = code_generator.convert_begin_else(if_comparison_equals_1)
+        code_generator.convert_literal(True)
+        code_generator.convert_end_if(if_comparison_not_equals_1)

--- a/boa3/internal/model/operation/binary/relational/strbytesgreaterthanorequal.py
+++ b/boa3/internal/model/operation/binary/relational/strbytesgreaterthanorequal.py
@@ -4,7 +4,6 @@ from boa3.internal.model.builtin.interop.interop import Interop
 from boa3.internal.model.operation.binary.binaryoperation import BinaryOperation
 from boa3.internal.model.operation.operator import Operator
 from boa3.internal.model.type.type import IType, Type
-from boa3.internal.neo.vm.opcode.Opcode import Opcode
 
 
 class StrBytesGreaterThanOrEqual(BinaryOperation):
@@ -37,6 +36,8 @@ class StrBytesGreaterThanOrEqual(BinaryOperation):
             return Type.none
 
     def generate_internal_opcodes(self, code_generator):
+        from boa3.internal.model.operation.binaryop import BinaryOp
+
         # comparing strings, on the stack the first string is the right one and the second is the left one
         Interop.MemoryCompare.generate_internal_opcodes(code_generator)
         # -1 means the left string is greater than the right string
@@ -45,11 +46,5 @@ class StrBytesGreaterThanOrEqual(BinaryOperation):
 
         # if comparison equals 1 (the left string is less than the right string), then return False
         code_generator.convert_literal(1)
-        if_comparison_equals_1 = code_generator.convert_begin_if()
-        code_generator.change_jump(if_comparison_equals_1, Opcode.JMPNE)
-        code_generator.convert_literal(False)
-
+        code_generator.convert_operation(BinaryOp.NumNotEq)
         # else, return True
-        if_comparison_not_equals_1 = code_generator.convert_begin_else(if_comparison_equals_1)
-        code_generator.convert_literal(True)
-        code_generator.convert_end_if(if_comparison_not_equals_1)

--- a/boa3/internal/model/operation/binary/relational/strbyteslessthan.py
+++ b/boa3/internal/model/operation/binary/relational/strbyteslessthan.py
@@ -1,0 +1,55 @@
+from typing import List
+
+from boa3.internal.model.builtin.interop.interop import Interop
+from boa3.internal.model.operation.binary.binaryoperation import BinaryOperation
+from boa3.internal.model.operation.operator import Operator
+from boa3.internal.model.type.type import IType, Type
+from boa3.internal.neo.vm.opcode.Opcode import Opcode
+
+
+class StrBytesLessThan(BinaryOperation):
+    """
+    A class used to represent a string/bytes less than comparison
+
+    :ivar operator: the operator of the operation. Inherited from :class:`IOperation`
+    :ivar left: the left operand type. Inherited from :class:`BinaryOperation`
+    :ivar right: the left operand type. Inherited from :class:`BinaryOperation`
+    :ivar result: the result type of the operation.  Inherited from :class:`IOperation`
+    """
+    _valid_types: List[IType] = [Type.bytes, Type.str]
+
+    def __init__(self, left: IType = Type.str, right: IType = None):
+        self.operator: Operator = Operator.Lt
+        super().__init__(left, right)
+
+    def validate_type(self, *types: IType) -> bool:
+        if len(types) != self.number_of_operands:
+            return False
+        left: IType = types[0]
+        right: IType = types[1]
+
+        return left == right and any(_type.is_type_of(left) for _type in self._valid_types)
+
+    def _get_result(self, left: IType, right: IType) -> IType:
+        if self.validate_type(left, right):
+            return Type.bool
+        else:
+            return Type.none
+
+    def generate_internal_opcodes(self, code_generator):
+        # comparing strings, on the stack the first string is the right one and the second is the left one
+        Interop.MemoryCompare.generate_internal_opcodes(code_generator)
+        # -1 means the left string is greater than the right string
+        # 1 means the left string is less than the right string
+        # 0 means the right string is equals to the left string
+
+        # if comparison equals 1 (the left string is less than the right string), then return True
+        code_generator.convert_literal(1)
+        if_comparison_equals_1 = code_generator.convert_begin_if()
+        code_generator.change_jump(if_comparison_equals_1, Opcode.JMPNE)
+        code_generator.convert_literal(True)
+
+        # else, return False
+        if_comparison_not_equals_1 = code_generator.convert_begin_else(if_comparison_equals_1)
+        code_generator.convert_literal(False)
+        code_generator.convert_end_if(if_comparison_not_equals_1)

--- a/boa3/internal/model/operation/binary/relational/strbyteslessthan.py
+++ b/boa3/internal/model/operation/binary/relational/strbyteslessthan.py
@@ -4,7 +4,6 @@ from boa3.internal.model.builtin.interop.interop import Interop
 from boa3.internal.model.operation.binary.binaryoperation import BinaryOperation
 from boa3.internal.model.operation.operator import Operator
 from boa3.internal.model.type.type import IType, Type
-from boa3.internal.neo.vm.opcode.Opcode import Opcode
 
 
 class StrBytesLessThan(BinaryOperation):
@@ -37,6 +36,8 @@ class StrBytesLessThan(BinaryOperation):
             return Type.none
 
     def generate_internal_opcodes(self, code_generator):
+        from boa3.internal.model.operation.binaryop import BinaryOp
+
         # comparing strings, on the stack the first string is the right one and the second is the left one
         Interop.MemoryCompare.generate_internal_opcodes(code_generator)
         # -1 means the left string is greater than the right string
@@ -45,11 +46,5 @@ class StrBytesLessThan(BinaryOperation):
 
         # if comparison equals 1 (the left string is less than the right string), then return True
         code_generator.convert_literal(1)
-        if_comparison_equals_1 = code_generator.convert_begin_if()
-        code_generator.change_jump(if_comparison_equals_1, Opcode.JMPNE)
-        code_generator.convert_literal(True)
-
+        code_generator.convert_operation(BinaryOp.NumEq)
         # else, return False
-        if_comparison_not_equals_1 = code_generator.convert_begin_else(if_comparison_equals_1)
-        code_generator.convert_literal(False)
-        code_generator.convert_end_if(if_comparison_not_equals_1)

--- a/boa3/internal/model/operation/binary/relational/strbyteslessthanorequal.py
+++ b/boa3/internal/model/operation/binary/relational/strbyteslessthanorequal.py
@@ -4,7 +4,6 @@ from boa3.internal.model.builtin.interop.interop import Interop
 from boa3.internal.model.operation.binary.binaryoperation import BinaryOperation
 from boa3.internal.model.operation.operator import Operator
 from boa3.internal.model.type.type import IType, Type
-from boa3.internal.neo.vm.opcode.Opcode import Opcode
 
 
 class StrBytesLessThanOrEqual(BinaryOperation):
@@ -37,6 +36,8 @@ class StrBytesLessThanOrEqual(BinaryOperation):
             return Type.none
 
     def generate_internal_opcodes(self, code_generator):
+        from boa3.internal.model.operation.binaryop import BinaryOp
+
         # comparing strings, on the stack the first string is the right one and the second is the left one
         Interop.MemoryCompare.generate_internal_opcodes(code_generator)
         # -1 means the left string is greater than the right string
@@ -45,11 +46,5 @@ class StrBytesLessThanOrEqual(BinaryOperation):
 
         # if comparison equals -1 (the left string is greater than the right string), then return False
         code_generator.convert_literal(-1)
-        if_comparison_equals_m1 = code_generator.convert_begin_if()
-        code_generator.change_jump(if_comparison_equals_m1, Opcode.JMPNE)
-        code_generator.convert_literal(False)
-
+        code_generator.convert_operation(BinaryOp.NumNotEq)
         # else, return True
-        if_comparison_not_equals_m1 = code_generator.convert_begin_else(if_comparison_equals_m1)
-        code_generator.convert_literal(True)
-        code_generator.convert_end_if(if_comparison_not_equals_m1)

--- a/boa3/internal/model/operation/binary/relational/strbyteslessthanorequal.py
+++ b/boa3/internal/model/operation/binary/relational/strbyteslessthanorequal.py
@@ -1,0 +1,55 @@
+from typing import List
+
+from boa3.internal.model.builtin.interop.interop import Interop
+from boa3.internal.model.operation.binary.binaryoperation import BinaryOperation
+from boa3.internal.model.operation.operator import Operator
+from boa3.internal.model.type.type import IType, Type
+from boa3.internal.neo.vm.opcode.Opcode import Opcode
+
+
+class StrBytesLessThanOrEqual(BinaryOperation):
+    """
+    A class used to represent a string/bytes less than or equal comparison
+
+    :ivar operator: the operator of the operation. Inherited from :class:`IOperation`
+    :ivar left: the left operand type. Inherited from :class:`BinaryOperation`
+    :ivar right: the left operand type. Inherited from :class:`BinaryOperation`
+    :ivar result: the result type of the operation.  Inherited from :class:`IOperation`
+    """
+    _valid_types: List[IType] = [Type.bytes, Type.str]
+
+    def __init__(self, left: IType = Type.str, right: IType = None):
+        self.operator: Operator = Operator.LtE
+        super().__init__(left, right)
+
+    def validate_type(self, *types: IType) -> bool:
+        if len(types) != self.number_of_operands:
+            return False
+        left: IType = types[0]
+        right: IType = types[1]
+
+        return left == right and any(_type.is_type_of(left) for _type in self._valid_types)
+
+    def _get_result(self, left: IType, right: IType) -> IType:
+        if self.validate_type(left, right):
+            return Type.bool
+        else:
+            return Type.none
+
+    def generate_internal_opcodes(self, code_generator):
+        # comparing strings, on the stack the first string is the right one and the second is the left one
+        Interop.MemoryCompare.generate_internal_opcodes(code_generator)
+        # -1 means the left string is greater than the right string
+        # 1 means the left string is less than the right string
+        # 0 means the right string is equals to the left string
+
+        # if comparison equals -1 (the left string is greater than the right string), then return False
+        code_generator.convert_literal(-1)
+        if_comparison_equals_m1 = code_generator.convert_begin_if()
+        code_generator.change_jump(if_comparison_equals_m1, Opcode.JMPNE)
+        code_generator.convert_literal(False)
+
+        # else, return True
+        if_comparison_not_equals_m1 = code_generator.convert_begin_else(if_comparison_equals_m1)
+        code_generator.convert_literal(True)
+        code_generator.convert_end_if(if_comparison_not_equals_m1)

--- a/boa3/internal/model/operation/binaryop.py
+++ b/boa3/internal/model/operation/binaryop.py
@@ -38,6 +38,10 @@ class BinaryOp:
     IsNot = NotIdentity()
     Eq = ObjectEquality()
     NotEq = ObjectInequality()
+    StrBytesGt = StrBytesGreaterThan()
+    StrBytesGtE = StrBytesGreaterThanOrEqual()
+    StrBytesLt = StrBytesLessThan()
+    StrBytesLtE = StrBytesLessThanOrEqual()
 
     # Logical operations
     And = BooleanAnd()

--- a/boa3_test/tests/compiler_tests/test_relational.py
+++ b/boa3_test/tests/compiler_tests/test_relational.py
@@ -55,10 +55,7 @@ class TestRelational(boatestcase.BoaTestCase):
             + Opcode.LDARG1
             + Opcode.CALLT + b'\x00\x00'
             + Opcode.PUSHM1
-            + Opcode.JMPNE + b'\x05'
-            + Opcode.PUSHT
-            + Opcode.JMP + b'\x03'
-            + Opcode.PUSHF
+            + Opcode.NUMEQUAL
             + Opcode.RET
         )
 
@@ -126,10 +123,7 @@ class TestRelational(boatestcase.BoaTestCase):
             + Opcode.LDARG1
             + Opcode.CALLT + b'\x00\x00'
             + Opcode.PUSH1
-            + Opcode.JMPNE + b'\x05'
-            + Opcode.PUSHF
-            + Opcode.JMP + b'\x03'
-            + Opcode.PUSHT
+            + Opcode.NUMNOTEQUAL
             + Opcode.RET
         )
 
@@ -306,10 +300,7 @@ class TestRelational(boatestcase.BoaTestCase):
             + Opcode.LDARG1
             + Opcode.CALLT + b'\x00\x00'
             + Opcode.PUSH1
-            + Opcode.JMPNE + b'\x05'
-            + Opcode.PUSHT
-            + Opcode.JMP + b'\x03'
-            + Opcode.PUSHF
+            + Opcode.NUMEQUAL
             + Opcode.RET
         )
 
@@ -377,10 +368,7 @@ class TestRelational(boatestcase.BoaTestCase):
             + Opcode.LDARG1
             + Opcode.CALLT + b'\x00\x00'
             + Opcode.PUSHM1
-            + Opcode.JMPNE + b'\x05'
-            + Opcode.PUSHF
-            + Opcode.JMP + b'\x03'
-            + Opcode.PUSHT
+            + Opcode.NUMNOTEQUAL
             + Opcode.RET
         )
 


### PR DESCRIPTION
**Summary or solution description**
 Refactored `test_relational` file to use `BoaTestCase `in place of BoaTest for unit testing.


**(Optional) Additional context**
Also fixed a bug on Gt, GtE, Lt, LtE operations when using str/bytes arguments
