### PR TITLE
Refactor test_logger.py to use BoaTestConstructor

### DIFF
--- a/boa3_test/tests/compiler_tests/test_bytes.py
+++ b/boa3_test/tests/compiler_tests/test_bytes.py
@@ -4,7 +4,6 @@ from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo.vm.type.StackItem import StackItemType
 from boa3.internal.neo3.vm import VMState
 from boa3_test.tests import boatestcase
-from boa3_test.tests.boatestcase import FaultException
 from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
@@ -1276,15 +1275,15 @@ class TestBytes(boatestcase.BoaTestCase):
         result, _ = await self.call('main', [bytes_, bytes_sequence, start, end], return_type=int)
         self.assertEqual(bytes_.index(bytes_sequence, start, end), result)
 
-        with self.assertRaises(FaultException) as context:
+        with self.assertRaises(boatestcase.FaultException) as context:
             await self.call('main', ['unit test', 'i', 3, 4], return_type=int)
         self.assertRegex(str(context.exception), f'{self.SUBSEQUENCE_NOT_FOUND_MSG}')
 
-        with self.assertRaises(FaultException) as context:
+        with self.assertRaises(boatestcase.FaultException) as context:
             await self.call('main', ['unit test', 'i', 4, -1], return_type=int)
         self.assertRegex(str(context.exception), f'{self.SUBSEQUENCE_NOT_FOUND_MSG}')
 
-        with self.assertRaises(FaultException) as context:
+        with self.assertRaises(boatestcase.FaultException) as context:
             await self.call('main', ['unit test', 'i', 0, -99], return_type=int)
         self.assertRegex(str(context.exception), f'{self.SUBSEQUENCE_NOT_FOUND_MSG}')
 
@@ -1318,14 +1317,14 @@ class TestBytes(boatestcase.BoaTestCase):
         bytes_ = b'unit test'
         bytes_sequence = b'i'
         start = 99
-        with self.assertRaises(FaultException) as context:
+        with self.assertRaises(boatestcase.FaultException) as context:
             await self.call('main', [bytes_, bytes_sequence, start], return_type=int)
         self.assertRegex(str(context.exception), f'{self.SUBSEQUENCE_NOT_FOUND_MSG}')
 
         bytes_ = b'unit test'
         bytes_sequence = b's'
         start = -1
-        with self.assertRaises(FaultException) as context:
+        with self.assertRaises(boatestcase.FaultException) as context:
             await self.call('main', [bytes_, bytes_sequence, start], return_type=int)
         self.assertRegex(str(context.exception), f'{self.SUBSEQUENCE_NOT_FOUND_MSG}')
 

--- a/boa3_test/tests/compiler_tests/test_dict.py
+++ b/boa3_test/tests/compiler_tests/test_dict.py
@@ -5,7 +5,6 @@ from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo.vm.type.String import String
 from boa3_test.tests import boatestcase
-from boa3_test.tests.boatestcase import FaultException
 
 
 class TestDict(boatestcase.BoaTestCase):
@@ -239,7 +238,7 @@ class TestDict(boatestcase.BoaTestCase):
         result, _ = await self.call('Main', [{0: 'zero'}], return_type=str)
         self.assertEqual('zero', result)
 
-        with self.assertRaises(FaultException) as context:
+        with self.assertRaises(boatestcase.FaultException) as context:
             await self.call('Main', [{1: 'one'}], return_type=str)
 
         self.assertRegex(str(context.exception), self.MAP_KEY_NOT_FOUND_ERROR_MSG)
@@ -539,7 +538,7 @@ class TestDict(boatestcase.BoaTestCase):
 
         dict_ = {'a': 1, 'b': 2, 'c': 3, 'd': 4}
         key = 'key not inside'
-        with self.assertRaises(FaultException) as context:
+        with self.assertRaises(boatestcase.FaultException) as context:
             await self.call('main', [dict_, key], return_type=tuple[dict[str, int], int])
 
         self.assertRegex(str(context.exception), self.MAP_KEY_NOT_FOUND_ERROR_MSG)

