### PR TITLE
Refactor test_interop/test_crypto.py to use BoaConstructor

### DIFF
--- a/boa3_test/tests/compiler_tests/test_interop/test_crypto.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_crypto.py
@@ -1,20 +1,15 @@
 import hashlib
 
-from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to avoid circular imports
 
 from boa3.internal.exception import CompilerError
-from boa3.internal.model.builtin.interop.interop import Interop
 from boa3.internal.model.type.type import Type
 from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3.internal.neo.vm.type.Integer import Integer
-from boa3.internal.neo.vm.type.String import String
-from boa3.internal.neo3.contracts.contracttypes import CallFlags
 from boa3.internal.neo3.contracts.namedcurve import NamedCurve
-from boa3.internal.neo3.vm import VMState
-from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
+from boa3_test.tests import boatestcase
 
 
-class TestCryptoInterop(BoaTest):
+class TestCryptoInterop(boatestcase.BoaTestCase):
     default_folder: str = 'test_sc/interop_test/crypto'
     ecpoint_init = (
         Opcode.DUP
@@ -31,77 +26,37 @@ class TestCryptoInterop(BoaTest):
         + Opcode.THROW
     )
 
-    def test_ripemd160_str(self):
-        path, _ = self.get_deploy_file_paths('Ripemd160Str.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_ripemd160_str(self):
+        await self.set_up_contract('Ripemd160Str.py')
 
         expected_result = hashlib.new('ripemd160', b'unit test')
-        invokes.append(runner.call_contract(path, 'Main', 'unit test'))
-        expected_results.append(expected_result.digest())
+        result, _ = await self.call('Main', ['unit test'], return_type=bytes)
+        self.assertEqual(expected_result.digest(), result)
 
         expected_result = hashlib.new('ripemd160', b'')
-        invokes.append(runner.call_contract(path, 'Main', ''))
-        expected_results.append(expected_result.digest())
+        result, _ = await self.call('Main', [''], return_type=bytes)
+        self.assertEqual(expected_result.digest(), result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_ripemd160_int(self):
-        path, _ = self.get_deploy_file_paths('Ripemd160Int.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_ripemd160_int(self):
+        await self.set_up_contract('Ripemd160Int.py')
 
         expected_result = hashlib.new('ripemd160', Integer(10).to_byte_array())
-        invokes.append(runner.call_contract(path, 'Main'))
-        expected_results.append(expected_result.digest())
+        result, _ = await self.call('Main', [], return_type=bytes)
+        self.assertEqual(expected_result.digest(), result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_ripemd160_bool(self):
-        path, _ = self.get_deploy_file_paths('Ripemd160Bool.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_ripemd160_bool(self):
+        await self.set_up_contract('Ripemd160Bool.py')
 
         expected_result = hashlib.new('ripemd160', Integer(1).to_byte_array())
-        invokes.append(runner.call_contract(path, 'Main'))
-        expected_results.append(expected_result.digest())
+        result, _ = await self.call('Main', [], return_type=bytes)
+        self.assertEqual(expected_result.digest(), result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_ripemd160_bytes(self):
-        path, _ = self.get_deploy_file_paths('Ripemd160Bytes.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_ripemd160_bytes(self):
+        await self.set_up_contract('Ripemd160Bytes.py')
 
         expected_result = hashlib.new('ripemd160', b'unit test')
-        invokes.append(runner.call_contract(path, 'Main'))
-        expected_results.append(expected_result.digest())
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        result, _ = await self.call('Main', [], return_type=bytes)
+        self.assertEqual(expected_result.digest(), result)
 
     def test_ripemd160_too_many_parameters(self):
         path = self.get_contract_path('Ripemd160TooManyArguments.py')
@@ -111,145 +66,65 @@ class TestCryptoInterop(BoaTest):
         path = self.get_contract_path('Ripemd160TooFewArguments.py')
         self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
 
-    def test_hash160_str(self):
-        path, _ = self.get_deploy_file_paths('Hash160Str.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_hash160_str(self):
+        await self.set_up_contract('Hash160Str.py')
 
         expected_result = hashlib.new('ripemd160', (hashlib.sha256(b'unit test').digest())).digest()
-        invokes.append(runner.call_contract(path, 'Main', 'unit test'))
-        expected_results.append(expected_result)
+        result, _ = await self.call('Main', ['unit test'], return_type=bytes)
+        self.assertEqual(expected_result, result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_hash160_int(self):
-        path, _ = self.get_deploy_file_paths('Hash160Int.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_hash160_int(self):
+        await self.set_up_contract('Hash160Int.py')
 
         expected_result = hashlib.new('ripemd160', (hashlib.sha256(Integer(10).to_byte_array()).digest())).digest()
-        invokes.append(runner.call_contract(path, 'Main'))
-        expected_results.append(expected_result)
+        result, _ = await self.call('Main', [], return_type=bytes)
+        self.assertEqual(expected_result, result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_hash160_bool(self):
-        path, _ = self.get_deploy_file_paths('Hash160Bool.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_hash160_bool(self):
+        await self.set_up_contract('Hash160Bool.py')
 
         expected_result = hashlib.new('ripemd160', (hashlib.sha256(Integer(1).to_byte_array()).digest())).digest()
-        invokes.append(runner.call_contract(path, 'Main'))
-        expected_results.append(expected_result)
+        result, _ = await self.call('Main', [], return_type=bytes)
+        self.assertEqual(expected_result, result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_hash160_bytes(self):
-        path, _ = self.get_deploy_file_paths('Hash160Bytes.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_hash160_bytes(self):
+        await self.set_up_contract('Hash160Bytes.py')
 
         expected_result = hashlib.new('ripemd160', (hashlib.sha256(b'unit test').digest())).digest()
-        invokes.append(runner.call_contract(path, 'Main'))
-        expected_results.append(expected_result)
+        result, _ = await self.call('Main', [], return_type=bytes)
+        self.assertEqual(expected_result, result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_sha256_str(self):
-        path, _ = self.get_deploy_file_paths('Sha256Str.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_sha256_str(self):
+        await self.set_up_contract('Sha256Str.py')
 
         expected_result = hashlib.sha256(b'unit test')
-        invokes.append(runner.call_contract(path, 'Main', 'unit test'))
-        expected_results.append(expected_result.digest())
+        result, _ = await self.call('Main', ['unit test'], return_type=bytes)
+        self.assertEqual(expected_result.digest(), result)
 
         expected_result = hashlib.sha256(b'')
-        invokes.append(runner.call_contract(path, 'Main', ''))
-        expected_results.append(expected_result.digest())
+        result, _ = await self.call('Main', [''], return_type=bytes)
+        self.assertEqual(expected_result.digest(), result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_sha256_int(self):
-        path, _ = self.get_deploy_file_paths('Sha256Int.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_sha256_int(self):
+        await self.set_up_contract('Sha256Int.py')
 
         expected_result = hashlib.sha256(Integer(10).to_byte_array())
-        invokes.append(runner.call_contract(path, 'Main'))
-        expected_results.append(expected_result.digest())
+        result, _ = await self.call('Main', [], return_type=bytes)
+        self.assertEqual(expected_result.digest(), result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_sha256_bool(self):
-        path, _ = self.get_deploy_file_paths('Sha256Bool.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_sha256_bool(self):
+        await self.set_up_contract('Sha256Bool.py')
 
         expected_result = hashlib.sha256(Integer(1).to_byte_array())
-        invokes.append(runner.call_contract(path, 'Main'))
-        expected_results.append(expected_result.digest())
+        result, _ = await self.call('Main', [], return_type=bytes)
+        self.assertEqual(expected_result.digest(), result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_sha256_bytes(self):
-        path, _ = self.get_deploy_file_paths('Sha256Bytes.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_sha256_bytes(self):
+        await self.set_up_contract('Sha256Bytes.py')
 
         expected_result = hashlib.sha256(b'unit test')
-        invokes.append(runner.call_contract(path, 'Main'))
-        expected_results.append(expected_result.digest())
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        result, _ = await self.call('Main', [], return_type=bytes)
+        self.assertEqual(expected_result.digest(), result)
 
     def test_sha256_too_many_parameters(self):
         path = self.get_contract_path('Sha256TooManyArguments.py')
@@ -259,77 +134,39 @@ class TestCryptoInterop(BoaTest):
         path = self.get_contract_path('Sha256TooFewArguments.py')
         self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
 
-    def test_hash256_str(self):
-        path, _ = self.get_deploy_file_paths('Hash256Str.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_hash256_str(self):
+        await self.set_up_contract('Hash256Str.py')
 
         expected_result = hashlib.sha256(hashlib.sha256(b'unit test').digest()).digest()
-        invokes.append(runner.call_contract(path, 'Main', 'unit test'))
-        expected_results.append(expected_result)
+        result, _ = await self.call('Main', ['unit test'], return_type=bytes)
+        self.assertEqual(expected_result, result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_hash256_int(self):
-        path, _ = self.get_deploy_file_paths('Hash256Int.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_hash256_int(self):
+        await self.set_up_contract('Hash256Int.py')
 
         expected_result = hashlib.sha256(hashlib.sha256(Integer(10).to_byte_array()).digest()).digest()
-        invokes.append(runner.call_contract(path, 'Main'))
-        expected_results.append(expected_result)
+        result, _ = await self.call('Main', [], return_type=bytes)
+        self.assertEqual(expected_result, result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_hash256_bool(self):
-        path, _ = self.get_deploy_file_paths('Hash256Bool.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_hash256_bool(self):
+        await self.set_up_contract('Hash256Bool.py')
 
         expected_result = hashlib.sha256(hashlib.sha256(Integer(1).to_byte_array()).digest()).digest()
-        invokes.append(runner.call_contract(path, 'Main'))
-        expected_results.append(expected_result)
+        result, _ = await self.call('Main', [], return_type=bytes)
+        self.assertEqual(expected_result, result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_hash256_bytes(self):
-        path, _ = self.get_deploy_file_paths('Hash256Bytes.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_hash256_bytes(self):
+        await self.set_up_contract('Hash256Bytes.py')
 
         expected_result = hashlib.sha256(hashlib.sha256(b'unit test').digest()).digest()
-        invokes.append(runner.call_contract(path, 'Main'))
-        expected_results.append(expected_result)
+        result, _ = await self.call('Main', [], return_type=bytes)
+        self.assertEqual(expected_result, result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_check_sig(self):
+    def test_check_sig_compile(self):
         byte_input0 = b'\x03\x5a\x92\x8f\x20\x16\x39\x20\x4e\x06\xb4\x36\x8b\x1a\x93\x36\x54\x62\xa8\xeb\xbf\xf0\xb8\x81\x81\x51\xb7\x4f\xaa\xb3\xa2\xb6\x1a'
         byte_input1 = b'wrongsignature'
+
+        from boa3.internal.model.builtin.interop.interop import Interop
 
         expected_output = (
             Opcode.INITSLOT
@@ -353,30 +190,22 @@ class TestCryptoInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('CheckSig.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('CheckSig.py')
         self.assertEqual(expected_output, output)
 
-        path, _ = self.get_deploy_file_paths(path)
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_check_sig_run(self):
+        await self.set_up_contract('CheckSig.py')
 
-        invokes = []
-        expected_results = []
+        result, _ = await self.call('main', [], return_type=bool)
+        self.assertEqual(False, result)
 
-        invokes.append(runner.call_contract(path, 'main'))
-        expected_results.append(False)
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_check_multisig(self):
+    def test_check_multisig_compile(self):
         byte_input0 = b'\x03\xcd\xb0g\xd90\xfdZ\xda\xa6\xc6\x85E\x01`D\xaa\xdd\xecd\xba9\xe5H%\x0e\xae\xa5Q\x17.S\\'
         byte_input1 = b'\x03l\x841\xccx\xb31w\xa6\x0bK\xcc\x02\xba\xf6\r\x05\xfe\xe5\x03\x8es9\xd3\xa6\x88\xe3\x94\xc2\xcb\xd8C'
         byte_input2 = b'wrongsignature1'
         byte_input3 = b'wrongsignature2'
+
+        from boa3.internal.model.builtin.interop.interop import Interop
 
         expected_output = (
             Opcode.INITSLOT
@@ -409,24 +238,14 @@ class TestCryptoInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('CheckMultisig.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('CheckMultisig.py')
         self.assertEqual(expected_output, output)
 
-        path, _ = self.get_deploy_file_paths(path)
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_check_multisig_run(self):
+        await self.set_up_contract('CheckMultisig.py')
 
-        invokes = []
-        expected_results = []
-
-        invokes.append(runner.call_contract(path, 'main'))
-        expected_results.append(False)
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        result, _ = await self.call('main', [], return_type=bool)
+        self.assertEqual(False, result)
 
     def test_verify_with_ecdsa(self):
         path = self.get_contract_path('VerifyWithECDsa.py')
@@ -487,52 +306,28 @@ class TestCryptoInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('VerifyWithECDsaSecp256k1Bytes.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('VerifyWithECDsaSecp256k1Bytes.py')
         self.assertEqual(expected_output, output)
 
     def test_verify_with_ecdsa_secp256k1_mismatched_type(self):
         path = self.get_contract_path('VerifyWithECDsaSecp256k1MismatchedType.py')
         self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
-    def test_import_crypto(self):
-        path, _ = self.get_deploy_file_paths('ImportCrypto.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_import_crypto(self):
+        await self.set_up_contract('ImportCrypto.py')
 
         expected_result = hashlib.new('ripemd160', (hashlib.sha256(b'unit test').digest())).digest()
-        invokes.append(runner.call_contract(path, 'main', 'unit test'))
-        expected_results.append(expected_result)
+        result, _ = await self.call('main', ['unit test'], return_type=bytes)
+        self.assertEqual(expected_result, result)
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
-
-    def test_import_interop_crypto(self):
-        path, _ = self.get_deploy_file_paths('ImportInteropCrypto.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invokes = []
-        expected_results = []
+    async def test_import_interop_crypto(self):
+        await self.set_up_contract('ImportInteropCrypto.py')
 
         expected_result = hashlib.new('ripemd160', (hashlib.sha256(b'unit test').digest())).digest()
-        invokes.append(runner.call_contract(path, 'main', 'unit test'))
-        expected_results.append(expected_result)
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        for x in range(len(invokes)):
-            self.assertEqual(expected_results[x], invokes[x].result)
+        result, _ = await self.call('main', ['unit test'], return_type=bytes)
+        self.assertEqual(expected_result, result)
 
     def test_murmur32(self):
-        function_id = String(Interop.Murmur32._sys_call).to_bytes()
-        call_flag = Integer(CallFlags.ALL).to_byte_array(signed=True, min_length=1)
-
         expected_output = (
             Opcode.INITSLOT
             + b'\x00'
@@ -543,8 +338,7 @@ class TestCryptoInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('Murmur32.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('Murmur32.py')
         self.assertEqual(expected_output, output)
 
     def test_bls12_381_add(self):
@@ -558,8 +352,7 @@ class TestCryptoInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('Bls12381Add.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('Bls12381Add.py')
         self.assertEqual(expected_output, output)
 
     def test_bls12_381_deserialize(self):
@@ -572,8 +365,7 @@ class TestCryptoInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('Bls12381Deserialize.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('Bls12381Deserialize.py')
         self.assertEqual(expected_output, output)
 
     def test_bls12_381_equal(self):
@@ -587,8 +379,7 @@ class TestCryptoInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('Bls12381Equal.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('Bls12381Equal.py')
         self.assertEqual(expected_output, output)
 
     def test_bls12_381_mul(self):
@@ -603,8 +394,7 @@ class TestCryptoInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('Bls12381Mul.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('Bls12381Mul.py')
         self.assertEqual(expected_output, output)
 
     def test_bls12_381_pairing(self):
@@ -618,8 +408,7 @@ class TestCryptoInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('Bls12381Pairing.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('Bls12381Pairing.py')
         self.assertEqual(expected_output, output)
 
     def test_bls12_381_serialize(self):
@@ -632,6 +421,5 @@ class TestCryptoInterop(BoaTest):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('Bls12381Serialize.py')
-        output = self.compile(path)
+        output, _ = self.assertCompile('Bls12381Serialize.py')
         self.assertEqual(expected_output, output)


### PR DESCRIPTION
Refactored `test_interop/test_crypto.py `files to use `BoaTestCase `in place of `BoaTest `for unit testing.