### PR TITLE
Refactor test_native/test_cryptolib.py to use BoaConstructor

### DIFF
--- a/boa3_test/tests/compiler_tests/test_native/test_cryptolib.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_cryptolib.py
@@ -1,6 +1,5 @@
 import hashlib
 
-from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to avoid circular imports
 
 from boa3.internal import constants
 from boa3.internal.exception import CompilerError
@@ -8,11 +7,10 @@ from boa3.internal.model.type.type import Type
 from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo3.contracts.namedcurve import NamedCurve
-from boa3.internal.neo3.vm import VMState
-from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
+from boa3_test.tests import boatestcase
 
 
-class TestCryptoLibClass(BoaTest):
+class TestCryptoLibClass(boatestcase.BoaTestCase):
     default_folder: str = 'test_sc/native_test/cryptolib'
     ecpoint_init = (
         Opcode.DUP
@@ -29,93 +27,43 @@ class TestCryptoLibClass(BoaTest):
         + Opcode.THROW
     )
 
-    def test_get_hash(self):
-        path, _ = self.get_deploy_file_paths('GetHash.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_get_hash(self):
+        await self.set_up_contract('GetHash.py')
 
-        invokes = []
-        expected_results = []
+        result, _ = await self.call('main', [], return_type=bytes)
+        self.assertEqual(constants.CRYPTO_SCRIPT, result)
 
-        invokes.append(runner.call_contract(path, 'main'))
-        expected_results.append(constants.CRYPTO_SCRIPT)
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_ripemd160_str(self):
-        path, _ = self.get_deploy_file_paths('Ripemd160Str.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_ripemd160_str(self):
+        await self.set_up_contract('Ripemd160Str.py')
 
         expected_result = hashlib.new('ripemd160', b'unit test')
-        invokes.append(runner.call_contract(path, 'Main', 'unit test'))
-        expected_results.append(expected_result.digest())
+        result, _ = await self.call('Main', ['unit test'], return_type=bytes)
+        self.assertEqual(expected_result.digest(), result)
 
         expected_result = hashlib.new('ripemd160', b'')
-        invokes.append(runner.call_contract(path, 'Main', ''))
-        expected_results.append(expected_result.digest())
+        result, _ = await self.call('Main', [''], return_type=bytes)
+        self.assertEqual(expected_result.digest(), result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_ripemd160_int(self):
-        path, _ = self.get_deploy_file_paths('Ripemd160Int.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_ripemd160_int(self):
+        await self.set_up_contract('Ripemd160Int.py')
 
         expected_result = hashlib.new('ripemd160', Integer(10).to_byte_array())
-        invokes.append(runner.call_contract(path, 'Main'))
-        expected_results.append(expected_result.digest())
+        result, _ = await self.call('Main', [], return_type=bytes)
+        self.assertEqual(expected_result.digest(), result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_ripemd160_bool(self):
-        path, _ = self.get_deploy_file_paths('Ripemd160Bool.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_ripemd160_bool(self):
+        await self.set_up_contract('Ripemd160Bool.py')
 
         expected_result = hashlib.new('ripemd160', Integer(1).to_byte_array())
-        invokes.append(runner.call_contract(path, 'Main'))
-        expected_results.append(expected_result.digest())
+        result, _ = await self.call('Main', [], return_type=bytes)
+        self.assertEqual(expected_result.digest(), result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_ripemd160_bytes(self):
-        path, _ = self.get_deploy_file_paths('Ripemd160Bytes.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_ripemd160_bytes(self):
+        await self.set_up_contract('Ripemd160Bytes.py')
 
         expected_result = hashlib.new('ripemd160', b'unit test')
-        invokes.append(runner.call_contract(path, 'Main'))
-        expected_results.append(expected_result.digest())
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        result, _ = await self.call('Main', [], return_type=bytes)
+        self.assertEqual(expected_result.digest(), result)
 
     def test_ripemd160_too_many_parameters(self):
         path = self.get_contract_path('Ripemd160TooManyArguments.py')
@@ -125,77 +73,37 @@ class TestCryptoLibClass(BoaTest):
         path = self.get_contract_path('Ripemd160TooFewArguments.py')
         self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
 
-    def test_sha256_str(self):
-        path, _ = self.get_deploy_file_paths('Sha256Str.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_sha256_str(self):
+        await self.set_up_contract('Sha256Str.py')
 
         expected_result = hashlib.sha256(b'unit test')
-        invokes.append(runner.call_contract(path, 'Main', 'unit test'))
-        expected_results.append(expected_result.digest())
+        result, _ = await self.call('Main', ['unit test'], return_type=bytes)
+        self.assertEqual(expected_result.digest(), result)
 
         expected_result = hashlib.sha256(b'')
-        invokes.append(runner.call_contract(path, 'Main', ''))
-        expected_results.append(expected_result.digest())
+        result, _ = await self.call('Main', [''], return_type=bytes)
+        self.assertEqual(expected_result.digest(), result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_sha256_int(self):
-        path, _ = self.get_deploy_file_paths('Sha256Int.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_sha256_int(self):
+        await self.set_up_contract('Sha256Int.py')
 
         expected_result = hashlib.sha256(Integer(10).to_byte_array())
-        invokes.append(runner.call_contract(path, 'Main'))
-        expected_results.append(expected_result.digest())
+        result, _ = await self.call('Main', [], return_type=bytes)
+        self.assertEqual(expected_result.digest(), result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_sha256_bool(self):
-        path, _ = self.get_deploy_file_paths('Sha256Bool.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_sha256_bool(self):
+        await self.set_up_contract('Sha256Bool.py')
 
         expected_result = hashlib.sha256(Integer(1).to_byte_array())
-        invokes.append(runner.call_contract(path, 'Main'))
-        expected_results.append(expected_result.digest())
+        result, _ = await self.call('Main', [], return_type=bytes)
+        self.assertEqual(expected_result.digest(), result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_sha256_bytes(self):
-        path, _ = self.get_deploy_file_paths('Sha256Bytes.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_sha256_bytes(self):
+        await self.set_up_contract('Sha256Bytes.py')
 
         expected_result = hashlib.sha256(b'unit test')
-        invokes.append(runner.call_contract(path, 'Main'))
-        expected_results.append(expected_result.digest())
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        result, _ = await self.call('Main', [], return_type=bytes)
+        self.assertEqual(expected_result.digest(), result)
 
     def test_sha256_too_many_parameters(self):
         path = self.get_contract_path('Sha256TooManyArguments.py')
@@ -244,8 +152,7 @@ class TestCryptoLibClass(BoaTest):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('VerifyWithECDsaSecp256r1Bytes.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('VerifyWithECDsaSecp256r1Bytes.py')
         self.assertEqual(expected_output, output)
 
     def test_verify_with_ecdsa_secp256r1_mismatched_type(self):
@@ -287,8 +194,7 @@ class TestCryptoLibClass(BoaTest):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('VerifyWithECDsaSecp256k1Bytes.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('VerifyWithECDsaSecp256k1Bytes.py')
         self.assertEqual(expected_output, output)
 
     def test_verify_with_ecdsa_secp256k1_mismatched_type(self):
@@ -306,8 +212,7 @@ class TestCryptoLibClass(BoaTest):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('Murmur32.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('Murmur32.py')
         self.assertEqual(expected_output, output)
 
     def test_bls12_381_add(self):
@@ -321,8 +226,7 @@ class TestCryptoLibClass(BoaTest):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('Bls12381Add.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('Bls12381Add.py')
         self.assertEqual(expected_output, output)
 
     def test_bls12_381_add_mismatched_type(self):
@@ -339,8 +243,7 @@ class TestCryptoLibClass(BoaTest):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('Bls12381Deserialize.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('Bls12381Deserialize.py')
         self.assertEqual(expected_output, output)
 
     def test_bls12_381_equal(self):
@@ -354,8 +257,7 @@ class TestCryptoLibClass(BoaTest):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('Bls12381Equal.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('Bls12381Equal.py')
         self.assertEqual(expected_output, output)
 
     def test_bls12_381_equal_mismatched_type(self):
@@ -374,8 +276,7 @@ class TestCryptoLibClass(BoaTest):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('Bls12381Mul.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('Bls12381Mul.py')
         self.assertEqual(expected_output, output)
 
     def test_bls12_381_mul_mismatched_type(self):
@@ -393,8 +294,7 @@ class TestCryptoLibClass(BoaTest):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('Bls12381Pairing.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('Bls12381Pairing.py')
         self.assertEqual(expected_output, output)
 
     def test_bls12_381_pairing_mismatched_type(self):
@@ -411,8 +311,7 @@ class TestCryptoLibClass(BoaTest):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('Bls12381Serialize.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('Bls12381Serialize.py')
         self.assertEqual(expected_output, output)
 
     def test_bls12_381_serialize_mismatched_type(self):


### PR DESCRIPTION
**Summary or solution description**
 Refactored `test_native/test_cryptolib.py `files to use `BoaTestCase `in place of `BoaTest `for unit testing.