--- a/boa3_test/tests/compiler_tests/test_list.py
+++ b/boa3_test/tests/compiler_tests/test_list.py
@@ -5,7 +5,6 @@ from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo.vm.type.String import String
 from boa3.internal.neo3.vm import VMState
 from boa3_test.tests import boatestcase
-from boa3_test.tests.boatestcase import FaultException
 from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
@@ -137,7 +136,7 @@ class TestList(boatestcase.BoaTestCase):
         result, _ = await self.call('Main', [[5, 3, 2]], return_type=int)
         self.assertEqual(5, result)
 
-        with self.assertRaises(FaultException) as context:
+        with self.assertRaises(boatestcase.FaultException) as context:
             await self.call('Main', [[]], return_type=int)
 
         self.assertRegex(str(context.exception), self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX)
@@ -169,7 +168,7 @@ class TestList(boatestcase.BoaTestCase):
         result, _ = await self.call('Main', [[5, 3, 2]], return_type=int)
         self.assertEqual(2, result)
 
-        with self.assertRaises(FaultException) as context:
+        with self.assertRaises(boatestcase.FaultException) as context:
             await self.call('Main', [[]], return_type=int)
 
         self.assertRegex(str(context.exception), self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX)
@@ -259,7 +258,7 @@ class TestList(boatestcase.BoaTestCase):
         result, _ = await self.call('Main', [[5, 3, 2]], return_type=list)
         self.assertEqual([1, 3, 2], result)
 
-        with self.assertRaises(FaultException) as context:
+        with self.assertRaises(boatestcase.FaultException) as context:
             await self.call('Main', [[]], return_type=list)
 
         self.assertRegex(str(context.exception), self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX)
@@ -276,7 +275,7 @@ class TestList(boatestcase.BoaTestCase):
         result, _ = await self.call('Main', [[5, 3, 2]], return_type=list)
         self.assertEqual([5, 3, 1], result)
 
-        with self.assertRaises(FaultException) as context:
+        with self.assertRaises(boatestcase.FaultException) as context:
             await self.call('Main', [[]], return_type=list)
 
         self.assertRegex(str(context.exception), self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX)
@@ -347,12 +346,12 @@ class TestList(boatestcase.BoaTestCase):
         result, _ = await self.call('Main', [[[1, 2], [3, 4]]], return_type=int)
         self.assertEqual(1, result)
 
-        with self.assertRaises(FaultException) as context:
+        with self.assertRaises(boatestcase.FaultException) as context:
             await self.call('Main', [[]], return_type=int)
 
         self.assertRegex(str(context.exception), self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX)
 
-        with self.assertRaises(FaultException) as context:
+        with self.assertRaises(boatestcase.FaultException) as context:
             await self.call('Main', [[[], [1, 2], [3, 4]]], return_type=int)
 
         self.assertRegex(str(context.exception), self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX)
@@ -1321,7 +1320,7 @@ class TestList(boatestcase.BoaTestCase):
 
         list_ = [1, 2, 3, 4, 5]
         index = 99999
-        with self.assertRaises(FaultException) as context:
+        with self.assertRaises(boatestcase.FaultException) as context:
             await self.call('pop_test', [index], return_type=int)
 
         self.assertRegex(str(context.exception), self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX)
@@ -1329,7 +1328,7 @@ class TestList(boatestcase.BoaTestCase):
 
         list_ = [1, 2, 3, 4, 5]
         index = -99999
-        with self.assertRaises(FaultException) as context:
+        with self.assertRaises(boatestcase.FaultException) as context:
             await self.call('pop_test', [index], return_type=int)
 
         self.assertRegex(str(context.exception), self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX)
@@ -1451,7 +1450,7 @@ class TestList(boatestcase.BoaTestCase):
         result, _ = await self.call('Main', [[1, 2, 3, 2, 3], 3], return_type=list)
         self.assertEqual([1, 2, 2, 3], result)
 
