### PR TITLE
CU-86drpnc8k - Refactor test_interop/test_json.py to use BoaConstructor

### DIFF
--- a/boa3_test/tests/compiler_tests/test_interop/test_json.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_json.py
@@ -1,169 +1,84 @@
 import json
 
-from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to avoid circular imports
-
-from boa3.internal.neo.vm.type.String import String
-from boa3.internal.neo3.vm import VMState
-from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
+from boa3_test.tests import boatestcase
 
 
-class TestJsonInterop(BoaTest):
+class TestJsonInterop(boatestcase.BoaTestCase):
     default_folder: str = 'test_sc/interop_test/json'
 
-    def test_json_serialize(self):
-        path, _ = self.get_deploy_file_paths('JsonSerialize.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_json_serialize(self):
+        await self.set_up_contract('JsonSerialize.py')
 
         test_input = {"one": 1, "two": 2, "three": 3}
         expected_result = json.dumps(test_input, separators=(',', ':'))
-        invokes.append(runner.call_contract(path, 'main', test_input))
-        expected_results.append(expected_result)
+        result, _ = await self.call('main', [test_input], return_type=str)
+        self.assertEqual(expected_result, result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_json_serialize_int(self):
-        path, _ = self.get_deploy_file_paths('JsonSerializeInt.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_json_serialize_int(self):
+        await self.set_up_contract('JsonSerializeInt.py')
 
         expected_result = json.dumps(10)
-        invokes.append(runner.call_contract(path, 'main'))
-        expected_results.append(expected_result)
+        result, _ = await self.call('main', [], return_type=str)
+        self.assertEqual(expected_result, result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_json_serialize_bool(self):
-        path, _ = self.get_deploy_file_paths('JsonSerializeBool.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_json_serialize_bool(self):
+        await self.set_up_contract('JsonSerializeBool.py')
 
         expected_result = json.dumps(True)
-        invokes.append(runner.call_contract(path, 'main'))
-        expected_results.append(expected_result)
+        result, _ = await self.call('main', [], return_type=str)
+        self.assertEqual(expected_result, result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_json_serialize_str(self):
-        path, _ = self.get_deploy_file_paths('JsonSerializeStr.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_json_serialize_str(self):
+        await self.set_up_contract('JsonSerializeStr.py')
 
         expected_result = json.dumps('unit test')
-        invokes.append(runner.call_contract(path, 'main'))
-        expected_results.append(expected_result)
+        result, _ = await self.call('main', [], return_type=str)
+        self.assertEqual(expected_result, result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_json_serialize_bytes(self):
-        path, _ = self.get_deploy_file_paths('JsonSerializeBytes.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_json_serialize_bytes(self):
+        await self.set_up_contract('JsonSerializeBytes.py')
 
         # Python does not accept bytes as parameter for json.dumps() method, since string and bytes ends up being the
         # same on Neo, it's being converted to string, before using dumps
-        expected_result = json.dumps(String().from_bytes(b'unit test'))
-        invokes.append(runner.call_contract(path, 'main'))
-        expected_results.append(expected_result)
+        expected_result = json.dumps('unit test')
+        result, _ = await self.call('main', [], return_type=str)
+        self.assertEqual(expected_result, result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_json_deserialize(self):
-        path, _ = self.get_deploy_file_paths('JsonDeserialize.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_json_deserialize(self):
+        await self.set_up_contract('JsonDeserialize.py')
 
         test_input = json.dumps(12345)
         expected_result = json.loads(test_input)
-        invokes.append(runner.call_contract(path, 'main', test_input))
-        expected_results.append(expected_result)
+        result, _ = await self.call('main', [test_input], return_type=int)
+        self.assertEqual(expected_result, result)
 
         test_input = json.dumps('unit test')
         expected_result = json.loads(test_input)
-        invokes.append(runner.call_contract(path, 'main', test_input))
-        expected_results.append(expected_result)
+        result, _ = await self.call('main', [test_input], return_type=str)
+        self.assertEqual(expected_result, result)
 
         test_input = json.dumps(True)
         expected_result = json.loads(test_input)
-        invokes.append(runner.call_contract(path, 'main', test_input))
-        expected_results.append(expected_result)
+        result, _ = await self.call('main', [test_input], return_type=bool)
+        self.assertEqual(expected_result, result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_import_json(self):
-        path, _ = self.get_deploy_file_paths('ImportJson.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_import_json(self):
+        await self.set_up_contract('ImportJson.py')
 
         value = 123
-        invokes.append(runner.call_contract(path, 'main', value))
-        expected_results.append(value)
+        result, _ = await self.call('main', [value], return_type=int)
+        self.assertEqual(value, result)
 
         value = 'string'
-        invokes.append(runner.call_contract(path, 'main', value))
-        expected_results.append(value)
+        result, _ = await self.call('main', [value], return_type=str)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_import_interop_json(self):
-        path, _ = self.get_deploy_file_paths('ImportInteropJson.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_import_interop_json(self):
+        await self.set_up_contract('ImportInteropJson.py')
 
         value = 123
-        invokes.append(runner.call_contract(path, 'main', value))
-        expected_results.append(value)
+        result, _ = await self.call('main', [value], return_type=int)
+        self.assertEqual(value, result)
 
         value = 'string'
-        invokes.append(runner.call_contract(path, 'main', value))
-        expected_results.append(value)
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        result, _ = await self.call('main', [value], return_type=str)
+        self.assertEqual(value, result)


### PR DESCRIPTION
**Summary or solution description**
 Refactored `test_interop/test_json.py` files to use `BoaTestCase` in place of `BoaTest` for unit testing.
