### PR TITLE
Refactor test_native/test_oracle.py to use BoaConstructor

### DIFF
--- a/boa3_test/tests/compiler_tests/test_native/test_oracle.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_oracle.py
@@ -1,12 +1,14 @@
-from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to avoid circular imports
+from dataclasses import dataclass
+
+from neo3.api import noderpc
+from neo3.contracts.contract import CONTRACT_HASHES
+from neo3.core import types
+from neo3.wallet import account
 
 from boa3.internal import constants
 from boa3.internal.exception import CompilerError
 from boa3.internal.neo.vm.opcode.Opcode import Opcode
-from boa3.internal.neo.vm.type.Integer import Integer
-from boa3.internal.neo.vm.type.String import String
-from boa3.internal.neo3.vm import VMState
-from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
+from boa3_test.tests import boatestcase
 
 
 def _deep_scan(iterable: [dict, list], key: str, list_of_values: list):
@@ -31,74 +33,111 @@ def _deep_scan(iterable: [dict, list], key: str, list_of_values: list):
                 _deep_scan(item, key, list_of_values)
 
 
-class TestNativeContracts(BoaTest):
+@dataclass
+class OracleRequestEvent(boatestcase.BoaTestEvent):
+    id: int
+    request_contract: types.UInt160
+    url: str
+    filter: str
+
+    @classmethod
+    def from_untyped_notification(cls, n: noderpc.Notification):
+        inner_args_types = tuple(cls.__annotations__.values())
+        e = super().from_notification(n, *inner_args_types)
+        return cls(e.contract, e.name, e.state, *e.state)
+
+
+@dataclass
+class OracleResponseEvent(boatestcase.BoaTestEvent):
+    id: int
+    original_tx: types.UInt256
+
+    @classmethod
+    def from_untyped_notification(cls, n: noderpc.Notification):
+        inner_args_types = tuple(cls.__annotations__.values())
+        e = super().from_notification(n, *inner_args_types)
+        return cls(e.contract, e.name, e.state, *e.state)
+
+
+class TestNativeContracts(boatestcase.BoaTestCase):
     default_folder: str = 'test_sc/native_test/oracle'
     ORACLE_CONTRACT_NAME = 'OracleContract'
+    ORACLE_SCRIPT_HASH = types.UInt160(constants.ORACLE_SCRIPT)
 
