### PR TITLE
CU-86drpnc9h - Refactor test_native/test_ledger.py to use BoaConstructor

### DIFF
--- a/boa3_test/tests/annotation.py
+++ b/boa3_test/tests/annotation.py
@@ -23,6 +23,26 @@ Transaction = tuple[
     bytes,  # script
 ]
 
+Block = tuple[
+    types.UInt256,  # hash
+    int,    # version
+    types.UInt256,  # previous hash
+    types.UInt256,  # merkle root
+    int,  # timestamp
+    int,  # nonce
+    int,  # index
+    types.UInt160,  # next consensus
+    int,  # tx count
+]
+
+Signer = tuple[
+    types.UInt160,  # account
+    int,  # witness scope type
+    types.UInt160,  # allowed contracts
+    types.UInt160,  # allowed groups
+    list[tuple[int, tuple[int]]],  # rules
+]
+
 ContractParameterType = int
 ContractMethod = tuple[
     str,  # name

--- a/boa3_test/tests/boatestcase.py
+++ b/boa3_test/tests/boatestcase.py
@@ -520,6 +520,11 @@ class BoaTestCase(SmartContractTestCase):
                 return await rpc_client.get_transaction(cls.called_tx)
 
     @classmethod
+    async def get_genesis_block(cls) -> block.Block:
+        async with noderpc.NeoRpcClient(cls.node.facade.rpc_host) as rpc_client:
+            return await rpc_client.get_block(0)
+
+    @classmethod
     async def get_latest_block(cls) -> block.Block:
         async with noderpc.NeoRpcClient(cls.node.facade.rpc_host) as rpc_client:
             best_block_hash = await rpc_client.get_best_block_hash()

--- a/boa3_test/tests/compiler_tests/test_native/test_contract_management.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_contract_management.py
@@ -9,7 +9,7 @@ from neo3.wallet import account
 from boa3.internal import constants
 from boa3.internal.exception import CompilerError
 from boa3.internal.neo.vm.type.String import String
-from boa3_test.tests import annotation, boatestcase
+from boa3_test.tests import annotation, boatestcase, stackitem
 
 
 @dataclass
@@ -85,7 +85,7 @@ class TestContractManagementContract(boatestcase.BoaTestCase):
         call_hash = await self.compile_and_deploy(call_contract_path)
 
         nef, manifest = self.get_serialized_output(call_contract_path)
-        manifest = annotation.manifest_from_json(manifest)
+        manifest = stackitem.from_manifest(manifest)
         result, _ = await self.call('main', [bytes(20)], return_type=None)
         self.assertIsNone(result)
 
@@ -115,7 +115,7 @@ class TestContractManagementContract(boatestcase.BoaTestCase):
         nef_file, manifest = self.get_serialized_output(call_contract_path)
         arg_manifest = String(json.dumps(manifest, separators=(',', ':'))).to_bytes()
 
-        manifest = annotation.manifest_from_json(manifest)
+        manifest = stackitem.from_manifest(manifest)
         result, notifications = await self.call('Main',
                                                 [nef_file, arg_manifest, None],
                                                 return_type=annotation.Contract
@@ -139,7 +139,7 @@ class TestContractManagementContract(boatestcase.BoaTestCase):
         self.compile_and_save(call_contract_path)
         nef_file, manifest = self.get_serialized_output(call_contract_path)
         arg_manifest = String(json.dumps(manifest, separators=(',', ':'))).to_bytes()
-        manifest = annotation.manifest_from_json(manifest)
+        manifest = stackitem.from_manifest(manifest)
 
         data = 'some sort of data'
         result, notifications = await self.call('Main',

--- a/boa3_test/tests/compiler_tests/test_native/test_ledger.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_ledger.py
@@ -1,101 +1,72 @@
-from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to avoid circular imports
+from neo3.core import types
+from neo3.network.payloads import block
 
 from boa3.internal import constants
 from boa3.internal.exception import CompilerError
-from boa3.internal.model.builtin.interop.interop import Interop
 from boa3.internal.neo.vm.opcode.Opcode import Opcode
-from boa3.internal.neo.vm.type.Integer import Integer
-from boa3.internal.neo.vm.type.String import String
-from boa3.internal.neo3.contracts import CallFlags
-from boa3.internal.neo3.core.types import UInt160, UInt256
-from boa3.internal.neo3.vm import VMState
-from boa3_test.tests.test_drive import neoxp
-from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
+from boa3_test.tests import annotation, boatestcase, stackitem
 
 
-class TestLedgerContract(BoaTest):
+class TestLedgerContract(boatestcase.BoaTestCase):
     default_folder: str = 'test_sc/native_test/ledger'
 
-    def test_get_hash(self):
-        path, _ = self.get_deploy_file_paths('GetHash.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
+    genesis_block: block.Block
 
-        invokes = []
-        expected_results = []
+    @classmethod
+    async def asyncSetupClass(cls) -> None:
+        await super().asyncSetupClass()
 
-        invokes.append(runner.call_contract(path, 'main'))
-        expected_results.append(constants.LEDGER_SCRIPT)
+        cls.genesis_block = await cls.get_genesis_block()
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+    async def test_get_hash(self):
+        await self.set_up_contract('GetHash.py')
 
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        expected = types.UInt160(constants.LEDGER_SCRIPT)
+        result, _ = await self.call('main', [], return_type=types.UInt160)
+        self.assertEqual(expected, result)
 
-    def test_get_block_by_hash(self):
-        path, _ = self.get_deploy_file_paths('GetBlockByHash.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_get_block_by_hash(self):
+        await self.set_up_contract('GetBlockByHash.py')
 
-        genesis_block = runner.get_genesis_block()
-        expected_result_size = len(Interop.BlockType.variables)
-        nonexistent_block_hash = UInt256.zero().to_array()
-        genesis_hash = genesis_block.hash.to_array()
-
-        get_nonexistent_block = runner.call_contract(path, 'Main', nonexistent_block_hash)
-        get_existent_block = runner.call_contract(path, 'Main', genesis_hash)
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        result = get_nonexistent_block.result
+        invalid_block_hash = types.UInt256(bytes(range(32)))
+        result, _ = await self.call('Main', [invalid_block_hash], return_type=None)
         self.assertIsNone(result)
 
-        result = get_existent_block.result
-        self.assertIsInstance(result, list)
-        self.assertEqual(expected_result_size, len(result))
+        valid_block = self.genesis_block
+        valid_block_hash = valid_block.hash()
+        expected = stackitem.from_block(valid_block)
+        result, _ = await self.call('Main', [valid_block_hash], return_type=annotation.Block)
+        self.assertEqual(len(expected), len(result))
+        self.assertEqual(expected, result)
 
-        self.assertEqual(genesis_hash, result[0])
-        self.assertEqual(genesis_block.timestamp, result[4])
-        self.assertEqual(genesis_block.index, result[6])
+    async def test_get_block_by_index(self):
+        await self.set_up_contract('GetBlockByIndex.py')
 
-    def test_get_block_by_index(self):
-        path, _ = self.get_deploy_file_paths('GetBlockByIndex.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
+        invalid_block_index = 10 ** 5
+        with self.assertRaises(boatestcase.FaultException) as context:
+            await self.call('Main', [invalid_block_index], return_type=annotation.Block)
 
-        test_index_0 = 0
-        test_index_10 = 10
-        test_index_nonexistent = 10 ** 5
-        expected_result_size = len(Interop.BlockType.variables)
+        self.assertRegex(str(context.exception), f'no block with index {invalid_block_index}')
 
-        runner.increase_block(test_index_10)
-        get_block_0 = runner.call_contract(path, 'Main', test_index_0)
-        get_block_10 = runner.call_contract(path, 'Main', test_index_10)
-        get_nonexistent_block = runner.call_contract(path, 'Main', test_index_nonexistent)
+        valid_block = self.genesis_block
+        block_index = valid_block.index
+        expected = stackitem.from_block(valid_block)
+        result, _ = await self.call('Main', [block_index], return_type=annotation.Block)
+        self.assertEqual(len(expected), len(result))
+        self.assertEqual(expected, result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        result = get_block_0.result
-        self.assertIsInstance(result, list)
-        self.assertEqual(expected_result_size, len(result))
-        self.assertEqual(test_index_0, result[6])
-
-        result = get_nonexistent_block.result
-        self.assertIsNone(result)
-
-        result = get_block_10.result
-        self.assertIsInstance(result, list)
-        self.assertEqual(expected_result_size, len(result))
-        self.assertEqual(test_index_10, result[6])
+        valid_block = await self.get_latest_block()
+        block_index = valid_block.index
+        expected = stackitem.from_block(valid_block)
+        result, _ = await self.call('Main', [block_index], return_type=annotation.Block)
+        self.assertEqual(len(expected), len(result))
+        self.assertEqual(expected, result)
 
     def test_get_block_mismatched_types(self):
         path = self.get_contract_path('GetBlockMismatchedTypes.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
-    def test_get_transaction(self):
-        call_flags = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
-        method = String('getTransaction').to_bytes()
-
+    def test_get_transaction_compile(self):
         expected_output = (
             Opcode.INITSLOT
             + b'\x00\x01'
@@ -103,53 +74,30 @@ class TestLedgerContract(BoaTest):
             + Opcode.CALLT + b'\x00\x00'
             + Opcode.RET
         )
-        path = self.get_contract_path('GetTransaction.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('GetTransaction.py')
         self.assertEqual(expected_output, output)
 
-        path, _ = self.get_deploy_file_paths(path)
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_get_transaction_run(self):
+        await self.set_up_contract('GetTransaction.py')
 
-        sender = neoxp.utils.get_default_account()
-        contract_deploy = runner.deploy_contract(path)
-        runner.update_contracts(export_checkpoint=True)
-
-        hash_ = contract_deploy.tx_id
-        self.assertIsInstance(hash_, UInt256, msg=runner.cli_log)
-
-        tx = runner.get_transaction(hash_)
-        self.assertIsNotNone(tx)
-
-        nonexistent_tx = runner.call_contract(path, 'main', UInt256(bytes(32)).to_array())
-
-        invoke = runner.call_contract(path, 'main', hash_.to_array())
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        result = nonexistent_tx.result
+        invalid_tx = types.UInt256.zero()
+        result, _ = await self.call('main', [invalid_tx], return_type=None, signing_accounts=[self.genesis])
         self.assertIsNone(result)
 
-        result = invoke.result
-        self.assertIsInstance(result, list)
-        self.assertEqual(8, len(result))
+        tx = await self.get_last_tx()
+        self.assertIsNotNone(tx)
+        hash_ = tx.hash()
 
-        self.assertEqual(hash_, UInt256(result[0]))  # hash
-        self.assertEqual(tx.version, result[1])  # version
-        self.assertEqual(tx.nonce, result[2])  # nonce
-        self.assertEqual(sender.script_hash, UInt160(result[3]))  # sender
-        self.assertEqual(tx.system_fee, result[4])  # system_fee
-        self.assertEqual(tx.network_fee, result[5])  # network_fee
-        self.assertEqual(tx.valid_until_block, result[6])  # valid_until_block
-        self.assertEqual(tx.script, result[7])  # script
+        expected = stackitem.from_transaction(tx)
+        result, _ = await self.call('main', [hash_], return_type=annotation.Transaction)
+        self.assertEqual(len(expected), len(result))
+        self.assertEqual(expected, result)
 
     def test_get_transaction_mismatched_type(self):
         path = self.get_contract_path('GetTransactionMismatchedType.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
-    def test_get_transaction_from_block_int(self):
-        call_flags = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
-        method = String('getTransactionFromBlock').to_bytes()
-
+    def test_get_transaction_from_block_int_compile(self):
         expected_output = (
             Opcode.INITSLOT
             + b'\x00\x02'
@@ -158,52 +106,33 @@ class TestLedgerContract(BoaTest):
             + Opcode.CALLT + b'\x00\x00'
             + Opcode.RET
         )
-        path = self.get_contract_path('GetTransactionFromBlockInt.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('GetTransactionFromBlockInt.py')
         self.assertEqual(expected_output, output)
 
-        path, _ = self.get_deploy_file_paths(path)
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_get_transaction_from_block_int_run(self):
+        await self.set_up_contract('GetTransactionFromBlockInt.py')
 
-        sender = neoxp.utils.get_default_account()
-        contract_deploy = runner.deploy_contract(path, account=sender)
-        runner.update_contracts(export_checkpoint=True)
+        with self.assertRaises(boatestcase.FaultException) as context:
+            await self.call('main',
+                            [0, 0],
+                            return_type=annotation.Transaction
+                            )
 
-        block = runner.get_latest_block()
-        expected_block_index = block.index
+        self.assertRegex(str(context.exception), 'wrong transaction index')
 
-        hash_ = contract_deploy.tx_id
-        self.assertIsInstance(hash_, UInt256)
+        block_ = await self.get_latest_block()
+        self.assertGreater(len(block_.transactions), 0)
 
-        tx = runner.get_transaction(hash_)
+        expected_block_index = block_.index
+        tx = block_.transactions[0]
         self.assertIsNotNone(tx)
 
-        nonexistent_tx = runner.call_contract(path, 'main', 123456789, 0)
+        expected = stackitem.from_transaction(tx)
+        result, _ = await self.call('main', [expected_block_index, 0], return_type=annotation.Transaction)
+        self.assertEqual(len(expected), len(result))
+        self.assertEqual(expected, result)
 
-        invoke = runner.call_contract(path, 'main', expected_block_index, 0)
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        result = nonexistent_tx.result
-        self.assertIsNone(result)
-
-        result = invoke.result
-        self.assertIsInstance(result, list)
-        self.assertEqual(8, len(result))
-
-        self.assertEqual(hash_, UInt256(result[0]))  # hash
-        self.assertEqual(tx.version, result[1])  # version
-        self.assertEqual(tx.nonce, result[2])  # nonce
-        self.assertEqual(sender.script_hash, UInt160(result[3]))  # sender
-        self.assertEqual(tx.system_fee, result[4])  # system_fee
-        self.assertEqual(tx.network_fee, result[5])  # network_fee
-        self.assertEqual(tx.valid_until_block, result[6])  # valid_until_block
-        self.assertEqual(tx.script, result[7])  # script
-
-    def test_get_transaction_from_block_uint256(self):
-        call_flags = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
-        method = String('getTransactionFromBlock').to_bytes()
-
+    def test_get_transaction_from_block_uint256_compile(self):
         expected_output = (
             Opcode.INITSLOT
             + b'\x00\x02'
@@ -212,54 +141,37 @@ class TestLedgerContract(BoaTest):
             + Opcode.CALLT + b'\x00\x00'
             + Opcode.RET
         )
-        path = self.get_contract_path('GetTransactionFromBlockUInt256.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('GetTransactionFromBlockUInt256.py')
         self.assertEqual(expected_output, output)
 
-        path, _ = self.get_deploy_file_paths(path)
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_get_transaction_from_block_uint256_run(self):
+        await self.set_up_contract('GetTransactionFromBlockUInt256.py')
 
-        runner.deploy_contract(path)  # to have a block with tx
-        runner.update_contracts(export_checkpoint=True)
-        block = runner.get_latest_block()
-        self.assertIsNotNone(block)
-        block_hash = block.hash.to_array()
+        with self.assertRaises(boatestcase.FaultException) as context:
+            await self.call('main',
+                            [types.UInt256.zero(), 0],
+                            return_type=annotation.Transaction
+                            )
 
-        txs = block.transactions
-        self.assertGreater(len(txs), 0)
-        tx_index = 0
-        expected_tx = txs[tx_index]
+        self.assertRegex(str(context.exception), 'wrong transaction index')
 
-        nonexistent_tx = runner.call_contract(path, 'main', UInt256(bytes(32)).to_array(), 0)
+        block_ = await self.get_latest_block()
+        self.assertGreater(len(block_.transactions), 0)
 
-        invoke = runner.call_contract(path, 'main', block_hash, tx_index)
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        expected_block_hash = block_.hash()
+        tx = block_.transactions[0]
+        self.assertIsNotNone(tx)
 
-        result = nonexistent_tx.result
-        self.assertIsNone(result)
-
-        result = invoke.result
-        self.assertIsInstance(result, list)
-        self.assertEqual(8, len(result))
-
-        self.assertEqual(expected_tx.hash, UInt256(result[0]))  # hash
-        self.assertEqual(expected_tx.version, result[1])  # version
-        self.assertEqual(expected_tx.nonce, result[2])  # nonce
-        self.assertEqual(expected_tx.sender.script_hash, UInt160(result[3]))  # sender
-        self.assertEqual(expected_tx.system_fee, result[4])  # system_fee
-        self.assertEqual(expected_tx.network_fee, result[5])  # network_fee
-        self.assertEqual(expected_tx.valid_until_block, result[6])  # valid_until_block
-        self.assertEqual(expected_tx.script, result[7])  # script
+        expected = stackitem.from_transaction(tx)
+        result, _ = await self.call('main', [expected_block_hash, 0], return_type=annotation.Transaction)
+        self.assertEqual(len(expected), len(result))
+        self.assertEqual(expected, result)
 
     def test_get_transaction_from_block_mismatched_type(self):
         path = self.get_contract_path('GetTransactionFromBlockMismatchedType.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
-    def test_get_transaction_height(self):
-        call_flags = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
-        method = String('getTransactionHeight').to_bytes()
-
+    def test_get_transaction_height_compile(self):
         expected_output = (
             Opcode.INITSLOT
             + b'\x00\x01'
@@ -267,43 +179,25 @@ class TestLedgerContract(BoaTest):
             + Opcode.CALLT + b'\x00\x00'
             + Opcode.RET
         )
-        path = self.get_contract_path('GetTransactionHeight.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('GetTransactionHeight.py')
         self.assertEqual(expected_output, output)
 
-        path, _ = self.get_deploy_file_paths(path)
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_get_transaction_height_run(self):
+        await self.set_up_contract('GetTransactionHeight.py')
 
-        invokes = []
-        expected_results = []
+        block_ = await self.get_latest_block()
+        self.assertGreater(len(block_.transactions), 0)
+        tx = block_.transactions[0]
 
-        expected_block_index = 10
-        blocks_to_mint = expected_block_index - 1  # mint blocks before running the tx to check
-
-        runner.increase_block(blocks_to_mint)
-        contract_deploy = runner.deploy_contract(path)
-        runner.update_contracts(export_checkpoint=True)
-
-        hash_ = contract_deploy.tx_id
-        self.assertIsInstance(hash_, UInt256)
-
-        invokes.append(runner.call_contract(path, 'main', hash_.to_array()))
-        expected_results.append(expected_block_index)
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        expected = block_.index
+        result, _ = await self.call('main', [tx.hash()], return_type=int)
+        self.assertEqual(expected, result)
 
     def test_get_transaction_height_mismatched_type(self):
         path = self.get_contract_path('GetTransactionHeightMismatchedType.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
-    def test_get_transaction_signers(self):
-        call_flags = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
-        method = String('getTransactionSigners').to_bytes()
-
+    def test_get_transaction_signers_compile(self):
         expected_output = (
             Opcode.INITSLOT
             + b'\x00\x01'
@@ -311,47 +205,38 @@ class TestLedgerContract(BoaTest):
             + Opcode.CALLT + b'\x00\x00'
             + Opcode.RET
         )
-        path = self.get_contract_path('GetTransactionSigners.py')
-        output, manifest = self.get_output(path)
+
+        output, _ = self.assertCompile('GetTransactionSigners.py')
         self.assertEqual(expected_output, output)
 
-        path, _ = self.get_deploy_file_paths(path)
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_get_transaction_signers_run(self):
+        await self.set_up_contract('GetTransactionSigners.py')
 
-        expected_block_index = 10
-        blocks_to_mint = expected_block_index - 1  # mint blocks before running the tx to check
+        invalid_tx = types.UInt256.zero()
+        result, _ = await self.call('main',
+                                    [invalid_tx],
+                                    return_type=None,
+                                    signing_accounts=[self.genesis]  # persist to emit a new block
+                                    )
+        self.assertIsNone(result)
 
-        runner.increase_block(blocks_to_mint)
-
-        contract_deploy = runner.deploy_contract(path)
-        runner.update_contracts(export_checkpoint=True)
-
-        hash_ = contract_deploy.tx_id
-        self.assertIsInstance(hash_, UInt256)
-
-        tx = runner.get_transaction(hash_)
+        tx = await self.get_last_tx()
         self.assertIsNotNone(tx)
+        self.assertGreater(len(tx.signers), 0)
+        hash_ = tx.hash()
 
-        invoke = runner.call_contract(path, 'main', hash_.to_array())
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        result = invoke.result
-        self.assertIsInstance(result, list)
-        self.assertEqual(len(result), len(tx.signers))
-
-        self.assertIsInstance(result[0], list)
-        self.assertEqual(len(result[0]), len(Interop.SignerType.variables))
-        self.assertEqual(result[0][0], tx.signers[0].account.to_array())
+        expected: list[annotation.Signer] = [
+            stackitem.from_signer(signer) for signer in tx.signers
+        ]
+        result, _ = await self.call('main', [hash_], return_type=list[annotation.Signer])
+        self.assertEqual(len(expected), len(result))
+        self.assertEqual(expected, result)
 
     def test_get_transaction_signers_mismatched_type(self):
         path = self.get_contract_path('GetTransactionSignersMismatchedType.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
-    def test_get_transaction_vm_state(self):
-        call_flags = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
-        method = String('getTransactionVMState').to_bytes()
-
+    def test_get_transaction_vm_state_compile(self):
         expected_output = (
             Opcode.INITSLOT
             + b'\x00\x01'
@@ -359,41 +244,35 @@ class TestLedgerContract(BoaTest):
             + Opcode.CALLT + b'\x00\x00'
             + Opcode.RET
         )
-        path = self.get_contract_path('GetTransactionVMState.py')
-        output, manifest = self.get_output(path)
+        output, _ = self.assertCompile('GetTransactionVMState.py')
         self.assertEqual(expected_output, output)
 
-        path, _ = self.get_deploy_file_paths(path)
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_get_transaction_vm_state_run(self):
+        await self.set_up_contract('GetTransactionVMState.py')
 
-        contract_deploy = runner.deploy_contract(path)
-        runner.update_contracts(export_checkpoint=True)
+        hash_ = self.called_tx
+        self.assertIsNotNone(hash_)
 
-        hash_ = contract_deploy.tx_id
-        self.assertIsInstance(hash_, UInt256)
+        native_result, _ = await self.call('getTransactionVMState',
+                                           [hash_],
+                                           return_type=int,
+                                           target_contract=types.UInt160(constants.LEDGER_SCRIPT)
+                                           )
 
-        native_invoke = runner.call_contract(constants.LEDGER_SCRIPT, 'getTransactionVMState', hash_.to_array())
-        contract_invoke = runner.call_contract(path, 'main', hash_.to_array())
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-        self.assertEqual(native_invoke.result, contract_invoke.result)
+        contract_invoke, _ = await self.call('main',
+                                             [hash_],
+                                             return_type=int
+                                             )
+        self.assertEqual(native_result, contract_invoke)
 
     def test_get_transaction_vm_state_mismatched_type(self):
         path = self.get_contract_path('GetTransactionVMStateMismatchedType.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
-    def test_get_current_index(self):
-        path, _ = self.get_deploy_file_paths('GetCurrentIndex.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_get_current_index(self):
+        await self.set_up_contract('GetCurrentIndex.py')
 
-        invokes = []
-        expected_results = []
-
-        invokes.append(runner.call_contract(path, 'main'))
-        expected_results.append(1)
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        block_ = await self.get_latest_block()
+        expected = block_.index
+        result, _ = await self.call('main', [], return_type=int)
+        self.assertEqual(expected, result)

--- a/boa3_test/tests/stackitem.py
+++ b/boa3_test/tests/stackitem.py
@@ -1,0 +1,113 @@
+from typing import Any, Protocol, TypeVar, cast
+
+from neo3.core import types, cryptography
+from neo3.network.payloads import block, transaction, verification
+
+from boa3_test.tests import annotation
+
+
+StackItem = TypeVar(
+    'StackItem',
+    int,
+    bool,
+    str,
+    bytes,
+    types.UInt160,
+    types.UInt256,
+    cryptography.ECPoint,
+    tuple,
+    list,
+    dict,
+    None
+)
+
+
+class StackItemProcessor(Protocol):
+    def __call__(self, data: Any) -> StackItem:
+        ...
+
+
+def from_block(block_: block.Block) -> annotation.Block:
+    return (
+        block_.hash(),
+        block_.version,
+        block_.prev_hash,
+        block_.merkle_root,
+        block_.timestamp,
+        block_.nonce,
+        block_.index,
+        block_.next_consensus,
+        len(block_.transactions)
+    )
+
+
+def from_transaction(tx: transaction.Transaction) -> annotation.Transaction:
+    return (
+        tx.hash(),
+        tx.version,
+        tx.nonce,
+        tx.sender,
+        tx.system_fee,
+        tx.network_fee,
+        tx.valid_until_block,
+        tx.script
+    )
+
+
+def from_signer(signer: verification.Signer) -> annotation.Signer:
+    return (
+        signer.account,
+        int(signer.scope),
+        signer.allowed_contracts,
+        signer.allowed_groups,
+        [(
+            int(rule.action),
+            (int(rule.condition.type),)
+        ) for rule in signer.rules]
+    )
+
+
+def from_manifest(json_: annotation.JsonObject) -> annotation.ContractManifest:
+    import json
+    from boa3.internal.neo.vm.type.ContractParameterType import ContractParameterType
+
+    name = json_['name']
+    groups = json_['groups'] if 'groups' in json_ else []
+    supported_standards = json_['supportedstandards'] if 'supportedstandards' in json_ else []
+    permissions = json_['permissions'] if 'permissions' in json_ else []
+    trusts = json_['trusts'] if 'trusts' in json_ else []
+    extra = json.dumps(json_['extra'], separators=(',', ':'))
+
+    json_methods, json_events = json_['abi'].values()
+    methods: list[annotation.ContractMethod] = [
+        (
+            cast(str, method['name']),
+            [(
+                cast(str, param['name']),
+                ContractParameterType._get_by_name(param['type'])
+            ) for param in method['parameters']],
+            ContractParameterType._get_by_name(method['returntype']),
+            cast(int, method['offset']),
+            cast(bool, method['safe'])
+        ) for method in json_methods
+    ]
+    events: list[annotation.ContractEvent] = [
+        (
+            cast(str, event['name']),
+            [(
+                cast(str, param['name']),
+                ContractParameterType._get_by_name(param['type'])
+            ) for param in event['parameters']]
+        ) for event in json_events
+    ]
+
+    return (
+        name,
+        groups,
+        {},
+        supported_standards,
+        (methods, events),
+        permissions,
+        trusts,
+        extra
+    )


### PR DESCRIPTION
**Summary or solution description**
 Refactored `test_native/test_ledger.py` files to use `BoaTestCase` in place of `BoaTest` for unit testing.