### PR TITLE
CU-86drpnc8v - Refactor test_native/test_contract_management.py to use BoaConstructor

### DIFF
--- a/boa3_test/tests/annotation.py
+++ b/boa3_test/tests/annotation.py
@@ -1,6 +1,9 @@
-from typing import TypeVar
+from typing import TypeVar, cast
 
 from neo3.core import types
+
+JsonToken = int | str | bool | None | list['JsonToken'] | dict[str, 'JsonToken']
+JsonObject = dict[str, JsonToken]
 
 NotificationState = TypeVar('NotificationState', list, tuple)
 Notification = tuple[
@@ -19,3 +22,83 @@ Transaction = tuple[
     int,  # valid until block
     bytes,  # script
 ]
+
+ContractParameterType = int
+ContractMethod = tuple[
+    str,  # name
+    list[tuple[str, ContractParameterType]],
+    ContractParameterType,  # return type
+    int,  # offset
+    bool  # safe
+]
+ContractEvent = tuple[
+    str,  # name
+    list[tuple[str, ContractParameterType]]
+]
+ContractAbi = tuple[
+    list[ContractMethod],
+    list[ContractEvent]
+]
+ContractManifest = tuple[
+    str,  # name
+    list,  # groups
+    dict,  # features
+    list,  # supported standards
+    ContractAbi,
+    list,  # permissions
+    list,  # trusts
+    str  # extra
+]
+Contract = tuple[
+    int,  # contract id
+    int,  # update counter
+    types.UInt160,  # contract hash
+    bytes,  # contract nef
+    ContractManifest  # contract manifest
+]
+
+
+def manifest_from_json(json_: JsonObject) -> ContractManifest:
+    import json
+    from boa3.internal.neo.vm.type.ContractParameterType import ContractParameterType
+
+    name = json_['name']
+    groups = json_['groups'] if 'groups' in json_ else []
+    supported_standards = json_['supportedstandards'] if 'supportedstandards' in json_ else []
+    permissions = json_['permissions'] if 'permissions' in json_ else []
+    trusts = json_['trusts'] if 'trusts' in json_ else []
+    extra = json.dumps(json_['extra'], separators=(',', ':'))
+
+    json_methods, json_events = json_['abi'].values()
+    methods: list[ContractMethod] = [
+        (
+            cast(str, method['name']),
+            [(
+                cast(str, param['name']),
+                ContractParameterType._get_by_name(param['type'])
+            ) for param in method['parameters']],
+            ContractParameterType._get_by_name(method['returntype']),
+            cast(int, method['offset']),
+            cast(bool, method['safe'])
+        ) for method in json_methods
+    ]
+    events: list[ContractEvent] = [
+        (
+            cast(str, event['name']),
+            [(
+                cast(str, param['name']),
+                ContractParameterType._get_by_name(param['type'])
+            ) for param in event['parameters']]
+        ) for event in json_events
+    ]
+
+    return (
+        name,
+        groups,
+        {},
+        supported_standards,
+        (methods, events),
+        permissions,
+        trusts,
+        extra
+    )

--- a/boa3_test/tests/compiler_tests/test_interop/test_iterator.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_iterator.py
@@ -23,7 +23,7 @@ class TestIteratorInterop(boatestcase.BoaTestCase):
 
         key = prefix + b'example1'
         value = 1
-        await self.call('store_data', [key, value], return_type=None)
+        await self.call('store_data', [key, value], return_type=None, signing_accounts=[self.genesis])
 
         contract_storage = cast(
             dict[bytes, int],
@@ -46,7 +46,7 @@ class TestIteratorInterop(boatestcase.BoaTestCase):
         self.assertIsNone(result)
 
         key = prefix + b'example1'
-        await self.call('store_data', [key, 1], return_type=None)
+        await self.call('store_data', [key, 1], return_type=None, signing_accounts=[self.genesis])
 
         contract_storage = cast(
             dict[bytes, int],
@@ -91,10 +91,10 @@ class TestIteratorInterop(boatestcase.BoaTestCase):
         result, _ = await self.call('search_storage', [prefix], return_type=dict[str, int])
         self.assertEqual({}, result)
 
-        result, _ = await self.call('store', [prefix + b'1', 1], return_type=None)
+        result, _ = await self.call('store', [prefix + b'1', 1], return_type=None, signing_accounts=[self.genesis])
         self.assertIsNone(result)
 
-        result, _ = await self.call('store', [prefix + b'2', 2], return_type=None)
+        result, _ = await self.call('store', [prefix + b'2', 2], return_type=None, signing_accounts=[self.genesis])
         self.assertIsNone(result)
 
         result, _ = await self.call('search_storage', [prefix], return_type=dict[str, int])
@@ -108,10 +108,10 @@ class TestIteratorInterop(boatestcase.BoaTestCase):
         result, _ = await self.call('search_storage', [prefix], return_type=dict[str, int])
         self.assertEqual({}, result)
 
-        result, _ = await self.call('store', [prefix + b'1', 1], return_type=None)
+        result, _ = await self.call('store', [prefix + b'1', 1], return_type=None, signing_accounts=[self.genesis])
         self.assertIsNone(result)
 
-        result, _ = await self.call('store', [prefix + b'2', 2], return_type=None)
+        result, _ = await self.call('store', [prefix + b'2', 2], return_type=None, signing_accounts=[self.genesis])
         self.assertIsNone(result)
 
         result, _ = await self.call('search_storage', [prefix], return_type=dict[str, int])

--- a/boa3_test/tests/compiler_tests/test_native/test_contract_management.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_contract_management.py
@@ -1,160 +1,169 @@
 import json
+from dataclasses import dataclass
 
-from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to avoid circular imports
+from neo3.api import noderpc
+from neo3.contracts.contract import CONTRACT_HASHES
+from neo3.core import types
+from neo3.wallet import account
 
 from boa3.internal import constants
 from boa3.internal.exception import CompilerError
 from boa3.internal.neo.vm.type.String import String
-from boa3.internal.neo3.vm import VMState
-from boa3_test.tests.test_classes.contract.neomanifeststruct import NeoManifestStruct
-from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
+from boa3_test.tests import annotation, boatestcase
 
 
-class TestContractManagementContract(BoaTest):
+@dataclass
+class DeployEvent(boatestcase.BoaTestEvent):
+    deployed_contract: types.UInt160
+
+    @classmethod
+    def from_untyped_notification(cls, n: noderpc.Notification):
+        inner_args_types = tuple(cls.__annotations__.values())
+        e = super().from_notification(n, *inner_args_types)
+        return cls(e.contract, e.name, e.state, *e.state)
+
+
+@dataclass
+class UpdateEvent(boatestcase.BoaTestEvent):
+    updated_contract: types.UInt160
+
+    @classmethod
+    def from_untyped_notification(cls, n: noderpc.Notification):
+        inner_args_types = tuple(cls.__annotations__.values())
+        e = super().from_notification(n, *inner_args_types)
+        return cls(e.contract, e.name, e.state, *e.state)
+
+
+@dataclass
+class DestroyEvent(boatestcase.BoaTestEvent):
+    destroyed_contract: types.UInt160
+
+    @classmethod
+    def from_untyped_notification(cls, n: noderpc.Notification):
+        inner_args_types = tuple(cls.__annotations__.values())
+        e = super().from_notification(n, *inner_args_types)
+        return cls(e.contract, e.name, e.state, *e.state)
+
+
+class TestContractManagementContract(boatestcase.BoaTestCase):
     default_folder: str = 'test_sc/native_test/contractmanagement'
+    account: account.Account
 
-    def test_get_hash(self):
-        path, _ = self.get_deploy_file_paths('GetHash.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
+    @classmethod
+    def setupTestCase(cls):
+        cls.account = cls.node.wallet.account_new(label='test', password='123')
+        super().setupTestCase()
 
-        invokes = []
-        expected_results = []
+    @classmethod
+    async def asyncSetupClass(cls) -> None:
+        await super().asyncSetupClass()
 
-        invokes.append(runner.call_contract(path, 'main'))
-        expected_results.append(constants.MANAGEMENT_SCRIPT)
+        await cls.transfer(CONTRACT_HASHES.GAS_TOKEN, cls.genesis.script_hash, cls.account.script_hash, 100)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+    async def test_get_hash(self):
+        await self.set_up_contract('GetHash.py')
 
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        expected = types.UInt160(constants.MANAGEMENT_SCRIPT)
+        result, _ = await self.call('main', [], return_type=types.UInt160)
+        self.assertEqual(expected, result)
 
-    def test_get_minimum_deployment_fee(self):
-        path, _ = self.get_deploy_file_paths('GetMinimumDeploymentFee.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_get_minimum_deployment_fee(self):
+        await self.set_up_contract('GetMinimumDeploymentFee.py')
 
         minimum_cost = 10 * 10 ** 8  # minimum deployment cost is 10 GAS right now
-        invokes.append(runner.call_contract(path, 'main'))
-        expected_results.append(minimum_cost)
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        result, _ = await self.call('main', [], return_type=int)
+        self.assertEqual(minimum_cost, result)
 
     def test_get_minimum_deployment_fee_too_many_parameters(self):
         path = self.get_contract_path('GetMinimumDeploymentFeeTooManyArguments.py')
         self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
 
-    def test_get_contract(self):
-        path, _ = self.get_deploy_file_paths('GetContract.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
-
-        invokes.append(runner.call_contract(path, 'main', bytes(20)))
-        expected_results.append(None)
-
+    async def test_get_contract(self):
         call_contract_path = self.get_contract_path('test_sc/arithmetic_test', 'Addition.py')
-        nef, manifest = self.get_bytes_output(call_contract_path)
 
-        call_contract_path, _ = self.get_deploy_file_paths(call_contract_path)
-        contract = runner.deploy_contract(call_contract_path)
-        runner.update_contracts(export_checkpoint=True)
-        call_hash = contract.script_hash
+        await self.set_up_contract('GetContract.py')
+        call_hash = await self.compile_and_deploy(call_contract_path)
 
-        invoke = runner.call_contract(path, 'main', call_hash)
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        nef, manifest = self.get_serialized_output(call_contract_path)
+        manifest = annotation.manifest_from_json(manifest)
+        result, _ = await self.call('main', [bytes(20)], return_type=None)
+        self.assertIsNone(result)
 
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-        result = invoke.result
+        result, _ = await self.call('main', [call_hash], return_type=annotation.Contract)
         self.assertEqual(5, len(result))
         self.assertEqual(call_hash, result[2])
         self.assertEqual(nef, result[3])
-        manifest_struct = NeoManifestStruct.from_json(manifest)
-        self.assertEqual(manifest_struct, result[4])
+        self.assertEqual(manifest, result[4])
 
-    def test_has_method(self):
-        path, _ = self.get_deploy_file_paths('HasMethod.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
-
-        call_contract_path, _ = self.get_deploy_file_paths('test_sc/arithmetic_test', 'Addition.py')
-        contract = runner.deploy_contract(call_contract_path)
-        runner.update_contracts(export_checkpoint=True)
-        call_hash = contract.script_hash
+    async def test_has_method(self):
+        await self.set_up_contract('HasMethod.py')
+        call_hash = await self.compile_and_deploy('test_sc/arithmetic_test', 'Addition.py')
 
         test_method = 'add'
         test_parameter_count = 2
-        invokes.append(runner.call_contract(path, 'main', bytes(20), test_method, test_parameter_count))
-        expected_results.append(False)
+        result, _ = await self.call('main', [bytes(20), test_method, test_parameter_count], return_type=bool)
+        self.assertEqual(False, result)
 
-        invokes.append(runner.call_contract(path, 'main', call_hash, test_method, test_parameter_count))
-        expected_results.append(True)
+        result, _ = await self.call('main', [call_hash, test_method, test_parameter_count], return_type=bool)
+        self.assertEqual(True, result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_deploy_contract(self):
-        path, _ = self.get_deploy_file_paths('DeployContract.py')
-        call_contract_path = self.get_contract_path('test_sc/arithmetic_test', 'Addition.py')
+    async def test_deploy_contract(self):
+        await self.set_up_contract('DeployContract.py')
+        call_contract_path = self.get_contract_path('test_sc/arithmetic_test', 'Subtraction.py')
 
         self.compile_and_save(call_contract_path)
-        nef_file, manifest = self.get_bytes_output(call_contract_path)
+        nef_file, manifest = self.get_serialized_output(call_contract_path)
         arg_manifest = String(json.dumps(manifest, separators=(',', ':'))).to_bytes()
 
-        runner = BoaTestRunner(runner_id=self.method_name())
-        invoke = runner.call_contract(path, 'Main', nef_file, arg_manifest, None)
+        manifest = annotation.manifest_from_json(manifest)
+        result, notifications = await self.call('Main',
+                                                [nef_file, arg_manifest, None],
+                                                return_type=annotation.Contract
+                                                )
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        deploy_events = self.filter_events(notifications,
+                                           event_name='Deploy',
+                                           notification_type=DeployEvent
+                                           )
+        self.assertEqual(1, len(deploy_events))
 
-        result = invoke.result
         self.assertEqual(5, len(result))
+        self.assertEqual(0, result[1])  # contract update counter must be zero on deploy
         self.assertEqual(nef_file, result[3])
-        manifest_struct = NeoManifestStruct.from_json(manifest)
-        self.assertEqual(manifest_struct, result[4])
+        self.assertEqual(manifest, result[4])
 
-    def test_deploy_contract_data_deploy(self):
-        path, _ = self.get_deploy_file_paths('DeployContract.py')
+    async def test_deploy_contract_data_deploy(self):
+        await self.set_up_contract('DeployContract.py')
         call_contract_path = self.get_contract_path('boa3_test/test_sc/interop_test/contract', 'NewContract.py')
 
         self.compile_and_save(call_contract_path)
-        nef_file, manifest = self.get_bytes_output(call_contract_path)
+        nef_file, manifest = self.get_serialized_output(call_contract_path)
         arg_manifest = String(json.dumps(manifest, separators=(',', ':'))).to_bytes()
-
-        runner = BoaTestRunner(runner_id=self.method_name())
-        runner.file_name = 'test_create_contract'
+        manifest = annotation.manifest_from_json(manifest)
 
         data = 'some sort of data'
-        invoke = runner.call_contract(path, 'Main', nef_file, arg_manifest, data)
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        result = invoke.result
+        result, notifications = await self.call('Main',
+                                                [nef_file, arg_manifest, data],
+                                                return_type=annotation.Contract
+                                                )
         self.assertEqual(5, len(result))
+        self.assertEqual(0, result[1])  # contract update counter must be zero on deploy
         self.assertEqual(nef_file, result[3])
-        manifest_struct = NeoManifestStruct.from_json(manifest)
-        self.assertEqual(manifest_struct, result[4])
+        self.assertEqual(manifest, result[4])
 
-        notifies = runner.get_events('notify')
+        deploy_events = self.filter_events(notifications,
+                                           event_name='Deploy',
+                                           notification_type=DeployEvent
+                                           )
+        self.assertEqual(1, len(deploy_events))
+
+        notifies = self.filter_events(notifications,
+                                      event_name='notify',
+                                      notification_type=boatestcase.BoaTestEvent
+                                      )
         self.assertEqual(2, len(notifies))
-        self.assertEqual(False, notifies[0].arguments[0])  # not updated
-        self.assertEqual(data, notifies[1].arguments[0])  # data
+        self.assertEqual(False, notifies[0].state[0])  # not updated
+        self.assertEqual(data, notifies[1].state[0])  # data
 
     def test_deploy_contract_too_many_parameters(self):
         path = self.get_contract_path('DeployContractTooManyArguments.py')
@@ -164,65 +173,67 @@ class TestContractManagementContract(BoaTest):
         path = self.get_contract_path('DeployContractTooFewArguments.py')
         self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
 
-    def test_update_contract(self):
-        path, _ = self.get_deploy_file_paths('UpdateContract.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_update_contract(self):
+        await self.set_up_contract('UpdateContract.py')
 
-        invokes = []
-        expected_results = []
+        updated_method = 'new_method'
+        with self.assertRaises(boatestcase.FaultException) as context:
+            await self.call(updated_method, [], return_type=None)
 
-        runner.call_contract(path, 'new_method')
-        runner.execute()
-        self.assertEqual(VMState.FAULT, runner.vm_state, msg=runner.cli_log)
-        self.assertRegex(runner.error, self.FORMAT_METHOD_DOESNT_EXIST_IN_CONTRACT_MSG_REGEX_PREFIX.format('new_method'))
+        self.assertRegex(str(context.exception), fr"method not found: {updated_method}/\d+")
 
         new_path = self.get_contract_path('test_sc/interop_test', 'UpdateContract.py')
         self.compile_and_save(new_path)
-        new_nef, new_manifest = self.get_bytes_output(new_path)
+        new_nef, new_manifest = self.get_serialized_output(new_path)
         arg_manifest = String(json.dumps(new_manifest, separators=(',', ':'))).to_bytes()
 
-        invokes.append(runner.call_contract(path, 'update', new_nef, arg_manifest, None))
-        expected_results.append(None)
+        result, notifications = await self.call('update',
+                                                [new_nef, arg_manifest, None],
+                                                return_type=None,
+                                                signing_accounts=[self.genesis]
+                                                )
+        self.assertIsNone(result)
+        update_events = self.filter_events(notifications,
+                                           event_name='Update',
+                                           notification_type=UpdateEvent
+                                           )
+        self.assertEqual(1, len(update_events))
+        self.assertEqual(self.contract_hash, update_events[0].updated_contract)
 
-        invokes.append(runner.call_contract(path, 'new_method'))
-        expected_results.append(42)
+        result, _ = await self.call(updated_method, [], return_type=int)
+        self.assertEqual(42, result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+    async def test_update_contract_data_deploy(self):
+        await self.set_up_contract('UpdateContract.py', signing_account=self.account)
 
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        updated_method = 'new_method'
+        with self.assertRaises(boatestcase.FaultException) as context:
+            await self.call(updated_method, [], return_type=int)
 
-    def test_update_contract_data_deploy(self):
-        path, _ = self.get_deploy_file_paths('UpdateContract.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
-
-        runner.call_contract(path, 'new_method')
-        runner.execute()
-        self.assertEqual(VMState.FAULT, runner.vm_state, msg=runner.cli_log)
-        self.assertRegex(runner.error, self.FORMAT_METHOD_DOESNT_EXIST_IN_CONTRACT_MSG_REGEX_PREFIX.format('new_method'))
+        self.assertRegex(str(context.exception), fr"method not found: {updated_method}/\d+")
 
         new_path = self.get_contract_path('test_sc/interop_test', 'UpdateContract.py')
-        new_nef, new_manifest = self.get_bytes_output(new_path)
+        self.compile_and_save(new_path)
+        new_nef, new_manifest = self.get_serialized_output(new_path)
         arg_manifest = String(json.dumps(new_manifest, separators=(',', ':'))).to_bytes()
 
         data = 'this function was deployed'
-        invokes.append(runner.call_contract(path, 'update', new_nef, arg_manifest, data))
-        expected_results.append(None)
+        result, notifications = await self.call('update', [new_nef, arg_manifest, data], return_type=None)
+        self.assertIsNone(result)
+        update_events = self.filter_events(notifications,
+                                           event_name='Update',
+                                           notification_type=UpdateEvent
+                                           )
+        self.assertEqual(1, len(update_events))
+        self.assertEqual(self.contract_hash, update_events[0].updated_contract)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-        notifies = runner.get_events('notify')
+        notifies = self.filter_events(notifications,
+                                      event_name='notify',
+                                      notification_type=boatestcase.BoaTestEvent
+                                      )
         self.assertEqual(2, len(notifies))
-        self.assertEqual(True, notifies[0].arguments[0])
-        self.assertEqual(data, notifies[1].arguments[0])
+        self.assertEqual(True, notifies[0].state[0])
+        self.assertEqual(data, notifies[1].state[0])
 
     def test_update_contract_too_many_parameters(self):
         path = self.get_contract_path('UpdateContractTooManyArguments.py')
@@ -232,30 +243,28 @@ class TestContractManagementContract(BoaTest):
         path = self.get_contract_path('UpdateContractTooFewArguments.py')
         self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
 
-    def test_destroy_contract(self):
-        path, _ = self.get_deploy_file_paths('DestroyContract.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_destroy_contract(self):
+        await self.set_up_contract('DestroyContract.py')
 
-        invokes = []
-        expected_results = []
+        contract_hash = self.contract_hash
+        result, notifications = await self.call('Main', [], return_type=None, signing_accounts=[self.genesis])
+        self.assertIsNone(result)
+        destroy_events = self.filter_events(notifications,
+                                            event_name='Destroy',
+                                            notification_type=DestroyEvent
+                                            )
+        self.assertEqual(1, len(destroy_events))
+        self.assertEqual(contract_hash, destroy_events[0].destroyed_contract)
 
-        call = runner.call_contract(path, 'Main')
-        invokes.append(call)
-        expected_results.append(None)
+        call_contract = await self.compile_and_deploy('boa3_test/test_sc/interop_test/contract', 'CallScriptHash.py')
+        with self.assertRaises(boatestcase.FaultException) as context:
+            await self.call('Main',
+                            [contract_hash, 'Main', []],
+                            return_type=None,
+                            target_contract=call_contract
+                            )
 
-        runner.execute(clear_invokes=False)
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-        script_hash = call.invoke.contract.script_hash
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-        call_contract_path, _ = self.get_deploy_file_paths('boa3_test/test_sc/interop_test/contract', 'CallScriptHash.py')
-        runner.call_contract(call_contract_path, 'Main',
-                             script_hash, 'Main', [])
-        runner.execute()
-        self.assertEqual(VMState.FAULT, runner.vm_state, msg=runner.cli_log)
-        self.assertRegex(runner.error, f'^{self.CALLED_CONTRACT_DOES_NOT_EXIST_MSG}')
+        self.assertRegex(str(context.exception), f'called contract {contract_hash} not found')
 
     def test_destroy_contract_too_many_parameters(self):
         path = self.get_contract_path('DestroyContractTooManyArguments.py')


### PR DESCRIPTION
**Summary or solution description**
 Refactored `test_native/test_contract_management.py` files to use `BoaTestCase` in place of `BoaTest` for unit testing.