### PR TITLE
#86drpndm8 - Refactor example_tests/test_hello_world.py to use BoaCon…

### DIFF
--- a/boa3_test/tests/examples_tests/test_hello_world.py
+++ b/boa3_test/tests/examples_tests/test_hello_world.py
@@ -1,27 +1,22 @@
-from boa3_test.tests.boa_test import BoaTest  # needs to be the first import to avoid circular imports
-
-from boa3.internal.neo3.vm import VMState
-from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
+from boa3_test.tests import boatestcase
 
 
-class TestTemplate(BoaTest):
+class TestTemplate(boatestcase.BoaTestCase):
     default_folder: str = 'examples'
 
     def test_hello_world_compile(self):
         path = self.get_contract_path('hello_world.py')
-        self.compile(path)
+        self.assertCompile(path)
 
-    def test_hello_world_main(self):
-        path, _ = self.get_deploy_file_paths('hello_world.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_hello_world_main(self):
+        await self.set_up_contract('hello_world.py')
 
-        invoke = runner.call_contract(path, 'Main')
+        result, _ = await self.call('Main', [], return_type=None, signing_accounts=[self.genesis])
+        self.assertIsNone(result)
 
-        hello_world_contract = invoke.invoke.contract
-        runner.execute(get_storage_from=hello_world_contract)
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+        key = b'hello'
+        expected_value = b'world'
 
-        self.assertIsNone(invoke.result)
-
-        storage_result = runner.storages.get(hello_world_contract, b'hello')
-        self.assertEqual(b'world', storage_result.as_bytes())
+        contract_storage = await self.get_storage()
+        self.assertIn(key, contract_storage)
+        self.assertEqual(expected_value, contract_storage[key])


### PR DESCRIPTION
**Summary or solution description**
Refactored `example_tests/test_hello_world.py` files to use `BoaTestCase` in place of `BoaTest` for unit testing.