### PR TITLE
Refactor test_interop/test_policy.py to use BoaConstructor

### DIFF
--- a/boa3_test/tests/compiler_tests/test_interop/test_policy.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_policy.py
@@ -1,67 +1,45 @@
-from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to avoid circular imports
-
 from boa3.internal.exception import CompilerError
-from boa3.internal.neo3.vm import VMState
-from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
+from boa3_test.tests import boatestcase
 
 
-class TestPolicyInterop(BoaTest):
+class TestPolicyInterop(boatestcase.BoaTestCase):
     default_folder: str = 'test_sc/interop_test/policy'
 
-    def test_get_exec_fee_factor(self):
-        path, _ = self.get_deploy_file_paths('GetExecFeeFactor.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_get_exec_fee_factor(self):
+        await self.set_up_contract('GetExecFeeFactor.py')
 
-        invoke = runner.call_contract(path, 'main')
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-        self.assertIsInstance(invoke.result, int)
+        result, _ = await self.call('main', [], return_type=int)
+        self.assertIsInstance(result, int)
 
     def test_get_exec_fee_too_many_parameters(self):
         path = self.get_contract_path('GetExecFeeFactorTooManyArguments.py')
         self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
 
-    def test_get_fee_per_byte(self):
-        path, _ = self.get_deploy_file_paths('GetFeePerByte.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_get_fee_per_byte(self):
+        await self.set_up_contract('GetFeePerByte.py')
 
-        invoke = runner.call_contract(path, 'main')
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-        self.assertIsInstance(invoke.result, int)
+        result, _ = await self.call('main', [], return_type=int)
+        self.assertIsInstance(result, int)
 
     def test_get_fee_per_byte_too_many_parameters(self):
         path = self.get_contract_path('GetFeePerByteTooManyArguments.py')
         self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
 
-    def test_get_storage_price(self):
-        path, _ = self.get_deploy_file_paths('GetStoragePrice.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_get_storage_price(self):
+        await self.set_up_contract('GetStoragePrice.py')
 
-        invoke = runner.call_contract(path, 'main')
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-        self.assertIsInstance(invoke.result, int)
+        result, _ = await self.call('main', [], return_type=int)
+        self.assertIsInstance(result, int)
 
     def test_get_storage_price_too_many_parameters(self):
         path = self.get_contract_path('GetStoragePriceTooManyArguments.py')
         self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
 
-    def test_is_blocked(self):
-        path, _ = self.get_deploy_file_paths('IsBlocked.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_is_blocked(self):
+        await self.set_up_contract('IsBlocked.py')
 
-        invokes = []
-        expected_results = []
-
-        invokes.append(runner.call_contract(path, 'main', bytes(20)))
-        expected_results.append(False)
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        result, _ = await self.call('main', [bytes(20)], return_type=bool)
+        self.assertEqual(False, result)
 
     def test_is_blocked_mismatched_type(self):
         path = self.get_contract_path('IsBlockedMismatchedTypeInt.py')
@@ -81,20 +59,14 @@ class TestPolicyInterop(BoaTest):
         path = self.get_contract_path('IsBlockedTooFewArguments.py')
         self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
 
-    def test_import_policy(self):
-        path, _ = self.get_deploy_file_paths('ImportPolicy.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_import_policy(self):
+        await self.set_up_contract('ImportPolicy.py')
 
-        invoke = runner.call_contract(path, 'main')
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-        self.assertIsInstance(invoke.result, int)
+        result, _ = await self.call('main', [], return_type=int)
+        self.assertIsInstance(result, int)
 
-    def test_import_interop_policy(self):
-        path, _ = self.get_deploy_file_paths('ImportInteropPolicy.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_import_interop_policy(self):
+        await self.set_up_contract('ImportInteropPolicy.py')
 
-        invoke = runner.call_contract(path, 'main')
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-        self.assertIsInstance(invoke.result, int)
+        result, _ = await self.call('main', [], return_type=int)
+        self.assertIsInstance(result, int)


### PR DESCRIPTION
**Summary or solution description**
 Refactored `test_interop/test_policy.py `file to use `BoaTestCase `in place of `BoaTest `for unit testing.