### PR TITLE
#86drpncuk - Refactor test_interop/test_storage.py to use BoaTestCons…

### DIFF
--- a/boa3_test/tests/compiler_tests/test_interop/test_storage.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_storage.py
@@ -37,8 +37,7 @@ class TestStorageInterop(boatestcase.BoaTestCase):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('StorageGetBytesKey.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('StorageGetBytesKey.py')
         self.assertEqual(expected_output, output)
 
     def test_storage_get_str_key(self):
@@ -57,13 +56,13 @@ class TestStorageInterop(boatestcase.BoaTestCase):
         stored_value = b'\x01\x02\x03'
 
         result, _ = await self.call('Main', [storage_key_1], return_type=None, signing_accounts=[self.genesis])
-        self.assertEqual(None, result)
+        self.assertIsNone(result)
 
         result, _ = await self.call('Main', [storage_key_2], return_type=None, signing_accounts=[self.genesis])
-        self.assertEqual(None, result)
+        self.assertIsNone(result)
 
         result, _ = await self.call('Main', [storage_key_2], return_type=None, signing_accounts=[self.genesis])
-        self.assertEqual(None, result)
+        self.assertIsNone(result)
 
         contract_storage = await self.get_storage()
 
@@ -90,8 +89,7 @@ class TestStorageInterop(boatestcase.BoaTestCase):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('StoragePutBytesKeyIntValue.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('StoragePutBytesKeyIntValue.py')
         self.assertEqual(expected_output, output)
 
     async def test_storage_put_bytes_key_int_value(self):
@@ -102,13 +100,13 @@ class TestStorageInterop(boatestcase.BoaTestCase):
         stored_value = 123
 
         result, _ = await self.call('Main', [storage_key_1], return_type=None, signing_accounts=[self.genesis])
-        self.assertEqual(None, result)
+        self.assertIsNone(result)
 
         result, _ = await self.call('Main', [storage_key_2], return_type=None, signing_accounts=[self.genesis])
-        self.assertEqual(None, result)
+        self.assertIsNone(result)
 
         result, _ = await self.call('Main', [storage_key_2], return_type=None, signing_accounts=[self.genesis])
-        self.assertEqual(None, result)
+        self.assertIsNone(result)
 
         contract_storage = await self.get_storage(values_post_processor=storage.as_int)
 
@@ -139,8 +137,7 @@ class TestStorageInterop(boatestcase.BoaTestCase):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('StoragePutBytesKeyStrValue.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('StoragePutBytesKeyStrValue.py')
         self.assertEqual(expected_output, output)
 
     async def test_storage_put_bytes_key_str_value(self):
@@ -151,13 +148,13 @@ class TestStorageInterop(boatestcase.BoaTestCase):
         stored_value = '123'
 
         result, _ = await self.call('Main', [storage_key_1], return_type=None, signing_accounts=[self.genesis])
-        self.assertEqual(None, result)
+        self.assertIsNone(result)
 
         result, _ = await self.call('Main', [storage_key_2], return_type=None, signing_accounts=[self.genesis])
-        self.assertEqual(None, result)
+        self.assertIsNone(result)
 
         result, _ = await self.call('Main', [storage_key_2], return_type=None, signing_accounts=[self.genesis])
-        self.assertEqual(None, result)
+        self.assertIsNone(result)
 
         contract_storage = await self.get_storage(values_post_processor=storage.as_str)
 
@@ -200,8 +197,7 @@ class TestStorageInterop(boatestcase.BoaTestCase):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('StorageDeleteBytesKey.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('StorageDeleteBytesKey.py')
         self.assertStartsWith(output, expected_output)
 
     async def test_storage_delete_bytes_key(self):
@@ -217,10 +213,10 @@ class TestStorageInterop(boatestcase.BoaTestCase):
         self.assertEqual(True, result)
 
         result, _ = await self.call('Main', [not_existing_key], return_type=None, signing_accounts=[self.genesis])
-        self.assertEqual(None, result)
+        self.assertIsNone(result)
 
         result, _ = await self.call('Main', [storage_key], return_type=None, signing_accounts=[self.genesis])
-        self.assertEqual(None, result)
+        self.assertIsNone(result)
 
         result, _ = await self.call('has_key', [storage_key], return_type=bool)
         self.assertEqual(False, result)
@@ -285,8 +281,8 @@ class TestStorageInterop(boatestcase.BoaTestCase):
             + self.storage_get_context_hash
             + Opcode.RET
         )
-        path = self.get_contract_path('StorageGetContext.py')
-        output, manifest = self.compile_and_save(path)
+
+        output, _ = self.assertCompile('StorageGetContext.py')
         self.assertEqual(expected_output, output)
 
     async def test_storage_get_context(self):
@@ -306,8 +302,8 @@ class TestStorageInterop(boatestcase.BoaTestCase):
             + Interop.StorageGetReadOnlyContext.interop_method_hash
             + Opcode.RET
         )
-        path = self.get_contract_path('StorageGetReadOnlyContext.py')
-        output, manifest = self.compile_and_save(path)
+
+        output, _ = self.assertCompile('StorageGetReadOnlyContext.py')
         self.assertEqual(expected_output, output)
 
     async def test_storage_get_read_only_context(self):
@@ -356,13 +352,13 @@ class TestStorageInterop(boatestcase.BoaTestCase):
         stored_value = b'\x01\x02\x03'
 
         result, _ = await self.call('Main', [storage_key_1], return_type=None, signing_accounts=[self.genesis])
-        self.assertEqual(None, result)
+        self.assertIsNone(result)
 
         result, _ = await self.call('Main', [storage_key_2], return_type=None, signing_accounts=[self.genesis])
-        self.assertEqual(None, result)
+        self.assertIsNone(result)
 
         result, _ = await self.call('Main', [storage_key_2], return_type=None, signing_accounts=[self.genesis])
-        self.assertEqual(None, result)
+        self.assertIsNone(result)
 
         contract_storage = await self.get_storage()
 
@@ -387,8 +383,7 @@ class TestStorageInterop(boatestcase.BoaTestCase):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('StorageDeleteWithContext.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('StorageDeleteWithContext.py')
         self.assertStartsWith(output, expected_output)
 
     async def test_storage_delete_with_context(self):
@@ -404,10 +399,10 @@ class TestStorageInterop(boatestcase.BoaTestCase):
         self.assertEqual(True, result)
 
         result, _ = await self.call('Main', [not_existing_key], return_type=None, signing_accounts=[self.genesis])
-        self.assertEqual(None, result)
+        self.assertIsNone(result)
 
         result, _ = await self.call('Main', [storage_key], return_type=None, signing_accounts=[self.genesis])
-        self.assertEqual(None, result)
+        self.assertIsNone(result)
 
         result, _ = await self.call('has_key', [storage_key], return_type=bool)
         self.assertEqual(False, result)
@@ -540,7 +535,7 @@ class TestStorageInterop(boatestcase.BoaTestCase):
         value = 42
 
         result, _ = await self.call('put_value', [key, value], return_type=None, signing_accounts=[self.genesis])
-        self.assertEqual(None, result)
+        self.assertIsNone(result)
 
         result, _ = await self.call('get_value', [key], return_type=int, target_contract=contract2)
         self.assertEqual(0, result)
@@ -566,7 +561,7 @@ class TestStorageInterop(boatestcase.BoaTestCase):
         self.assertEqual(b'', result)
 
         result, _ = await self.call('insert_to_map', [storage_key, stored_value], return_type=None, signing_accounts=[self.genesis])
-        self.assertEqual(None, result)
+        self.assertIsNone(result)
 
         result, _ = await self.call('get_from_map', [b'test1'], return_type=bytes)
         self.assertEqual(stored_value, result)
@@ -579,7 +574,7 @@ class TestStorageInterop(boatestcase.BoaTestCase):
         self.assertEqual(stored_value, contract_storage[map_key + storage_key])
 
         result, _ = await self.call('delete_from_map', [b'test1'], return_type=None, signing_accounts=[self.genesis])
-        self.assertEqual(None, result)
+        self.assertIsNone(result)
 
         result, _ = await self.call('get_from_map', [b'test1'], return_type=bytes)
         self.assertEqual(b'', result)
@@ -606,7 +601,7 @@ class TestStorageInterop(boatestcase.BoaTestCase):
         self.assertEqual({}, contract_storage)
 
         result, _ = await self.call('put_value', [key, value], return_type=None, signing_accounts=[self.genesis])
-        self.assertEqual(None, result)
+        self.assertIsNone(result)
 
         result, _ = await self.call('get_value', [key], return_type=int)
         self.assertEqual(value, result)
@@ -625,7 +620,7 @@ class TestStorageInterop(boatestcase.BoaTestCase):
         await self.call('get_value', [key], return_type=int)
 
         result, _ = await self.call('delete_value', [key], return_type=None, signing_accounts=[self.genesis])
-        self.assertEqual(None, result)
+        self.assertIsNone(result)
 
         result, _ = await self.call('get_value', [key], return_type=int)
         self.assertEqual(0, result)
@@ -662,7 +657,7 @@ class TestStorageInterop(boatestcase.BoaTestCase):
         self.assertEqual({}, contract_storage)
 
         result, _ = await self.call('put_value', [key, value], return_type=None, signing_accounts=[self.genesis])
-        self.assertEqual(None, result)
+        self.assertIsNone(result)
 
         result, _ = await self.call('get_value', [key], return_type=int)
         self.assertEqual(value, result)
@@ -681,7 +676,7 @@ class TestStorageInterop(boatestcase.BoaTestCase):
         await self.call('get_value', [key], return_type=int)
 
         result, _ = await self.call('delete_value', [key], return_type=None, signing_accounts=[self.genesis])
-        self.assertEqual(None, result)
+        self.assertIsNone(result)
 
         result, _ = await self.call('get_value', [key], return_type=int)
         self.assertEqual(0, result)
@@ -705,7 +700,7 @@ class TestStorageInterop(boatestcase.BoaTestCase):
 
         # Putting old value in the storage
         result, _ = await self.call('put_value_in_storage', [key, value_old], return_type=None, signing_accounts=[self.genesis])
-        self.assertEqual(None, result)
+        self.assertIsNone(result)
 
         result, _ = await self.call('get_value_in_storage_read_only', [key], return_type=str)
         self.assertEqual(value_old, result)

--- a/boa3_test/tests/compiler_tests/test_interop/test_storage.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_storage.py
@@ -1,18 +1,21 @@
-from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to avoid circular imports
+from boaconstructor import storage
 
 from boa3.internal.exception import CompilerError
-from boa3.internal.model.builtin.interop.interop import Interop
-from boa3.internal.neo.core.types.InteropInterface import InteropInterface
 from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo.vm.type.String import String
 from boa3.internal.neo3.contracts import FindOptions
-from boa3.internal.neo3.vm import VMState
-from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
+from boa3_test.tests import boatestcase
 
 
-class TestStorageInterop(BoaTest):
+class TestStorageInterop(boatestcase.BoaTestCase):
+    from boa3.internal.model.builtin.interop.interop import Interop
     default_folder: str = 'test_sc/interop_test/storage'
+
+    storage_get_context_hash = Interop.StorageGetContext.interop_method_hash
+    storage_get_hash = Interop.StorageGet.interop_method_hash
+    storage_put_hash = Interop.StoragePut.interop_method_hash
+    storage_delete_hash = Interop.StorageDelete.interop_method_hash
 
     def test_storage_get_bytes_key(self):
         expected_output = (
@@ -21,9 +24,9 @@ class TestStorageInterop(BoaTest):
             + b'\x01'
             + Opcode.LDARG0
             + Opcode.SYSCALL
-            + Interop.StorageGetContext.interop_method_hash
+            + self.storage_get_context_hash
             + Opcode.SYSCALL
-            + Interop.StorageGet.interop_method_hash
+            + self.storage_get_hash
             + Opcode.DUP
             + Opcode.ISNULL
             + Opcode.JMPIFNOT
@@ -46,40 +49,31 @@ class TestStorageInterop(BoaTest):
         path = self.get_contract_path('StorageGetMismatchedType.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
-    def test_storage_put_bytes_key_bytes_value(self):
-        path, _ = self.get_deploy_file_paths('StoragePutBytesKeyBytesValue.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_storage_put_bytes_key_bytes_value(self):
+        await self.set_up_contract('StoragePutBytesKeyBytesValue.py')
 
         storage_key_1 = b'test1'
         storage_key_2 = b'test2'
         stored_value = b'\x01\x02\x03'
 
-        invokes.append(runner.call_contract(path, 'Main', storage_key_1))
-        expected_results.append(None)
+        result, _ = await self.call('Main', [storage_key_1], return_type=None, signing_accounts=[self.genesis])
+        self.assertEqual(None, result)
 
-        invokes.append(runner.call_contract(path, 'Main', storage_key_2))
-        expected_results.append(None)
+        result, _ = await self.call('Main', [storage_key_2], return_type=None, signing_accounts=[self.genesis])
+        self.assertEqual(None, result)
 
-        invokes.append(runner.call_contract(path, 'Main', storage_key_2))
-        expected_results.append(None)
+        result, _ = await self.call('Main', [storage_key_2], return_type=None, signing_accounts=[self.genesis])
+        self.assertEqual(None, result)
 
-        storage_contract = invokes[0].invoke.contract
-        runner.execute(get_storage_from=storage_contract)
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        contract_storage = await self.get_storage()
 
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        self.assertIn(storage_key_1, contract_storage)
+        self.assertEqual(stored_value, contract_storage[storage_key_1])
 
-        storage_result_1 = runner.storages.get(storage_contract, storage_key_1)
-        self.assertEqual(stored_value, storage_result_1.as_bytes())
+        self.assertIn(storage_key_2, contract_storage)
+        self.assertEqual(stored_value, contract_storage[storage_key_2])
 
-        storage_result_2 = runner.storages.get(storage_contract, storage_key_2)
-        self.assertEqual(stored_value, storage_result_2.as_bytes())
-
-    def test_storage_put_bytes_key_int_value(self):
+    def test_storage_put_bytes_key_int_value_compile(self):
         value = Integer(123).to_byte_array()
         expected_output = (
             Opcode.INITSLOT
@@ -90,9 +84,9 @@ class TestStorageInterop(BoaTest):
             + Opcode.PUSHINT8 + value
             + Opcode.LDARG0
             + Opcode.SYSCALL
-            + Interop.StorageGetContext.interop_method_hash
+            + self.storage_get_context_hash
             + Opcode.SYSCALL
-            + Interop.StoragePut.interop_method_hash
+            + self.storage_put_hash
             + Opcode.RET
         )
 
@@ -100,39 +94,31 @@ class TestStorageInterop(BoaTest):
         output = self.compile(path)
         self.assertEqual(expected_output, output)
 
-        path, _ = self.get_deploy_file_paths(path)
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_storage_put_bytes_key_int_value(self):
+        await self.set_up_contract('StoragePutBytesKeyIntValue.py')
 
         storage_key_1 = b'test1'
         storage_key_2 = b'test2'
         stored_value = 123
 
-        invokes.append(runner.call_contract(path, 'Main', storage_key_1))
-        expected_results.append(None)
+        result, _ = await self.call('Main', [storage_key_1], return_type=None, signing_accounts=[self.genesis])
+        self.assertEqual(None, result)
 
-        invokes.append(runner.call_contract(path, 'Main', storage_key_2))
-        expected_results.append(None)
+        result, _ = await self.call('Main', [storage_key_2], return_type=None, signing_accounts=[self.genesis])
+        self.assertEqual(None, result)
 
-        invokes.append(runner.call_contract(path, 'Main', storage_key_2))
-        expected_results.append(None)
+        result, _ = await self.call('Main', [storage_key_2], return_type=None, signing_accounts=[self.genesis])
+        self.assertEqual(None, result)
 
-        storage_contract = invokes[0].invoke.contract
-        runner.execute(get_storage_from=storage_contract)
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        contract_storage = await self.get_storage(values_post_processor=storage.as_int)
 
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        self.assertIn(storage_key_1, contract_storage)
+        self.assertEqual(stored_value, contract_storage[storage_key_1])
 
-        storage_result_1 = runner.storages.get(storage_contract, storage_key_1)
-        self.assertEqual(stored_value, storage_result_1.as_int())
+        self.assertIn(storage_key_2, contract_storage)
+        self.assertEqual(stored_value, contract_storage[storage_key_2])
 
-        storage_result_2 = runner.storages.get(storage_contract, storage_key_2)
-        self.assertEqual(stored_value, storage_result_2.as_int())
-
-    def test_storage_put_bytes_key_str_value(self):
+    def test_storage_put_bytes_key_str_value_compile(self):
         value = String('123').to_bytes()
         expected_output = (
             Opcode.INITSLOT
@@ -147,9 +133,9 @@ class TestStorageInterop(BoaTest):
             + value
             + Opcode.LDARG0
             + Opcode.SYSCALL
-            + Interop.StorageGetContext.interop_method_hash
+            + self.storage_get_context_hash
             + Opcode.SYSCALL
-            + Interop.StoragePut.interop_method_hash
+            + self.storage_put_hash
             + Opcode.RET
         )
 
@@ -157,37 +143,29 @@ class TestStorageInterop(BoaTest):
         output = self.compile(path)
         self.assertEqual(expected_output, output)
 
-        path, _ = self.get_deploy_file_paths(path)
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_storage_put_bytes_key_str_value(self):
+        await self.set_up_contract('StoragePutBytesKeyStrValue.py')
 
         storage_key_1 = b'test1'
         storage_key_2 = b'test2'
         stored_value = '123'
 
-        invokes.append(runner.call_contract(path, 'Main', storage_key_1))
-        expected_results.append(None)
+        result, _ = await self.call('Main', [storage_key_1], return_type=None, signing_accounts=[self.genesis])
+        self.assertEqual(None, result)
 
-        invokes.append(runner.call_contract(path, 'Main', storage_key_2))
-        expected_results.append(None)
+        result, _ = await self.call('Main', [storage_key_2], return_type=None, signing_accounts=[self.genesis])
+        self.assertEqual(None, result)
 
-        invokes.append(runner.call_contract(path, 'Main', storage_key_2))
-        expected_results.append(None)
+        result, _ = await self.call('Main', [storage_key_2], return_type=None, signing_accounts=[self.genesis])
+        self.assertEqual(None, result)
 
-        storage_contract = invokes[0].invoke.contract
-        runner.execute(get_storage_from=storage_contract)
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        contract_storage = await self.get_storage(values_post_processor=storage.as_str)
 
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        self.assertIn(storage_key_1, contract_storage)
+        self.assertEqual(stored_value, contract_storage[storage_key_1])
 
-        storage_result_1 = runner.storages.get(storage_contract, storage_key_1)
-        self.assertEqual(stored_value, storage_result_1.as_str())
-
-        storage_result_2 = runner.storages.get(storage_contract, storage_key_2)
-        self.assertEqual(stored_value, storage_result_2.as_str())
+        self.assertIn(storage_key_2, contract_storage)
+        self.assertEqual(stored_value, contract_storage[storage_key_2])
 
     def test_storage_put_str_key_bytes_value(self):
         path = self.get_contract_path('StoragePutStrKeyBytesValue.py')
@@ -209,16 +187,16 @@ class TestStorageInterop(BoaTest):
         path = self.get_contract_path('StoragePutMismatchedTypeValue.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
-    def test_storage_delete_bytes_key(self):
+    def test_storage_delete_bytes_key_compile(self):
         expected_output = (
             Opcode.INITSLOT
             + b'\x00'
             + b'\x01'
             + Opcode.LDARG0
             + Opcode.SYSCALL
-            + Interop.StorageGetContext.interop_method_hash
+            + self.storage_get_context_hash
             + Opcode.SYSCALL
-            + Interop.StorageDelete.interop_method_hash
+            + self.storage_delete_hash
             + Opcode.RET
         )
 
@@ -226,39 +204,31 @@ class TestStorageInterop(BoaTest):
         output = self.compile(path)
         self.assertStartsWith(output, expected_output)
 
-        path, _ = self.get_deploy_file_paths(path)
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_storage_delete_bytes_key(self):
+        await self.set_up_contract('StorageDeleteBytesKey.py')
 
         not_existing_key = b'unknown_key'
         storage_key = b'example'
 
-        invokes.append(runner.call_contract(path, 'has_key', not_existing_key))
-        expected_results.append(False)
+        result, _ = await self.call('has_key', [not_existing_key], return_type=bool)
+        self.assertEqual(False, result)
 
-        invokes.append(runner.call_contract(path, 'has_key', storage_key))
-        expected_results.append(True)
+        result, _ = await self.call('has_key', [storage_key], return_type=bool)
+        self.assertEqual(True, result)
 
-        invokes.append(runner.call_contract(path, 'Main', not_existing_key))
-        expected_results.append(None)
+        result, _ = await self.call('Main', [not_existing_key], return_type=None, signing_accounts=[self.genesis])
+        self.assertEqual(None, result)
 
-        invokes.append(runner.call_contract(path, 'Main', storage_key))
-        expected_results.append(None)
+        result, _ = await self.call('Main', [storage_key], return_type=None, signing_accounts=[self.genesis])
+        self.assertEqual(None, result)
 
-        invokes.append(runner.call_contract(path, 'has_key', storage_key))
-        expected_results.append(False)
+        result, _ = await self.call('has_key', [storage_key], return_type=bool)
+        self.assertEqual(False, result)
 
-        storage_contract = invokes[0].invoke.contract
-        runner.execute(get_storage_from=storage_contract)
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        contract_storage = await self.get_storage()
 
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-        self.assertIsNone(runner.storages.get(storage_contract, not_existing_key))
-        self.assertIsNone(runner.storages.get(storage_contract, storage_key))
+        self.assertNotIn(not_existing_key, contract_storage)
+        self.assertNotIn(storage_key, contract_storage)
 
     def test_storage_delete_str_key(self):
         path = self.get_contract_path('StorageDeleteStrKey.py')
@@ -268,35 +238,38 @@ class TestStorageInterop(BoaTest):
         path = self.get_contract_path('StorageDeleteMismatchedType.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
-    def test_storage_find_bytes_prefix(self):
-        path, _ = self.get_deploy_file_paths('StorageFindBytesPrefix.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_storage_find_bytes_prefix(self):
+        await self.set_up_contract('StorageFindBytesPrefix.py')
 
-        invokes = []
-        expected_results = []
+        # TODO: #86drqwhx0 neo-go in the current version of boa-test-constructor is not configured to return Iterators
+        with self.assertRaises(ValueError) as context:
+            result, _ = await self.call('find_by_prefix', [b'example'], return_type=list)
+            self.assertEqual([], result)
 
-        invokes.append(runner.call_contract(path, 'find_by_prefix', b'example'))
-        expected_results.append([])
+        self.assertRegex(str(context.exception), 'Interop stack item only supports iterators')
 
-        runner.execute()  # getting result of multiple iterators is failing
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        contract_storage = await self.get_storage(prefix=b'example')
+        self.assertEqual({}, contract_storage)
 
-        storage = {'example_0': '0',
-                   'example_1': '1',
-                   'example_2': '3'}
-        expected_result = [[key, value] for key, value in storage.items()]
+        example_storage = {
+            'example_0': '0',
+            'example_1': '1',
+            'example_2': '3'
+        }
+        expected_result = [[key, value] for key, value in example_storage.items()]
 
         for (key, value) in expected_result:
-            runner.call_contract(path, 'put_on_storage', key, value)
+            await self.call('put_on_storage', [key, value], return_type=None, signing_accounts=[self.genesis])
 
-        invokes.append(runner.call_contract(path, 'find_by_prefix', b'example'))
-        expected_results.append(expected_result)
+        # TODO: #86drqwhx0 neo-go in the current version of boa-test-constructor is not configured to return Iterators
+        with self.assertRaises(ValueError) as context:
+            result, _ = await self.call('find_by_prefix', [b'example'], return_type=list)
+            self.assertEqual(expected_result, result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        self.assertRegex(str(context.exception), 'Interop stack item only supports iterators')
 
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        contract_storage = await self.get_storage(prefix=b'example', key_post_processor=storage.as_str, values_post_processor=storage.as_str)
+        self.assertEqual(example_storage, contract_storage)
 
     def test_storage_find_str_prefix(self):
         path = self.get_contract_path('StorageFindStrPrefix.py')
@@ -306,32 +279,28 @@ class TestStorageInterop(BoaTest):
         path = self.get_contract_path('StorageFindMismatchedType.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
-    def test_storage_get_context(self):
+    def test_storage_get_context_compile(self):
         expected_output = (
             Opcode.SYSCALL
-            + Interop.StorageGetContext.interop_method_hash
+            + self.storage_get_context_hash
             + Opcode.RET
         )
         path = self.get_contract_path('StorageGetContext.py')
         output, manifest = self.compile_and_save(path)
         self.assertEqual(expected_output, output)
 
-        path, _ = self.get_deploy_file_paths(path)
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_storage_get_context(self):
+        await self.set_up_contract('StorageGetContext.py')
 
-        invokes = []
-        expected_results = []
+        # StorageContext is an InteropInterface, so it is not possible validate outside of Neo
+        with self.assertRaises(ValueError) as context:
+            await self.call('main', [], return_type=None)
 
-        invokes.append(runner.call_contract(path, 'main'))
-        expected_results.append(InteropInterface)  # returns an interop interface
+        self.assertRegex(str(context.exception), 'Interop stack item only supports iterators')
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+    def test_storage_get_read_only_context_compile(self):
+        from boa3.internal.model.builtin.interop.interop import Interop
 
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_storage_get_read_only_context(self):
         expected_output = (
             Opcode.SYSCALL
             + Interop.StorageGetReadOnlyContext.interop_method_hash
@@ -341,103 +310,80 @@ class TestStorageInterop(BoaTest):
         output, manifest = self.compile_and_save(path)
         self.assertEqual(expected_output, output)
 
-        path, _ = self.get_deploy_file_paths(path)
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_storage_get_read_only_context(self):
+        await self.set_up_contract('StorageGetReadOnlyContext.py')
 
-        invokes = []
-        expected_results = []
+        # StorageContext is an InteropInterface, so it is not possible validate outside of Neo
+        with self.assertRaises(ValueError) as context:
+            await self.call('main', [], return_type=None)
 
-        invokes.append(runner.call_contract(path, 'main'))
-        expected_results.append(InteropInterface)  # returns an interop interface
+        self.assertRegex(str(context.exception), 'Interop stack item only supports iterators')
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+    async def test_storage_get_with_context(self):
+        await self.set_up_contract('StorageGetWithContext.py')
 
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        not_existing_key = b'unknown_key'
+        result, _ = await self.call('Main', [not_existing_key], return_type=bytes)
+        self.assertEqual(b'', result)
 
-    def test_storage_get_with_context(self):
-        path, _ = self.get_deploy_file_paths('StorageGetWithContext.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
+        storage_key_1 = b'example'
+        storage_key_2 = b'test'
+        
+        stored_value_1 = Integer(23).to_byte_array()
+        stored_value_2 = Integer(42).to_byte_array()
+        
+        result, _ = await self.call('Main', [storage_key_1], return_type=bytes)
+        self.assertEqual(stored_value_1, result)
 
-        invokes = []
-        expected_results = []
+        result, _ = await self.call('Main', [storage_key_2], return_type=bytes)
+        self.assertEqual(stored_value_2, result)
 
-        not_existing_key = 'unknown_key'
-        invokes.append(runner.call_contract(path, 'Main', not_existing_key,
-                                            expected_result_type=bytes))
-        expected_results.append(b'')
+        contract_storage = await self.get_storage()
 
-        storage_key_1 = 'example'
-        storage_key_2 = 'test'
-        invokes.append(runner.call_contract(path, 'Main', storage_key_1,
-                                            expected_result_type=bytes))
-        expected_results.append(Integer(23).to_byte_array())
+        self.assertNotIn(not_existing_key, contract_storage)
 
-        invokes.append(runner.call_contract(path, 'Main', storage_key_2,
-                                            expected_result_type=bytes))
-        expected_results.append(Integer(42).to_byte_array())
+        self.assertIn(storage_key_1, contract_storage)
+        self.assertEqual(stored_value_1, contract_storage[storage_key_1])
 
-        storage_contract = invokes[0].invoke.contract
-        runner.execute(get_storage_from=storage_contract)
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        self.assertIn(storage_key_2, contract_storage)
+        self.assertEqual(stored_value_2, contract_storage[storage_key_2])
 
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+    async def test_storage_put_with_context(self):
+        await self.set_up_contract('StoragePutWithContext.py')
 
-        self.assertIsNone(runner.storages.get(storage_contract, not_existing_key))
-
-        storage_result_1 = runner.storages.get(storage_contract, storage_key_1)
-        self.assertEqual(expected_results[1], storage_result_1.as_bytes())
-
-        storage_result_2 = runner.storages.get(storage_contract, storage_key_2)
-        self.assertEqual(expected_results[2], storage_result_2.as_bytes())
-
-    def test_storage_put_with_context(self):
-        path, _ = self.get_deploy_file_paths('StoragePutWithContext.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
-
-        storage_key_1 = 'test1'
-        storage_key_2 = 'test2'
+        storage_key_1 = b'test1'
+        storage_key_2 = b'test2'
         stored_value = b'\x01\x02\x03'
 
-        invokes.append(runner.call_contract(path, 'Main', storage_key_1))
-        expected_results.append(None)
+        result, _ = await self.call('Main', [storage_key_1], return_type=None, signing_accounts=[self.genesis])
+        self.assertEqual(None, result)
 
-        invokes.append(runner.call_contract(path, 'Main', storage_key_2))
-        expected_results.append(None)
+        result, _ = await self.call('Main', [storage_key_2], return_type=None, signing_accounts=[self.genesis])
+        self.assertEqual(None, result)
 
-        invokes.append(runner.call_contract(path, 'Main', storage_key_2))
-        expected_results.append(None)
+        result, _ = await self.call('Main', [storage_key_2], return_type=None, signing_accounts=[self.genesis])
+        self.assertEqual(None, result)
 
-        storage_contract = invokes[0].invoke.contract
-        runner.execute(get_storage_from=storage_contract)
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        contract_storage = await self.get_storage()
 
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        self.assertIn(storage_key_1, contract_storage)
+        self.assertEqual(stored_value, contract_storage[storage_key_1])
 
-        storage_result_1 = runner.storages.get(storage_contract, storage_key_1)
-        self.assertEqual(stored_value, storage_result_1.as_bytes())
+        self.assertIn(storage_key_2, contract_storage)
+        self.assertEqual(stored_value, contract_storage[storage_key_2])
 
-        storage_result_2 = runner.storages.get(storage_contract, storage_key_2)
-        self.assertEqual(stored_value, storage_result_2.as_bytes())
-
-    def test_storage_delete_with_context(self):
+    def test_storage_delete_with_context_compile(self):
         expected_output = (
             Opcode.INITSLOT
             + b'\x01'
             + b'\x01'
             + Opcode.SYSCALL  # context = get_context()
-            + Interop.StorageGetContext.interop_method_hash
+            + self.storage_get_context_hash
             + Opcode.STLOC0
             + Opcode.LDARG0  # delete(key, context)
             + Opcode.LDLOC0
             + Opcode.SYSCALL
-            + Interop.StorageDelete.interop_method_hash
+            + self.storage_delete_hash
             + Opcode.RET
         )
 
@@ -445,421 +391,366 @@ class TestStorageInterop(BoaTest):
         output = self.compile(path)
         self.assertStartsWith(output, expected_output)
 
-        path, _ = self.get_deploy_file_paths(path)
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_storage_delete_with_context(self):
+        await self.set_up_contract('StorageDeleteWithContext.py')
 
         not_existing_key = 'unknown_key'
         storage_key = 'example'
 
-        invokes.append(runner.call_contract(path, 'has_key', not_existing_key))
-        expected_results.append(False)
+        result, _ = await self.call('has_key', [not_existing_key], return_type=bool)
+        self.assertEqual(False, result)
 
-        invokes.append(runner.call_contract(path, 'has_key', storage_key))
-        expected_results.append(True)
+        result, _ = await self.call('has_key', [storage_key], return_type=bool)
+        self.assertEqual(True, result)
 
-        invokes.append(runner.call_contract(path, 'Main', not_existing_key))
-        expected_results.append(None)
+        result, _ = await self.call('Main', [not_existing_key], return_type=None, signing_accounts=[self.genesis])
+        self.assertEqual(None, result)
 
-        invokes.append(runner.call_contract(path, 'Main', storage_key))
-        expected_results.append(None)
+        result, _ = await self.call('Main', [storage_key], return_type=None, signing_accounts=[self.genesis])
+        self.assertEqual(None, result)
 
-        invokes.append(runner.call_contract(path, 'has_key', storage_key))
-        expected_results.append(False)
+        result, _ = await self.call('has_key', [storage_key], return_type=bool)
+        self.assertEqual(False, result)
 
-        storage_contract = invokes[0].invoke.contract
-        runner.execute(get_storage_from=storage_contract)
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        contract_storage = await self.get_storage()
 
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        self.assertNotIn(not_existing_key, contract_storage)
+        self.assertNotIn(storage_key, contract_storage)
 
-        self.assertIsNone(runner.storages.get(storage_contract, not_existing_key))
-        self.assertIsNone(runner.storages.get(storage_contract, storage_key))
+    async def test_storage_find_with_context(self):
+        await self.set_up_contract('StorageFindWithContext.py')
 
-    def test_storage_find_with_context(self):
-        path, _ = self.get_deploy_file_paths('StorageFindWithContext.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
+        # TODO: #86drqwhx0 neo-go in the current version of boa-test-constructor is not configured to return Iterators
+        with self.assertRaises(ValueError) as context:
+            result, _ = await self.call('find_by_prefix', ['example'], return_type=list)
+            self.assertEqual([], result)
 
-        invokes = []
-        expected_results = []
+        self.assertRegex(str(context.exception), 'Interop stack item only supports iterators')
 
-        invokes.append(runner.call_contract(path, 'find_by_prefix', 'example'))
-        expected_results.append([])
+        contract_storage = await self.get_storage(prefix=b'example')
+        self.assertEqual({}, contract_storage)
 
-        runner.execute()  # getting result of multiple iterators is failing
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        storage = {'example_0': '0',
-                   'example_1': '1',
-                   'example_2': '3'}
-        expected_result = [[key, value] for key, value in storage.items()]
+        example_storage = {
+            'example_0': '0',
+            'example_1': '1',
+            'example_2': '3'
+        }
+        expected_result = [[key, value] for key, value in example_storage.items()]
 
         for (key, value) in expected_result:
-            runner.call_contract(path, 'put_on_storage', key, value)
+            await self.call('put_on_storage', [key, value], return_type=None, signing_accounts=[self.genesis])
 
-        invokes.append(runner.call_contract(path, 'find_by_prefix', b'example'))
-        expected_results.append(expected_result)
+        # TODO: #86drqwhx0 neo-go in the current version of boa-test-constructor is not configured to return Iterators
+        with self.assertRaises(ValueError) as context:
+            result, _ = await self.call('find_by_prefix', [b'example'], return_type=list)
+            self.assertEqual(expected_result, result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        self.assertRegex(str(context.exception), 'Interop stack item only supports iterators')
 
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        contract_storage = await self.get_storage(prefix=b'example', key_post_processor=storage.as_str, values_post_processor=storage.as_str)
+        self.assertEqual(example_storage, contract_storage)
 
-    def test_storage_find_with_options(self):
-        path, _ = self.get_deploy_file_paths('StorageFindWithOptions.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
-
-        invokes.append(runner.call_contract(path, 'find_by_prefix', 'example'))
-        expected_results.append([])
-
-        runner.execute()  # getting result of multiple iterators is failing
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+    async def test_storage_find_with_options(self):
+        await self.set_up_contract('StorageFindWithOptions.py')
 
         prefix = 'example'
+
+        # TODO: #86drqwhx0 neo-go in the current version of boa-test-constructor is not configured to return Iterators
+        with self.assertRaises(ValueError) as context:
+            result, _ = await self.call('find_by_prefix', [prefix], return_type=list)
+            self.assertEqual([], result)
+
+        self.assertRegex(str(context.exception), 'Interop stack item only supports iterators')
+
+        contract_storage = await self.get_storage(prefix=b'example')
+        self.assertEqual({}, contract_storage)
+
         expected_result = [['_0', '0'],
                            ['_1', '1'],
                            ['_2', '2']
                            ]
+        expected_storage = {item[0]: item[1] for item in expected_result}
 
         for (key, value) in expected_result:
-            runner.call_contract(path, 'put_on_storage', (prefix + key), value)
+            await self.call('put_on_storage', [(prefix + key), value], return_type=None, signing_accounts=[self.genesis])
 
-        invokes.append(runner.call_contract(path, 'find_by_prefix', 'example'))
-        expected_results.append(expected_result)
+        # TODO: #86drqwhx0 neo-go in the current version of boa-test-constructor is not configured to return Iterators
+        with self.assertRaises(ValueError) as context:
+            result, _ = await self.call('find_by_prefix', [prefix], return_type=list)
+            self.assertEqual(expected_result, result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        self.assertRegex(str(context.exception), 'Interop stack item only supports iterators')
 
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        contract_storage = await self.get_storage(prefix=String(prefix).to_bytes(), remove_prefix=True, key_post_processor=storage.as_str, values_post_processor=storage.as_str)
+        self.assertEqual(expected_storage, contract_storage)
 
-    def test_boa2_storage_test(self):
-        path, _ = self.get_deploy_file_paths('StorageBoa2Test.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_boa2_storage_test(self):
+        await self.set_up_contract('StorageBoa2Test.py')
 
         storage_key = b'something'
-        invokes.append(runner.call_contract(path, 'main', 'sget', storage_key, 'blah',
-                                            expected_result_type=bytes))
-        expected_results.append(b'')
+        result, _ = await self.call('main', ['sget', storage_key, 'blah'], return_type=bytes)
+        self.assertEqual(b'', result)
 
-        invokes.append(runner.call_contract(path, 'main', 'sput', storage_key, 'blah'))
-        expected_results.append(True)
+        result, _ = await self.call('main', ['sput', storage_key, 'blah'], return_type=bool, signing_accounts=[self.genesis])
+        self.assertEqual(True, result)
 
-        invokes.append(runner.call_contract(path, 'main', 'sget', storage_key, 'blah',
-                                            expected_result_type=bytes))
-        expected_results.append(b'blah')
+        result, _ = await self.call('main', ['sget', storage_key, 'blah'], return_type=bytes)
+        self.assertEqual(b'blah', result)
 
-        invokes.append(runner.call_contract(path, 'main', 'sdel', storage_key, 'blah'))
-        expected_results.append(True)
+        result, _ = await self.call('main', ['sdel', storage_key, 'blah'], return_type=bool, signing_accounts=[self.genesis])
+        self.assertEqual(True, result)
 
-        invokes.append(runner.call_contract(path, 'main', 'sget', storage_key, 'blah',
-                                            expected_result_type=bytes))
-        expected_results.append(b'')
+        result, _ = await self.call('main', ['sget', storage_key, 'blah'], return_type=bytes)
+        self.assertEqual(b'', result)
 
-        storage_contract = invokes[0].invoke.contract
-        runner.execute(get_storage_from=storage_contract)
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        contract_storage = await self.get_storage()
 
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        self.assertNotIn(storage_key, contract_storage)
 
-        self.assertIsNone(runner.storages.get(storage_contract, storage_key))
+    async def test_boa2_storage_test2(self):
+        await self.set_up_contract('StorageBoa2Test.py')
 
-    def test_boa2_storage_test2(self):
-        path, _ = self.get_deploy_file_paths('StorageBoa2Test.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+        value = 10000000000
 
         storage_key = Integer(100)
-        invokes.append(runner.call_contract(path, 'main', 'sget', storage_key, 10000000000,
-                                            expected_result_type=bytes))
-        expected_results.append(b'')
+        result, _ = await self.call('main', ['sget', storage_key, value], return_type=bytes)
+        self.assertEqual(b'', result)
 
-        invokes.append(runner.call_contract(path, 'main', 'sput', storage_key, 10000000000))
-        expected_results.append(True)
+        result, _ = await self.call('main', ['sput', storage_key, value], return_type=bool, signing_accounts=[self.genesis])
+        self.assertEqual(True, result)
 
-        invokes.append(runner.call_contract(path, 'main', 'sget', storage_key, 10000000000,
-                                            expected_result_type=int))
-        expected_results.append(10000000000)
+        result, _ = await self.call('main', ['sget', storage_key, value], return_type=bytes)
+        self.assertEqual(Integer(value).to_byte_array(), result)
 
-        invokes.append(runner.call_contract(path, 'main', 'sdel', storage_key, 10000000000))
-        expected_results.append(True)
+        result, _ = await self.call('main', ['sdel', storage_key, value], return_type=bool, signing_accounts=[self.genesis])
+        self.assertEqual(True, result)
 
-        invokes.append(runner.call_contract(path, 'main', 'sget', storage_key, 10000000000,
-                                            expected_result_type=bytes))
-        expected_results.append(b'')
+        result, _ = await self.call('main', ['sget', storage_key, value], return_type=bytes)
+        self.assertEqual(b'', result)
 
-        storage_contract = invokes[0].invoke.contract
-        runner.execute(get_storage_from=storage_contract)
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        contract_storage = await self.get_storage()
 
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        self.assertNotIn(storage_key.to_byte_array(), contract_storage)
 
-        self.assertIsNone(runner.storages.get(storage_contract, storage_key.to_byte_array()))
-
-    def test_storage_between_contracts(self):
-        path1, _ = self.get_deploy_file_paths('StorageGetAndPut1.py')
-        path2, _ = self.get_deploy_file_paths('StorageGetAndPut2.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_storage_between_contracts(self):
+        await self.set_up_contract('StorageGetAndPut1.py')
+        contract2 = await self.compile_and_deploy('StorageGetAndPut2.py')
 
         key = b'example_key'
         value = 42
 
-        invokes.append(runner.call_contract(path1, 'put_value', key, value))
-        expected_results.append(None)
-        contract_1 = invokes[-1].invoke.contract
+        result, _ = await self.call('put_value', [key, value], return_type=None, signing_accounts=[self.genesis])
+        self.assertEqual(None, result)
 
-        invokes.append(runner.call_contract(path2, 'get_value', key))
-        expected_results.append(0)
+        result, _ = await self.call('get_value', [key], return_type=int, target_contract=contract2)
+        self.assertEqual(0, result)
 
-        invokes.append(runner.call_contract(path1, 'get_value', key))
-        expected_results.append(value)
+        result, _ = await self.call('get_value', [key], return_type=int)
+        self.assertEqual(value, result)
 
-        runner.execute(get_storage_from=contract_1)
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        contract1_storage = await self.get_storage(values_post_processor=storage.as_int)
+        self.assertIn(key, contract1_storage)
+        self.assertEqual(value, contract1_storage[key])
 
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        contract2_storage = await self.get_storage(target_contract=contract2)
+        self.assertNotIn(key, contract2_storage)
 
-        storage_result = runner.storages.get(contract_1, key)
-        self.assertEqual(value, storage_result.as_int())
-
-    def test_create_map(self):
-        path, _ = self.get_deploy_file_paths('StorageCreateMap.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_create_map(self):
+        await self.set_up_contract('StorageCreateMap.py')
 
         map_key = b'example_'
         storage_key = b'test1'
         stored_value = b'123'
 
-        invokes.append(runner.call_contract(path, 'get_from_map', storage_key,
-                                            expected_result_type=bytes))
-        expected_results.append(b'')
-        storage_contract = invokes[-1].invoke.contract
+        result, _ = await self.call('get_from_map', [storage_key], return_type=bytes)
+        self.assertEqual(b'', result)
 
-        invokes.append(runner.call_contract(path, 'insert_to_map', storage_key, stored_value))
-        expected_results.append(None)
+        result, _ = await self.call('insert_to_map', [storage_key, stored_value], return_type=None, signing_accounts=[self.genesis])
+        self.assertEqual(None, result)
 
-        invokes.append(runner.call_contract(path, 'get_from_map', b'test1',
-                                            expected_result_type=bytes))
-        expected_results.append(stored_value)
+        result, _ = await self.call('get_from_map', [b'test1'], return_type=bytes)
+        self.assertEqual(stored_value, result)
 
-        runner.execute(get_storage_from=storage_contract)
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        contract_storage = await self.get_storage()
 
-        self.assertIsNone(runner.storages.get(storage_contract, storage_key))
-        storage_result = runner.storages.get(storage_contract, map_key + storage_key)
-        self.assertEqual(stored_value, storage_result.as_bytes())
+        self.assertNotIn(storage_key, contract_storage)
 
-        invokes.append(runner.call_contract(path, 'delete_from_map', b'test1'))
-        expected_results.append(None)
+        self.assertIn(map_key + storage_key, contract_storage)
+        self.assertEqual(stored_value, contract_storage[map_key + storage_key])
 
-        invokes.append(runner.call_contract(path, 'get_from_map', b'test1',
-                                            expected_result_type=bytes))
-        expected_results.append(b'')
+        result, _ = await self.call('delete_from_map', [b'test1'], return_type=None, signing_accounts=[self.genesis])
+        self.assertEqual(None, result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        result, _ = await self.call('get_from_map', [b'test1'], return_type=bytes)
+        self.assertEqual(b'', result)
 
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_import_storage(self):
-        path, _ = self.get_deploy_file_paths('ImportStorage.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_import_storage(self):
+        await self.set_up_contract('ImportStorage.py')
 
         prefix = b'unit'
         key = prefix + b'_test'
         key_str = String.from_bytes(key)
         value = 1234
 
-        invokes.append(runner.call_contract(path, 'get_value', key))
-        expected_results.append(0)
+        result, _ = await self.call('get_value', [key], return_type=int)
+        self.assertEqual(0, result)
 
-        invokes.append(runner.call_contract(path, 'find_by_prefix', prefix))
-        expected_results.append([])
+        # TODO: #86drqwhx0 neo-go in the current version of boa-test-constructor is not configured to return Iterators
+        with self.assertRaises(ValueError) as context:
+            result, _ = await self.call('find_by_prefix', [prefix], return_type=list)
+            self.assertEqual([], result)
 
-        runner.execute()  # getting result of multiple iterators is failing
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        self.assertRegex(str(context.exception), 'Interop stack item only supports iterators')
 
-        invokes.append(runner.call_contract(path, 'put_value', key, value))
-        expected_results.append(None)
+        contract_storage = await self.get_storage(prefix=prefix)
+        self.assertEqual({}, contract_storage)
 
-        invokes.append(runner.call_contract(path, 'get_value', key))
-        expected_results.append(value)
+        result, _ = await self.call('put_value', [key, value], return_type=None, signing_accounts=[self.genesis])
+        self.assertEqual(None, result)
 
-        invokes.append(runner.call_contract(path, 'find_by_prefix', prefix))
-        expected_results.append([[key_str, Integer(value).to_byte_array()]])
+        result, _ = await self.call('get_value', [key], return_type=int)
+        self.assertEqual(value, result)
 
-        runner.execute()  # getting result of multiple iterators is failing
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        # TODO: #86drqwhx0 neo-go in the current version of boa-test-constructor is not configured to return Iterators
+        with self.assertRaises(ValueError) as context:
+            result, _ = await self.call('find_by_prefix', [prefix], return_type=list)
+            self.assertEqual([[key_str, Integer(value).to_byte_array()]], result)
 
-        runner.call_contract(path, 'put_value', key, value)
-        runner.call_contract(path, 'get_value', key)
+        self.assertRegex(str(context.exception), 'Interop stack item only supports iterators')
 
-        invokes.append(runner.call_contract(path, 'delete_value', key))
-        expected_results.append(None)
+        contract_storage = await self.get_storage(prefix=prefix, key_post_processor=storage.as_str)
+        self.assertEqual({key_str: Integer(value).to_byte_array()}, contract_storage)
 
-        invokes.append(runner.call_contract(path, 'get_value', key))
-        expected_results.append(0)
+        await self.call('put_value', [key, value], return_type=None, signing_accounts=[self.genesis])
+        await self.call('get_value', [key], return_type=int)
 
-        invokes.append(runner.call_contract(path, 'find_by_prefix', prefix))
-        expected_results.append([])
+        result, _ = await self.call('delete_value', [key], return_type=None, signing_accounts=[self.genesis])
+        self.assertEqual(None, result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        result, _ = await self.call('get_value', [key], return_type=int)
+        self.assertEqual(0, result)
 
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        # TODO: #86drqwhx0 neo-go in the current version of boa-test-constructor is not configured to return Iterators
+        with self.assertRaises(ValueError) as context:
+            result, _ = await self.call('find_by_prefix', [prefix], return_type=list)
+            self.assertEqual([], result)
 
-    def test_import_interop_storage(self):
-        path, _ = self.get_deploy_file_paths('ImportInteropStorage.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
+        self.assertRegex(str(context.exception), 'Interop stack item only supports iterators')
 
-        invokes = []
-        expected_results = []
+        contract_storage = await self.get_storage(prefix=prefix)
+        self.assertEqual({}, contract_storage)
+
+    async def test_import_interop_storage(self):
+        await self.set_up_contract('ImportInteropStorage.py')
 
         prefix = b'unit'
         key = prefix + b'_test'
         key_str = String.from_bytes(key)
         value = 1234
 
-        invokes.append(runner.call_contract(path, 'get_value', key))
-        expected_results.append(0)
+        result, _ = await self.call('get_value', [key], return_type=int)
+        self.assertEqual(0, result)
 
-        invokes.append(runner.call_contract(path, 'find_by_prefix', prefix))
-        expected_results.append([])
+        # TODO: #86drqwhx0 neo-go in the current version of boa-test-constructor is not configured to return Iterators
+        with self.assertRaises(ValueError) as context:
+            result, _ = await self.call('find_by_prefix', [prefix], return_type=list)
+            self.assertEqual([], result)
 
-        runner.execute()  # getting result of multiple iterators is failing
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        self.assertRegex(str(context.exception), 'Interop stack item only supports iterators')
 
-        invokes.append(runner.call_contract(path, 'put_value', key, value))
-        expected_results.append(None)
+        contract_storage = await self.get_storage(prefix=prefix)
+        self.assertEqual({}, contract_storage)
 
-        invokes.append(runner.call_contract(path, 'get_value', key))
-        expected_results.append(value)
+        result, _ = await self.call('put_value', [key, value], return_type=None, signing_accounts=[self.genesis])
+        self.assertEqual(None, result)
 
-        invokes.append(runner.call_contract(path, 'find_by_prefix', prefix))
-        expected_results.append([[key_str, Integer(value).to_byte_array()]])
+        result, _ = await self.call('get_value', [key], return_type=int)
+        self.assertEqual(value, result)
 
-        runner.execute()  # getting result of multiple iterators is failing
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        # TODO: #86drqwhx0 neo-go in the current version of boa-test-constructor is not configured to return Iterators
+        with self.assertRaises(ValueError) as context:
+            result, _ = await self.call('find_by_prefix', [prefix], return_type=list)
+            self.assertEqual([[key_str, Integer(value).to_byte_array()]], result)
 
-        runner.call_contract(path, 'put_value', key, value)
-        runner.call_contract(path, 'get_value', key)
+        self.assertRegex(str(context.exception), 'Interop stack item only supports iterators')
 
-        invokes.append(runner.call_contract(path, 'delete_value', key))
-        expected_results.append(None)
+        contract_storage = await self.get_storage(prefix=prefix, key_post_processor=storage.as_str)
+        self.assertEqual({key_str: Integer(value).to_byte_array()}, contract_storage)
 
-        invokes.append(runner.call_contract(path, 'get_value', key))
-        expected_results.append(0)
+        await self.call('put_value', [key, value], return_type=None, signing_accounts=[self.genesis])
+        await self.call('get_value', [key], return_type=int)
 
-        invokes.append(runner.call_contract(path, 'find_by_prefix', prefix))
-        expected_results.append([])
+        result, _ = await self.call('delete_value', [key], return_type=None, signing_accounts=[self.genesis])
+        self.assertEqual(None, result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        result, _ = await self.call('get_value', [key], return_type=int)
+        self.assertEqual(0, result)
 
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        # TODO: #86drqwhx0 neo-go in the current version of boa-test-constructor is not configured to return Iterators
+        with self.assertRaises(ValueError) as context:
+            result, _ = await self.call('find_by_prefix', [prefix], return_type=list)
+            self.assertEqual([], result)
 
-    def test_as_read_only(self):
-        path, _ = self.get_deploy_file_paths('StorageAsReadOnly.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
+        self.assertRegex(str(context.exception), 'Interop stack item only supports iterators')
 
-        invokes = []
-        expected_results = []
+        contract_storage = await self.get_storage(prefix=prefix)
+        self.assertEqual({}, contract_storage)
+
+    async def test_as_read_only(self):
+        await self.set_up_contract('StorageAsReadOnly.py')
 
         key = b'key'
         value_old = 'old value'
         value_new = 'new value'
 
         # Putting old value in the storage
-        invokes.append(runner.call_contract(path, 'put_value_in_storage', key, value_old))
-        expected_results.append(None)
+        result, _ = await self.call('put_value_in_storage', [key, value_old], return_type=None, signing_accounts=[self.genesis])
+        self.assertEqual(None, result)
 
-        invokes.append(runner.call_contract(path, 'get_value_in_storage_read_only', key))
-        expected_results.append(value_old)
+        result, _ = await self.call('get_value_in_storage_read_only', [key], return_type=str)
+        self.assertEqual(value_old, result)
 
-        invokes.append(runner.call_contract(path, 'get_value_in_storage', key))
-        expected_results.append(value_old)
+        result, _ = await self.call('get_value_in_storage', [key], return_type=str)
+        self.assertEqual(value_old, result)
 
-        invokes.append(runner.call_contract(path, 'get_value_in_storage_read_only', key))
-        expected_results.append(value_old)
+        result, _ = await self.call('get_value_in_storage_read_only', [key], return_type=str)
+        self.assertEqual(value_old, result)
 
-        invokes.append(runner.call_contract(path, 'get_value_in_storage', key))
-        expected_results.append(value_old)
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        result, _ = await self.call('get_value_in_storage', [key], return_type=str)
+        self.assertEqual(value_old, result)
 
         # Trying to put a new value in the storage using read_only won't work
-        runner.call_contract(path, 'put_value_in_storage_read_only', key, value_new)
-        runner.execute()
-        self.assertEqual(VMState.FAULT, runner.vm_state, msg=runner.cli_log)
-        self.assertRegex(runner.error, self.VALUE_DOES_NOT_FALL_WITHIN_EXPECTED_RANGE_MSG)
+        with self.assertRaises(boatestcase.FaultException) as context:
+            await self.call('put_value_in_storage_read_only', [key, value_new], return_type=None, signing_accounts=[self.genesis])
 
-    def test_find_options_values(self):
-        path, _ = self.get_deploy_file_paths('FindOptionsValues.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
+        self.assertRegex(str(context.exception), 'storage.Context is read only')
 
-        invokes = []
-        expected_results = []
+    async def test_find_options_values(self):
+        await self.set_up_contract('FindOptionsValues.py')
 
-        invokes.append(runner.call_contract(path, 'main', FindOptions.KEYS_ONLY))
-        expected_results.append(FindOptions.KEYS_ONLY)
+        result, _ = await self.call('main', [FindOptions.KEYS_ONLY], return_type=int)
+        self.assertEqual(FindOptions.KEYS_ONLY, result)
 
-        invokes.append(runner.call_contract(path, 'option_keys_only'))
-        expected_results.append(FindOptions.KEYS_ONLY)
+        result, _ = await self.call('option_keys_only', [], return_type=int)
+        self.assertEqual(FindOptions.KEYS_ONLY, result)
 
-        invokes.append(runner.call_contract(path, 'option_remove_prefix'))
-        expected_results.append(FindOptions.REMOVE_PREFIX)
+        result, _ = await self.call('option_remove_prefix', [], return_type=int)
+        self.assertEqual(FindOptions.REMOVE_PREFIX, result)
 
-        invokes.append(runner.call_contract(path, 'option_values_only'))
-        expected_results.append(FindOptions.VALUES_ONLY)
+        result, _ = await self.call('option_values_only', [], return_type=int)
+        self.assertEqual(FindOptions.VALUES_ONLY, result)
 
-        invokes.append(runner.call_contract(path, 'option_deserialize_values'))
-        expected_results.append(FindOptions.DESERIALIZE_VALUES)
+        result, _ = await self.call('option_deserialize_values', [], return_type=int)
+        self.assertEqual(FindOptions.DESERIALIZE_VALUES, result)
 
-        invokes.append(runner.call_contract(path, 'option_pick_field_0'))
-        expected_results.append(FindOptions.PICK_FIELD_0)
+        result, _ = await self.call('option_pick_field_0', [], return_type=int)
+        self.assertEqual(FindOptions.PICK_FIELD_0, result)
 
-        invokes.append(runner.call_contract(path, 'option_pick_field_1'))
-        expected_results.append(FindOptions.PICK_FIELD_1)
+        result, _ = await self.call('option_pick_field_1', [], return_type=int)
+        self.assertEqual(FindOptions.PICK_FIELD_1, result)
 
-        invokes.append(runner.call_contract(path, 'option_backwards'))
-        expected_results.append(FindOptions.BACKWARDS)
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        result, _ = await self.call('option_backwards', [], return_type=int)
+        self.assertEqual(FindOptions.BACKWARDS, result)
 
     def test_find_options_mismatched_type(self):
         path = self.get_contract_path('FindOptionsMismatchedType.py')

--- a/boa3_test/tests/compiler_tests/test_variable.py
+++ b/boa3_test/tests/compiler_tests/test_variable.py
@@ -493,48 +493,20 @@ class TestVariable(boatestcase.BoaTestCase):
         path = self.get_contract_path('GlobalAssignmentWithTuples.py')
         self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
 
-    # TODO: Storage is not working properly, to be fixed by #86a1z5xy9
-    # async def test_global_chained_multiple_assignments(self):
-    #     await self.set_up_contract('GlobalMultipleAssignments.py', compile_if_found=True)
-    #
-    #     result, _ = await self.call('get_a', [], return_type=int)
-    #     self.assertEqual(10, result)
-    #
-    #     result, _ = await self.call('get_c', [], return_type=int)
-    #     self.assertEqual(15, result)
-    #
-    #     result, _ = await self.call('set_a', [100], return_type=None)
-    #     self.assertEqual(None, result)
-    #
-    #     result, _ = await self.call('get_a', [], return_type=int)
-    #     self.assertEqual(100, result)
-    def test_global_chained_multiple_assignments(self):
-        from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
-        from boa3.internal.neo3.vm import VMState
+    async def test_global_chained_multiple_assignments(self):
+        await self.set_up_contract('GlobalMultipleAssignments.py', compile_if_found=True)
 
-        path, _ = self.get_deploy_file_paths('GlobalMultipleAssignments.py', compile_if_found=True)
-        runner = BoaTestRunner(runner_id=self.method_name())
+        result, _ = await self.call('get_a', [], return_type=int)
+        self.assertEqual(10, result)
 
-        invokes = []
-        expected_results = []
+        result, _ = await self.call('get_c', [], return_type=int)
+        self.assertEqual(15, result)
 
-        invokes.append(runner.call_contract(path, 'get_a'))
-        expected_results.append(10)
+        result, _ = await self.call('set_a', [100], return_type=None)
+        self.assertEqual(None, result)
 
-        invokes.append(runner.call_contract(path, 'get_c'))
-        expected_results.append(15)
-
-        invokes.append(runner.call_contract(path, 'set_a', 100))
-        expected_results.append(None)
-
-        invokes.append(runner.call_contract(path, 'get_a'))
-        expected_results.append(100)
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        result, _ = await self.call('get_a', [], return_type=int)
+        self.assertEqual(100, result)
 
     def test_many_global_assignments_compile(self):
         expected_output = (
@@ -767,54 +739,23 @@ class TestVariable(boatestcase.BoaTestCase):
         result, _ = await self.call('Main', [-140], return_type=int)
         self.assertEqual(-140, result)
 
-    # TODO: Storage is not working properly, to be fixed by #86a1z5xy9
-    # async def test_assign_global_in_function_with_global_keyword(self):
-    #     await self.set_up_contract('GlobalAssignmentInFunctionWithArgument.py', compile_if_found=True)
-    #
-    #     result, _ = await self.call('get_b', [], return_type=int)
-    #     self.assertEqual(0, result)
-    #
-    #     result, _ = await self.call('Main', [10], return_type=int)
-    #     self.assertEqual(10, result)
-    #
-    #     result, _ = await self.call('get_b', [], return_type=int)
-    #     self.assertEqual(10, result)
-    #
-    #     result, _ = await self.call('Main', [-140], return_type=int)
-    #     self.assertEqual(-140, result)
-    #
-    #     result, _ = await self.call('get_b', [], return_type=int)
-    #     self.assertEqual(-140, result)
-    def test_assign_global_in_function_with_global_keyword(self):
-        from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
-        from boa3.internal.neo3.vm import VMState
+    async def test_assign_global_in_function_with_global_keyword(self):
+        await self.set_up_contract('GlobalAssignmentInFunctionWithArgument.py')
 
-        path, _ = self.get_deploy_file_paths('GlobalAssignmentInFunctionWithArgument.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
+        result, _ = await self.call('get_b', [], return_type=int)
+        self.assertEqual(0, result)
 
-        invokes = []
-        expected_results = []
+        result, _ = await self.call('Main', [10], return_type=int)
+        self.assertEqual(10, result)
 
-        invokes.append(runner.call_contract(path, 'get_b'))
-        expected_results.append(0)
+        result, _ = await self.call('get_b', [], return_type=int)
+        self.assertEqual(10, result)
 
-        invokes.append(runner.call_contract(path, 'Main', 10))
-        expected_results.append(10)
+        result, _ = await self.call('Main', [-140], return_type=int)
+        self.assertEqual(-140, result)
 
-        invokes.append(runner.call_contract(path, 'get_b'))
-        expected_results.append(10)
-
-        invokes.append(runner.call_contract(path, 'Main', -140))
-        expected_results.append(-140)
-
-        invokes.append(runner.call_contract(path, 'get_b'))
-        expected_results.append(-140)
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        result, _ = await self.call('get_b', [], return_type=int)
+        self.assertEqual(-140, result)
 
     def test_assign_void_function_call_compile(self):
         output, _ = self.assertCompile('AssignVoidFunctionCall.py')


### PR DESCRIPTION
**Summary or solution description**
Refactored `test_interop/test_storage.py` files to use `BoaTestCase` in place of `BoaTest` for unit testing.