-        with self.assertRaises(FaultException) as context:
+        with self.assertRaises(boatestcase.FaultException) as context:
             await self.call('Main', [[1, 2, 3, 4], 6], return_type=list)
 
         self.assertRegex(str(context.exception), self.INVALID_INDEX_MSG)
@@ -1559,17 +1558,17 @@ class TestList(boatestcase.BoaTestCase):
         self.assertEqual(list_.index(value, start, end), result)
 
         from boa3.internal.model.builtin.builtin import Builtin
-        with self.assertRaises(FaultException) as context:
+        with self.assertRaises(boatestcase.FaultException) as context:
             await self.call('main', [[1, 2, 3, 4], 3, 3, 4], return_type=int)
 
         self.assertRegex(str(context.exception), f'{Builtin.SequenceIndex.exception_message}')
 
-        with self.assertRaises(FaultException) as context:
+        with self.assertRaises(boatestcase.FaultException) as context:
             await self.call('main', [[1, 2, 3, 4], 3, 4, -1], return_type=int)
 
         self.assertRegex(str(context.exception), f'{Builtin.SequenceIndex.exception_message}')
 
-        with self.assertRaises(FaultException) as context:
+        with self.assertRaises(boatestcase.FaultException) as context:
             await self.call('main', [[1, 2, 3, 4], 3, 0, -99], return_type=int)
 
         self.assertRegex(str(context.exception), f'{Builtin.SequenceIndex.exception_message}')
@@ -1590,12 +1589,12 @@ class TestList(boatestcase.BoaTestCase):
         self.assertEqual(list_.index(value, start), result)
 
         from boa3.internal.model.builtin.builtin import Builtin
-        with self.assertRaises(FaultException) as context:
+        with self.assertRaises(boatestcase.FaultException) as context:
             await self.call('main', [[1, 2, 3, 4], 2, 99], return_type=int)
 
         self.assertRegex(str(context.exception), f'{Builtin.SequenceIndex.exception_message}')
 
-        with self.assertRaises(FaultException) as context:
+        with self.assertRaises(boatestcase.FaultException) as context:
             await self.call('main', [[1, 2, 3, 4], 4, -1], return_type=int)
 
         self.assertRegex(str(context.exception), f'{Builtin.SequenceIndex.exception_message}')

--- a/boa3_test/tests/compiler_tests/test_logger.py
+++ b/boa3_test/tests/compiler_tests/test_logger.py
@@ -1,7 +1,7 @@
-from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to avoid circular imports
+from boa3_test.tests import boatestcase
 
 
-class TestImport(BoaTest):
+class TestImport(boatestcase.BoaTestCase):
     def test_log_multiple_errors_on_import(self):
         path = self.get_contract_path('test_sc/import_test', 'ImportFailInnerNotExistingMethod.py')
         errors, _ = self.get_all_compile_log_data(path, fail_fast=False)

--- a/boa3_test/tests/compiler_tests/test_range.py
+++ b/boa3_test/tests/compiler_tests/test_range.py
@@ -3,7 +3,6 @@ from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo.vm.type.String import String
 from boa3_test.tests import boatestcase
-from boa3_test.tests.boatestcase import FaultException
 
 
 class TestRange(boatestcase.BoaTestCase):
@@ -291,7 +290,7 @@ class TestRange(boatestcase.BoaTestCase):
         result, _ = await self.call('Main', [[5, 3, 2]], return_type=int)
         self.assertEqual(5, result)
 
-        with self.assertRaises(FaultException) as context:
+        with self.assertRaises(boatestcase.FaultException) as context:
             await self.call('Main', [[]], return_type=int)
 
         self.assertRegex(str(context.exception), r'The value \d+ is out of range.')

