### PR TITLE
CU-86drpnc7w - Refactor test_interop/test_runtime.py to use BoaConstructor

### DIFF
--- a/boa3_test/tests/annotation.py
+++ b/boa3_test/tests/annotation.py
@@ -1,0 +1,21 @@
+from typing import TypeVar
+
+from neo3.core import types
+
+NotificationState = TypeVar('NotificationState', list, tuple)
+Notification = tuple[
+    types.UInt160,  # contract
+    str,  # notification name
+    NotificationState  # state
+]
+
+Transaction = tuple[
+    types.UInt256,  # hash
+    int,  # version
+    int,  # nonce
+    types.UInt160,  # sender
+    int,  # system fee
+    int,  # network fee
+    int,  # valid until block
+    bytes,  # script
+]

--- a/boa3_test/tests/compiler_tests/test_import.py
+++ b/boa3_test/tests/compiler_tests/test_import.py
@@ -1,9 +1,7 @@
-from neo3.core import types
-
 from boa3.internal.exception import CompilerError
 from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3.internal.neo.vm.type.Integer import Integer
-from boa3_test.tests import boatestcase
+from boa3_test.tests import annotation, boatestcase
 
 
 class TestImport(boatestcase.BoaTestCase):
@@ -287,7 +285,7 @@ class TestImport(boatestcase.BoaTestCase):
     async def test_import_user_module_with_not_imported_symbols(self):
         await self.set_up_contract('ImportUserModuleWithNotImportedSymbols.py')
 
-        Notification = tuple[types.UInt160, str, list]
+        Notification = annotation.Notification[list[int]]
         script = self.contract_hash
         result, _ = await self.call('main', [[], script], return_type=list)
         self.assertEqual([], result)
@@ -299,11 +297,11 @@ class TestImport(boatestcase.BoaTestCase):
         result, _ = await self.call('main', [arg, script], return_type=list[Notification])
         self.assertEqual(expected_result, result)
 
-        result, _ = await self.call('main', [arg,  b'\x01' * 20], return_type=list)
+        result, _ = await self.call('main', [arg,  b'\x01' * 20], return_type=list[Notification])
         self.assertEqual([], result)
 
         # 'with_param' is a public method, so it should be included in the manifest when imported
-        result, _ = await self.call('with_param', [arg,  b'\x01' * 20], return_type=list)
+        result, _ = await self.call('with_param', [arg,  b'\x01' * 20], return_type=list[Notification])
         self.assertEqual([], result)
 
         # 'without_param' is a public method, but it isn't imported, so it shouldn't be included in the manifest


### PR DESCRIPTION
**Summary or solution description**
 Refactored `test_interop/test_runtime.py` files to use `BoaTestCase` in place of `BoaTest` for unit testing.
