### PR TITLE
#86drw9whb - When compiling more extent smart contracts it's logging …

### DIFF
--- a/boa3/internal/compiler/codegenerator/engine/neoengine.py
+++ b/boa3/internal/compiler/codegenerator/engine/neoengine.py
@@ -78,6 +78,6 @@ class NeoEngine:
     def _execute_instruction(self, current_opcode: VMCode):
         match current_opcode.opcode:
             case Opcode.INITSLOT | Opcode.INITSSLOT:
-                print()
+                return
             case Opcode.RET:
                 self._state_stack.pop()


### PR DESCRIPTION
**Summary or solution description**
Removed erroneous `print()` function call that was logging extra empty lines when compiling contracts with many methods