### PR TITLE
Refactor test_native/test_rolemanagement.py to use BoaConstructor

### DIFF
--- a/boa3_test/tests/compiler_tests/test_native/test_rolemanagement.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_rolemanagement.py
@@ -1,39 +1,22 @@
-from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to avoid circular imports
+from neo3.core import types
 
 from boa3.internal import constants
 from boa3.internal.exception import CompilerError
-from boa3.internal.model.builtin.interop.interop import Interop
 from boa3.internal.neo.vm.opcode.Opcode import Opcode
-from boa3.internal.neo.vm.type.Integer import Integer
-from boa3.internal.neo.vm.type.String import String
-from boa3.internal.neo3.contracts import CallFlags
-from boa3.internal.neo3.vm import VMState
-from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
+from boa3_test.tests import boatestcase
 
 
-class TestRoleManagementClass(BoaTest):
+class TestRoleManagementClass(boatestcase.BoaTestCase):
     default_folder: str = 'test_sc/native_test/rolemanagement'
 
-    def test_get_hash(self):
-        path, _ = self.get_deploy_file_paths('GetHash.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_get_hash(self):
+        await self.set_up_contract('GetHash.py')
 
-        invokes = []
-        expected_results = []
-
-        invokes.append(runner.call_contract(path, 'main'))
-        expected_results.append(constants.ROLE_MANAGEMENT)
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        expected = types.UInt160(constants.ROLE_MANAGEMENT)
+        result, _ = await self.call('main', [], return_type=types.UInt160)
+        self.assertEqual(expected, result)
 
     def test_get_designated_by_role(self):
-        call_flags = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
-        method = String(Interop.GetDesignatedByRole.method_name).to_bytes()
-
         expected_output = (
             Opcode.INITSLOT
             + b'\x00\x02'
@@ -42,9 +25,7 @@ class TestRoleManagementClass(BoaTest):
             + Opcode.CALLT + b'\x00\x00'
             + Opcode.RET
         )
-
-        path = self.get_contract_path('GetDesignatedByRole.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('GetDesignatedByRole.py')
         self.assertEqual(expected_output, output)
 
     def test_get_designated_by_role_too_many_parameters(self):


### PR DESCRIPTION
 Refactored `test_native/test_rolemanagement.py `files to use `BoaTestCase `in place of `BoaTest `for unit testing.