### PR TITLE
CU-86dt50abt - Error when compiling using union type notation with | (bitwise or) in Event argument type

### DIFF
--- a/boa3/builtin/contract/__init__.py
+++ b/boa3/builtin/contract/__init__.py
@@ -8,7 +8,7 @@ __all__ = [
     'to_script_hash',
 ]
 
-from typing import Any, Union
+from typing import Any
 
 from boa3.builtin.compile_time import CreateNewEvent
 from boa3.builtin.contract.Nep17Contract import Nep17Contract
@@ -16,10 +16,10 @@ from boa3.builtin.type import ECPoint, UInt160, Event
 
 Nep11TransferEvent: Event = CreateNewEvent(
     [
-        ('from', Union[UInt160, None]),
-        ('to', Union[UInt160, None]),
+        ('from', UInt160 | None),
+        ('to', UInt160 | None),
         ('amount', int),
-        ('tokenId', Union[str, bytes])
+        ('tokenId', str | bytes)
     ],
     'Transfer'
 )
@@ -49,8 +49,8 @@ Check out the `proposal <https://github.com/neo-project/proposals/blob/master/ne
 
 Nep17TransferEvent: Event = CreateNewEvent(
     [
-        ('from', Union[UInt160, None]),
-        ('to', Union[UInt160, None]),
+        ('from', UInt160 | None),
+        ('to', UInt160 | None),
         ('amount', int)
     ],
     'Transfer'

--- a/boa3/internal/model/builtin/method/createeventmethod.py
+++ b/boa3/internal/model/builtin/method/createeventmethod.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from boa3.internal.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.internal.model.expression import IExpression
+from boa3.internal.model.type.collection.sequence.mutable.listtype import ListType
 from boa3.internal.model.type.itype import IType
 from boa3.internal.model.variable import Variable
 from boa3.internal.neo.vm.type.AbiType import AbiType
@@ -11,14 +12,21 @@ class CreateEventMethod(IBuiltinMethod):
     def __init__(self):
         import ast
         from boa3.internal.model.type.type import Type
+        from boa3.internal.model.type.typeutils import TypeUtils
         identifier = 'CreateNewEvent'
         args = {
-            'arguments': Variable(Type.list.build(Type.tuple)),
+            'arguments': Variable(Type.list.build(
+                Type.tuple.build_collection((Type.str, TypeUtils.type))
+            )),
             'event_name': Variable(Type.str)
         }
         event_name_default = ast.parse("'{0}'".format(Type.str.default_value)
                                        ).body[0].value
         super().__init__(identifier, args, defaults=[event_name_default], return_type=EventType)
+
+    @property
+    def arguments_type(self) -> ListType:
+        return self.args['arguments'].type
 
     def validate_parameters(self, *params: IExpression) -> bool:
         return len(params) == len(self.args)

--- a/boa3_test/examples/auxiliary_contracts/update_contract.py
+++ b/boa3_test/examples/auxiliary_contracts/update_contract.py
@@ -1,4 +1,4 @@
-from typing import Any, Union
+from typing import Any
 
 from boa3.builtin.compile_time import CreateNewEvent, NeoMetadata, public
 from boa3.builtin.interop import storage, runtime
@@ -42,8 +42,8 @@ def manifest_metadata() -> NeoMetadata:
 
 on_transfer = CreateNewEvent(
     [
-        ('from_addr', Union[UInt160, None]),
-        ('to_addr', Union[UInt160, None]),
+        ('from_addr', UInt160 | None),
+        ('to_addr', UInt160 | None),
         ('amount', int)
     ],
     'Transfer'

--- a/boa3_test/examples/nep11_non_divisible.py
+++ b/boa3_test/examples/nep11_non_divisible.py
@@ -7,13 +7,13 @@ from typing import Any, Dict, List, Union, cast
 
 from boa3.builtin.compile_time import CreateNewEvent, NeoMetadata, public
 from boa3.builtin.contract import abort
+from boa3.builtin.interop import storage
 from boa3.builtin.interop.blockchain import get_contract
 from boa3.builtin.interop.contract import CallFlags, call_contract, destroy_contract, get_call_flags, update_contract
 from boa3.builtin.interop.iterator import Iterator
 from boa3.builtin.interop.json import json_deserialize
 from boa3.builtin.interop.runtime import check_witness, get_network, script_container
 from boa3.builtin.interop.stdlib import deserialize, serialize
-from boa3.builtin.interop import storage
 from boa3.builtin.interop.storage.findoptions import FindOptions
 from boa3.builtin.type import UInt160, helper as type_helper
 
@@ -80,8 +80,8 @@ AUTH_ADDRESSES = b'AUTH_ADDRESSES'
 on_transfer = CreateNewEvent(
     # trigger when tokens are transferred, including zero value transfers.
     [
-        ('from_addr', Union[UInt160, None]),
-        ('to_addr', Union[UInt160, None]),
+        ('from_addr', UInt160 | None),
+        ('to_addr', UInt160 | None),
         ('amount', int),
         ('tokenId', bytes)
     ],

--- a/boa3_test/examples/update_contract.py
+++ b/boa3_test/examples/update_contract.py
@@ -1,4 +1,4 @@
-from typing import Any, Union
+from typing import Any
 
 from boa3.builtin.compile_time import CreateNewEvent, NeoMetadata, public
 from boa3.builtin.interop import storage, runtime
@@ -46,8 +46,8 @@ def manifest_metadata() -> NeoMetadata:
 
 on_transfer = CreateNewEvent(
     [
-        ('from_addr', Union[UInt160, None]),
-        ('to_addr', Union[UInt160, None]),
+        ('from_addr', UInt160 | None),
+        ('to_addr', UInt160 | None),
         ('amount', int)
     ],
     'Transfer'

--- a/boa3_test/test_sc/event_test/EventNep17TransferBuilt.py
+++ b/boa3_test/test_sc/event_test/EventNep17TransferBuilt.py
@@ -1,12 +1,10 @@
-from typing import Union
-
 from boa3.builtin.compile_time import public, CreateNewEvent
 from boa3.builtin.type import UInt160
 
 transfer = CreateNewEvent(
     [
-        ('from', Union[UInt160, None]),
-        ('to', Union[UInt160, None]),
+        ('from', UInt160 | None),
+        ('to', UInt160 | None),
         ('amount', int)
     ],
     'Transfer'

--- a/boa3_test/test_sc/generation_test/ManifestOptionalUnionEvent.py
+++ b/boa3_test/test_sc/generation_test/ManifestOptionalUnionEvent.py
@@ -6,6 +6,7 @@ event = CreateNewEvent(
     [
         ('optional', Optional[str]),
         ('union', Union[int, None]),
+        ('union2', bool | None)
     ],
     'event'
 )
@@ -13,4 +14,4 @@ event = CreateNewEvent(
 
 @public
 def main():
-    event('foo', 1)
+    event('foo', 1, True)

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsByteStringAsBytes.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsByteStringAsBytes.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Union
+from typing import Any, Dict
 
 from boa3.builtin.compile_time import CreateNewEvent, NeoMetadata, public
 from boa3.builtin.interop.iterator import Iterator
@@ -7,8 +7,8 @@ from boa3.builtin.type import UInt160
 on_transfer = CreateNewEvent(
     # trigger when tokens are transferred, including zero value transfers.
     [
-        ('from_addr', Union[UInt160, None]),
-        ('to_addr', Union[UInt160, None]),
+        ('from_addr', UInt160 | None),
+        ('to_addr', UInt160 | None),
         ('amount', int),
         ('tokenId', bytes)
     ],

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsByteStringAsStr.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsByteStringAsStr.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Union
+from typing import Any, Dict
 
 from boa3.builtin.compile_time import CreateNewEvent, NeoMetadata, public
 from boa3.builtin.interop.iterator import Iterator
@@ -7,8 +7,8 @@ from boa3.builtin.type import UInt160
 on_transfer = CreateNewEvent(
     # trigger when tokens are transferred, including zero value transfers.
     [
-        ('from_addr', Union[UInt160, None]),
-        ('to_addr', Union[UInt160, None]),
+        ('from_addr', UInt160 | None),
+        ('to_addr', UInt160 | None),
         ('amount', int),
         ('tokenId', str)
     ],

--- a/boa3_test/test_sc/metadata_test/aux_package/internal_package/__init__.py
+++ b/boa3_test/test_sc/metadata_test/aux_package/internal_package/__init__.py
@@ -1,12 +1,12 @@
-from boa3.builtin.compile_time import CreateNewEvent
-
 from typing import Union
+
+from boa3.builtin.compile_time import CreateNewEvent
 from boa3.builtin.type import UInt160
 
 on_transfer = CreateNewEvent(
     [
-        ('from_addr', Union[UInt160, None]),
-        ('to_addr', Union[UInt160, None]),
+        ('from_addr', UInt160 | None),
+        ('to_addr', UInt160 | None),
         ('amount', int),
     ],
     'Transfer'

--- a/boa3_test/tests/compiler_tests/test_event.py
+++ b/boa3_test/tests/compiler_tests/test_event.py
@@ -222,9 +222,9 @@ class TestEvent(boatestcase.BoaTestCase):
         event = boatestcase.BoaTestEvent.from_notification(events[0], bytes, bytes, int, bytes)
         self.assertEqual(transfer_args, event.state)
 
-    def test_event_with_return(self):
+    def test_event_without_types(self):
         path = self.get_contract_path('EventWithoutTypes.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
 
     async def test_event_with_duplicated_name(self):
         await self.set_up_contract('EventWithDuplicatedName.py')

--- a/boa3_test/tests/compiler_tests/test_file_generation.py
+++ b/boa3_test/tests/compiler_tests/test_file_generation.py
@@ -320,9 +320,9 @@ class TestFileGeneration(boatestcase.BoaTestCase):
         self.assertIn('parameters', event)
         self.assertEqual(3, len(event['parameters']))
         parameters = event['parameters']
-        self.assertEqual(('var4', 'Integer'), (parameters[0]['name'], parameters[0]['type']))
-        self.assertEqual(('var5', 'String'), (parameters[1]['name'], parameters[1]['type']))
-        self.assertEqual(('var6', 'ByteArray'), (parameters[2]['name'], parameters[2]['type']))
+        self.assertEqual(('var4', AbiType.Integer), (parameters[0]['name'], parameters[0]['type']))
+        self.assertEqual(('var5', AbiType.String), (parameters[1]['name'], parameters[1]['type']))
+        self.assertEqual(('var6', AbiType.ByteArray), (parameters[2]['name'], parameters[2]['type']))
 
     def test_metadata_abi_method_safe_mismatched_type(self):
         path = self.get_contract_path('MetadataMethodSafeMismatchedType.py')
@@ -795,10 +795,10 @@ class TestFileGeneration(boatestcase.BoaTestCase):
         _, abi_methods = self.verify_parameters_and_return_manifest(path)     # type: dict, list
 
         abi_method_main = abi_methods[0]
-        self.assertEqual('Array', abi_method_main['returntype'])
+        self.assertEqual(AbiType.Array, abi_method_main['returntype'])
         self.assertIn('returngeneric', abi_method_main)
         self.assertIn('type', abi_method_main['returngeneric'])
-        self.assertEqual('Array', abi_method_main['returngeneric']['type'])
+        self.assertEqual(AbiType.Array, abi_method_main['returngeneric']['type'])
         self.assertIn('generic', abi_method_main['returngeneric'])
         self.assertIn('type', abi_method_main['returngeneric']['generic'])
 
@@ -811,7 +811,7 @@ class TestFileGeneration(boatestcase.BoaTestCase):
         _, abi_methods = self.verify_parameters_and_return_manifest(path)     # type: dict, list
 
         abi_method_main = abi_methods[0]
-        self.assertEqual('Map', abi_method_main['returntype'])
+        self.assertEqual(AbiType.Map, abi_method_main['returntype'])
         self.assertIn('returngenerickey', abi_method_main)
         self.assertIn('type', abi_method_main['returngenerickey'])
         self.assertIn('returngenericitem', abi_method_main)
@@ -828,7 +828,7 @@ class TestFileGeneration(boatestcase.BoaTestCase):
         _, abi_methods = self.verify_parameters_and_return_manifest(path)     # type: dict, list
 
         abi_method_main = abi_methods[0]
-        self.assertEqual('Any', abi_method_main['returntype'])
+        self.assertEqual(AbiType.Any, abi_method_main['returntype'])
         self.assertIn('returnunion', abi_method_main)
         self.assertIsInstance(abi_method_main['returnunion'], list)
         for union_type in abi_method_main['returnunion']:
@@ -850,7 +850,7 @@ class TestFileGeneration(boatestcase.BoaTestCase):
         _, abi_methods = self.verify_parameters_and_return_manifest(path)     # type: dict, list
 
         abi_method_main = abi_methods[0]
-        self.assertEqual('Integer', abi_method_main['returntype'])
+        self.assertEqual(AbiType.Integer, abi_method_main['returntype'])
         self.assertIn('returnnullable', abi_method_main)
 
         abi_method_main_parameters = abi_method_main['parameters']
@@ -865,7 +865,7 @@ class TestFileGeneration(boatestcase.BoaTestCase):
         _, abi_methods = self.verify_parameters_and_return_manifest(path)     # type: dict, list
 
         abi_method_main = abi_methods[0]
-        self.assertEqual('InteropInterface', abi_method_main['returntype'])
+        self.assertEqual(AbiType.InteropInterface, abi_method_main['returntype'])
         self.assertIn('returnhint', abi_method_main)
         self.assertEqual(abi_method_main['returnhint'], 'StorageContext')
 
@@ -874,7 +874,7 @@ class TestFileGeneration(boatestcase.BoaTestCase):
         _, abi_methods = self.verify_parameters_and_return_manifest(path)     # type: dict, list
 
         abi_method_main = abi_methods[0]
-        self.assertEqual('InteropInterface', abi_method_main['returntype'])
+        self.assertEqual(AbiType.InteropInterface, abi_method_main['returntype'])
         self.assertIn('returnhint', abi_method_main)
         self.assertEqual(abi_method_main['returnhint'], 'Iterator')
 
@@ -888,7 +888,7 @@ class TestFileGeneration(boatestcase.BoaTestCase):
         self.assertIsInstance(method_main.return_type, AddressType)
 
         abi_method_main = abi_methods[0]
-        self.assertEqual(abi_method_main['returntype'], 'String')
+        self.assertEqual(abi_method_main['returntype'], AbiType.String)
         self.assertIn('returnhint', abi_method_main)
         self.assertEqual(abi_method_main['returnhint'], 'Address')
 
@@ -911,7 +911,7 @@ class TestFileGeneration(boatestcase.BoaTestCase):
         self.assertIsInstance(method_main.return_type, BlockHashType)
 
         abi_method_main = abi_methods[0]
-        self.assertEqual(abi_method_main['returntype'], 'Hash256')
+        self.assertEqual(abi_method_main['returntype'], AbiType.Hash256)
         self.assertIn('returnhint', abi_method_main)
         self.assertEqual(abi_method_main['returnhint'], 'BlockHash')
 
@@ -934,7 +934,7 @@ class TestFileGeneration(boatestcase.BoaTestCase):
         self.assertIsInstance(method_main.return_type, PublicKeyType)
 
         abi_method_main = abi_methods[0]
-        self.assertEqual(abi_method_main['returntype'], 'PublicKey')
+        self.assertEqual(abi_method_main['returntype'], AbiType.PublicKey)
         # 'PublicKey' already is a abi type, so there is no need to use a 'returnhint'
         self.assertNotIn('returnhint', abi_method_main)
 
@@ -957,7 +957,7 @@ class TestFileGeneration(boatestcase.BoaTestCase):
         self.assertIsInstance(method_main.return_type, ScriptHashType)
 
         abi_method_main = abi_methods[0]
-        self.assertEqual(abi_method_main['returntype'], 'Hash160')
+        self.assertEqual(abi_method_main['returntype'], AbiType.Hash160)
         self.assertIn('returnhint', abi_method_main)
         self.assertEqual(abi_method_main['returnhint'], 'ScriptHash')
 
@@ -980,7 +980,7 @@ class TestFileGeneration(boatestcase.BoaTestCase):
         self.assertIsInstance(method_main.return_type, ScriptHashLittleEndianType)
 
         abi_method_main = abi_methods[0]
-        self.assertEqual(abi_method_main['returntype'], 'Hash160')
+        self.assertEqual(abi_method_main['returntype'], AbiType.Hash160)
         self.assertIn('returnhint', abi_method_main)
         self.assertEqual(abi_method_main['returnhint'], 'ScriptHashLittleEndian')
 
@@ -1003,7 +1003,7 @@ class TestFileGeneration(boatestcase.BoaTestCase):
         self.assertIsInstance(method_main.return_type, TransactionIdType)
 
         abi_method_main = abi_methods[0]
-        self.assertEqual(abi_method_main['returntype'], 'Hash256')
+        self.assertEqual(abi_method_main['returntype'], AbiType.Hash256)
         self.assertIn('returnhint', abi_method_main)
         self.assertEqual(abi_method_main['returnhint'], 'TransactionId')
 
@@ -1021,7 +1021,7 @@ class TestFileGeneration(boatestcase.BoaTestCase):
         _, abi_methods = self.verify_parameters_and_return_manifest(path)  # type: dict, list
 
         abi_method_main = abi_methods[0]
-        self.assertEqual(abi_method_main['returntype'], 'Any')
+        self.assertEqual(abi_method_main['returntype'], AbiType.Any)
         # verifying if 'returnunion' was not wrongfully added to the manifest
         self.assertNotIn('returnunion', abi_method_main)
 
@@ -1033,25 +1033,25 @@ class TestFileGeneration(boatestcase.BoaTestCase):
         abi_method_main_parameter = abi_method_main['parameters'][0]
 
         # verifying arg type
-        self.assertEqual('Map', abi_method_main_parameter['type'])
+        self.assertEqual(AbiType.Map, abi_method_main_parameter['type'])
         self.assertIn('generickey', abi_method_main_parameter)
         self.assertIn('type', abi_method_main_parameter['generickey'])
-        self.assertEqual('String', abi_method_main_parameter['generickey']['type'])
+        self.assertEqual(AbiType.String, abi_method_main_parameter['generickey']['type'])
         self.assertIn('genericitem', abi_method_main_parameter)
         self.assertIn('type', abi_method_main_parameter['genericitem'])
-        self.assertEqual('Array', abi_method_main_parameter['genericitem']['type'])
+        self.assertEqual(AbiType.Array, abi_method_main_parameter['genericitem']['type'])
         self.assertIn('generic', abi_method_main_parameter['genericitem'])
         self.assertIn('type', abi_method_main_parameter['genericitem']['generic'])
 
         # verifying return type
-        self.assertEqual('Array', abi_method_main['returntype'])
+        self.assertEqual(AbiType.Array, abi_method_main['returntype'])
         self.assertIn('returngeneric', abi_method_main)
         self.assertIn('type', abi_method_main['returngeneric'])
-        self.assertEqual('Any', abi_method_main['returngeneric']['type'])
+        self.assertEqual(AbiType.Any, abi_method_main['returngeneric']['type'])
         self.assertIn('union', abi_method_main['returngeneric'])
         self.assertEqual(3, len(abi_method_main['returngeneric']['union']))
         self.assertTrue(any(
-            union_type['type'] == 'Map' and 'generickey' in union_type and 'genericitem' in union_type
+            union_type['type'] == AbiType.Map and 'generickey' in union_type and 'genericitem' in union_type
             for union_type in abi_method_main['returngeneric']['union']
         ))
 
@@ -1063,19 +1063,19 @@ class TestFileGeneration(boatestcase.BoaTestCase):
         abi_method_main_parameter = abi_method_main['parameters'][0]
 
         # verifying arg type
-        self.assertEqual('Map', abi_method_main_parameter['type'])
+        self.assertEqual(AbiType.Map, abi_method_main_parameter['type'])
         self.assertIn('generickey', abi_method_main_parameter)
         self.assertIn('type', abi_method_main_parameter['generickey'])
-        self.assertEqual('Any', abi_method_main_parameter['generickey']['type'])
+        self.assertEqual(AbiType.Any, abi_method_main_parameter['generickey']['type'])
         self.assertIn('genericitem', abi_method_main_parameter)
         self.assertIn('type', abi_method_main_parameter['genericitem'])
-        self.assertEqual('Any', abi_method_main_parameter['genericitem']['type'])
+        self.assertEqual(AbiType.Any, abi_method_main_parameter['genericitem']['type'])
 
         # verifying return type
-        self.assertEqual('Array', abi_method_main['returntype'])
+        self.assertEqual(AbiType.Array, abi_method_main['returntype'])
         self.assertIn('returngeneric', abi_method_main)
         self.assertIn('type', abi_method_main['returngeneric'])
-        self.assertEqual('Any', abi_method_main['returngeneric']['type'])
+        self.assertEqual(AbiType.Any, abi_method_main['returngeneric']['type'])
 
     def verify_parameters_and_return_manifest(self, path: str) -> tuple[dict, list]:
         nef_output, expected_manifest_output = self.get_deploy_file_paths_without_compiling(path)
@@ -1125,5 +1125,8 @@ class TestFileGeneration(boatestcase.BoaTestCase):
             compiler.compile_and_save(path, nef_output)
             _, manifest = self.get_output(nef_output)
 
-        self.assertEqual(manifest['abi']['events'][0]['parameters'][0]['type'], 'String')
-        self.assertEqual(manifest['abi']['events'][0]['parameters'][1]['type'], 'Integer')
+        events_parameters = manifest['abi']['events'][0]['parameters']
+        self.assertEqual(3, len(events_parameters))
+        self.assertEqual(events_parameters[0]['type'], AbiType.String)
+        self.assertEqual(events_parameters[1]['type'], AbiType.Integer)
+        self.assertEqual(events_parameters[2]['type'], AbiType.Boolean)


### PR DESCRIPTION
**Summary or solution description**
Fixed the behavior of `typeA | typeB` to have the same behavior as `Union[typeA, typeB]` on Event definitions.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/446f3ad102944a780720aaf8d123450874e889a5/boa3_test/test_sc/event_test/EventNep17TransferBuilt.py#L4-L11

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/446f3ad102944a780720aaf8d123450874e889a5/boa3_test/tests/compiler_tests/test_event.py#L158-L239