### PR TITLE
Refactor test_set.py to use BoaTestConstructor

### DIFF
--- a/boa3_test/tests/compiler_tests/test_set.py
+++ b/boa3_test/tests/compiler_tests/test_set.py
@@ -1,9 +1,8 @@
-from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to avoid circular imports
-
 from boa3.internal.exception import CompilerError
+from boa3_test.tests import boatestcase
 
 
-class TestSet(BoaTest):
+class TestSet(boatestcase.BoaTestCase):
     default_folder: str = 'test_sc/set_test'
 
     def test_set_from_typing(self):


### PR DESCRIPTION
**Summary or solution description**
Refactored `test_set.py` file to use `BoaTestCase `in place of `BoaTest `for unit testing.