-    def test_get_hash(self):
-        path, _ = self.get_deploy_file_paths('GetHash.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
+    owner: account.Account
 
-        invokes = []
-        expected_results = []
+    @classmethod
+    def setupTestCase(cls):
+        cls.owner = cls.node.wallet.account_new(label='owner', password='123')
 
-        invokes.append(runner.call_contract(path, 'main'))
-        expected_results.append(constants.ORACLE_SCRIPT)
+        super().setupTestCase()
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+    @classmethod
+    async def asyncSetupClass(cls) -> None:
+        await super().asyncSetupClass()
 
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        await cls.transfer(CONTRACT_HASHES.GAS_TOKEN, cls.genesis.script_hash, cls.owner.script_hash, 100)
 
-    def test_oracle_request(self):
-        path, _ = self.get_deploy_file_paths('OracleRequestCall.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_get_hash(self):
+        await self.set_up_contract('GetHash.py')
 
-        invokes = []
-        expected_results = []
+        expected = self.ORACLE_SCRIPT_HASH
+        result, _ = await self.call('main', [], return_type=types.UInt160)
+        self.assertEqual(expected, result)
+
+    async def test_oracle_request(self):
+        await self.set_up_contract('OracleRequestCall.py')
 
         test_url = 'abc'
         request_filter = 'ABC'
         callback = '123'
         gas_for_response = 1_0000000
 
-        oracle_invoke = runner.call_contract(path, 'oracle_call',
-                                             test_url, request_filter, callback, None, gas_for_response)
-        invokes.append(oracle_invoke)
-        expected_results.append(True)
+        result, notifications = await self.call('oracle_call',
+                                                [test_url, request_filter, callback, None, gas_for_response],
+                                                return_type=bool
+                                                )
+        self.assertEqual(True, result)
+        contract_script = self.contract_hash
 
-        runner.execute(clear_invokes=False)
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-        contract_script = oracle_invoke.invoke.contract.script_hash
+        oracle_requests = self.filter_events(notifications,
+                                             event_name='OracleRequest',
+                                             origin=self.ORACLE_SCRIPT_HASH,
+                                             notification_type=OracleRequestEvent
+                                             )
 
-        oracle_requests = runner.get_events('OracleRequest', constants.ORACLE_SCRIPT)
         self.assertEqual(1, len(oracle_requests))
-        self.assertEqual(4, len(oracle_requests[0].arguments))
-        self.assertEqual(contract_script, oracle_requests[0].arguments[1])
-        self.assertEqual(test_url, oracle_requests[0].arguments[2])
-        self.assertEqual(request_filter, oracle_requests[0].arguments[3])
+        self.assertEqual(contract_script, oracle_requests[0].request_contract)
+        self.assertEqual(test_url, oracle_requests[0].url)
+        self.assertEqual(request_filter, oracle_requests[0].filter)
 
         test_url = 'abc'
         request_filter = 'ABC'
         callback = 'test_callback'
         gas_for_response = 1_0000000
 
-        invokes.append(runner.call_contract(path, 'oracle_call',
-                                            test_url, request_filter, callback, None, gas_for_response))
-        expected_results.append(True)
+        result, notifications = await self.call('oracle_call',
+                                                [test_url, request_filter, callback, None, gas_for_response],
+                                                return_type=bool
+                                                )
+        self.assertEqual(True, result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        oracle_requests = self.filter_events(notifications,
+                                             event_name='OracleRequest',
+                                             origin=self.ORACLE_SCRIPT_HASH,
+                                             notification_type=OracleRequestEvent
+                                             )
 
-        oracle_requests = runner.get_events('OracleRequest', constants.ORACLE_SCRIPT)
-        self.assertEqual(2, len(oracle_requests))
-        self.assertEqual(4, len(oracle_requests[1].arguments))
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        self.assertEqual(1, len(oracle_requests))
+        self.assertEqual(contract_script, oracle_requests[0].request_contract)
+        self.assertEqual(test_url, oracle_requests[0].url)
+        self.assertEqual(request_filter, oracle_requests[0].filter)
 
     def test_oracle_response(self):
+        from boa3.internal.neo3.vm import VMState
+        from boa3_test.tests.test_drive import neoxp
+        from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
+
         path, _ = self.get_deploy_file_paths('OracleRequestCall.py')
         runner = BoaTestRunner(runner_id=self.method_name())
 
@@ -110,9 +149,7 @@ class TestNativeContracts(BoaTest):
         user_data = 'Any Data Here'
         gas_for_response = 1 * 10 ** 8
 
-        from boa3_test.tests.test_drive import neoxp
         OWNER = neoxp.utils.get_account_by_name('owner')
-
         genesis = neoxp.utils.get_account_by_name('genesis')
         runner.oracle_enable(genesis)
 
@@ -163,6 +200,10 @@ class TestNativeContracts(BoaTest):
         self.assertEqual(json_data, response_tx_attr['result'])
 
     def test_oracle_response_filter(self):
+        from boa3.internal.neo3.vm import VMState
+        from boa3_test.tests.test_drive import neoxp
+        from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
+
         path, _ = self.get_deploy_file_paths('OracleRequestCall.py')
         runner = BoaTestRunner(runner_id=self.method_name())
 
@@ -174,10 +215,8 @@ class TestNativeContracts(BoaTest):
         user_data = 'Any Data Here'
         gas_for_response = 1 * 10 ** 8
 
-        from boa3_test.tests.test_drive import neoxp
         OWNER = neoxp.utils.get_account_by_name('owner')
         runner.add_gas(OWNER.address, 1000 * 10 ** 8)
-
         genesis = neoxp.utils.get_account_by_name('genesis')
         runner.oracle_enable(genesis)
 
@@ -231,72 +270,65 @@ class TestNativeContracts(BoaTest):
         everything_inside_store = [json_data['store'][key] for key in json_data['store']]
         self.assertEqual(everything_inside_store, response_tx_attributes[2]['result'])
 
-    def test_oracle_request_invalid_gas(self):
-        path, _ = self.get_deploy_file_paths('OracleRequestCall.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_oracle_request_invalid_gas(self):
+        await self.set_up_contract('OracleRequestCall.py')
 
         test_url = 'https://unittest.fake.url/api/0/'
         callback = 'callback_method'
         user_data = 'Any Data Here'
         filter = "$.store.*"
-        gas_for_response = 9999999     # GAS can not be lower than 0.1 GAS
+        gas_for_response = 9999999  # GAS can not be lower than 0.1 GAS
 
-        from boa3_test.tests.test_drive import neoxp
-        genesis = neoxp.utils.get_account_by_name('genesis')
-        runner.oracle_enable(genesis)
+        with self.assertRaises(boatestcase.FaultException) as context:
+            await self.call('oracle_call',
+                            [test_url, filter, callback, user_data, gas_for_response],
+                            return_type=bool
+                            )
 
-        runner.call_contract(path, 'oracle_call', test_url, filter, callback, user_data, gas_for_response)
+        self.assertRegex(str(context.exception), 'not enough gas for response')
 
-        runner.execute()
-        self.assertEqual(VMState.FAULT, runner.vm_state, msg=runner.cli_log)
-        self.assertRegex(runner.error, self.VALUE_DOES_NOT_FALL_WITHIN_EXPECTED_RANGE_MSG)
-
-    def test_oracle_request_invalid_callback(self):
-        path, _ = self.get_deploy_file_paths('OracleRequestCall.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_oracle_request_invalid_callback(self):
+        await self.set_up_contract('OracleRequestCall.py')
 
         test_url = 'https://unittest.fake.url/api/0/'
         user_data = 'Any Data Here'
         filter = "$.store.*"
         gas_for_response = 1 * 10 ** 8
 
-        from boa3_test.tests.test_drive import neoxp
-        genesis = neoxp.utils.get_account_by_name('genesis')
-        runner.oracle_enable(genesis)
+        callback = '_private_method'  # method can not start with '_' (underscore)
+        with self.assertRaises(boatestcase.FaultException) as context:
+            await self.call('oracle_call',
+                            [test_url, filter, callback, user_data, gas_for_response],
+                            return_type=bool
+                            )
 
-        callback = '_private_method'    # method can not start with '_' (underscore)
-        runner.call_contract(path, 'oracle_call', test_url, filter, callback, user_data, gas_for_response)
+        self.assertRegex(str(context.exception), r"disallowed callback method \(starts with '_'\)")
 
-        runner.execute()
-        self.assertEqual(VMState.FAULT, runner.vm_state, msg=runner.cli_log)
-        self.assertRegex(runner.error, self.VALUE_DOES_NOT_FALL_WITHIN_EXPECTED_RANGE_MSG)
+        callback = 'a' * 33  # callback length can not be greater than 32
+        with self.assertRaises(boatestcase.FaultException) as context:
+            await self.call('oracle_call',
+                            [test_url, filter, callback, user_data, gas_for_response],
+                            return_type=bool
+                            )
 
-        callback = 'a' * 33    # callback length can not be greater than 32
-        runner.call_contract(path, 'oracle_call', test_url, filter, callback, user_data, gas_for_response)
+        self.assertRegex(str(context.exception), 'some of the arguments are invalid')
 
-        runner.execute()
-        self.assertEqual(VMState.FAULT, runner.vm_state, msg=runner.cli_log)
-        self.assertRegex(runner.error, self.VALUE_DOES_NOT_FALL_WITHIN_EXPECTED_RANGE_MSG)
-
-    def test_oracle_request_invalid_filter(self):
-        path, _ = self.get_deploy_file_paths('OracleRequestCall.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_oracle_request_invalid_filter(self):
+        await self.set_up_contract('OracleRequestCall.py')
 
         test_url = 'https://unittest.fake.url/api/0/'
         callback = 'callback_method'
         user_data = 'Any Data Here'
         gas_for_response = 1 * 10 ** 8
 
-        from boa3_test.tests.test_drive import neoxp
-        genesis = neoxp.utils.get_account_by_name('genesis')
-        runner.oracle_enable(genesis)
+        filter = "a" * 129  # filter length can not be greater than 128
+        with self.assertRaises(boatestcase.FaultException) as context:
+            await self.call('oracle_call',
+                            [test_url, filter, callback, user_data, gas_for_response],
+                            return_type=bool
+                            )
 
-        filter = "a" * 129   # filter length can not be greater than 128
-        runner.call_contract(path, 'oracle_call', test_url, filter, callback, user_data, gas_for_response)
-
-        runner.execute()
-        self.assertEqual(VMState.FAULT, runner.vm_state, msg=runner.cli_log)
-        self.assertRegex(runner.error, self.VALUE_DOES_NOT_FALL_WITHIN_EXPECTED_RANGE_MSG)
+        self.assertRegex(str(context.exception), 'some of the arguments are invalid')
 
     def test_oracle_request_url_mismatched_type(self):
         path = self.get_contract_path('OracleRequestUrlMismatchedType.py')
@@ -314,88 +346,67 @@ class TestNativeContracts(BoaTest):
         path = self.get_contract_path('OracleRequestGasMismatchedType.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
-    def test_import_interop_oracle(self):
-        path, _ = self.get_deploy_file_paths('ImportOracle.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_import_interop_oracle(self):
+        await self.set_up_contract('ImportOracle.py')
 
         test_url = 'abc'
         request_filter = 'ABC'
         callback = '123'
         gas_for_response = 1_0000000
 
-        oracle_invoke = runner.call_contract(path, 'oracle_call',
-                                             test_url, request_filter, callback, None, gas_for_response)
-        invokes.append(oracle_invoke)
-        expected_results.append(None)
+        result, notifications = await self.call('oracle_call',
+                                                [test_url, request_filter, callback, None, gas_for_response],
+                                                return_type=None
+                                                )
+        self.assertIsNone(result)
+        contract_script = self.contract_hash
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-        contract_script = oracle_invoke.invoke.contract.script_hash
-
-        oracle_requests = runner.get_events('OracleRequest', constants.ORACLE_SCRIPT)
+        oracle_requests = self.filter_events(notifications,
+                                             origin=self.ORACLE_SCRIPT_HASH,
+                                             event_name='OracleRequest',
+                                             notification_type=OracleRequestEvent
+                                             )
         self.assertEqual(1, len(oracle_requests))
-        self.assertEqual(4, len(oracle_requests[0].arguments))
-        self.assertEqual(contract_script, oracle_requests[0].arguments[1])
-        self.assertEqual(test_url, oracle_requests[0].arguments[2])
-        self.assertEqual(request_filter, oracle_requests[0].arguments[3])
+        self.assertEqual(contract_script, oracle_requests[0].request_contract)
+        self.assertEqual(test_url, oracle_requests[0].url)
+        self.assertEqual(request_filter, oracle_requests[0].filter)
 
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_import_interop_oracle_package(self):
-        path, _ = self.get_deploy_file_paths('ImportInteropOracle.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_import_interop_oracle_package(self):
+        await self.set_up_contract('ImportInteropOracle.py')
 
         test_url = 'abc'
         request_filter = 'ABC'
         callback = '123'
         gas_for_response = 1_0000000
 
-        oracle_invoke = runner.call_contract(path, 'oracle_call',
-                                             test_url, request_filter, callback, None, gas_for_response)
-        invokes.append(oracle_invoke)
-        expected_results.append(None)
+        result, notifications = await self.call('oracle_call',
+                                                [test_url, request_filter, callback, None, gas_for_response],
+                                                return_type=None
+                                                )
+        self.assertIsNone(result)
+        contract_script = self.contract_hash
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-        contract_script = oracle_invoke.invoke.contract.script_hash
-
-        oracle_requests = runner.get_events('OracleRequest', constants.ORACLE_SCRIPT)
+        oracle_requests = self.filter_events(notifications,
+                                             origin=self.ORACLE_SCRIPT_HASH,
+                                             event_name='OracleRequest',
+                                             notification_type=OracleRequestEvent
+                                             )
         self.assertEqual(1, len(oracle_requests))
-        self.assertEqual(4, len(oracle_requests[0].arguments))
-        self.assertEqual(contract_script, oracle_requests[0].arguments[1])
-        self.assertEqual(test_url, oracle_requests[0].arguments[2])
-        self.assertEqual(request_filter, oracle_requests[0].arguments[3])
+        self.assertEqual(contract_script, oracle_requests[0].request_contract)
+        self.assertEqual(test_url, oracle_requests[0].url)
+        self.assertEqual(request_filter, oracle_requests[0].filter)
 
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_oracle_get_price(self):
-        from boa3.internal.neo3.contracts import CallFlags
-        from boa3.internal.model.builtin.interop.oracle.oraclegetpricemethod import OracleGetPriceMethod
-
-        call_flags = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
-        method = String(OracleGetPriceMethod().method_name).to_bytes()
-
+    def test_oracle_get_price_compile(self):
         expected_output = (
             Opcode.CALLT + b'\x00\x00'
             + Opcode.RET
         )
 
-        path = self.get_contract_path('OracleGetPrice.py')
-        output, manifest = self.compile_and_save(path)
+        output, _ = self.assertCompile('OracleGetPrice.py')
         self.assertEqual(expected_output, output)
 
-        path, _ = self.get_deploy_file_paths(path)
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_oracle_get_price_run(self):
+        await self.set_up_contract('OracleGetPrice.py')
 
-        invoke = runner.call_contract(path, 'main')
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-        self.assertIsInstance(invoke.result, int)
+        result, _ = await self.call('main', [], return_type=int)
+        self.assertGreater(result, 0)

--- a/boa3_test/tests/compiler_tests/test_while.py
+++ b/boa3_test/tests/compiler_tests/test_while.py
@@ -281,19 +281,20 @@ class TestWhile(boatestcase.BoaTestCase):
 
         await self.set_up_contract('WhileWithInteropCondition.py', compile_if_found=True)
 
-        result, notifications = await self.call('test_end_while_jump', [], return_type=bool)
+        result, events = await self.call('test_end_while_jump', [], return_type=bool)
         self.assertEqual(True, result)
 
         # test notifications inserted into the code for validating if the code flow is correct
+        notifications = self.filter_events(events, notification_type=NotifyTestEvent)
         self.assertEqual(2, len(notifications))
 
-        event = NotifyTestEvent.from_notification(notifications[0])
+        event = notifications[0]
         self.assertEqual(CONTRACT_HASHES.GAS_TOKEN, event.token)
         self.assertEqual(self.contract_hash, event.executing)
         self.assertEqual(types.UInt160.zero(), event.fee_receiver)
         self.assertEqual(10, event.fee_amount)
 
-        event = NotifyTestEvent.from_notification(notifications[1])
+        event = notifications[1]
         self.assertEqual(CONTRACT_HASHES.NEO_TOKEN, event.token)
         self.assertEqual(self.contract_hash, event.executing)
         self.assertEqual(types.UInt160.zero(), event.fee_receiver)

--- a/boa3_test/tests/examples_tests/test_simple_nep17.py
+++ b/boa3_test/tests/examples_tests/test_simple_nep17.py
@@ -103,9 +103,9 @@ class TestSimpleNEP17Template(boatestcase.BoaTestCase):
         self.assertEqual(True, result)
 
         # fire the transfer event when transferring to yourself
-        transfer_events = notifications
+        transfer_events = self.filter_events(notifications, notification_type=boatestcase.Nep17TransferEvent)
         self.assertEqual(1, len(transfer_events))
-        event = boatestcase.Nep17TransferEvent.from_notification(notifications[0])
+        event = transfer_events[0]
 
         self.assertEqual(from_script_hash, event.source)
         self.assertEqual(from_script_hash, event.destination)
@@ -121,9 +121,9 @@ class TestSimpleNEP17Template(boatestcase.BoaTestCase):
         self.assertEqual(True, result)
 
         # fire the transfer event when transferring to yourself
-        transfer_events = notifications
+        transfer_events = self.filter_events(notifications, notification_type=boatestcase.Nep17TransferEvent)
         self.assertEqual(1, len(transfer_events))
-        event = boatestcase.Nep17TransferEvent.from_notification(notifications[0])
+        event = transfer_events[0]
 
         self.assertEqual(from_script_hash, event.source)
         self.assertEqual(to_script_hash, event.destination)


### PR DESCRIPTION
**Summary or solution description**
 Refactored `test_native/test_oracle.py` files to use `BoaTestCase` in place of `BoaTest` for unit testing.

**(Optional) Additional context**
Couldn't make Send Oracle Response to work, so I kept the tests related to this as they are. There's another task to work on these later