--- a/boa3_test/tests/compiler_tests/test_string.py
+++ b/boa3_test/tests/compiler_tests/test_string.py
@@ -5,7 +5,6 @@ from boa3.internal.neo.vm.type.StackItem import StackItemType
 from boa3.internal.neo.vm.type.String import String
 from boa3.internal.neo3.vm import VMState
 from boa3_test.tests import boatestcase
-from boa3_test.tests.boatestcase import FaultException
 from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
@@ -41,7 +40,7 @@ class TestString(boatestcase.BoaTestCase):
         result, _ = await self.call('Main', ['123'], return_type=str)
         self.assertEqual('1', result)
 
-        with self.assertRaises(FaultException) as context:
+        with self.assertRaises(boatestcase.FaultException) as context:
             await self.call('Main', [''], return_type=str)
 
         self.assertRegex(str(context.exception), self.INVALID_OFFSET_MSG)
@@ -75,7 +74,7 @@ class TestString(boatestcase.BoaTestCase):
         result, _ = await self.call('main', ['abc'], return_type=str)
         self.assertEqual('c', result)
 
-        with self.assertRaises(FaultException) as context:
+        with self.assertRaises(boatestcase.FaultException) as context:
             await self.call('main', [[]], return_type=str)
 
         self.assertRegex(str(context.exception), self.NEGATIVE_INDEX_MSG)
@@ -133,7 +132,7 @@ class TestString(boatestcase.BoaTestCase):
         result, _ = await self.call('Main', ['123'], return_type=str)
         self.assertEqual('1', result)
 
-        with self.assertRaises(FaultException) as context:
+        with self.assertRaises(boatestcase.FaultException) as context:
             await self.call('Main', [''], return_type=str)
 
         self.assertRegex(str(context.exception), self.INVALID_OFFSET_MSG)
@@ -969,17 +968,17 @@ class TestString(boatestcase.BoaTestCase):
         result, _ = await self.call('main', [string, substring, start, end], return_type=int)
         self.assertEqual(string.index(substring, start, end), result)
 
-        with self.assertRaises(FaultException) as context:
+        with self.assertRaises(boatestcase.FaultException) as context:
             await self.call('main', ['unit test', 'i', 3, 4], return_type=int)
 
         self.assertRegex(str(context.exception), self.SUBSTRING_NOT_FOUND_MSG)
 
-        with self.assertRaises(FaultException) as context:
+        with self.assertRaises(boatestcase.FaultException) as context:
             await self.call('main', ['unit test', 'i', 4, -1], return_type=int)
 
         self.assertRegex(str(context.exception), self.SUBSTRING_NOT_FOUND_MSG)
 
-        with self.assertRaises(FaultException) as context:
+        with self.assertRaises(boatestcase.FaultException) as context:
             await self.call('main', ['unit test', 'i', 0, -99], return_type=int)
 
         self.assertRegex(str(context.exception), self.SUBSTRING_NOT_FOUND_MSG)
@@ -1014,7 +1013,7 @@ class TestString(boatestcase.BoaTestCase):
         string = 'unit test'
         substring = 'i'
         start = 99
-        with self.assertRaises(FaultException) as context:
+        with self.assertRaises(boatestcase.FaultException) as context:
             await self.call('main', [string, substring, start], return_type=int)
 
         self.assertRegex(str(context.exception), self.SUBSTRING_NOT_FOUND_MSG)
@@ -1023,7 +1022,7 @@ class TestString(boatestcase.BoaTestCase):
         string = 'unit test'
         substring = 's'
         start = -1
-        with self.assertRaises(FaultException) as context:
+        with self.assertRaises(boatestcase.FaultException) as context:
             await self.call('main', [string, substring, start], return_type=int)
 
         self.assertRegex(str(context.exception), self.SUBSTRING_NOT_FOUND_MSG)


### PR DESCRIPTION
**Summary or solution description**
Refactored `test_logger` file to use `BoaTestCase` in place of `BoaTest` for unit testing.
Also removed `FaultException` imports when `boatestcase` was already imported
