### PR TITLE
Refactor test_interop/test_iterator.py to use BoaConstructor

### DIFF
--- a/boa3_test/tests/boatestcase.py
+++ b/boa3_test/tests/boatestcase.py
@@ -21,7 +21,8 @@ from typing import Any, Optional, TypeVar, Type, Sequence
 from boaconstructor import (SmartContractTestCase,
                             AbortException,
                             AssertException,
-                            Nep17TransferEvent as _Nep17TransferEvent
+                            Nep17TransferEvent as _Nep17TransferEvent,
+                            PostProcessor,
                             )
 from neo3.api import noderpc
 from neo3.api.wrappers import GenericContract
@@ -242,6 +243,9 @@ class BoaTestCase(SmartContractTestCase):
         else:
             internal_return_type = return_type_class
 
+        if signing_accounts is None:
+            signing_accounts = [cls.genesis]
+
         result, events = await super().call(method,
                                             args,
                                             return_type=internal_return_type,
@@ -293,6 +297,27 @@ class BoaTestCase(SmartContractTestCase):
                 raise e
 
             return cls.deployed_contracts[_manifest.name]
+
+    @classmethod
+    async def get_storage(
+            cls,
+            prefix: Optional[bytes] = None,
+            *,
+            target_contract: Optional[types.UInt160] = None,
+            remove_prefix: bool = False,
+            key_post_processor: Optional[PostProcessor] = None,
+            values_post_processor: Optional[PostProcessor] = None,
+    ) -> dict[bytes, bytes]:
+        try:
+            return await super().get_storage(
+                prefix,
+                target_contract=target_contract,
+                remove_prefix=remove_prefix,
+                key_post_processor=key_post_processor,
+                values_post_processor=values_post_processor
+            )
+        except TypeError:
+            return {}
 
     @classmethod
     def unwrap_inner_values(cls, value: list | dict, *args: type, expected_result: Type[T] | None = None):

--- a/boa3_test/tests/compiler_tests/test_interop/test_iterator.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_iterator.py
@@ -1,149 +1,118 @@
-from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to avoid circular imports
+from typing import cast
+
+from boaconstructor import storage
 
 from boa3.internal.exception import CompilerError
 from boa3.internal.neo.vm.type.String import String
-from boa3.internal.neo3.vm import VMState
-from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
+from boa3_test.tests import boatestcase
 
 
-class TestIteratorInterop(BoaTest):
+class TestIteratorInterop(boatestcase.BoaTestCase):
     default_folder: str = 'test_sc/interop_test/iterator'
 
     def test_iterator_create(self):
         path = self.get_contract_path('IteratorCreate.py')
         self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
 
-    def test_iterator_next(self):
-        path, _ = self.get_deploy_file_paths('IteratorNext.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_iterator_next(self):
+        await self.set_up_contract('IteratorNext.py')
 
         prefix = b'test_iterator_next'
-        invokes.append(runner.call_contract(path, 'has_next', prefix))
-        expected_results.append(False)
+        result, _ = await self.call('has_next', [prefix], return_type=bool)
+        self.assertEqual(False, result)
 
         key = prefix + b'example1'
-        runner.call_contract(path, 'store_data', key, 1)
-        invokes.append(runner.call_contract(path, 'has_next', prefix))
-        expected_results.append(True)
+        value = 1
+        await self.call('store_data', [key, value], return_type=None)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        contract_storage = cast(
+            dict[bytes, int],
+            await self.get_storage(
+                prefix=prefix,
+                values_post_processor=storage.as_int
+            )
+        )
+        self.assertIn(key, contract_storage)
+        self.assertEqual(value, contract_storage[key])
 
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        result, _ = await self.call('has_next', [prefix], return_type=bool)
+        self.assertEqual(True, result)
 
-    def test_iterator_value(self):
-        path, _ = self.get_deploy_file_paths('IteratorValue.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_iterator_value(self):
+        await self.set_up_contract('IteratorValue.py')
 
         prefix = b'test_iterator_value'
-        invokes.append(runner.call_contract(path, 'test_iterator', prefix))
-        expected_results.append(None)
+        result, _ = await self.call('test_iterator', [prefix], return_type=None)
+        self.assertIsNone(result)
 
         key = prefix + b'example1'
-        key_str = String.from_bytes(key)
-        runner.call_contract(path, 'store_data', key, 1)
-        invokes.append(runner.call_contract(path, 'test_iterator', prefix))
-        expected_results.append([key_str, '\x01'])
+        await self.call('store_data', [key, 1], return_type=None)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        contract_storage = cast(
+            dict[bytes, int],
+            await self.get_storage(
+                prefix=prefix
+            )
+        )
+        self.assertIn(key, contract_storage)
 
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        result, _ = await self.call('test_iterator', [prefix], return_type=tuple[bytes, bytes])
+        self.assertEqual((key, contract_storage[key]), result)
 
     def test_iterator_value_dict_mismatched_type(self):
         path = self.get_contract_path('IteratorValueMismatchedType.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
-    def test_import_iterator(self):
-        path, _ = self.get_deploy_file_paths('ImportIterator.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_import_iterator(self):
+        await self.set_up_contract('ImportIterator.py')
 
-        invokes = []
-        expected_results = []
+        # neo-go in the current version of boa-test-constructor is not configured to return Iterators
+        with self.assertRaises(ValueError) as context:
+            result, _ = await self.call('return_iterator', [], return_type=list)
+            self.assertEqual([], result)
 
-        invokes.append(runner.call_contract(path, 'return_iterator'))
-        expected_results.append([])
+        self.assertRegex(str(context.exception), 'Interop stack item only supports iterators')
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+    async def test_import_interop_iterator(self):
+        await self.set_up_contract('ImportInteropIterator.py')
 
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        # neo-go in the current version of boa-test-constructor is not configured to return Iterators
+        with self.assertRaises(ValueError) as context:
+            result, _ = await self.call('return_iterator', [], return_type=list)
+            self.assertEqual([], result)
 
-    def test_import_interop_iterator(self):
-        path, _ = self.get_deploy_file_paths('ImportInteropIterator.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
+        self.assertRegex(str(context.exception), 'Interop stack item only supports iterators')
 
-        invokes = []
-        expected_results = []
-
-        invokes.append(runner.call_contract(path, 'return_iterator'))
-        expected_results.append([])
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_iterator_implicit_typing(self):
-        path, _ = self.get_deploy_file_paths('IteratorImplicitTyping.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_iterator_implicit_typing(self):
+        await self.set_up_contract('IteratorImplicitTyping.py')
 
         prefix = b'test_iterator_'
         prefix_str = String.from_bytes(prefix)
-        invokes.append(runner.call_contract(path, 'search_storage', prefix))
-        expected_results.append({})
+        result, _ = await self.call('search_storage', [prefix], return_type=dict[str, int])
+        self.assertEqual({}, result)
 
-        invokes.append(runner.call_contract(path, 'store', prefix + b'1', 1))
-        expected_results.append(None)
+        result, _ = await self.call('store', [prefix + b'1', 1], return_type=None)
+        self.assertIsNone(result)
 
-        invokes.append(runner.call_contract(path, 'store', prefix + b'2', 2))
-        expected_results.append(None)
+        result, _ = await self.call('store', [prefix + b'2', 2], return_type=None)
+        self.assertIsNone(result)
 
-        invokes.append(runner.call_contract(path, 'search_storage', prefix))
-        expected_results.append({f'{prefix_str}1': 1, f'{prefix_str}2': 2})
+        result, _ = await self.call('search_storage', [prefix], return_type=dict[str, int])
+        self.assertEqual({f'{prefix_str}1': 1, f'{prefix_str}2': 2}, result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_iterator_value_access(self):
-        path, _ = self.get_deploy_file_paths('IteratorValueAccess.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_iterator_value_access(self):
+        await self.set_up_contract('IteratorValueAccess.py')
 
         prefix = b'test_iterator_'
         prefix_str = String.from_bytes(prefix)
-        invokes.append(runner.call_contract(path, 'search_storage', prefix))
-        expected_results.append({})
+        result, _ = await self.call('search_storage', [prefix], return_type=dict[str, int])
+        self.assertEqual({}, result)
 
-        invokes.append(runner.call_contract(path, 'store', prefix + b'1', 1))
-        expected_results.append(None)
+        result, _ = await self.call('store', [prefix + b'1', 1], return_type=None)
+        self.assertIsNone(result)
 
-        invokes.append(runner.call_contract(path, 'store', prefix + b'2', 2))
-        expected_results.append(None)
+        result, _ = await self.call('store', [prefix + b'2', 2], return_type=None)
+        self.assertIsNone(result)
 
-        invokes.append(runner.call_contract(path, 'search_storage', prefix))
-        expected_results.append({f'{prefix_str}1': 1, f'{prefix_str}2': 2})
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        result, _ = await self.call('search_storage', [prefix], return_type=dict[str, int])
+        self.assertEqual({f'{prefix_str}1': 1, f'{prefix_str}2': 2}, result)

--- a/boa3_test/tests/compiler_tests/test_interop/test_iterator.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_iterator.py
@@ -66,7 +66,7 @@ class TestIteratorInterop(boatestcase.BoaTestCase):
     async def test_import_iterator(self):
         await self.set_up_contract('ImportIterator.py')
 
-        # neo-go in the current version of boa-test-constructor is not configured to return Iterators
+        # TODO: #86drqwhx0 neo-go in the current version of boa-test-constructor is not configured to return Iterators
         with self.assertRaises(ValueError) as context:
             result, _ = await self.call('return_iterator', [], return_type=list)
             self.assertEqual([], result)
@@ -76,7 +76,7 @@ class TestIteratorInterop(boatestcase.BoaTestCase):
     async def test_import_interop_iterator(self):
         await self.set_up_contract('ImportInteropIterator.py')
 
-        # neo-go in the current version of boa-test-constructor is not configured to return Iterators
+        # TODO: #86drqwhx0 neo-go in the current version of boa-test-constructor is not configured to return Iterators
         with self.assertRaises(ValueError) as context:
             result, _ = await self.call('return_iterator', [], return_type=list)
             self.assertEqual([], result)


### PR DESCRIPTION
**Summary or solution description**
 Refactored `test_interop/test_iterator.py` files to use `BoaTestCase` in place of `BoaTest` for unit testing.
