### PR TITLE
CU-86drpncrq - Refactor assertCompilerLogs to handle path the same way as assertCompile

### DIFF
--- a/boa3_test/tests/boatestcase.py
+++ b/boa3_test/tests/boatestcase.py
@@ -617,13 +617,13 @@ class BoaTestCase(SmartContractTestCase):
 
     def assertCompilerLogs(self,
                            expected_logged_exception,
-                           path
+                           *path: str
                            ) -> CompilerOutput | str:
+        py_abs_path = self.get_contract_path(*path)
+        output, error_msg = self._assert_compiler_logs_error(expected_logged_exception, py_abs_path)
 
-        output, error_msg = self._assert_compiler_logs_error(expected_logged_exception, path)
-        manifest = {}
         if not issubclass(expected_logged_exception, CompilerError):
-            return output, manifest
+            return self.compile_and_save(py_abs_path)
         else:
             # filter to get only the error message, without location information
             import re

--- a/boa3_test/tests/compiler_tests/test_any.py
+++ b/boa3_test/tests/compiler_tests/test_any.py
@@ -34,8 +34,7 @@ class TestAny(boatestcase.BoaTestCase):
         self.assertEqual(expected_output, output)
 
     def test_variable_assignment_with_any(self):
-        path = self.get_contract_path('VariableAssignmentWithAny.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'VariableAssignmentWithAny.py')
 
     def test_any_list(self):
         ok = String('ok').to_bytes()
@@ -76,8 +75,7 @@ class TestAny(boatestcase.BoaTestCase):
         self.assertEqual(expected_output, output)
 
     def test_any_operation(self):
-        path = self.get_contract_path('OperationWithAny.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'OperationWithAny.py')
 
     def test_function_any_param(self):
         ok = String('ok').to_bytes()
@@ -346,6 +344,5 @@ class TestAny(boatestcase.BoaTestCase):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('SequenceOfAnyIntSequence.py')
-        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, 'SequenceOfAnyIntSequence.py')
         self.assertEqual(expected_output, output)

--- a/boa3_test/tests/compiler_tests/test_arithmetic.py
+++ b/boa3_test/tests/compiler_tests/test_arithmetic.py
@@ -318,12 +318,10 @@ class TestArithmetic(boatestcase.BoaTestCase):
     # region Division
 
     def test_division_operation(self):
-        path = self.get_contract_path('Division.py')
-        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'Division.py')
 
     def test_division_augmented_assignment(self):
-        path = self.get_contract_path('DivisionAugmentedAssignment.py')
-        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'DivisionAugmentedAssignment.py')
 
     async def test_division_builtin_type(self):
         await self.set_up_contract('DivisionBuiltinType.py')
@@ -404,12 +402,10 @@ class TestArithmetic(boatestcase.BoaTestCase):
     # region Mismatched
 
     def test_mismatched_type_binary_operation(self):
-        path = self.get_contract_path('MismatchedOperandBinary.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MismatchedOperandBinary.py')
 
     def test_mismatched_type_unary_operation(self):
-        path = self.get_contract_path('MismatchedOperandUnary.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MismatchedOperandUnary.py')
 
     # endregion
 

--- a/boa3_test/tests/compiler_tests/test_assert.py
+++ b/boa3_test/tests/compiler_tests/test_assert.py
@@ -123,16 +123,13 @@ class TestAssert(boatestcase.BoaTestCase):
         self.assertRegex(String(str(context.exception)).to_bytes(), assert_msg)
 
     def test_assert_with_int_message(self):
-        path = self.get_contract_path('AssertWithIntMessage.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'AssertWithIntMessage.py')
 
     def test_assert_with_bool_message(self):
-        path = self.get_contract_path('AssertWithBoolMessage.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'AssertWithBoolMessage.py')
 
     def test_assert_with_list_message(self):
-        path = self.get_contract_path('AssertWithListMessage.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'AssertWithListMessage.py')
 
     def test_assert_with_str_var_message_compile(self):
         assert_msg = String('a must be greater than zero').to_bytes()

--- a/boa3_test/tests/compiler_tests/test_boa_builtin_method.py
+++ b/boa3_test/tests/compiler_tests/test_boa_builtin_method.py
@@ -123,12 +123,10 @@ class TestBoaBuiltinMethod(boatestcase.BoaTestCase):
         self.assertEqual(10, result)
 
     def test_deploy_def_incorrect_signature(self):
-        path = self.get_contract_path('DeployDefWrongSignature.py')
-        self.assertCompilerLogs(CompilerError.InternalIncorrectSignature, path)
+        self.assertCompilerLogs(CompilerError.InternalIncorrectSignature, 'DeployDefWrongSignature.py')
 
     def test_will_not_compile(self):
-        path = self.get_contract_path('WillNotCompile.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, 'WillNotCompile.py')
 
     # region math builtins
 

--- a/boa3_test/tests/compiler_tests/test_builtin_method.py
+++ b/boa3_test/tests/compiler_tests/test_builtin_method.py
@@ -101,28 +101,23 @@ class TestBuiltinMethod(boatestcase.BoaTestCase):
         self.assertEqual(3, result)
 
     def test_len_of_no_collection(self):
-        path = self.get_contract_path('LenMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'LenMismatchedType.py')
 
     def test_len_too_many_parameters(self):
-        path = self.get_contract_path('LenTooManyParameters.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'LenTooManyParameters.py')
 
     def test_len_too_few_parameters(self):
-        path = self.get_contract_path('LenTooFewParameters.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'LenTooFewParameters.py')
 
     # endregion
 
     # region append test
 
     def test_append_tuple(self):
-        path = self.get_contract_path('AppendTuple.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'AppendTuple.py')
 
     def test_append_sequence(self):
-        path = self.get_contract_path('AppendSequence.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'AppendSequence.py')
 
     def test_append_mutable_sequence_compile(self):
         expected_output = (
@@ -201,20 +196,17 @@ class TestBuiltinMethod(boatestcase.BoaTestCase):
         self.assertEqual([1, 2, 3, 4], result)
 
     def test_append_too_many_parameters(self):
-        path = self.get_contract_path('AppendTooManyParameters.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'AppendTooManyParameters.py')
 
     def test_append_too_few_parameters(self):
-        path = self.get_contract_path('AppendTooFewParameters.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'AppendTooFewParameters.py')
 
     # endregion
 
     # region clear test
 
     def test_clear_tuple(self):
-        path = self.get_contract_path('ClearTuple.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'ClearTuple.py')
 
     def test_clear_mutable_sequence_compile(self):
         expected_output = (
@@ -297,20 +289,17 @@ class TestBuiltinMethod(boatestcase.BoaTestCase):
         self.assertEqual([], result)
 
     def test_clear_too_many_parameters(self):
-        path = self.get_contract_path('ClearTooManyParameters.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'ClearTooManyParameters.py')
 
     def test_clear_too_few_parameters(self):
-        path = self.get_contract_path('ClearTooFewParameters.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'ClearTooFewParameters.py')
 
     # endregion
 
     # region reverse test
 
     def test_reverse_tuple(self):
-        path = self.get_contract_path('ReverseTuple.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'ReverseTuple.py')
 
     def test_reverse_mutable_sequence_compile(self):
         expected_output = (
@@ -344,24 +333,20 @@ class TestBuiltinMethod(boatestcase.BoaTestCase):
         self.assertEqual(b'\x03\x02\x01', result)
 
     def test_reverse_too_many_parameters(self):
-        path = self.get_contract_path('ReverseTooManyParameters.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'ReverseTooManyParameters.py')
 
     def test_reverse_too_few_parameters(self):
-        path = self.get_contract_path('ReverseTooFewParameters.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'ReverseTooFewParameters.py')
 
     # endregion
 
     # region extend test
 
     def test_extend_tuple(self):
-        path = self.get_contract_path('ExtendTuple.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'ExtendTuple.py')
 
     def test_extend_sequence(self):
-        path = self.get_contract_path('ExtendSequence.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'ExtendSequence.py')
 
     async def test_extend_mutable_sequence(self):
         await self.set_up_contract('ExtendMutableSequence.py')
@@ -376,12 +361,10 @@ class TestBuiltinMethod(boatestcase.BoaTestCase):
         self.assertEqual([1, 2, 3, 4, 5, 6], result)
 
     def test_extend_too_many_parameters(self):
-        path = self.get_contract_path('ExtendTooManyParameters.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'ExtendTooManyParameters.py')
 
     def test_extend_too_few_parameters(self):
-        path = self.get_contract_path('ExtendTooFewParameters.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'ExtendTooFewParameters.py')
 
     # endregion
 
@@ -395,8 +378,7 @@ class TestBuiltinMethod(boatestcase.BoaTestCase):
         self.assertEqual(to_script_hash(Integer(123).to_byte_array()), result)
 
     def test_script_hash_int_with_builtin(self):
-        path = self.get_contract_path('ScriptHashIntBuiltinCall.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, 'ScriptHashIntBuiltinCall.py')
 
     async def test_script_hash_str(self):
         await self.set_up_contract('ScriptHashStr.py')
@@ -411,8 +393,7 @@ class TestBuiltinMethod(boatestcase.BoaTestCase):
         self.assertEqual(expected_result, result)
 
     def test_script_hash_str_with_builtin(self):
-        path = self.get_contract_path('ScriptHashStrBuiltinCall.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, 'ScriptHashStrBuiltinCall.py')
 
     async def test_script_hash_variable(self):
         await self.set_up_contract('ScriptHashVariable.py')
@@ -432,24 +413,19 @@ class TestBuiltinMethod(boatestcase.BoaTestCase):
         self.assertRegex(str(context.exception), 'invalid base58 digit')
 
     def test_script_hash_variable_with_builtin(self):
-        path = self.get_contract_path('ScriptHashVariableBuiltinCall.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, 'ScriptHashVariableBuiltinCall.py')
 
     def test_script_hash_too_many_parameters(self):
-        path = self.get_contract_path('ScriptHashTooManyParameters.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'ScriptHashTooManyParameters.py')
 
     def test_script_hash_too_few_parameters(self):
-        path = self.get_contract_path('ScriptHashTooFewParameters.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'ScriptHashTooFewParameters.py')
 
     def test_script_hash_mismatched_types(self):
-        path = self.get_contract_path('ScriptHashMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'ScriptHashMismatchedType.py')
 
     def test_script_hash_builtin(self):
-        path = self.get_contract_path('ScriptHashBuiltinWrongUsage.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, 'ScriptHashBuiltinWrongUsage.py')
 
     # endregion
 
@@ -490,16 +466,13 @@ class TestBuiltinMethod(boatestcase.BoaTestCase):
         self.assertEqual(hex_str, result)
 
     def test_hex_str_too_many_parameters(self):
-        path = self.get_contract_path('HexStrTooManyParameters.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'HexStrTooManyParameters.py')
 
     def test_hex_str_too_few_parameters(self):
-        path = self.get_contract_path('HexStrTooFewParameters.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'HexStrTooFewParameters.py')
 
     def test_hex_str_mismatched_types(self):
-        path = self.get_contract_path('HexStrMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'HexStrMismatchedType.py')
 
     # endregion
 
@@ -520,8 +493,7 @@ class TestBuiltinMethod(boatestcase.BoaTestCase):
         self.assertEqual(value, result)
 
     def test_int_to_bytes_with_builtin(self):
-        path = self.get_contract_path('IntToBytesWithBuiltin.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, 'IntToBytesWithBuiltin.py')
 
     async def test_int_to_bytes_as_parameter(self):
         await self.set_up_contract('IntToBytesAsParameter.py')
@@ -549,12 +521,10 @@ class TestBuiltinMethod(boatestcase.BoaTestCase):
         self.assertEqual(String('123').to_bytes(), result)
 
     def test_str_to_bytes_with_builtin(self):
-        path = self.get_contract_path('StrToBytesWithBuiltin.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, 'StrToBytesWithBuiltin.py')
 
     def test_to_bytes_mismatched_types(self):
-        path = self.get_contract_path('ToBytesMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'ToBytesMismatchedType.py')
 
     # endregion
 
@@ -730,8 +700,7 @@ class TestBuiltinMethod(boatestcase.BoaTestCase):
         self.assertEqual(0, len(invoke_logs))
 
     def test_print_missing_outer_function_return(self):
-        path = self.get_contract_path('PrintIntMissingFunctionReturn.py')
-        self.assertCompilerLogs(CompilerError.MissingReturnStatement, path)
+        self.assertCompilerLogs(CompilerError.MissingReturnStatement, 'PrintIntMissingFunctionReturn.py')
 
     # endregion
 
@@ -975,12 +944,10 @@ class TestBuiltinMethod(boatestcase.BoaTestCase):
         self.assertEqual(max(values), result)
 
     def test_max_too_few_parameters(self):
-        path = self.get_contract_path('MaxTooFewParameters.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'MaxTooFewParameters.py')
 
     def test_max_mismatched_types(self):
-        path = self.get_contract_path('MaxMismatchedTypes.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MaxMismatchedTypes.py')
 
     # endregion
 
@@ -1056,12 +1023,10 @@ class TestBuiltinMethod(boatestcase.BoaTestCase):
         self.assertEqual(min(values), result)
 
     def test_min_too_few_parameters(self):
-        path = self.get_contract_path('MinTooFewParameters.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'MinTooFewParameters.py')
 
     def test_min_mismatched_types(self):
-        path = self.get_contract_path('MinMismatchedTypes.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MinMismatchedTypes.py')
 
     # endregion
 
@@ -1081,20 +1046,16 @@ class TestBuiltinMethod(boatestcase.BoaTestCase):
         self.assertEqual(abs(1), result)
 
     def test_abs_bytes(self):
-        path = self.get_contract_path('AbsMismatchedTypesBytes.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'AbsMismatchedTypesBytes.py')
 
     def test_abs_string(self):
-        path = self.get_contract_path('AbsMismatchedTypesString.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'AbsMismatchedTypesString.py')
 
     def test_abs_too_few_parameters(self):
-        path = self.get_contract_path('AbsTooFewParameters.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'AbsTooFewParameters.py')
 
     def test_abs_too_many_parameters(self):
-        path = self.get_contract_path('AbsTooManyParameters.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'AbsTooManyParameters.py')
 
     # endregion
 
@@ -1123,16 +1084,13 @@ class TestBuiltinMethod(boatestcase.BoaTestCase):
         self.assertEqual(sum(val, 20), result)
 
     def test_sum_mismatched_type(self):
-        path = self.get_contract_path('SumMismatchedTypes.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'SumMismatchedTypes.py')
 
     def test_sum_too_few_parameters(self):
-        path = self.get_contract_path('SumTooFewParameters.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'SumTooFewParameters.py')
 
     def test_sum_too_many_parameters(self):
-        path = self.get_contract_path('SumTooManyParameters.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'SumTooManyParameters.py')
 
     # endregion
 
@@ -1316,12 +1274,10 @@ class TestBuiltinMethod(boatestcase.BoaTestCase):
         self.assertEqual(range(10).count(1), result)
 
     def test_count_sequence_too_many_parameters(self):
-        path = self.get_contract_path('CountSequenceTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'CountSequenceTooManyArguments.py')
 
     def test_count_sequence_too_few_parameters(self):
-        path = self.get_contract_path('CountSequenceTooFewArguments.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'CountSequenceTooFewArguments.py')
 
     async def test_count_str(self):
         await self.set_up_contract('CountStr.py')
@@ -1445,12 +1401,10 @@ class TestBuiltinMethod(boatestcase.BoaTestCase):
         self.assertEqual(expected_result, result)
 
     def test_count_str_too_many_parameters(self):
-        path = self.get_contract_path('CountStrTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'CountStrTooManyArguments.py')
 
     def test_count_str_too_few_parameters(self):
-        path = self.get_contract_path('CountStrTooFewArguments.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'CountStrTooFewArguments.py')
 
     # endregion
 
@@ -1458,8 +1412,7 @@ class TestBuiltinMethod(boatestcase.BoaTestCase):
 
     def test_super_with_args(self):
         # TODO: Change when super with args is implemented #2kq1rw4
-        path = self.get_contract_path('SuperWithArgs.py')
-        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'SuperWithArgs.py')
 
     async def test_super_call_method(self):
         await self.set_up_contract('SuperCallMethod.py')
@@ -1683,8 +1636,7 @@ class TestBuiltinMethod(boatestcase.BoaTestCase):
         self.assertEqual(int(value), result)
 
     def test_int_int_too_many_parameters(self):
-        path = self.get_contract_path('IntIntTooManyParameters.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'IntIntTooManyParameters.py')
 
     async def test_int_no_parameters(self):
         await self.set_up_contract('IntNoParameters.py')
@@ -1853,8 +1805,7 @@ class TestBuiltinMethod(boatestcase.BoaTestCase):
         self.assertEqual(new_list, result)
 
     def test_list_sequence_mismatched_return_type(self):
-        path = self.get_contract_path('ListSequenceMismatchedReturnType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'ListSequenceMismatchedReturnType.py')
 
     async def test_list_mapping(self):
         await self.set_up_contract('ListMapping.py')
@@ -1882,8 +1833,7 @@ class TestBuiltinMethod(boatestcase.BoaTestCase):
         self.assertEqual(list(val), result)
 
     def test_list_mapping_mismatched_return_type(self):
-        path = self.get_contract_path('ListMappingMismatchedReturnType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'ListMappingMismatchedReturnType.py')
 
     async def test_list_bytes(self):
         await self.set_up_contract('ListBytes.py')
@@ -1893,8 +1843,7 @@ class TestBuiltinMethod(boatestcase.BoaTestCase):
         self.assertEqual(list(val), result)
 
     def test_list_bytes_mismatched_return_type(self):
-        path = self.get_contract_path('ListBytesMismatchedReturnType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'ListBytesMismatchedReturnType.py')
 
     async def test_list_str(self):
         await self.set_up_contract('ListString.py')
@@ -1904,8 +1853,7 @@ class TestBuiltinMethod(boatestcase.BoaTestCase):
         self.assertEqual(list(val), result)
 
     def test_list_str_mismatched_return_type(self):
-        path = self.get_contract_path('ListStringMismatchedReturnType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'ListStringMismatchedReturnType.py')
 
     async def test_list_bytes_str(self):
         await self.set_up_contract('ListBytesString.py')
@@ -1961,7 +1909,6 @@ class TestBuiltinMethod(boatestcase.BoaTestCase):
         self.assertEqual(str(value), result)
 
     def test_str_too_many_parameters(self):
-        path = self.get_contract_path('StrTooManyParameters.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'StrTooManyParameters.py')
 
     # endregion

--- a/boa3_test/tests/compiler_tests/test_bytes.py
+++ b/boa3_test/tests/compiler_tests/test_bytes.py
@@ -78,16 +78,13 @@ class TestBytes(boatestcase.BoaTestCase):
         self.assertEqual(48, result)
 
     def test_bytes_set_value(self):
-        path = self.get_contract_path('BytesSetValue.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedOperation, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedOperation, 'BytesSetValue.py')
 
     def test_bytes_clear(self):
-        path = self.get_contract_path('BytesClear.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'BytesClear.py')
 
     def test_bytes_reverse(self):
-        path = self.get_contract_path('BytesReverse.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'BytesReverse.py')
 
     async def test_bytes_to_int(self):
         await self.set_up_contract('BytesToInt.py')
@@ -96,8 +93,7 @@ class TestBytes(boatestcase.BoaTestCase):
         self.assertEqual(513, result)
 
     def test_bytes_to_int_with_builtin(self):
-        path = self.get_contract_path('BytesToIntWithBuiltin.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, 'BytesToIntWithBuiltin.py')
 
     async def test_bytes_to_bool(self):
         await self.set_up_contract('BytesToBool.py')
@@ -112,8 +108,7 @@ class TestBytes(boatestcase.BoaTestCase):
         self.assertEqual(True, result)
 
     def test_bytes_to_bool_with_builtin(self):
-        path = self.get_contract_path('BytesToBoolWithBuiltin.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, 'BytesToBoolWithBuiltin.py')
 
     async def test_bytes_to_str(self):
         await self.set_up_contract('BytesToStr.py')
@@ -122,8 +117,7 @@ class TestBytes(boatestcase.BoaTestCase):
         self.assertEqual('abc', result)
 
     def test_bytes_to_str_with_builtin(self):
-        path = self.get_contract_path('BytesToStrWithBuiltin.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, 'BytesToStrWithBuiltin.py')
 
     def test_bytes_from_byte_array(self):
         data = b'\x01\x02\x03'
@@ -510,8 +504,7 @@ class TestBytes(boatestcase.BoaTestCase):
             + Opcode.RET        # return
         )
 
-        path = self.get_contract_path('BytearrayLiteral.py')
-        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, 'BytearrayLiteral.py')
         self.assertEqual(expected_output, output)
 
     def test_byte_array_default_compile(self):
@@ -595,8 +588,7 @@ class TestBytes(boatestcase.BoaTestCase):
         self.assertRegex(context.exception.__str__(), 'invalid size')
 
     def test_byte_array_from_list_of_int(self):
-        path = self.get_contract_path('BytearrayFromListOfInt.py')
-        compiler_error_message = self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+        compiler_error_message = self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'BytearrayFromListOfInt.py')
 
         from boa3.internal.model.builtin.builtin import Builtin
         from boa3.internal.model.type.type import Type
@@ -619,8 +611,7 @@ class TestBytes(boatestcase.BoaTestCase):
         self.assertEqual(expected, result)
 
     def test_byte_array_string_with_encoding(self):
-        path = self.get_contract_path('BytearrayFromStringWithEncoding.py')
-        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'BytearrayFromStringWithEncoding.py')
 
     async def test_byte_array_append(self):
         await self.set_up_contract('BytearrayAppend.py')
@@ -684,12 +675,10 @@ class TestBytes(boatestcase.BoaTestCase):
         self.assertEqual(513, result)
 
     def test_byte_array_to_int_with_builtin(self):
-        path = self.get_contract_path('BytearrayToIntWithBuiltin.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, 'BytearrayToIntWithBuiltin.py')
 
     def test_byte_array_to_int_with_bytes_builtin(self):
-        path = self.get_contract_path('BytearrayToIntWithBytesBuiltin.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, 'BytearrayToIntWithBytesBuiltin.py')
 
     async def test_boa2_byte_array_test(self):
         await self.set_up_contract('BytearrayBoa2Test.py')
@@ -698,8 +687,7 @@ class TestBytes(boatestcase.BoaTestCase):
         self.assertEqual(b'\t\x01\x02', result)
 
     def test_boa2_byte_array_test2(self):
-        path = self.get_contract_path('BytearrayBoa2Test2.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'BytearrayBoa2Test2.py')
 
     async def test_boa2_byte_array_test3(self):
         await self.set_up_contract('BytearrayBoa2Test3.py')
@@ -1104,8 +1092,7 @@ class TestBytes(boatestcase.BoaTestCase):
         self.assertEqual(bytes_.index(bytes_sequence), result)
 
     def test_bytes_index_mismatched_type(self):
-        path = self.get_contract_path('IndexBytesMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'IndexBytesMismatchedType.py')
 
     async def test_bytes_property_slicing(self):
         await self.set_up_contract('BytesPropertySlicing.py')
@@ -1214,13 +1201,10 @@ class TestBytes(boatestcase.BoaTestCase):
         self.assertEqual(string.replace(old, new), result)
 
     def test_bytes_replace_mismatched_type(self):
-        path = self.get_contract_path('ReplaceBytesMethodMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'ReplaceBytesMethodMismatchedType.py')
 
     def test_bytes_replace_too_many_arguments(self):
-        path = self.get_contract_path('ReplaceBytesMethodTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'ReplaceBytesMethodTooManyArguments.py')
 
     def test_bytes_replace_too_few_arguments(self):
-        path = self.get_contract_path('ReplaceBytesMethodTooFewArguments.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'ReplaceBytesMethodTooFewArguments.py')

--- a/boa3_test/tests/compiler_tests/test_class.py
+++ b/boa3_test/tests/compiler_tests/test_class.py
@@ -88,8 +88,7 @@ class TestClass(boatestcase.BoaTestCase):
         self.assertEqual(42, result)
 
     def test_user_class_with_static_method_from_object(self):
-        path = self.get_contract_path('UserClassWithStaticMethodFromObject.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, 'UserClassWithStaticMethodFromObject.py')
 
     async def test_user_class_with_static_method_with_args(self):
         await self.set_up_contract('UserClassWithStaticMethodWithArgs.py')
@@ -195,12 +194,10 @@ class TestClass(boatestcase.BoaTestCase):
         self.assertEqual(2, result)
 
     def test_user_class_update_class_variable(self):
-        path = self.get_contract_path('UserClassUpdateClassVariable.py')
-        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'UserClassUpdateClassVariable.py')
 
     def test_user_class_update_instance_variable_on_init(self):
-        path = self.get_contract_path('UserClassUpdateClassVariableOnInit.py')
-        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'UserClassUpdateClassVariableOnInit.py')
 
     async def test_user_class_with_class_variable_and_class_method(self):
         await self.set_up_contract('UserClassWithClassVariableAndClassMethod.py')
@@ -238,12 +235,10 @@ class TestClass(boatestcase.BoaTestCase):
         self.assertEqual(42, result)
 
     def test_user_class_with_instance_method_from_class(self):
-        path = self.get_contract_path('UserClassWithInstanceMethodFromClass.py')
-        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'UserClassWithInstanceMethodFromClass.py')
 
     def test_user_class_with_instance_variable_from_class(self):
-        path = self.get_contract_path('UserClassWithInstanceVariableFromClass.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, 'UserClassWithInstanceVariableFromClass.py')
 
     async def test_user_class_with_instance_variable_from_object(self):
         await self.set_up_contract('UserClassWithInstanceVariableFromObject.py')
@@ -293,8 +288,7 @@ class TestClass(boatestcase.BoaTestCase):
         self.assertEqual(4, result)
 
     def test_user_class_with_base(self):
-        path = self.get_contract_path('UserClassWithBuiltinBase.py')
-        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'UserClassWithBuiltinBase.py')
 
     async def test_user_class_with_created_base(self):
         await self.set_up_contract('UserClassWithCreatedBase.py')
@@ -382,20 +376,16 @@ class TestClass(boatestcase.BoaTestCase):
         self.assertObjectEqual(expected_result, result)
 
     def test_user_class_with_created_base_with_more_variables_without_super_init(self):
-        path = self.get_contract_path('UserClassWithCreatedBaseWithMoreVariablesWithoutSuperInit.py')
-        self.assertCompilerLogs(CompilerError.MissingInitCall, path)
+        self.assertCompilerLogs(CompilerError.MissingInitCall, 'UserClassWithCreatedBaseWithMoreVariablesWithoutSuperInit.py')
 
     def test_user_class_with_multiple_bases(self):
-        path = self.get_contract_path('UserClassWithMultipleBases.py')
-        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'UserClassWithMultipleBases.py')
 
     def test_user_class_with_keyword_base(self):
-        path = self.get_contract_path('UserClassWithKeywordBase.py')
-        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'UserClassWithKeywordBase.py')
 
     def test_user_class_with_decorator(self):
-        path = self.get_contract_path('UserClassWithDecorator.py')
-        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'UserClassWithDecorator.py')
 
     async def test_user_class_with_property_from_object(self):
         await self.set_up_contract('UserClassWithPropertyFromObject.py')
@@ -422,20 +412,16 @@ class TestClass(boatestcase.BoaTestCase):
         self.assertEqual(47, result)
 
     def test_user_class_with_property_from_class(self):
-        path = self.get_contract_path('UserClassWithPropertyFromClass.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, 'UserClassWithPropertyFromClass.py')
 
     def test_user_class_with_property_using_arguments(self):
-        path = self.get_contract_path('UserClassWithPropertyUsingArguments.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, 'UserClassWithPropertyUsingArguments.py')
 
     def test_user_class_with_property_mismatched_type(self):
-        path = self.get_contract_path('UserClassWithPropertyMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'UserClassWithPropertyMismatchedType.py')
 
     def test_user_class_with_property_without_self(self):
-        path = self.get_contract_path('UserClassWithPropertyWithoutSelf.py')
-        self.assertCompilerLogs(CompilerError.SelfArgumentError, path)
+        self.assertCompilerLogs(CompilerError.SelfArgumentError, 'UserClassWithPropertyWithoutSelf.py')
 
     async def test_user_class_with_augmented_assignment_operator_with_variable(self):
         await self.set_up_contract('UserClassWithAugmentedAssignmentOperatorWithVariable.py')
@@ -466,8 +452,7 @@ class TestClass(boatestcase.BoaTestCase):
         self.assertObjectEqual(Example(), result)
 
     def test_del_class(self):
-        path = self.get_contract_path('DelClass.py')
-        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'DelClass.py')
 
     async def test_class_property_and_parameter_with_same_name(self):
         await self.set_up_contract('ClassPropertyAndParameterWithSameName.py')

--- a/boa3_test/tests/compiler_tests/test_contract_interface.py
+++ b/boa3_test/tests/compiler_tests/test_contract_interface.py
@@ -22,32 +22,25 @@ class TestContractInterface(boatestcase.BoaTestCase):
         self.compile(path)  # test if compiles because the smart contract doesn't exist
 
     def test_contract_interface_decorator_invalid_hash(self):
-        path = self.get_contract_path('ContractInterfaceInvalidHash.py')
-        self.assertCompilerLogs(CompilerError.InvalidUsage, path)
+        self.assertCompilerLogs(CompilerError.InvalidUsage, 'ContractInterfaceInvalidHash.py')
 
     def test_contract_interface_decorator_variable_hash(self):
-        path = self.get_contract_path('ContractInterfaceVariableArgument.py')
-        self.assertCompilerLogs(CompilerError.InvalidUsage, path)
+        self.assertCompilerLogs(CompilerError.InvalidUsage, 'ContractInterfaceVariableArgument.py')
 
     def test_contract_interface_decorator_too_few_arguments(self):
-        path = self.get_contract_path('ContractInterfaceTooFewArguments.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'ContractInterfaceTooFewArguments.py')
 
     def test_contract_interface_decorator_too_many_arguments(self):
-        path = self.get_contract_path('ContractInterfaceTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'ContractInterfaceTooManyArguments.py')
 
     def test_contract_interface_decorator_without_call(self):
-        path = self.get_contract_path('ContractInterfaceWithoutCall.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'ContractInterfaceWithoutCall.py')
 
     def test_contract_interface_with_instance_method(self):
-        path = self.get_contract_path('ContractInterfaceInstanceMethod.py')
-        self.assertCompilerLogs(CompilerError.InvalidUsage, path)
+        self.assertCompilerLogs(CompilerError.InvalidUsage, 'ContractInterfaceInstanceMethod.py')
 
     def test_contract_interface_with_class_method(self):
-        path = self.get_contract_path('ContractInterfaceClassMethod.py')
-        self.assertCompilerLogs(CompilerError.InvalidUsage, path)
+        self.assertCompilerLogs(CompilerError.InvalidUsage, 'ContractInterfaceClassMethod.py')
 
     async def test_contract_interface_nep17(self):
         await self.set_up_contract('Nep17Interface.py')
@@ -67,20 +60,16 @@ class TestContractInterface(boatestcase.BoaTestCase):
         self.compile(path)  # test if compiles because the smart contract doesn't exist
 
     def test_contract_interface_display_name_variable_name(self):
-        path = self.get_contract_path('ContractInterfaceDisplayNameVariableArgument.py')
-        self.assertCompilerLogs(CompilerError.InvalidUsage, path)
+        self.assertCompilerLogs(CompilerError.InvalidUsage, 'ContractInterfaceDisplayNameVariableArgument.py')
 
     def test_contract_interface_display_name_too_few_arguments(self):
-        path = self.get_contract_path('ContractInterfaceDisplayNameTooFewArguments.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'ContractInterfaceDisplayNameTooFewArguments.py')
 
     def test_contract_interface_display_name_without_call(self):
-        path = self.get_contract_path('ContractInterfaceDisplayNameWithoutCall.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'ContractInterfaceDisplayNameWithoutCall.py')
 
     def test_contract_interface_display_name_too_many_arguments(self):
-        path = self.get_contract_path('ContractInterfaceDisplayNameTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'ContractInterfaceDisplayNameTooManyArguments.py')
 
     async def test_contract_interface_nep17_with_display_name(self):
         await self.set_up_contract('Nep17InterfaceWithDisplayName.py')

--- a/boa3_test/tests/compiler_tests/test_dict.py
+++ b/boa3_test/tests/compiler_tests/test_dict.py
@@ -244,8 +244,7 @@ class TestDict(boatestcase.BoaTestCase):
         self.assertRegex(str(context.exception), self.MAP_KEY_NOT_FOUND_ERROR_MSG)
 
     def test_dict_get_value_mismatched_type(self):
-        path = self.get_contract_path('MismatchedTypeDictGetValue.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MismatchedTypeDictGetValue.py')
 
     def test_dict_set_value_compile(self):
         ok = String('ok').to_bytes()
@@ -277,8 +276,7 @@ class TestDict(boatestcase.BoaTestCase):
         self.assertEqual({0: 'ok', 1: 'one'}, result)
 
     def test_dict_set_value_mismatched_type(self):
-        path = self.get_contract_path('MismatchedTypeDictSetValue.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MismatchedTypeDictSetValue.py')
 
     def test_dict_keys_compile(self):
         one = String('one').to_bytes()
@@ -361,8 +359,7 @@ class TestDict(boatestcase.BoaTestCase):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('MismatchedTypeKeysDict.py')
-        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, 'MismatchedTypeKeysDict.py')
         self.assertEqual(expected_output, output)
 
     async def test_dict_keys_mismatched_type(self):
@@ -452,8 +449,7 @@ class TestDict(boatestcase.BoaTestCase):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('MismatchedTypeValuesDict.py')
-        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, 'MismatchedTypeValuesDict.py')
         self.assertEqual(expected_output, output)
 
     async def test_dict_values_mismatched_type(self):
@@ -595,5 +591,4 @@ class TestDict(boatestcase.BoaTestCase):
         self.assertEqual(({True: 1, False: 0}, {True: 99, False: 0}), result)
 
     def test_del_dict_pair(self):
-        path = self.get_contract_path('DelPair.py')
-        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'DelPair.py')

--- a/boa3_test/tests/compiler_tests/test_event.py
+++ b/boa3_test/tests/compiler_tests/test_event.py
@@ -223,8 +223,7 @@ class TestEvent(boatestcase.BoaTestCase):
         self.assertEqual(transfer_args, event.state)
 
     def test_event_without_types(self):
-        path = self.get_contract_path('EventWithoutTypes.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'EventWithoutTypes.py')
 
     async def test_event_with_duplicated_name(self):
         await self.set_up_contract('EventWithDuplicatedName.py')
@@ -239,52 +238,40 @@ class TestEvent(boatestcase.BoaTestCase):
         self.assertEqual((arg,), event.state)
 
     def test_event_call_too_many_arguments(self):
-        path = self.get_contract_path('TooManyArgumentsCallEvent.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'TooManyArgumentsCallEvent.py')
 
     def test_event_call_too_few_arguments(self):
-        path = self.get_contract_path('TooFewArgumentsCallEvent.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'TooFewArgumentsCallEvent.py')
 
     def test_event_call_mismatched_type_integer(self):
-        path = self.get_contract_path('MismatchedTypeCallEventInteger.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MismatchedTypeCallEventInteger.py')
 
     def test_event_call_mismatched_type_boolean(self):
-        path = self.get_contract_path('MismatchedTypeCallEventBoolean.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MismatchedTypeCallEventBoolean.py')
 
     def test_event_call_mismatched_type_hash160(self):
-        path = self.get_contract_path('MismatchedTypeCallEventHash160.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MismatchedTypeCallEventHash160.py')
 
     def test_event_call_mismatched_type_hash256(self):
-        path = self.get_contract_path('MismatchedTypeCallEventHash256.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MismatchedTypeCallEventHash256.py')
 
     def test_event_call_mismatched_type_bytearray(self):
-        path = self.get_contract_path('MismatchedTypeCallEventByteArray.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MismatchedTypeCallEventByteArray.py')
 
     def test_event_call_mismatched_type_public_key(self):
-        path = self.get_contract_path('MismatchedTypeCallEventPublicKey.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MismatchedTypeCallEventPublicKey.py')
 
     def test_event_call_mismatched_type_string(self):
-        path = self.get_contract_path('MismatchedTypeCallEventString.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MismatchedTypeCallEventString.py')
 
     def test_event_call_mismatched_type_array(self):
-        path = self.get_contract_path('MismatchedTypeCallEventArray.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MismatchedTypeCallEventArray.py')
 
     def test_event_call_mismatched_type_map(self):
-        path = self.get_contract_path('MismatchedTypeCallEventMap.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MismatchedTypeCallEventMap.py')
 
     def test_event_with_interop_interface_argument_mismatched_type(self):
-        path = self.get_contract_path('MismatchedTypeCreateEventWithInteropInterface.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MismatchedTypeCreateEventWithInteropInterface.py')
 
     async def test_event_with_abort(self):
         await self.set_up_contract('EventWithAbort.py')

--- a/boa3_test/tests/compiler_tests/test_exception.py
+++ b/boa3_test/tests/compiler_tests/test_exception.py
@@ -212,8 +212,7 @@ class TestException(boatestcase.BoaTestCase):
         self.assertRegex(str(context.exception), self.UNHANDLED_ERROR_MESSAGE.format(self.default_message))
 
     def test_raise_mismatched_type(self):
-        path = self.get_contract_path('RaiseMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'RaiseMismatchedType.py')
 
     def test_try_except_without_exception_compile(self):
         expected_output = (
@@ -302,8 +301,7 @@ class TestException(boatestcase.BoaTestCase):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('TryExceptSpecificException.py')
-        output, _ = self.assertCompilerLogs(CompilerWarning.UsingSpecificException, path)
+        output, _ = self.assertCompilerLogs(CompilerWarning.UsingSpecificException, 'TryExceptSpecificException.py')
         self.assertEqual(expected_output, output)
 
     async def test_try_except_specific_exception_run(self):
@@ -316,8 +314,7 @@ class TestException(boatestcase.BoaTestCase):
         self.assertEqual(-110, result)
 
     def test_try_except_with_name(self):
-        path = self.get_contract_path('TryExceptWithName.py')
-        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'TryExceptWithName.py')
 
     def test_try_except_finally_compile(self):
         expected_output = (

--- a/boa3_test/tests/compiler_tests/test_file_generation.py
+++ b/boa3_test/tests/compiler_tests/test_file_generation.py
@@ -229,8 +229,7 @@ class TestFileGeneration(boatestcase.BoaTestCase):
         self.assertEqual('Add', method0['name'])
 
     def test_metadata_abi_method_name_mismatched_type(self):
-        path = self.get_contract_path('MetadataMethodNameMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MetadataMethodNameMismatchedType.py')
 
     def test_metadata_abi_method_with_duplicated_name_but_different_args(self):
         path = self.get_contract_path('MetadataMethodDuplicatedNameDifferentArgs.py')
@@ -259,8 +258,7 @@ class TestFileGeneration(boatestcase.BoaTestCase):
         self.assertEqual(2, len(method1['parameters']))
 
     def test_metadata_abi_method_with_duplicated_name_and_args(self):
-        path = self.get_contract_path('MetadataMethodDuplicatedNameAndArgs.py')
-        self.assertCompilerLogs(CompilerError.DuplicatedManifestIdentifier, path)
+        self.assertCompilerLogs(CompilerError.DuplicatedManifestIdentifier, 'MetadataMethodDuplicatedNameAndArgs.py')
 
     def test_generate_manifest_file_with_public_safe_decorator_kwarg(self):
         path = self.get_contract_path('MetadataMethodSafe.py')
@@ -325,8 +323,7 @@ class TestFileGeneration(boatestcase.BoaTestCase):
         self.assertEqual(('var6', AbiType.ByteArray), (parameters[2]['name'], parameters[2]['type']))
 
     def test_metadata_abi_method_safe_mismatched_type(self):
-        path = self.get_contract_path('MetadataMethodSafeMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MetadataMethodSafeMismatchedType.py')
 
     def test_generate_nefdbgnfo_file(self):
         from boa3.internal.model.type.itype import IType

--- a/boa3_test/tests/compiler_tests/test_for.py
+++ b/boa3_test/tests/compiler_tests/test_for.py
@@ -125,8 +125,7 @@ class TestFor(boatestcase.BoaTestCase):
         self.assertEqual(6, result)
 
     def test_for_mismatched_type_condition(self):
-        path = self.get_contract_path('MismatchedTypeCondition.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MismatchedTypeCondition.py')
 
     def test_for_no_condition(self):
         path = self.get_contract_path('NoCondition.py')
@@ -305,8 +304,7 @@ class TestFor(boatestcase.BoaTestCase):
         self.assertEqual(6, result)
 
     def test_for_iterate_dict(self):
-        path = self.get_contract_path('ForIterateDict.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'ForIterateDict.py')
 
     async def test_boa2_iteration_test(self):
         await self.set_up_contract('IterBoa2Test.py')
@@ -327,8 +325,7 @@ class TestFor(boatestcase.BoaTestCase):
         self.assertEqual(7, result)
 
     def test_boa2_iteration_test4(self):
-        path = self.get_contract_path('IterBoa2Test4.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'IterBoa2Test4.py')
 
     async def test_boa2_iteration_test5(self):
         await self.set_up_contract('IterBoa2Test5.py')

--- a/boa3_test/tests/compiler_tests/test_function.py
+++ b/boa3_test/tests/compiler_tests/test_function.py
@@ -92,8 +92,7 @@ class TestFunction(boatestcase.BoaTestCase):
         self.assertEqual([2, 4, 6, 8, 10], result)
 
     def test_arg_without_type_hint(self):
-        path = self.get_contract_path('ArgWithoutTypeHintFunction.py')
-        self.assertCompilerLogs(CompilerError.TypeHintMissing, path)
+        self.assertCompilerLogs(CompilerError.TypeHintMissing, 'ArgWithoutTypeHintFunction.py')
 
     def test_no_return_hint_function_with_empty_return_statement_compile(self):
         expected_output = (
@@ -149,20 +148,16 @@ class TestFunction(boatestcase.BoaTestCase):
         self.assertIsNone(result)
 
     def test_return_type_hint_function_with_empty_return(self):
-        path = self.get_contract_path('ExpectingReturnFunction.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'ExpectingReturnFunction.py')
 
     def test_multiple_return_function(self):
-        path = self.get_contract_path('MultipleReturnFunction.py')
-        self.assertCompilerLogs(CompilerError.TooManyReturns, path)
+        self.assertCompilerLogs(CompilerError.TooManyReturns, 'MultipleReturnFunction.py')
 
     def test_tuple_function(self):
-        path = self.get_contract_path('TupleFunction.py')
-        self.assertCompilerLogs(CompilerError.TooManyReturns, path)
+        self.assertCompilerLogs(CompilerError.TooManyReturns, 'TupleFunction.py')
 
     def test_default_return(self):
-        path = self.get_contract_path('DefaultReturn.py')
-        self.assertCompilerLogs(CompilerError.MissingReturnStatement, path)
+        self.assertCompilerLogs(CompilerError.MissingReturnStatement, 'DefaultReturn.py')
 
     def test_empty_list_return_compile(self):
         expected_output = (
@@ -179,12 +174,10 @@ class TestFunction(boatestcase.BoaTestCase):
         result, _ = await self.call('Main', [], return_type=list)
 
     def test_mismatched_return_type(self):
-        path = self.get_contract_path('MismatchedReturnType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MismatchedReturnType.py')
 
     def test_mismatched_return_type_with_if(self):
-        path = self.get_contract_path('MismatchedReturnTypeWithIf.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MismatchedReturnTypeWithIf.py')
 
     def test_call_void_function_without_args_compile(self):
         called_function_address = Integer(4).to_byte_array(min_length=1, signed=True)
@@ -508,8 +501,7 @@ class TestFunction(boatestcase.BoaTestCase):
         self.assertIsNone(result)
 
     def test_return_void_function_mismatched_type(self):
-        path = self.get_contract_path('ReturnVoidFunctionMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'ReturnVoidFunctionMismatchedType.py')
 
     async def test_return_inside_if(self):
         await self.set_up_contract('ReturnIf.py')
@@ -524,16 +516,13 @@ class TestFunction(boatestcase.BoaTestCase):
         self.assertEqual(6, result)
 
     def test_missing_return_inside_if(self):
-        path = self.get_contract_path('ReturnIfMissing.py')
-        self.assertCompilerLogs(CompilerError.MissingReturnStatement, path)
+        self.assertCompilerLogs(CompilerError.MissingReturnStatement, 'ReturnIfMissing.py')
 
     def test_missing_return_inside_elif(self):
-        path = self.get_contract_path('ReturnElifMissing.py')
-        self.assertCompilerLogs(CompilerError.MissingReturnStatement, path)
+        self.assertCompilerLogs(CompilerError.MissingReturnStatement, 'ReturnElifMissing.py')
 
     def test_missing_return_inside_else(self):
-        path = self.get_contract_path('ReturnElseMissing.py')
-        self.assertCompilerLogs(CompilerError.MissingReturnStatement, path)
+        self.assertCompilerLogs(CompilerError.MissingReturnStatement, 'ReturnElseMissing.py')
 
     async def test_return_inside_multiple_inner_if(self):
         await self.set_up_contract('ReturnMultipleInnerIf.py')
@@ -545,8 +534,7 @@ class TestFunction(boatestcase.BoaTestCase):
         self.assertEqual(9, result)
 
     def test_missing_return_inside_multiple_inner_if(self):
-        path = self.get_contract_path('ReturnMultipleInnerIfMissing.py')
-        self.assertCompilerLogs(CompilerError.MissingReturnStatement, path)
+        self.assertCompilerLogs(CompilerError.MissingReturnStatement, 'ReturnMultipleInnerIfMissing.py')
 
     def test_return_if_expression_compiler(self):
         expected_output = (
@@ -576,8 +564,7 @@ class TestFunction(boatestcase.BoaTestCase):
         self.assertEqual(10, result)
 
     def test_return_if_expression_mismatched_type(self):
-        path = self.get_contract_path('ReturnIfExpressionMismatched.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'ReturnIfExpressionMismatched.py')
 
     def test_return_inside_for_compile(self):
         expected_output = (
@@ -692,8 +679,7 @@ class TestFunction(boatestcase.BoaTestCase):
         self.assertEqual(0, result)
 
     def test_missing_return_inside_for_else(self):
-        path = self.get_contract_path('ReturnForElseMissing.py')
-        self.assertCompilerLogs(CompilerError.MissingReturnStatement, path)
+        self.assertCompilerLogs(CompilerError.MissingReturnStatement, 'ReturnForElseMissing.py')
 
     def test_return_inside_while_compile(self):
         expected_output = (
@@ -780,8 +766,7 @@ class TestFunction(boatestcase.BoaTestCase):
         self.assertEqual(100, result)
 
     def test_missing_return_inside_while_without_else(self):
-        path = self.get_contract_path('ReturnWhileWithoutElse.py')
-        self.assertCompilerLogs(CompilerError.MissingReturnStatement, path)
+        self.assertCompilerLogs(CompilerError.MissingReturnStatement, 'ReturnWhileWithoutElse.py')
 
     async def test_multiple_function_large_call(self):
         await self.set_up_contract('MultipleFunctionLargeCall.py')
@@ -955,30 +940,24 @@ class TestFunction(boatestcase.BoaTestCase):
         self.assertEqual(204, result)
 
     def test_call_function_with_kwargs_only(self):
-        path = self.get_contract_path('CallFunctionWithKwargsOnly.py')
         # TODO: change the test when creating a function that only accepts keywords is implemented #2ewewtz
-        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'CallFunctionWithKwargsOnly.py')
 
     def test_call_function_with_kwargs_self(self):
-        path = self.get_contract_path('CallFunctionWithKwargsSelf.py')
         # TODO: change the test when calling a function using the class is implemented #2ewewtz #2ewexau
-        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'CallFunctionWithKwargsSelf.py')
 
     def test_call_function_with_kwargs_wrong_type(self):
-        path = self.get_contract_path('CallFunctionWithKwargsWrongType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'CallFunctionWithKwargsWrongType.py')
 
     def test_call_function_with_kwargs_too_few_parameters(self):
-        path = self.get_contract_path('CallFunctionWithKwargsTooFewArguments.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'CallFunctionWithKwargsTooFewArguments.py')
 
     def test_call_function_with_kwargs_too_many_parameters(self):
-        path = self.get_contract_path('CallFunctionWithKwargsTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'CallFunctionWithKwargsTooManyArguments.py')
 
     def test_call_function_with_kwargs_too_many_kw_parameters(self):
-        path = self.get_contract_path('CallFunctionWithKwargsTooManyKwArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'CallFunctionWithKwargsTooManyKwArguments.py')
 
     async def test_boa2_fibonacci_test(self):
         await self.set_up_contract('FibonacciBoa2Test.py')
@@ -1089,12 +1068,10 @@ class TestFunction(boatestcase.BoaTestCase):
         self.assertEqual([10, 20], result)
 
     def test_function_with_dictionary_unpacking_operator(self):
-        path = self.get_contract_path('FunctionWithDictionaryUnpackingOperator.py')
-        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'FunctionWithDictionaryUnpackingOperator.py')
 
     def test_functions_with_duplicated_name(self):
-        path = self.get_contract_path('FunctionsWithDuplicatedName.py')
-        self.assertCompilerLogs(CompilerError.DuplicatedIdentifier, path)
+        self.assertCompilerLogs(CompilerError.DuplicatedIdentifier, 'FunctionsWithDuplicatedName.py')
 
     async def test_function_as_arg(self):
         await self.set_up_contract('FunctionAsArg.py')
@@ -1128,17 +1105,13 @@ class TestFunction(boatestcase.BoaTestCase):
         self.assertIsNone(result)
 
     def test_inner_function(self):
-        path = self.get_contract_path('InnerFunction.py')
-        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'InnerFunction.py')
 
     def test_lambda_function(self):
-        path = self.get_contract_path('LambdaFunction.py')
-        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'LambdaFunction.py')
 
     def test_function_custom_decorator_with_global_function(self):
-        path = self.get_contract_path('CustomDecoratorWithGlobalFunction.py')
-        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'CustomDecoratorWithGlobalFunction.py')
 
     def test_function_builtin_function_decorators_with_class(self):
-        path = self.get_contract_path('BuiltinContractDecoratorWithFunction.py')
-        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'BuiltinContractDecoratorWithFunction.py')

--- a/boa3_test/tests/compiler_tests/test_import.py
+++ b/boa3_test/tests/compiler_tests/test_import.py
@@ -139,8 +139,7 @@ class TestImport(boatestcase.BoaTestCase):
         self.assertEqual('bar', result)
 
     def test_typing_python_library(self):
-        path = self.get_contract_path('ImportPythonLib.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, 'ImportPythonLib.py')
 
     def test_from_typing_import(self):
         expected_output = (
@@ -165,8 +164,7 @@ class TestImport(boatestcase.BoaTestCase):
         self.assertEqual(expected_output, output)
 
     def test_from_typing_import_not_supported_type(self):
-        path = self.get_contract_path('FromImportTypingNotImplementedType.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, 'FromImportTypingNotImplementedType.py')
 
     def test_from_import_all_compile(self):
         expected_output = (
@@ -266,8 +264,7 @@ class TestImport(boatestcase.BoaTestCase):
         self.assertEqual([], result)
 
     def test_import_non_existent_package(self):
-        path = self.get_contract_path('ImportNonExistentPackage.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, 'ImportNonExistentPackage.py')
 
     async def test_import_interop_with_alias(self):
         await self.set_up_contract('ImportInteropWithAlias.py')
@@ -275,12 +272,10 @@ class TestImport(boatestcase.BoaTestCase):
         result, _ = await self.call('Main', [], return_type=None)
         self.assertIsNone(result)
     def test_import_user_module_recursive_import(self):
-        path = self.get_contract_path('ImportUserModuleRecursiveImport.py')
-        self.assertCompilerLogs(CompilerError.CircularImport, path)
+        self.assertCompilerLogs(CompilerError.CircularImport, 'ImportUserModuleRecursiveImport.py')
 
     def test_from_import_user_module_recursive_import(self):
-        path = self.get_contract_path('FromImportUserModuleRecursiveImport.py')
-        self.assertCompilerLogs(CompilerError.CircularImport, path)
+        self.assertCompilerLogs(CompilerError.CircularImport, 'FromImportUserModuleRecursiveImport.py')
 
     async def test_import_user_module_with_not_imported_symbols(self):
         await self.set_up_contract('ImportUserModuleWithNotImportedSymbols.py')
@@ -353,21 +348,16 @@ class TestImport(boatestcase.BoaTestCase):
         self.assertEqual(5, result)
 
     def test_not_imported_builtin_public(self):
-        path = self.get_contract_path('NotImportedBuiltinPublic.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, 'NotImportedBuiltinPublic.py')
 
     def test_not_imported_builtin_from_typing(self):
-        path = self.get_contract_path('NotImportedBuiltinFromTypingInReturn.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, 'NotImportedBuiltinFromTypingInReturn.py')
 
-        path = self.get_contract_path('NotImportedBuiltinFromTypingInArgs.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, 'NotImportedBuiltinFromTypingInArgs.py')
 
-        path = self.get_contract_path('NotImportedBuiltinFromTypingInSubscript.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, 'NotImportedBuiltinFromTypingInSubscript.py')
 
-        path = self.get_contract_path('NotImportedBuiltinFromTypingInVariable.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, 'NotImportedBuiltinFromTypingInVariable.py')
 
     async def test_incorrect_circular_import(self):
         await self.set_up_contract('incorrect_circular_import', 'IncorrectCircularImportDetection.py')
@@ -408,13 +398,10 @@ class TestImport(boatestcase.BoaTestCase):
         self.assertEqual(expected_result.var_str, result)
 
     def test_from_import_not_existing_method(self):
-        path = self.get_contract_path('FromImportNotExistingMethod.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, 'FromImportNotExistingMethod.py')
 
     def test_import_not_existing_method(self):
-        path = self.get_contract_path('ImportNotExistingMethod.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, 'ImportNotExistingMethod.py')
 
     def test_import_boa_invalid_package(self):
-        path = self.get_contract_path('ImportBoaInvalidPackage.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, 'ImportBoaInvalidPackage.py')

--- a/boa3_test/tests/compiler_tests/test_interop/test_blockchain.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_blockchain.py
@@ -93,8 +93,7 @@ class TestBlockchainInterop(boatestcase.BoaTestCase):
         self.assertEqual(expected, result)
 
     def test_get_block_mismatched_types(self):
-        path = self.get_contract_path('GetBlockMismatchedTypes.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'GetBlockMismatchedTypes.py')
 
     async def test_transaction_init(self):
         await self.set_up_contract('Transaction.py')
@@ -141,8 +140,7 @@ class TestBlockchainInterop(boatestcase.BoaTestCase):
         self.assertEqual(expected, result)
 
     def test_get_transaction_mismatched_type(self):
-        path = self.get_contract_path('GetTransactionMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'GetTransactionMismatchedType.py')
 
     def test_get_transaction_from_block_int_compile(self):
         expected_output = (
@@ -215,8 +213,7 @@ class TestBlockchainInterop(boatestcase.BoaTestCase):
         self.assertEqual(expected, result)
 
     def test_get_transaction_from_block_mismatched_type(self):
-        path = self.get_contract_path('GetTransactionFromBlockMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'GetTransactionFromBlockMismatchedType.py')
 
     def test_get_transaction_height_compile(self):
         expected_output = (
@@ -241,8 +238,7 @@ class TestBlockchainInterop(boatestcase.BoaTestCase):
         self.assertEqual(expected, result)
 
     def test_get_transaction_height_mismatched_type(self):
-        path = self.get_contract_path('GetTransactionHeightMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'GetTransactionHeightMismatchedType.py')
 
     def test_get_transaction_signers_compile(self):
         expected_output = (
@@ -279,8 +275,7 @@ class TestBlockchainInterop(boatestcase.BoaTestCase):
         self.assertEqual(expected, result)
 
     def test_get_transaction_signers_mismatched_type(self):
-        path = self.get_contract_path('GetTransactionSignersMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'GetTransactionSignersMismatchedType.py')
 
     def test_get_transaction_vm_state_compile(self):
         expected_output = (
@@ -312,8 +307,7 @@ class TestBlockchainInterop(boatestcase.BoaTestCase):
         self.assertEqual(native_result, contract_invoke)
 
     def test_get_transaction_vm_state_mismatched_type(self):
-        path = self.get_contract_path('GetTransactionVMStateMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'GetTransactionVMStateMismatchedType.py')
 
     async def test_import_blockchain(self):
         await self.set_up_contract('ImportBlockchain.py')

--- a/boa3_test/tests/compiler_tests/test_interop/test_contract.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_contract.py
@@ -215,12 +215,10 @@ class TestContractInterop(boatestcase.BoaTestCase):
         self.assertRegex(str(context.exception), 'method not found: {0}/{1}'.format('Main', 2))
 
     def test_call_contract_too_many_parameters(self):
-        path = self.get_contract_path('CallScriptHashTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'CallScriptHashTooManyArguments.py')
 
     def test_call_contract_too_few_parameters(self):
-        path = self.get_contract_path('CallScriptHashTooFewArguments.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'CallScriptHashTooFewArguments.py')
 
     async def test_create_contract(self):
         await self.set_up_contract('CreateContract.py')
@@ -283,12 +281,10 @@ class TestContractInterop(boatestcase.BoaTestCase):
         self.assertEqual(data, notifies[1].state[0])
 
     def test_create_contract_too_many_parameters(self):
-        path = self.get_contract_path('CreateContractTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'CreateContractTooManyArguments.py')
 
     def test_create_contract_too_few_parameters(self):
-        path = self.get_contract_path('CreateContractTooFewArguments.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'CreateContractTooFewArguments.py')
 
     async def test_update_contract(self):
         await self.set_up_contract('UpdateContract.py')
@@ -353,12 +349,10 @@ class TestContractInterop(boatestcase.BoaTestCase):
         self.assertEqual(data, notifies[1].state[0])
 
     def test_update_contract_too_many_parameters(self):
-        path = self.get_contract_path('UpdateContractTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'UpdateContractTooManyArguments.py')
 
     def test_update_contract_too_few_parameters(self):
-        path = self.get_contract_path('UpdateContractTooFewArguments.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'UpdateContractTooFewArguments.py')
 
     async def test_destroy_contract(self):
         await self.set_up_contract('DestroyContract.py')
@@ -384,8 +378,7 @@ class TestContractInterop(boatestcase.BoaTestCase):
         self.assertRegex(str(context.exception), f'called contract {contract_hash} not found')
 
     def test_destroy_contract_too_many_parameters(self):
-        path = self.get_contract_path('DestroyContractTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'DestroyContractTooManyArguments.py')
 
     def test_get_neo_native_script_hash_compile(self):
         from boa3.internal.neo.vm.type.Integer import Integer
@@ -418,8 +411,7 @@ class TestContractInterop(boatestcase.BoaTestCase):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('NeoScriptHashCantAssign.py')
-        output, _ = self.assertCompilerLogs(CompilerWarning.NameShadowing, path)
+        output, _ = self.assertCompilerLogs(CompilerWarning.NameShadowing, 'NeoScriptHashCantAssign.py')
         self.assertEqual(expected_output, output)
 
     def test_get_gas_native_script_hash_compile(self):
@@ -453,8 +445,7 @@ class TestContractInterop(boatestcase.BoaTestCase):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('GasScriptHashCantAssign.py')
-        output, _ = self.assertCompilerLogs(CompilerWarning.NameShadowing, path)
+        output, _ = self.assertCompilerLogs(CompilerWarning.NameShadowing, 'GasScriptHashCantAssign.py')
         self.assertEqual(expected_output, output)
 
     async def test_call_flags_type(self):
@@ -580,12 +571,10 @@ class TestContractInterop(boatestcase.BoaTestCase):
         self.assertEqual(expected, result)
 
     def test_create_standard_account_too_few_parameters(self):
-        path = self.get_contract_path('CreateStandardAccountTooFewArguments.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'CreateStandardAccountTooFewArguments.py')
 
     def test_create_standard_account_too_many_parameters(self):
-        path = self.get_contract_path('CreateStandardAccountTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'CreateStandardAccountTooManyArguments.py')
 
     async def test_get_minimum_deployment_fee(self):
         await self.set_up_contract('GetMinimumDeploymentFee.py')
@@ -595,8 +584,7 @@ class TestContractInterop(boatestcase.BoaTestCase):
         self.assertEqual(minimum_cost, result)
 
     def test_get_minimum_deployment_fee_too_many_parameters(self):
-        path = self.get_contract_path('GetMinimumDeploymentFeeTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'GetMinimumDeploymentFeeTooManyArguments.py')
 
     def test_create_multisig_account_compile(self):
         from boa3.internal.model.builtin.interop.interop import Interop
@@ -634,9 +622,7 @@ class TestContractInterop(boatestcase.BoaTestCase):
         self.assertEqual(expected, result)
 
     def test_create_multisig_account_too_few_parameters(self):
-        path = self.get_contract_path('CreateMultisigAccountTooFewArguments.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'CreateMultisigAccountTooFewArguments.py')
 
     def test_create_multisig_account_too_many_parameters(self):
-        path = self.get_contract_path('CreateMultisigAccountTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'CreateMultisigAccountTooManyArguments.py')

--- a/boa3_test/tests/compiler_tests/test_interop/test_crypto.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_crypto.py
@@ -59,12 +59,10 @@ class TestCryptoInterop(boatestcase.BoaTestCase):
         self.assertEqual(expected_result.digest(), result)
 
     def test_ripemd160_too_many_parameters(self):
-        path = self.get_contract_path('Ripemd160TooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'Ripemd160TooManyArguments.py')
 
     def test_ripemd160_too_few_parameters(self):
-        path = self.get_contract_path('Ripemd160TooFewArguments.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'Ripemd160TooFewArguments.py')
 
     async def test_hash160_str(self):
         await self.set_up_contract('Hash160Str.py')
@@ -127,12 +125,10 @@ class TestCryptoInterop(boatestcase.BoaTestCase):
         self.assertEqual(expected_result.digest(), result)
 
     def test_sha256_too_many_parameters(self):
-        path = self.get_contract_path('Sha256TooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'Sha256TooManyArguments.py')
 
     def test_sha256_too_few_parameters(self):
-        path = self.get_contract_path('Sha256TooFewArguments.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'Sha256TooFewArguments.py')
 
     async def test_hash256_str(self):
         await self.set_up_contract('Hash256Str.py')
@@ -252,36 +248,28 @@ class TestCryptoInterop(boatestcase.BoaTestCase):
         self.compile(path)
 
     def test_verify_with_ecdsa_secp256r1_str(self):
-        path = self.get_contract_path('VerifyWithECDsaSecp256r1Str.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'VerifyWithECDsaSecp256r1Str.py')
 
     def test_verify_with_ecdsa_secp256r1_bool(self):
-        path = self.get_contract_path('VerifyWithECDsaSecp256r1Bool.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'VerifyWithECDsaSecp256r1Bool.py')
 
     def test_verify_with_ecdsa_secp256r1_int(self):
-        path = self.get_contract_path('VerifyWithECDsaSecp256r1Int.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'VerifyWithECDsaSecp256r1Int.py')
 
     def test_verify_with_ecdsa_secp256r1_bytes(self):
-        path = self.get_contract_path('VerifyWithECDsaSecp256k1Bool.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'VerifyWithECDsaSecp256k1Bool.py')
 
     def test_verify_with_ecdsa_secp256r1_mismatched_type(self):
-        path = self.get_contract_path('VerifyWithECDsaSecp256r1MismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'VerifyWithECDsaSecp256r1MismatchedType.py')
 
     def test_verify_with_ecdsa_secp256k1_str(self):
-        path = self.get_contract_path('VerifyWithECDsaSecp256k1Str.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'VerifyWithECDsaSecp256k1Str.py')
 
     def test_verify_with_ecdsa_secp256k1_bool(self):
-        path = self.get_contract_path('VerifyWithECDsaSecp256k1Bool.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'VerifyWithECDsaSecp256k1Bool.py')
 
     def test_verify_with_ecdsa_secp256k1_int(self):
-        path = self.get_contract_path('VerifyWithECDsaSecp256k1Int.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'VerifyWithECDsaSecp256k1Int.py')
 
     def test_verify_with_ecdsa_secp256k1_bytes(self):
         byte_input1 = b'0123456789ABCDEFGHIJKLMNOPQRSTUVW'
@@ -310,8 +298,7 @@ class TestCryptoInterop(boatestcase.BoaTestCase):
         self.assertEqual(expected_output, output)
 
     def test_verify_with_ecdsa_secp256k1_mismatched_type(self):
-        path = self.get_contract_path('VerifyWithECDsaSecp256k1MismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'VerifyWithECDsaSecp256k1MismatchedType.py')
 
     async def test_import_crypto(self):
         await self.set_up_contract('ImportCrypto.py')

--- a/boa3_test/tests/compiler_tests/test_interop/test_iterator.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_iterator.py
@@ -11,8 +11,7 @@ class TestIteratorInterop(boatestcase.BoaTestCase):
     default_folder: str = 'test_sc/interop_test/iterator'
 
     def test_iterator_create(self):
-        path = self.get_contract_path('IteratorCreate.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, 'IteratorCreate.py')
 
     async def test_iterator_next(self):
         await self.set_up_contract('IteratorNext.py')
@@ -60,8 +59,7 @@ class TestIteratorInterop(boatestcase.BoaTestCase):
         self.assertEqual((key, contract_storage[key]), result)
 
     def test_iterator_value_dict_mismatched_type(self):
-        path = self.get_contract_path('IteratorValueMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'IteratorValueMismatchedType.py')
 
     async def test_import_iterator(self):
         await self.set_up_contract('ImportIterator.py')

--- a/boa3_test/tests/compiler_tests/test_interop/test_policy.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_policy.py
@@ -12,8 +12,7 @@ class TestPolicyInterop(boatestcase.BoaTestCase):
         self.assertIsInstance(result, int)
 
     def test_get_exec_fee_too_many_parameters(self):
-        path = self.get_contract_path('GetExecFeeFactorTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'GetExecFeeFactorTooManyArguments.py')
 
     async def test_get_fee_per_byte(self):
         await self.set_up_contract('GetFeePerByte.py')
@@ -22,8 +21,7 @@ class TestPolicyInterop(boatestcase.BoaTestCase):
         self.assertIsInstance(result, int)
 
     def test_get_fee_per_byte_too_many_parameters(self):
-        path = self.get_contract_path('GetFeePerByteTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'GetFeePerByteTooManyArguments.py')
 
     async def test_get_storage_price(self):
         await self.set_up_contract('GetStoragePrice.py')
@@ -32,8 +30,7 @@ class TestPolicyInterop(boatestcase.BoaTestCase):
         self.assertIsInstance(result, int)
 
     def test_get_storage_price_too_many_parameters(self):
-        path = self.get_contract_path('GetStoragePriceTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'GetStoragePriceTooManyArguments.py')
 
     async def test_is_blocked(self):
         await self.set_up_contract('IsBlocked.py')
@@ -42,22 +39,17 @@ class TestPolicyInterop(boatestcase.BoaTestCase):
         self.assertEqual(False, result)
 
     def test_is_blocked_mismatched_type(self):
-        path = self.get_contract_path('IsBlockedMismatchedTypeInt.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'IsBlockedMismatchedTypeInt.py')
 
-        path = self.get_contract_path('IsBlockedMismatchedTypeStr.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'IsBlockedMismatchedTypeStr.py')
 
-        path = self.get_contract_path('IsBlockedMismatchedTypeBool.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'IsBlockedMismatchedTypeBool.py')
 
     def test_is_blocked_too_many_parameters(self):
-        path = self.get_contract_path('IsBlockedTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'IsBlockedTooManyArguments.py')
 
     def test_is_blocked_too_few_parameters(self):
-        path = self.get_contract_path('IsBlockedTooFewArguments.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'IsBlockedTooFewArguments.py')
 
     async def test_import_policy(self):
         await self.set_up_contract('ImportPolicy.py')

--- a/boa3_test/tests/compiler_tests/test_interop/test_role.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_role.py
@@ -20,12 +20,10 @@ class TestRoleInterop(boatestcase.BoaTestCase):
         self.assertEqual(expected_output, output)
 
     def test_get_designated_by_role_too_many_parameters(self):
-        path = self.get_contract_path('GetDesignatedByRoleTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'GetDesignatedByRoleTooManyArguments.py')
 
     def test_get_designated_by_role_too_few_parameters(self):
-        path = self.get_contract_path('GetDesignatedByRoleTooFewArguments.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'GetDesignatedByRoleTooFewArguments.py')
 
     def test_import_role(self):
         expected_output = (

--- a/boa3_test/tests/compiler_tests/test_interop/test_runtime.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_runtime.py
@@ -82,8 +82,7 @@ class TestRuntimeInterop(boatestcase.BoaTestCase):
         self.assertEqual(True, result)
 
     def test_check_witness_mismatched_type(self):
-        path = self.get_contract_path('CheckWitnessMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'CheckWitnessMismatchedType.py')
 
     def test_notify_str_compile(self):
         from boa3.internal.model.builtin.interop.interop import Interop
@@ -295,8 +294,7 @@ class TestRuntimeInterop(boatestcase.BoaTestCase):
         self.assertEqual((10,), event_notifications[0].state)
 
     def test_log_mismatched_type(self):
-        path = self.get_contract_path('LogMismatchedValueInt.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'LogMismatchedValueInt.py')
 
     def test_log_str_commpile(self):
         from boa3.internal.model.builtin.interop.interop import Interop
@@ -427,8 +425,7 @@ class TestRuntimeInterop(boatestcase.BoaTestCase):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('CallingScriptHashCantAssign.py')
-        output, _ = self.assertCompilerLogs(CompilerWarning.NameShadowing, path)
+        output, _ = self.assertCompilerLogs(CompilerWarning.NameShadowing, 'CallingScriptHashCantAssign.py')
         self.assertEqual(expected_output, output)
 
     def test_get_executing_script_hash_compile(self):
@@ -459,8 +456,7 @@ class TestRuntimeInterop(boatestcase.BoaTestCase):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('ExecutingScriptHashCantAssign.py')
-        output, _ = self.assertCompilerLogs(CompilerWarning.NameShadowing, path)
+        output, _ = self.assertCompilerLogs(CompilerWarning.NameShadowing, 'ExecutingScriptHashCantAssign.py')
         self.assertEqual(expected_output, output)
 
     async def test_get_executing_script_hash_on_deploy(self):
@@ -502,8 +498,7 @@ class TestRuntimeInterop(boatestcase.BoaTestCase):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('BlockTimeCantAssign.py')
-        output, _ = self.assertCompilerLogs(CompilerWarning.NameShadowing, path)
+        output, _ = self.assertCompilerLogs(CompilerWarning.NameShadowing, 'BlockTimeCantAssign.py')
         self.assertEqual(expected_output, output)
 
     def test_get_gas_left_compile(self):
@@ -534,8 +529,7 @@ class TestRuntimeInterop(boatestcase.BoaTestCase):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('GasLeftCantAssign.py')
-        output, _ = self.assertCompilerLogs(CompilerWarning.NameShadowing, path)
+        output, _ = self.assertCompilerLogs(CompilerWarning.NameShadowing, 'GasLeftCantAssign.py')
         self.assertEqual(expected_output, output)
 
     def test_get_invocation_counter_compile(self):
@@ -567,8 +561,7 @@ class TestRuntimeInterop(boatestcase.BoaTestCase):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('InvocationCounterCantAssign.py')
-        output, _ = self.assertCompilerLogs(CompilerWarning.NameShadowing, path)
+        output, _ = self.assertCompilerLogs(CompilerWarning.NameShadowing, 'InvocationCounterCantAssign.py')
         self.assertEqual(expected_output, output)
 
     async def test_get_notifications(self):
@@ -683,8 +676,7 @@ class TestRuntimeInterop(boatestcase.BoaTestCase):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('EntryScriptHashCantAssign.py')
-        output, _ = self.assertCompilerLogs(CompilerWarning.NameShadowing, path)
+        output, _ = self.assertCompilerLogs(CompilerWarning.NameShadowing, 'EntryScriptHashCantAssign.py')
         self.assertEqual(expected_output, output)
 
     def test_platform_compile(self):
@@ -715,8 +707,7 @@ class TestRuntimeInterop(boatestcase.BoaTestCase):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('PlatformCantAssign.py')
-        output, _ = self.assertCompilerLogs(CompilerWarning.NameShadowing, path)
+        output, _ = self.assertCompilerLogs(CompilerWarning.NameShadowing, 'PlatformCantAssign.py')
         self.assertEqual(expected_output, output)
 
     async def test_burn_gas(self):
@@ -845,8 +836,7 @@ class TestRuntimeInterop(boatestcase.BoaTestCase):
         self.assertEqual(network_protocol.network, result)
 
     def test_get_network_too_many_parameters(self):
-        path = self.get_contract_path('GetNetworkTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'GetNetworkTooManyArguments.py')
 
     async def test_import_runtime(self):
         await self.set_up_contract('ImportRuntime.py')
@@ -867,8 +857,7 @@ class TestRuntimeInterop(boatestcase.BoaTestCase):
         self.assertGreater(result, 0)
 
     def test_get_random_too_many_parameters(self):
-        path = self.get_contract_path('GetRandomTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'GetRandomTooManyArguments.py')
 
     async def test_address_version(self):
         await self.set_up_contract('AddressVersion.py')
@@ -881,8 +870,7 @@ class TestRuntimeInterop(boatestcase.BoaTestCase):
         self.assertEqual(network_protocol.address_version, result)
 
     def test_address_version_cant_assign(self):
-        path = self.get_contract_path('AddressVersionCantAssign.py')
-        self.assertCompilerLogs(CompilerWarning.NameShadowing, path)
+        self.assertCompilerLogs(CompilerWarning.NameShadowing, 'AddressVersionCantAssign.py')
 
     async def test_load_script(self):
         await self.set_up_contract('LoadScriptDynamicCall.py')

--- a/boa3_test/tests/compiler_tests/test_interop/test_stdlib.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_stdlib.py
@@ -35,8 +35,7 @@ class TestStdlibInterop(boatestcase.BoaTestCase):
         self.assertEqual(expected_result, result)
 
     def test_base64_encode_mismatched_type(self):
-        path = self.get_contract_path('Base64EncodeMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'Base64EncodeMismatchedType.py')
 
     async def test_base64_decode(self):
         import base64
@@ -63,8 +62,7 @@ class TestStdlibInterop(boatestcase.BoaTestCase):
         self.assertEqual(String(long_string).to_bytes(), result)
 
     def test_base64_decode_mismatched_type(self):
-        path = self.get_contract_path('Base64DecodeMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'Base64DecodeMismatchedType.py')
 
     async def test_base58_encode(self):
         import base58
@@ -91,8 +89,7 @@ class TestStdlibInterop(boatestcase.BoaTestCase):
         self.assertEqual(expected_result, result)
 
     def test_base58_encode_mismatched_type(self):
-        path = self.get_contract_path('Base58EncodeMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'Base58EncodeMismatchedType.py')
 
     async def test_base58_decode(self):
         import base58
@@ -121,8 +118,7 @@ class TestStdlibInterop(boatestcase.BoaTestCase):
         self.assertEqual(long_string, result)
 
     def test_base58_decode_mismatched_type(self):
-        path = self.get_contract_path('Base58DecodeMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'Base58DecodeMismatchedType.py')
 
     async def test_base58_check_decode(self):
         import base58
@@ -151,8 +147,7 @@ class TestStdlibInterop(boatestcase.BoaTestCase):
         self.assertEqual(long_string, result)
 
     def test_base58_check_decode_mismatched_type(self):
-        path = self.get_contract_path('Base58CheckDecodeMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'Base58CheckDecodeMismatchedType.py')
 
     async def test_base58_check_encode(self):
         import base58
@@ -179,8 +174,7 @@ class TestStdlibInterop(boatestcase.BoaTestCase):
         self.assertEqual(expected_result, result)
 
     def test_base58_check_encode_mismatched_type(self):
-        path = self.get_contract_path('Base58CheckEncodeMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'Base58CheckEncodeMismatchedType.py')
 
     async def test_serialize_int(self):
         await self.set_up_contract('SerializeInt.py')
@@ -257,8 +251,7 @@ class TestStdlibInterop(boatestcase.BoaTestCase):
         self.assertEqual(expected_result, result)
 
     def test_deserialize_mismatched_type(self):
-        path = self.get_contract_path('DeserializeMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'DeserializeMismatchedType.py')
 
     async def test_boa2_serialization_test1(self):
         await self.set_up_contract('SerializationBoa2Test.py')
@@ -361,16 +354,13 @@ class TestStdlibInterop(boatestcase.BoaTestCase):
         self.assertRegex(str(context.exception), self.INVALID_FORMAT_MSG)
 
     def test_atoi_too_few_parameters(self):
-        path = self.get_contract_path('AtoiTooFewArguments.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'AtoiTooFewArguments.py')
 
     def test_atoi_too_many_parameters(self):
-        path = self.get_contract_path('AtoiTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'AtoiTooManyArguments.py')
 
     def test_atoi_mismatched_type(self):
-        path = self.get_contract_path('AtoiMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'AtoiMismatchedType.py')
 
     async def test_itoa(self):
         await self.set_up_contract('Itoa')
@@ -405,16 +395,13 @@ class TestStdlibInterop(boatestcase.BoaTestCase):
         self.assertEqual('-1', result)
 
     def test_itoa_too_few_arguments(self):
-        path = self.get_contract_path('ItoaTooFewArguments')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'ItoaTooFewArguments')
 
     def test_itoa_too_many_arguments(self):
-        path = self.get_contract_path('ItoaTooManyArguments')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'ItoaTooManyArguments')
 
     def test_itoa_mismatched_type(self):
-        path = self.get_contract_path('ItoaMismatchedType')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'ItoaMismatchedType')
 
     async def test_import_stdlib(self):
         await self.set_up_contract('ImportStdlib')
@@ -567,16 +554,13 @@ class TestStdlibInterop(boatestcase.BoaTestCase):
         self.assertEqual(-1, result)
 
     def test_memory_search_mismatched_type(self):
-        path = self.get_contract_path('MemorySearchMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MemorySearchMismatchedType.py')
 
     def test_memory_search_too_few_parameters(self):
-        path = self.get_contract_path('MemorySearchTooFewArguments.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'MemorySearchTooFewArguments.py')
 
     def test_memory_search_too_many_parameters(self):
-        path = self.get_contract_path('MemorySearchTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'MemorySearchTooManyArguments.py')
 
     async def test_memory_compare(self):
         await self.set_up_contract('MemoryCompare')
@@ -600,13 +584,10 @@ class TestStdlibInterop(boatestcase.BoaTestCase):
         self.assertEqual(-1, result)
 
     def test_memory_compare_too_few_parameters(self):
-        path = self.get_contract_path('MemoryCompareTooFewArguments.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'MemoryCompareTooFewArguments.py')
 
     def test_memory_compare_too_many_parameters(self):
-        path = self.get_contract_path('MemoryCompareTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'MemoryCompareTooManyArguments.py')
 
     def test_memory_compare_mismatched_type(self):
-        path = self.get_contract_path('MemoryCompareMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MemoryCompareMismatchedType.py')

--- a/boa3_test/tests/compiler_tests/test_interop/test_storage.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_storage.py
@@ -42,12 +42,10 @@ class TestStorageInterop(boatestcase.BoaTestCase):
         self.assertEqual(expected_output, output)
 
     def test_storage_get_str_key(self):
-        path = self.get_contract_path('StorageGetStrKey.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'StorageGetStrKey.py')
 
     def test_storage_get_mismatched_type(self):
-        path = self.get_contract_path('StorageGetMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'StorageGetMismatchedType.py')
 
     async def test_storage_put_bytes_key_bytes_value(self):
         await self.set_up_contract('StoragePutBytesKeyBytesValue.py')
@@ -166,24 +164,19 @@ class TestStorageInterop(boatestcase.BoaTestCase):
         self.assertEqual(stored_value, contract_storage[storage_key_2])
 
     def test_storage_put_str_key_bytes_value(self):
-        path = self.get_contract_path('StoragePutStrKeyBytesValue.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'StoragePutStrKeyBytesValue.py')
 
     def test_storage_put_str_key_int_value(self):
-        path = self.get_contract_path('StoragePutStrKeyIntValue.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'StoragePutStrKeyIntValue.py')
 
     def test_storage_put_str_key_str_value(self):
-        path = self.get_contract_path('StoragePutStrKeyStrValue.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'StoragePutStrKeyStrValue.py')
 
     def test_storage_put_mismatched_type_key(self):
-        path = self.get_contract_path('StoragePutMismatchedTypeKey.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'StoragePutMismatchedTypeKey.py')
 
     def test_storage_put_mismatched_type_value(self):
-        path = self.get_contract_path('StoragePutMismatchedTypeValue.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'StoragePutMismatchedTypeValue.py')
 
     def test_storage_delete_bytes_key_compile(self):
         expected_output = (
@@ -228,12 +221,10 @@ class TestStorageInterop(boatestcase.BoaTestCase):
         self.assertNotIn(storage_key, contract_storage)
 
     def test_storage_delete_str_key(self):
-        path = self.get_contract_path('StorageDeleteStrKey.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'StorageDeleteStrKey.py')
 
     def test_storage_delete_mismatched_type(self):
-        path = self.get_contract_path('StorageDeleteMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'StorageDeleteMismatchedType.py')
 
     async def test_storage_find_bytes_prefix(self):
         await self.set_up_contract('StorageFindBytesPrefix.py')
@@ -276,12 +267,10 @@ class TestStorageInterop(boatestcase.BoaTestCase):
         self.assertEqual(example_storage, contract_storage)
 
     def test_storage_find_str_prefix(self):
-        path = self.get_contract_path('StorageFindStrPrefix.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'StorageFindStrPrefix.py')
 
     def test_storage_find_mismatched_type(self):
-        path = self.get_contract_path('StorageFindMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'StorageFindMismatchedType.py')
 
     def test_storage_get_context_compile(self):
         expected_output = (
@@ -777,5 +766,4 @@ class TestStorageInterop(boatestcase.BoaTestCase):
         self.assertEqual(FindOptions.BACKWARDS, result)
 
     def test_find_options_mismatched_type(self):
-        path = self.get_contract_path('FindOptionsMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'FindOptionsMismatchedType.py')

--- a/boa3_test/tests/compiler_tests/test_list.py
+++ b/boa3_test/tests/compiler_tests/test_list.py
@@ -111,8 +111,7 @@ class TestList(boatestcase.BoaTestCase):
         self.assertEqual(expected_output, output)
 
     def test_non_sequence_get_value(self):
-        path = self.get_contract_path('MismatchedTypeListGetValue.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedOperation, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedOperation, 'MismatchedTypeListGetValue.py')
 
     def test_list_get_value_compile(self):
         expected_output = (
@@ -243,8 +242,7 @@ class TestList(boatestcase.BoaTestCase):
         self.assertEqual(expected_output, output)
 
     def test_list_set_into_list_slice(self):
-        path = self.get_contract_path('SetListIntoListSlice.py')
-        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'SetListIntoListSlice.py')
 
     def test_list_set_value_compile(self):
         path = self.get_contract_path('ListSetValue.py')
@@ -281,12 +279,10 @@ class TestList(boatestcase.BoaTestCase):
         self.assertRegex(str(context.exception), self.VALUE_IS_OUT_OF_RANGE_MSG_REGEX_SUFFIX)
 
     def test_non_sequence_set_value(self):
-        path = self.get_contract_path('MismatchedTypeListSetValue.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedOperation, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedOperation, 'MismatchedTypeListSetValue.py')
 
     def test_list_index_mismatched_type(self):
-        path = self.get_contract_path('MismatchedTypeListIndex.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MismatchedTypeListIndex.py')
 
     async def test_array_boa2_test1(self):
         await self.set_up_contract('ArrayBoa2Test1.py')
@@ -913,8 +909,7 @@ class TestList(boatestcase.BoaTestCase):
         self.assertEqual([1, 2, 3, '4'], result)
 
     def test_list_append_mismatched_type(self):
-        path = self.get_contract_path('MismatchedTypeListAppendValue.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MismatchedTypeListAppendValue.py')
 
     def test_list_append_with_builtin_compile(self):
         expected_output = (
@@ -955,8 +950,7 @@ class TestList(boatestcase.BoaTestCase):
         self.assertEqual([1, 2, 3, 4], result)
 
     def test_list_append_with_builtin_mismatched_type(self):
-        path = self.get_contract_path('MismatchedTypeListAppendWithBuiltin.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MismatchedTypeListAppendWithBuiltin.py')
 
     async def test_boa2_list_append_test(self):
         await self.set_up_contract('ListAppendBoa2Test.py')
@@ -1052,12 +1046,10 @@ class TestList(boatestcase.BoaTestCase):
         self.assertEqual([1, 2, 3, '4', 5, 1], result)
 
     def test_list_extend_mismatched_type(self):
-        path = self.get_contract_path('MismatchedTypeListExtendValue.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MismatchedTypeListExtendValue.py')
 
     def test_list_extend_mismatched_iterable_value_type(self):
-        path = self.get_contract_path('MismatchedTypeListExtendTupleValue.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MismatchedTypeListExtendTupleValue.py')
 
     async def test_list_extend_with_builtin(self):
         await self.set_up_contract('ListExtendWithBuiltin.py')
@@ -1066,8 +1058,7 @@ class TestList(boatestcase.BoaTestCase):
         self.assertEqual([1, 2, 3, 4, 5, 6], result)
 
     def test_list_extend_with_builtin_mismatched_type(self):
-        path = self.get_contract_path('MismatchedTypeListExtendWithBuiltin.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MismatchedTypeListExtendWithBuiltin.py')
 
     # endregion
 
@@ -1335,8 +1326,7 @@ class TestList(boatestcase.BoaTestCase):
         self.assertRaises(IndexError, list_.pop, index)
 
     def test_list_pop_mismatched_type_argument(self):
-        path = self.get_contract_path('PopListMismatchedTypeArgument.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'PopListMismatchedTypeArgument.py')
 
     def test_list_pop_mismatched_type_result_compile(self):
         expected_output = (
@@ -1371,8 +1361,7 @@ class TestList(boatestcase.BoaTestCase):
             + Opcode.LDLOC1     # return b
             + Opcode.RET
         )
-        path = self.get_contract_path('PopListMismatchedTypeResult.py')
-        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, 'PopListMismatchedTypeResult.py')
         self.assertEqual(expected_output, output)
 
     async def test_list_pop_mismatched_type_result(self):
@@ -1382,8 +1371,7 @@ class TestList(boatestcase.BoaTestCase):
         self.assertEqual(3, result)
 
     def test_list_pop_too_many_arguments(self):
-        path = self.get_contract_path('PopListTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'PopListTooManyArguments.py')
 
     async def test_boa2_list_remove_test(self):
         await self.set_up_contract('ListRemoveBoa2Test.py')
@@ -1650,8 +1638,7 @@ class TestList(boatestcase.BoaTestCase):
 
     def test_list_sort_with_args(self):
         # list.sort arguments must be used as kwargs
-        path = self.get_contract_path('SortArgsList.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'SortArgsList.py')
 
     async def test_list_sort_reverse_true(self):
         await self.set_up_contract('SortReverseTrueList.py')
@@ -1670,31 +1657,26 @@ class TestList(boatestcase.BoaTestCase):
         self.assertEqual(sorted_list, result)
 
     def test_list_sort_key(self):
-        path = self.get_contract_path('SortKeyList.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'SortKeyList.py')
 
     def test_list_any_sort(self):
-        path = self.get_contract_path('SortListAny.py')
-        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'SortListAny.py')
 
     def test_list_of_list_sort(self):
-        path = self.get_contract_path('SortListOfList.py')
-        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'SortListOfList.py')
 
     # endregion
 
     # region TestComprehension
 
     def test_list_comprehension_str(self):
-        path = self.get_contract_path('ListComprehensionStr.py')
-        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'ListComprehensionStr.py')
 
     # endregion
 
     # region TestDel
 
     def test_del_list_item(self):
-        path = self.get_contract_path('ListDelItem.py')
-        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'ListDelItem.py')
 
     # endregion

--- a/boa3_test/tests/compiler_tests/test_logical.py
+++ b/boa3_test/tests/compiler_tests/test_logical.py
@@ -39,8 +39,7 @@ class TestLogical(boatestcase.BoaTestCase):
         self.assertEqual(False, result)
 
     def test_mismatched_type_binary_operation(self):
-        path = self.get_contract_path('LogicMismatchedOperandAnd.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'LogicMismatchedOperandAnd.py')
 
     # endregion
 
@@ -69,8 +68,7 @@ class TestLogical(boatestcase.BoaTestCase):
         self.assertEqual(True, result)
 
     async def test_mismatched_type_unary_operation(self):
-        path = self.get_contract_path('LogicMismatchedOperandNot.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'LogicMismatchedOperandNot.py')
 
     # endregion
 
@@ -173,8 +171,7 @@ class TestLogical(boatestcase.BoaTestCase):
         self.assertEqual(FindOptions.NONE << FindOptions.DESERIALIZE_VALUES, result)
 
     async def test_mismatched_type_logic_left_shift(self):
-        path = self.get_contract_path('LogicMismatchedOperandLogicLeftShift.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'LogicMismatchedOperandLogicLeftShift.py')
 
     # endregion
 
@@ -240,8 +237,7 @@ class TestLogical(boatestcase.BoaTestCase):
         self.assertEqual(FindOptions.NONE & FindOptions.DESERIALIZE_VALUES, result)
 
     async def test_mismatched_type_logic_and(self):
-        path = self.get_contract_path('LogicMismatchedOperandLogicAnd.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'LogicMismatchedOperandLogicAnd.py')
 
     # endregion
 
@@ -301,8 +297,7 @@ class TestLogical(boatestcase.BoaTestCase):
         self.assertEqual(3, result)
 
     async def test_mismatched_type_logic_not(self):
-        path = self.get_contract_path('LogicMismatchedOperandLogicNot.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'LogicMismatchedOperandLogicNot.py')
 
     # endregion
 
@@ -380,8 +375,7 @@ class TestLogical(boatestcase.BoaTestCase):
         self.assertEqual(123456789, result)
 
     async def test_mismatched_type_logic_or(self):
-        path = self.get_contract_path('LogicMismatchedOperandLogicOr.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'LogicMismatchedOperandLogicOr.py')
 
     # endregion
 
@@ -446,8 +440,7 @@ class TestLogical(boatestcase.BoaTestCase):
         self.assertEqual(FindOptions.NONE ^ FindOptions.DESERIALIZE_VALUES, result)
 
     async def test_mismatched_type_logic_xor(self):
-        path = self.get_contract_path('LogicMismatchedOperandLogicXor.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'LogicMismatchedOperandLogicXor.py')
 
     # endregion
 
@@ -597,7 +590,6 @@ class TestLogical(boatestcase.BoaTestCase):
         self.assertEqual(FindOptions.NONE >> FindOptions.DESERIALIZE_VALUES, result)
 
     async def test_mismatched_type_logic_right_shift(self):
-        path = self.get_contract_path('LogicMismatchedOperandLogicRightShift.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'LogicMismatchedOperandLogicRightShift.py')
 
     # endregion

--- a/boa3_test/tests/compiler_tests/test_math.py
+++ b/boa3_test/tests/compiler_tests/test_math.py
@@ -7,8 +7,7 @@ class TestMath(boatestcase.BoaTestCase):
     default_folder: str = 'test_sc/math_test'
 
     def test_no_import(self):
-        path = self.get_contract_path('NoImport.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, 'NoImport.py')
 
     # region pow test
 

--- a/boa3_test/tests/compiler_tests/test_metadata.py
+++ b/boa3_test/tests/compiler_tests/test_metadata.py
@@ -31,17 +31,14 @@ class TestMetadata(boatestcase.BoaTestCase):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('MetadataInfoWithDecorator.py')
-        output, _ = self.assertCompilerLogs(CompilerWarning.DeprecatedSymbol, path)
+        output, _ = self.assertCompilerLogs(CompilerWarning.DeprecatedSymbol, 'MetadataInfoWithDecorator.py')
         self.assertEqual(expected_output, output)
 
     def test_metadata_info_method_mismatched_type(self):
-        path = self.get_contract_path('MetadataInfoMethodMismatchedReturn.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MetadataInfoMethodMismatchedReturn.py')
 
     def test_metadata_info_method_no_return(self):
-        path = self.get_contract_path('MetadataInfoMethodNoReturn.py')
-        self.assertCompilerLogs(CompilerError.MissingReturnStatement, path)
+        self.assertCompilerLogs(CompilerError.MissingReturnStatement, 'MetadataInfoMethodNoReturn.py')
 
     def test_metadata_info_multiple_method(self):
         expected_output = (
@@ -49,10 +46,8 @@ class TestMetadata(boatestcase.BoaTestCase):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('MetadataInfoMultipleMethod.py')
-        self.assertCompilerLogs(CompilerWarning.RedeclaredSymbol, path)
+        output, manifest = self.assertCompilerLogs(CompilerWarning.RedeclaredSymbol, 'MetadataInfoMultipleMethod.py')
 
-        output, manifest = self.compile_and_save(path)
         self.assertEqual(expected_output, output)
 
         self.assertIn('extra', manifest)
@@ -61,20 +56,16 @@ class TestMetadata(boatestcase.BoaTestCase):
         self.assertEqual('func1', manifest['extra']['Description'])
 
     def test_metadata_method_with_args(self):
-        path = self.get_contract_path('MetadataMethodWithArgs.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'MetadataMethodWithArgs.py')
 
     def test_metadata_method_called_by_user_method(self):
-        path = self.get_contract_path('MetadataMethodCalledByUserMethod.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, 'MetadataMethodCalledByUserMethod.py')
 
     def test_metadata_object_call_user_method(self):
-        path = self.get_contract_path('MetadataObjectCallUserMethod.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, 'MetadataObjectCallUserMethod.py')
 
     def test_metadata_object_type_user_method(self):
-        path = self.get_contract_path('MetadataObjectTypeUserMethod.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, 'MetadataObjectTypeUserMethod.py')
 
     def test_metadata_info_author(self):
         expected_output = (
@@ -92,8 +83,7 @@ class TestMetadata(boatestcase.BoaTestCase):
         self.assertEqual('Test', manifest['extra']['Author'])
 
     def test_metadata_info_author_mismatched_type(self):
-        path = self.get_contract_path('MetadataInfoAuthorMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MetadataInfoAuthorMismatchedType.py')
 
     def test_metadata_info_email(self):
         expected_output = (
@@ -111,8 +101,7 @@ class TestMetadata(boatestcase.BoaTestCase):
         self.assertEqual('test@test.com', manifest['extra']['Email'])
 
     def test_metadata_info_email_mismatched_type(self):
-        path = self.get_contract_path('MetadataInfoEmailMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MetadataInfoEmailMismatchedType.py')
 
     def test_metadata_info_description(self):
         expected_output = (
@@ -130,8 +119,7 @@ class TestMetadata(boatestcase.BoaTestCase):
         self.assertEqual('This is an example', manifest['extra']['Description'])
 
     def test_metadata_info_description_mismatched_type(self):
-        path = self.get_contract_path('MetadataInfoDescriptionMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MetadataInfoDescriptionMismatchedType.py')
 
     def test_metadata_info_extras(self):
         expected_output = (
@@ -271,8 +259,7 @@ class TestMetadata(boatestcase.BoaTestCase):
         self.assertEqual(len(manifest['supportedstandards']), 0)
 
     def test_metadata_info_supported_standards_missing_implementations_nep17(self):
-        path = self.get_contract_path('MetadataInfoSupportedStandardsMissingImplementationNEP17.py')
-        self.assertCompilerLogs(CompilerError.MissingStandardDefinition, path)
+        self.assertCompilerLogs(CompilerError.MissingStandardDefinition, 'MetadataInfoSupportedStandardsMissingImplementationNEP17.py')
 
     def test_metadata_info_supported_standards_nep11_divisible(self):
         path = self.get_contract_path('MetadataInfoSupportedStandardsNEP11Divisible.py')
@@ -311,24 +298,19 @@ class TestMetadata(boatestcase.BoaTestCase):
         self.assertIn('NEP-11', manifest['supportedstandards'])
 
     def test_metadata_info_supported_standards_missing_implementations_nep11(self):
-        path = self.get_contract_path('MetadataInfoSupportedStandardsMissingImplementationNEP11.py')
-        self.assertCompilerLogs(CompilerError.MissingStandardDefinition, path)
+        self.assertCompilerLogs(CompilerError.MissingStandardDefinition, 'MetadataInfoSupportedStandardsMissingImplementationNEP11.py')
 
     def test_metadata_info_supported_standards_missing_implementations_nep11_divisible(self):
-        path = self.get_contract_path('MetadataInfoSupportedStandardsMissingImplementationNEP11Divisible.py')
-        self.assertCompilerLogs(CompilerError.MissingStandardDefinition, path)
+        self.assertCompilerLogs(CompilerError.MissingStandardDefinition, 'MetadataInfoSupportedStandardsMissingImplementationNEP11Divisible.py')
 
     def test_metadata_info_supported_standards_missing_implementations_nep11_optional_method(self):
-        path = self.get_contract_path('MetadataInfoSupportedStandardsMissingImplementationNEP11OptionalMethods.py')
-        self.assertCompilerLogs(CompilerError.MissingStandardDefinition, path)
+        self.assertCompilerLogs(CompilerError.MissingStandardDefinition, 'MetadataInfoSupportedStandardsMissingImplementationNEP11OptionalMethods.py')
 
     def test_metadata_info_supported_standards_missing_event_nep11(self):
-        path = self.get_contract_path('MetadataInfoSupportedStandardsMissingEventNEP11.py')
-        self.assertCompilerLogs(CompilerError.MissingStandardDefinition, path)
+        self.assertCompilerLogs(CompilerError.MissingStandardDefinition, 'MetadataInfoSupportedStandardsMissingEventNEP11.py')
 
     def test_metadata_info_supported_standards_mismatched_type(self):
-        path = self.get_contract_path('MetadataInfoDescriptionMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MetadataInfoDescriptionMismatchedType.py')
 
     def test_metadata_info_supported_standards_bytestring_as_bytes(self):
         path = self.get_contract_path('MetadataInfoSupportedStandardsByteStringAsBytes.py')
@@ -534,8 +516,7 @@ class TestMetadata(boatestcase.BoaTestCase):
         self.assertEqual((manifest['name']), "MetadataInfoDefault")
 
     def test_metadata_info_name_mismatched_type(self):
-        path = self.get_contract_path('MetadataInfoNameMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MetadataInfoNameMismatchedType.py')
 
     async def test_metadata_info_groups(self):
         path = self.get_contract_path('MetadataInfoGroups.py')
@@ -601,8 +582,7 @@ class TestMetadata(boatestcase.BoaTestCase):
         self.assertEqual(generated_source, '')
 
     def test_metadata_info_source_mismatched_type(self):
-        path = self.get_contract_path('MetadataInfoSourceMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MetadataInfoSourceMismatchedType.py')
 
     def test_metadata_importing_external_contract_before_metadata_method(self):
         path = self.get_contract_path('MetadataImportingExternalContractBeforeMetadataMethod.py')

--- a/boa3_test/tests/compiler_tests/test_native/test_contract_management.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_contract_management.py
@@ -40,8 +40,7 @@ class TestContractManagementContract(boatestcase.BoaTestCase):
         self.assertEqual(minimum_cost, result)
 
     def test_get_minimum_deployment_fee_too_many_parameters(self):
-        path = self.get_contract_path('GetMinimumDeploymentFeeTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'GetMinimumDeploymentFeeTooManyArguments.py')
 
     async def test_get_contract(self):
         call_contract_path = self.get_contract_path('test_sc/arithmetic_test', 'Addition.py')
@@ -131,12 +130,10 @@ class TestContractManagementContract(boatestcase.BoaTestCase):
         self.assertEqual(data, notifies[1].state[0])  # data
 
     def test_deploy_contract_too_many_parameters(self):
-        path = self.get_contract_path('DeployContractTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'DeployContractTooManyArguments.py')
 
     def test_deploy_contract_too_few_parameters(self):
-        path = self.get_contract_path('DeployContractTooFewArguments.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'DeployContractTooFewArguments.py')
 
     async def test_update_contract(self):
         await self.set_up_contract('UpdateContract.py')
@@ -201,12 +198,10 @@ class TestContractManagementContract(boatestcase.BoaTestCase):
         self.assertEqual(data, notifies[1].state[0])
 
     def test_update_contract_too_many_parameters(self):
-        path = self.get_contract_path('UpdateContractTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'UpdateContractTooManyArguments.py')
 
     def test_update_contract_too_few_parameters(self):
-        path = self.get_contract_path('UpdateContractTooFewArguments.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'UpdateContractTooFewArguments.py')
 
     async def test_destroy_contract(self):
         await self.set_up_contract('DestroyContract.py')
@@ -232,5 +227,4 @@ class TestContractManagementContract(boatestcase.BoaTestCase):
         self.assertRegex(str(context.exception), f'called contract {contract_hash} not found')
 
     def test_destroy_contract_too_many_parameters(self):
-        path = self.get_contract_path('DestroyContractTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'DestroyContractTooManyArguments.py')

--- a/boa3_test/tests/compiler_tests/test_native/test_cryptolib.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_cryptolib.py
@@ -66,12 +66,10 @@ class TestCryptoLibClass(boatestcase.BoaTestCase):
         self.assertEqual(expected_result.digest(), result)
 
     def test_ripemd160_too_many_parameters(self):
-        path = self.get_contract_path('Ripemd160TooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'Ripemd160TooManyArguments.py')
 
     def test_ripemd160_too_few_parameters(self):
-        path = self.get_contract_path('Ripemd160TooFewArguments.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'Ripemd160TooFewArguments.py')
 
     async def test_sha256_str(self):
         await self.set_up_contract('Sha256Str.py')
@@ -106,28 +104,23 @@ class TestCryptoLibClass(boatestcase.BoaTestCase):
         self.assertEqual(expected_result.digest(), result)
 
     def test_sha256_too_many_parameters(self):
-        path = self.get_contract_path('Sha256TooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'Sha256TooManyArguments.py')
 
     def test_sha256_too_few_parameters(self):
-        path = self.get_contract_path('Sha256TooFewArguments.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'Sha256TooFewArguments.py')
 
     def test_verify_with_ecdsa(self):
         path = self.get_contract_path('VerifyWithECDsa.py')
         self.compile(path)
 
     def test_verify_with_ecdsa_secp256r1_str(self):
-        path = self.get_contract_path('VerifyWithECDsaSecp256r1Str.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'VerifyWithECDsaSecp256r1Str.py')
 
     def test_verify_with_ecdsa_secp256r1_bool(self):
-        path = self.get_contract_path('VerifyWithECDsaSecp256r1Bool.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'VerifyWithECDsaSecp256r1Bool.py')
 
     def test_verify_with_ecdsa_secp256r1_int(self):
-        path = self.get_contract_path('VerifyWithECDsaSecp256r1Int.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'VerifyWithECDsaSecp256r1Int.py')
 
     def test_verify_with_ecdsa_secp256r1_bytes(self):
         byte_input1 = b'0123456789ABCDEFGHIJKLMNOPQRSTUVW'
@@ -156,20 +149,16 @@ class TestCryptoLibClass(boatestcase.BoaTestCase):
         self.assertEqual(expected_output, output)
 
     def test_verify_with_ecdsa_secp256r1_mismatched_type(self):
-        path = self.get_contract_path('VerifyWithECDsaSecp256r1MismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'VerifyWithECDsaSecp256r1MismatchedType.py')
 
     def test_verify_with_ecdsa_secp256k1_str(self):
-        path = self.get_contract_path('VerifyWithECDsaSecp256k1Str.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'VerifyWithECDsaSecp256k1Str.py')
 
     def test_verify_with_ecdsa_secp256k1_bool(self):
-        path = self.get_contract_path('VerifyWithECDsaSecp256k1Bool.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'VerifyWithECDsaSecp256k1Bool.py')
 
     def test_verify_with_ecdsa_secp256k1_int(self):
-        path = self.get_contract_path('VerifyWithECDsaSecp256k1Int.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'VerifyWithECDsaSecp256k1Int.py')
 
     def test_verify_with_ecdsa_secp256k1_bytes(self):
         byte_input1 = b'0123456789ABCDEFGHIJKLMNOPQRSTUVW'
@@ -198,8 +187,7 @@ class TestCryptoLibClass(boatestcase.BoaTestCase):
         self.assertEqual(expected_output, output)
 
     def test_verify_with_ecdsa_secp256k1_mismatched_type(self):
-        path = self.get_contract_path('VerifyWithECDsaSecp256k1MismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'VerifyWithECDsaSecp256k1MismatchedType.py')
 
     def test_murmur32(self):
         expected_output = (
@@ -230,8 +218,7 @@ class TestCryptoLibClass(boatestcase.BoaTestCase):
         self.assertEqual(expected_output, output)
 
     def test_bls12_381_add_mismatched_type(self):
-        path = self.get_contract_path('Bls12381AddMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'Bls12381AddMismatchedType.py')
 
     def test_bls12_381_deserialize(self):
         expected_output = (
@@ -261,8 +248,7 @@ class TestCryptoLibClass(boatestcase.BoaTestCase):
         self.assertEqual(expected_output, output)
 
     def test_bls12_381_equal_mismatched_type(self):
-        path = self.get_contract_path('Bls12381EqualMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'Bls12381EqualMismatchedType.py')
 
     def test_bls12_381_mul(self):
         expected_output = (
@@ -280,8 +266,7 @@ class TestCryptoLibClass(boatestcase.BoaTestCase):
         self.assertEqual(expected_output, output)
 
     def test_bls12_381_mul_mismatched_type(self):
-        path = self.get_contract_path('Bls12381MulMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'Bls12381MulMismatchedType.py')
 
     def test_bls12_381_pairing(self):
         expected_output = (
@@ -298,8 +283,7 @@ class TestCryptoLibClass(boatestcase.BoaTestCase):
         self.assertEqual(expected_output, output)
 
     def test_bls12_381_pairing_mismatched_type(self):
-        path = self.get_contract_path('Bls12381PairingMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'Bls12381PairingMismatchedType.py')
 
     def test_bls12_381_serialize(self):
         expected_output = (
@@ -315,5 +299,4 @@ class TestCryptoLibClass(boatestcase.BoaTestCase):
         self.assertEqual(expected_output, output)
 
     def test_bls12_381_serialize_mismatched_type(self):
-        path = self.get_contract_path('Bls12381SerializeMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'Bls12381SerializeMismatchedType.py')

--- a/boa3_test/tests/compiler_tests/test_native/test_gas.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_gas.py
@@ -45,8 +45,7 @@ class TestGasClass(boatestcase.BoaTestCase):
         self.assertEqual('GAS', result)
 
     def test_symbol_too_many_parameters(self):
-        path = self.get_contract_path('SymbolTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'SymbolTooManyArguments.py')
 
     async def test_decimals(self):
         await self.set_up_contract('Decimals.py')
@@ -55,8 +54,7 @@ class TestGasClass(boatestcase.BoaTestCase):
         self.assertEqual(self.GAS_DECIMALS, result)
 
     def test_decimals_too_many_parameters(self):
-        path = self.get_contract_path('DecimalsTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'DecimalsTooManyArguments.py')
 
     async def test_total_supply(self):
         await self.set_up_contract('TotalSupply.py')
@@ -65,8 +63,7 @@ class TestGasClass(boatestcase.BoaTestCase):
         self.assertGreater(result, 0)
 
     def test_total_supply_too_many_parameters(self):
-        path = self.get_contract_path('TotalSupplyTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'TotalSupplyTooManyArguments.py')
 
     async def test_balance_of(self):
         await self.set_up_contract('BalanceOf.py')
@@ -80,8 +77,7 @@ class TestGasClass(boatestcase.BoaTestCase):
         self.assertEqual(expected, result)
 
     def test_balance_of_too_many_parameters(self):
-        path = self.get_contract_path('BalanceOfTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'BalanceOfTooManyArguments.py')
 
     async def test_transfer(self):
         await self.set_up_contract('Transfer.py')
@@ -171,12 +167,10 @@ class TestGasClass(boatestcase.BoaTestCase):
         self.assertEqual(amount, transfers[0].amount)
 
     def test_transfer_too_many_parameters(self):
-        path = self.get_contract_path('TransferTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'TransferTooManyArguments.py')
 
     def test_transfer_too_few__parameters(self):
-        path = self.get_contract_path('TransferTooFewArguments.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'TransferTooFewArguments.py')
 
     async def test_import_with_alias(self):
         await self.set_up_contract('ImportWithAlias.py')

--- a/boa3_test/tests/compiler_tests/test_native/test_ledger.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_ledger.py
@@ -63,8 +63,7 @@ class TestLedgerContract(boatestcase.BoaTestCase):
         self.assertEqual(expected, result)
 
     def test_get_block_mismatched_types(self):
-        path = self.get_contract_path('GetBlockMismatchedTypes.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'GetBlockMismatchedTypes.py')
 
     def test_get_transaction_compile(self):
         expected_output = (
@@ -94,8 +93,7 @@ class TestLedgerContract(boatestcase.BoaTestCase):
         self.assertEqual(expected, result)
 
     def test_get_transaction_mismatched_type(self):
-        path = self.get_contract_path('GetTransactionMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'GetTransactionMismatchedType.py')
 
     def test_get_transaction_from_block_int_compile(self):
         expected_output = (
@@ -168,8 +166,7 @@ class TestLedgerContract(boatestcase.BoaTestCase):
         self.assertEqual(expected, result)
 
     def test_get_transaction_from_block_mismatched_type(self):
-        path = self.get_contract_path('GetTransactionFromBlockMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'GetTransactionFromBlockMismatchedType.py')
 
     def test_get_transaction_height_compile(self):
         expected_output = (
@@ -194,8 +191,7 @@ class TestLedgerContract(boatestcase.BoaTestCase):
         self.assertEqual(expected, result)
 
     def test_get_transaction_height_mismatched_type(self):
-        path = self.get_contract_path('GetTransactionHeightMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'GetTransactionHeightMismatchedType.py')
 
     def test_get_transaction_signers_compile(self):
         expected_output = (
@@ -233,8 +229,7 @@ class TestLedgerContract(boatestcase.BoaTestCase):
         self.assertEqual(expected, result)
 
     def test_get_transaction_signers_mismatched_type(self):
-        path = self.get_contract_path('GetTransactionSignersMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'GetTransactionSignersMismatchedType.py')
 
     def test_get_transaction_vm_state_compile(self):
         expected_output = (
@@ -266,8 +261,7 @@ class TestLedgerContract(boatestcase.BoaTestCase):
         self.assertEqual(native_result, contract_invoke)
 
     def test_get_transaction_vm_state_mismatched_type(self):
-        path = self.get_contract_path('GetTransactionVMStateMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'GetTransactionVMStateMismatchedType.py')
 
     async def test_get_current_index(self):
         await self.set_up_contract('GetCurrentIndex.py')

--- a/boa3_test/tests/compiler_tests/test_native/test_neo.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_neo.py
@@ -89,8 +89,7 @@ class TestNeoClass(boatestcase.BoaTestCase):
         self.assertEqual('NEO', result)
 
     def test_symbol_too_many_parameters(self):
-        path = self.get_contract_path('SymbolTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'SymbolTooManyArguments.py')
 
     async def test_decimals(self):
         await self.set_up_contract('Decimals.py')
@@ -99,8 +98,7 @@ class TestNeoClass(boatestcase.BoaTestCase):
         self.assertEqual(0, result)
 
     def test_decimals_too_many_parameters(self):
-        path = self.get_contract_path('DecimalsTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'DecimalsTooManyArguments.py')
 
     async def test_total_supply(self):
         await self.set_up_contract('TotalSupply.py')
@@ -109,8 +107,7 @@ class TestNeoClass(boatestcase.BoaTestCase):
         self.assertEqual(100_000_000, result)
 
     def test_total_supply_too_many_parameters(self):
-        path = self.get_contract_path('TotalSupplyTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'TotalSupplyTooManyArguments.py')
 
     async def test_balance_of(self):
         await self.set_up_contract('BalanceOf.py')
@@ -123,8 +120,7 @@ class TestNeoClass(boatestcase.BoaTestCase):
         self.assertEqual(self.balance_test_amount, result)
 
     def test_balance_of_too_many_parameters(self):
-        path = self.get_contract_path('BalanceOfTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'BalanceOfTooManyArguments.py')
 
     async def test_transfer(self):
         await self.set_up_contract('Transfer.py')
@@ -218,12 +214,10 @@ class TestNeoClass(boatestcase.BoaTestCase):
         self.assertEqual(amount, transfers[0].amount)
 
     def test_transfer_too_many_parameters(self):
-        path = self.get_contract_path('TransferTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'TransferTooManyArguments.py')
 
     def test_transfer_too_few__parameters(self):
-        path = self.get_contract_path('TransferTooFewArguments.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'TransferTooFewArguments.py')
 
     async def test_get_gas_per_block(self):
         await self.set_up_contract('GetGasPerBlock.py')
@@ -443,12 +437,10 @@ class TestNeoClass(boatestcase.BoaTestCase):
         self.assertIn((candidate_pubkey, 0), result)
 
     def test_un_vote_too_many_parameters(self):
-        path = self.get_contract_path('UnVoteTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'UnVoteTooManyArguments.py')
 
     def test_un_vote_too_few_parameters(self):
-        path = self.get_contract_path('UnVoteTooFewArguments.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'UnVoteTooFewArguments.py')
 
     async def test_get_all_candidates(self):
         await self.set_up_contract('GetAllCandidates.py')

--- a/boa3_test/tests/compiler_tests/test_native/test_oracle.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_oracle.py
@@ -331,20 +331,16 @@ class TestNativeContracts(boatestcase.BoaTestCase):
         self.assertRegex(str(context.exception), 'some of the arguments are invalid')
 
     def test_oracle_request_url_mismatched_type(self):
-        path = self.get_contract_path('OracleRequestUrlMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'OracleRequestUrlMismatchedType.py')
 
     def test_oracle_request_filter_mismatched_type(self):
-        path = self.get_contract_path('OracleRequestFilterMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'OracleRequestFilterMismatchedType.py')
 
     def test_oracle_request_callback_mismatched_type(self):
-        path = self.get_contract_path('OracleRequestCallCallbackMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'OracleRequestCallCallbackMismatchedType.py')
 
     def test_oracle_request_gas_mismatched_type(self):
-        path = self.get_contract_path('OracleRequestGasMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'OracleRequestGasMismatchedType.py')
 
     async def test_import_interop_oracle(self):
         await self.set_up_contract('ImportOracle.py')

--- a/boa3_test/tests/compiler_tests/test_native/test_policy.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_policy.py
@@ -40,8 +40,7 @@ class TestPolicyContract(boatestcase.BoaTestCase):
         self.assertEqual(expected, result)
 
     def test_get_exec_fee_too_many_parameters(self):
-        path = self.get_contract_path('GetExecFeeFactorTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'GetExecFeeFactorTooManyArguments.py')
 
     async def test_get_fee_per_byte(self):
         await self.set_up_contract('GetFeePerByte.py')
@@ -51,8 +50,7 @@ class TestPolicyContract(boatestcase.BoaTestCase):
         self.assertEqual(expected, result)
 
     def test_get_fee_per_byte_too_many_parameters(self):
-        path = self.get_contract_path('GetFeePerByteTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'GetFeePerByteTooManyArguments.py')
 
     async def test_get_storage_price(self):
         await self.set_up_contract('GetStoragePrice.py')
@@ -62,8 +60,7 @@ class TestPolicyContract(boatestcase.BoaTestCase):
         self.assertEqual(expected, result)
 
     def test_get_storage_price_too_many_parameters(self):
-        path = self.get_contract_path('GetStoragePriceTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'GetStoragePriceTooManyArguments.py')
 
     async def test_is_blocked(self):
         await self.set_up_contract('IsBlocked.py')
@@ -72,19 +69,14 @@ class TestPolicyContract(boatestcase.BoaTestCase):
         self.assertEqual(False, result)
 
     def test_is_blocked_mismatched_type(self):
-        path = self.get_contract_path('IsBlockedMismatchedTypeInt.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'IsBlockedMismatchedTypeInt.py')
 
-        path = self.get_contract_path('IsBlockedMismatchedTypeStr.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'IsBlockedMismatchedTypeStr.py')
 
-        path = self.get_contract_path('IsBlockedMismatchedTypeBool.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'IsBlockedMismatchedTypeBool.py')
 
     def test_is_blocked_too_many_parameters(self):
-        path = self.get_contract_path('IsBlockedTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'IsBlockedTooManyArguments.py')
 
     def test_is_blocked_too_few_parameters(self):
-        path = self.get_contract_path('IsBlockedTooFewArguments.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'IsBlockedTooFewArguments.py')

--- a/boa3_test/tests/compiler_tests/test_native/test_rolemanagement.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_rolemanagement.py
@@ -29,9 +29,7 @@ class TestRoleManagementClass(boatestcase.BoaTestCase):
         self.assertEqual(expected_output, output)
 
     def test_get_designated_by_role_too_many_parameters(self):
-        path = self.get_contract_path('GetDesignatedByRoleTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'GetDesignatedByRoleTooManyArguments.py')
 
     def test_get_designated_by_role_too_few_parameters(self):
-        path = self.get_contract_path('GetDesignatedByRoleTooFewArguments.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'GetDesignatedByRoleTooFewArguments.py')

--- a/boa3_test/tests/compiler_tests/test_native/test_stdlib.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_stdlib.py
@@ -43,8 +43,7 @@ class TestStdlibClass(boatestcase.BoaTestCase):
         self.assertEqual(expected_result, result)
 
     def test_base64_encode_mismatched_type(self):
-        path = self.get_contract_path('Base64EncodeMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'Base64EncodeMismatchedType.py')
 
     async def test_base64_decode(self):
         import base64
@@ -71,8 +70,7 @@ class TestStdlibClass(boatestcase.BoaTestCase):
         self.assertEqual(String(long_string).to_bytes(), result)
 
     def test_base64_decode_mismatched_type(self):
-        path = self.get_contract_path('Base64DecodeMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'Base64DecodeMismatchedType.py')
 
     async def test_base58_encode(self):
         import base58
@@ -99,8 +97,7 @@ class TestStdlibClass(boatestcase.BoaTestCase):
         self.assertEqual(expected_result, result)
 
     def test_base58_encode_mismatched_type(self):
-        path = self.get_contract_path('Base58EncodeMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'Base58EncodeMismatchedType.py')
 
     async def test_base58_decode(self):
         import base58
@@ -129,8 +126,7 @@ class TestStdlibClass(boatestcase.BoaTestCase):
         self.assertEqual(long_string, result)
 
     def test_base58_decode_mismatched_type(self):
-        path = self.get_contract_path('Base58DecodeMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'Base58DecodeMismatchedType.py')
 
     async def test_base58_check_decode(self):
         import base58
@@ -159,8 +155,7 @@ class TestStdlibClass(boatestcase.BoaTestCase):
         self.assertEqual(long_string, result)
 
     def test_base58_check_decode_mismatched_type(self):
-        path = self.get_contract_path('Base58CheckDecodeMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'Base58CheckDecodeMismatchedType.py')
 
     async def test_base58_check_encode(self):
         import base58
@@ -187,8 +182,7 @@ class TestStdlibClass(boatestcase.BoaTestCase):
         self.assertEqual(expected_result, result)
 
     def test_base58_check_encode_mismatched_type(self):
-        path = self.get_contract_path('Base58CheckEncodeMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'Base58CheckEncodeMismatchedType.py')
 
     async def test_serialize_int(self):
         await self.set_up_contract('SerializeInt.py')
@@ -265,8 +259,7 @@ class TestStdlibClass(boatestcase.BoaTestCase):
         self.assertEqual(expected_result, result)
 
     def test_deserialize_mismatched_type(self):
-        path = self.get_contract_path('DeserializeMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'DeserializeMismatchedType.py')
 
     async def test_json_serialize(self):
         await self.set_up_contract('JsonSerialize.py')
@@ -406,16 +399,13 @@ class TestStdlibClass(boatestcase.BoaTestCase):
         self.assertRegex(str(context.exception), self.INVALID_FORMAT_MSG)
 
     def test_atoi_too_few_parameters(self):
-        path = self.get_contract_path('AtoiTooFewArguments.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'AtoiTooFewArguments.py')
 
     def test_atoi_too_many_parameters(self):
-        path = self.get_contract_path('AtoiTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'AtoiTooManyArguments.py')
 
     def test_atoi_mismatched_type(self):
-        path = self.get_contract_path('AtoiMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'AtoiMismatchedType.py')
 
     async def test_itoa(self):
         await self.set_up_contract('Itoa')
@@ -450,16 +440,13 @@ class TestStdlibClass(boatestcase.BoaTestCase):
         self.assertEqual('-1', result)
 
     def test_itoa_too_few_arguments(self):
-        path = self.get_contract_path('ItoaTooFewArguments')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'ItoaTooFewArguments')
 
     def test_itoa_too_many_arguments(self):
-        path = self.get_contract_path('ItoaTooManyArguments')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'ItoaTooManyArguments')
 
     def test_itoa_mismatched_type(self):
-        path = self.get_contract_path('ItoaMismatchedType')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'ItoaMismatchedType')
 
     async def test_memory_search(self):
         await self.set_up_contract('MemorySearch')
@@ -594,16 +581,13 @@ class TestStdlibClass(boatestcase.BoaTestCase):
         self.assertEqual(-1, result)
 
     def test_memory_search_mismatched_type(self):
-        path = self.get_contract_path('MemorySearchMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MemorySearchMismatchedType.py')
 
     def test_memory_search_too_few_parameters(self):
-        path = self.get_contract_path('MemorySearchTooFewArguments.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'MemorySearchTooFewArguments.py')
 
     def test_memory_search_too_many_parameters(self):
-        path = self.get_contract_path('MemorySearchTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'MemorySearchTooManyArguments.py')
 
     async def test_memory_compare(self):
         await self.set_up_contract('MemoryCompare')
@@ -627,13 +611,10 @@ class TestStdlibClass(boatestcase.BoaTestCase):
         self.assertEqual(-1, result)
 
     def test_memory_compare_too_few_parameters(self):
-        path = self.get_contract_path('MemoryCompareTooFewArguments.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'MemoryCompareTooFewArguments.py')
 
     def test_memory_compare_too_many_parameters(self):
-        path = self.get_contract_path('MemoryCompareTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'MemoryCompareTooManyArguments.py')
 
     def test_memory_compare_mismatched_type(self):
-        path = self.get_contract_path('MemoryCompareMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MemoryCompareMismatchedType.py')

--- a/boa3_test/tests/compiler_tests/test_neo_types.py
+++ b/boa3_test/tests/compiler_tests/test_neo_types.py
@@ -79,8 +79,7 @@ class TestNeoTypes(boatestcase.BoaTestCase):
         self.assertEqual(value.to_array() + b'123', result)
 
     def test_uint160_mismatched_type(self):
-        path = self.get_contract_path('uint160', 'UInt160CallMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'uint160', 'UInt160CallMismatchedType.py')
 
     # endregion
 
@@ -155,8 +154,7 @@ class TestNeoTypes(boatestcase.BoaTestCase):
         self.assertEqual(value.to_array() + b'123', result)
 
     def test_uint256_mismatched_type(self):
-        path = self.get_contract_path('uint256', 'UInt256CallMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'uint256', 'UInt256CallMismatchedType.py')
 
     # endregion
 
@@ -188,8 +186,7 @@ class TestNeoTypes(boatestcase.BoaTestCase):
         self.assertRegex(str(context.exception), 'unhandled exception')
 
     def test_ecpoint_call_without_args(self):
-        path = self.get_contract_path('ecpoint', 'ECPointCallWithoutArgs.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'ecpoint', 'ECPointCallWithoutArgs.py')
 
     async def test_ecpoint_return_bytes(self):
         await self.set_up_contract('ecpoint', 'ECPointReturnBytes.py')
@@ -226,8 +223,7 @@ class TestNeoTypes(boatestcase.BoaTestCase):
         self.assertEqual(self.ecpoint_to_array(value) + b'123', result)
 
     def test_ecpoint_mismatched_type(self):
-        path = self.get_contract_path('ecpoint', 'ECPointCallMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'ecpoint', 'ECPointCallMismatchedType.py')
 
     async def test_ecpoint_script_hash(self):
         await self.set_up_contract('ecpoint', 'ECPointScriptHash.py')
@@ -303,8 +299,7 @@ class TestNeoTypes(boatestcase.BoaTestCase):
         self.assertEqual(concat_bytes + arg, result)
 
     def test_opcode_concat_mismatched_type(self):
-        path = self.get_contract_path('opcode', 'ConcatMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'opcode', 'ConcatMismatchedType.py')
 
     async def test_opcode_multiplication(self):
         from boa3.internal.neo.vm.opcode.Opcode import Opcode
@@ -361,16 +356,13 @@ class TestNeoTypes(boatestcase.BoaTestCase):
         # self.assertEqual(True, result)
 
     def test_transaction_cast_and_get_hash(self):
-        path = self.get_contract_path('CastTransactionGetHash.py')
-        self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+        self.assertCompilerLogs(CompilerWarning.TypeCasting, 'CastTransactionGetHash.py')
 
     def test_transaction_implicit_cast_and_get_hash(self):
-        path = self.get_contract_path('ImplicitCastTransactionGetHash.py')
-        self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+        self.assertCompilerLogs(CompilerWarning.TypeCasting, 'ImplicitCastTransactionGetHash.py')
 
     def test_transaction_cast_and_assign_hash_to_variable(self):
-        path = self.get_contract_path('CastTransactionGetHashToVariable.py')
-        self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+        self.assertCompilerLogs(CompilerWarning.TypeCasting, 'CastTransactionGetHashToVariable.py')
 
     async def test_isinstance_transaction(self):
         await self.set_up_contract('IsInstanceTransaction.py')

--- a/boa3_test/tests/compiler_tests/test_none.py
+++ b/boa3_test/tests/compiler_tests/test_none.py
@@ -88,12 +88,10 @@ class TestNone(boatestcase.BoaTestCase):
         self.assertEqual(True, result)
 
     def test_none_equality(self):
-        path = self.get_contract_path('NoneEquality.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'NoneEquality.py')
 
     def test_mismatched_type_int_operation(self):
-        path = self.get_contract_path('MismatchedTypesInOperation.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MismatchedTypesInOperation.py')
 
     def test_reassign_variable_with_none_compile(self):
         expected_output = (
@@ -141,5 +139,4 @@ class TestNone(boatestcase.BoaTestCase):
         self.assertEqual(None, result)
 
     def test_boa2_none_test(self):
-        path = self.get_contract_path('NoneBoa2Test.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'NoneBoa2Test.py')

--- a/boa3_test/tests/compiler_tests/test_python_operation.py
+++ b/boa3_test/tests/compiler_tests/test_python_operation.py
@@ -21,8 +21,7 @@ class TestPythonOperation(boatestcase.BoaTestCase):
         self.assertEqual(b'34' in b'1234', result)
 
     def test_bytes_membership_mismatched_type(self):
-        path = self.get_contract_path('BytesMembershipMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'BytesMembershipMismatchedType.py')
 
     async def test_int_in_bytes(self):
         await self.set_up_contract('BytesMembershipWithInt.py')
@@ -49,8 +48,7 @@ class TestPythonOperation(boatestcase.BoaTestCase):
         self.assertEqual('4' in {1: '2', '4': 8}, result)
 
     def test_dict_membership_mismatched_type(self):
-        path = self.get_contract_path('DictMembershipMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'DictMembershipMismatchedType.py')
 
     async def test_in_list(self):
         await self.set_up_contract('ListIn.py')
@@ -65,8 +63,7 @@ class TestPythonOperation(boatestcase.BoaTestCase):
         self.assertEqual('4' in [1, 2, '3', '4'], result)
 
     def test_list_membership_mismatched_type(self):
-        path = self.get_contract_path('ListMembershipMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'ListMembershipMismatchedType.py')
 
     async def test_in_str(self):
         await self.set_up_contract('StringIn.py')
@@ -78,8 +75,7 @@ class TestPythonOperation(boatestcase.BoaTestCase):
         self.assertEqual('42' in '1234', result)
 
     def test_str_membership_mismatched_type(self):
-        path = self.get_contract_path('StringMembershipMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'StringMembershipMismatchedType.py')
 
     async def test_in_tuple(self):
         await self.set_up_contract('TupleIn.py')
@@ -94,8 +90,7 @@ class TestPythonOperation(boatestcase.BoaTestCase):
         self.assertEqual('4' in (1, 2, '3', '4'), result)
 
     def test_tuple_membership_mismatched_type(self):
-        path = self.get_contract_path('TupleMembershipMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'TupleMembershipMismatchedType.py')
 
     async def test_in_typed_dict_builtin_type(self):
         await self.set_up_contract('TypedDictBuiltinTypeIn.py')

--- a/boa3_test/tests/compiler_tests/test_range.py
+++ b/boa3_test/tests/compiler_tests/test_range.py
@@ -193,8 +193,7 @@ class TestRange(boatestcase.BoaTestCase):
         self.assertEqual(list(range(-2, 10, 3)), result)
 
     def test_range_parameter_mismatched_type(self):
-        path = self.get_contract_path('RangeParameterMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'RangeParameterMismatchedType.py')
 
     def test_range_as_sequence_compile(self):
         expected_output = (
@@ -257,16 +256,13 @@ class TestRange(boatestcase.BoaTestCase):
         self.assertEqual(list(range(-10, 0)), result)
 
     def test_range_mismatched_type(self):
-        path = self.get_contract_path('RangeMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'RangeMismatchedType.py')
 
     def test_range_too_few_parameters(self):
-        path = self.get_contract_path('RangeTooFewParameters.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'RangeTooFewParameters.py')
 
     def test_range_too_many_parameters(self):
-        path = self.get_contract_path('RangeTooManyParameters.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'RangeTooManyParameters.py')
 
     def test_range_get_value_compile(self):
         expected_output = (
@@ -296,8 +292,7 @@ class TestRange(boatestcase.BoaTestCase):
         self.assertRegex(str(context.exception), r'The value \d+ is out of range.')
 
     def test_range_set_value(self):
-        path = self.get_contract_path('RangeSetValue.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedOperation, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedOperation, 'RangeSetValue.py')
 
     async def test_range_slicing(self):
         await self.set_up_contract('RangeSlicingLiteralValues.py')
@@ -561,6 +556,5 @@ class TestRange(boatestcase.BoaTestCase):
         self.assertEqual(list(range(100, 120)), result)
 
     def test_range_index(self):
-        path = self.get_contract_path('IndexRange.py')
         # TODO: change when index() with only one argument is implemented for range #2kq1y13
-        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'IndexRange.py')

--- a/boa3_test/tests/compiler_tests/test_relational.py
+++ b/boa3_test/tests/compiler_tests/test_relational.py
@@ -17,8 +17,7 @@ class TestRelational(boatestcase.BoaTestCase):
         self.assertEqual(FindOptions.VALUES_ONLY > FindOptions.DESERIALIZE_VALUES, result)
 
     def test_mixed_greater_than_operation(self):
-        path = self.get_contract_path('MixedGreaterThan.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MixedGreaterThan.py')
 
     def test_number_greater_than_operation_compile(self):
         expected_output = (
@@ -85,8 +84,7 @@ class TestRelational(boatestcase.BoaTestCase):
         self.assertEqual(FindOptions.VALUES_ONLY >= FindOptions.VALUES_ONLY, result)
 
     def test_mixed_greater_or_equal_than_operation(self):
-        path = self.get_contract_path('MixedGreaterOrEqual.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MixedGreaterOrEqual.py')
 
     def test_number_greater_or_equal_than_operation_compile(self):
         expected_output = (
@@ -262,8 +260,7 @@ class TestRelational(boatestcase.BoaTestCase):
         self.assertEqual(FindOptions.VALUES_ONLY < FindOptions.VALUES_ONLY, result)
 
     def test_mixed_less_than_operation(self):
-        path = self.get_contract_path('MixedLessThan.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MixedLessThan.py')
 
     def test_number_less_than_operation_compile(self):
         expected_output = (
@@ -330,8 +327,7 @@ class TestRelational(boatestcase.BoaTestCase):
         self.assertEqual(FindOptions.VALUES_ONLY <= FindOptions.VALUES_ONLY, result)
 
     def test_mixed_less_or_equal_than_operation(self):
-        path = self.get_contract_path('MixedLessOrEqual.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MixedLessOrEqual.py')
 
     def test_number_less_or_equal_than_operation_compile(self):
         expected_output = (

--- a/boa3_test/tests/compiler_tests/test_reversed.py
+++ b/boa3_test/tests/compiler_tests/test_reversed.py
@@ -87,5 +87,4 @@ class TestReversed(boatestcase.BoaTestCase):
         self.assertEqual(reversed_list, result)
 
     def test_mismatched_type(self):
-        path = self.get_contract_path('ReversedParameterMismatchedType')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'ReversedParameterMismatchedType')

--- a/boa3_test/tests/compiler_tests/test_set.py
+++ b/boa3_test/tests/compiler_tests/test_set.py
@@ -6,13 +6,10 @@ class TestSet(boatestcase.BoaTestCase):
     default_folder: str = 'test_sc/set_test'
 
     def test_set_from_typing(self):
-        path = self.get_contract_path('SetTyping.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, 'SetTyping.py')
 
     def test_set_literal(self):
-        path = self.get_contract_path('SetLiteral.py')
-        self.assertCompilerLogs(CompilerError.InvalidType, path)
+        self.assertCompilerLogs(CompilerError.InvalidType, 'SetLiteral.py')
 
     def test_set_from_constructor(self):
-        path = self.get_contract_path('SetConstructor.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, 'SetConstructor.py')

--- a/boa3_test/tests/compiler_tests/test_string.py
+++ b/boa3_test/tests/compiler_tests/test_string.py
@@ -138,8 +138,7 @@ class TestString(boatestcase.BoaTestCase):
         self.assertRegex(str(context.exception), self.INVALID_OFFSET_MSG)
 
     def test_string_set_value(self):
-        path = self.get_contract_path('StringSetValue.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedOperation, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedOperation, 'StringSetValue.py')
 
     async def test_string_slicing(self):
         await self.set_up_contract('StringSlicingLiteralValues.py')
@@ -1047,8 +1046,7 @@ class TestString(boatestcase.BoaTestCase):
         self.assertEqual(string.index(substring), result)
 
     def test_string_index_mismatched_type(self):
-        path = self.get_contract_path('IndexStringMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'IndexStringMismatchedType.py')
 
     async def test_string_property_slicing(self):
         await self.set_up_contract('StringPropertySlicing.py')
@@ -1171,12 +1169,10 @@ class TestString(boatestcase.BoaTestCase):
         self.assertEqual('F-string: {"string":"unit test","number":123}', result)
 
     def test_f_string_any_var(self):
-        path = self.get_contract_path('FStringAnyVar.py')
-        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'FStringAnyVar.py')
 
     def test_f_string_union_var(self):
-        path = self.get_contract_path('FStringUnionVar.py')
-        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'FStringUnionVar.py')
 
     async def test_string_replace(self):
         await self.set_up_contract('ReplaceStringMethod.py')
@@ -1228,13 +1224,10 @@ class TestString(boatestcase.BoaTestCase):
         self.assertEqual(string.replace(old, new), result)
 
     def test_string_replace_mismatched_type(self):
-        path = self.get_contract_path('ReplaceStringMethodMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'ReplaceStringMethodMismatchedType.py')
 
     def test_string_replace_too_many_arguments(self):
-        path = self.get_contract_path('ReplaceStringMethodTooManyArguments.py')
-        self.assertCompilerLogs(CompilerError.UnexpectedArgument, path)
+        self.assertCompilerLogs(CompilerError.UnexpectedArgument, 'ReplaceStringMethodTooManyArguments.py')
 
     def test_string_replace_too_few_arguments(self):
-        path = self.get_contract_path('ReplaceStringMethodTooFewArguments.py')
-        self.assertCompilerLogs(CompilerError.UnfilledArgument, path)
+        self.assertCompilerLogs(CompilerError.UnfilledArgument, 'ReplaceStringMethodTooFewArguments.py')

--- a/boa3_test/tests/compiler_tests/test_tuple.py
+++ b/boa3_test/tests/compiler_tests/test_tuple.py
@@ -137,16 +137,13 @@ class TestTuple(boatestcase.BoaTestCase):
         self.assertRegex(str(context.exception), self.VALUE_OUT_OF_RANGE_ERROR)
 
     def test_non_sequence_get_value(self):
-        path = self.get_contract_path('TupleGetValueMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedOperation, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedOperation, 'TupleGetValueMismatchedType.py')
 
     def test_tuple_set_value(self):
-        path = self.get_contract_path('TupleSetValue.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedOperation, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedOperation, 'TupleSetValue.py')
 
     def test_non_sequence_set_value(self):
-        path = self.get_contract_path('SetValueMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedOperation, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedOperation, 'SetValueMismatchedType.py')
 
     def test_tuple_get_value_typed_tuple_compile(self):
         ok = String('ok').to_bytes()
@@ -177,8 +174,7 @@ class TestTuple(boatestcase.BoaTestCase):
         self.assertEqual(1, result)
 
     def test_tuple_index_mismatched_type(self):
-        path = self.get_contract_path('TupleIndexMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'TupleIndexMismatchedType.py')
 
     def test_tuple_of_tuple_compile(self):
         expected_output = (

--- a/boa3_test/tests/compiler_tests/test_typing.py
+++ b/boa3_test/tests/compiler_tests/test_typing.py
@@ -19,8 +19,7 @@ class TestTyping(boatestcase.BoaTestCase):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('CastToInt.py')
-        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, 'CastToInt.py')
         self.assertEqual(expected_output, output)
 
     def test_cast_to_str(self):
@@ -34,8 +33,7 @@ class TestTyping(boatestcase.BoaTestCase):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('CastToStr.py')
-        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, 'CastToStr.py')
         self.assertEqual(expected_output, output)
 
     def test_cast_to_list(self):
@@ -49,8 +47,7 @@ class TestTyping(boatestcase.BoaTestCase):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('CastToList.py')
-        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, 'CastToList.py')
         self.assertEqual(expected_output, output)
 
     def test_cast_to_typed_list(self):
@@ -66,8 +63,7 @@ class TestTyping(boatestcase.BoaTestCase):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('CastToTypedList.py')
-        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, 'CastToTypedList.py')
         self.assertEqual(expected_output, output)
 
     def test_cast_to_dict(self):
@@ -81,8 +77,7 @@ class TestTyping(boatestcase.BoaTestCase):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('CastToDict.py')
-        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, 'CastToDict.py')
         self.assertEqual(expected_output, output)
 
     def test_cast_to_typed_dict(self):
@@ -101,13 +96,11 @@ class TestTyping(boatestcase.BoaTestCase):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('CastToTypedDict.py')
-        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, 'CastToTypedDict.py')
         self.assertEqual(expected_output, output)
 
     def test_cast_mismatched_type(self):
-        path = self.get_contract_path('CastMismatchedType.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'CastMismatchedType.py')
 
     def test_cast_to_uint160_compile(self):
         expected_output = (
@@ -120,8 +113,7 @@ class TestTyping(boatestcase.BoaTestCase):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('CastToUInt160.py')
-        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, 'CastToUInt160.py')
         self.assertEqual(expected_output, output)
 
     async def test_cast_to_uint160_run(self):
@@ -142,8 +134,7 @@ class TestTyping(boatestcase.BoaTestCase):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('CastToTransaction.py')
-        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, 'CastToTransaction.py')
         self.assertEqual(expected_output, output)
 
     async def test_cast_inside_if(self):

--- a/boa3_test/tests/compiler_tests/test_variable.py
+++ b/boa3_test/tests/compiler_tests/test_variable.py
@@ -47,8 +47,7 @@ class TestVariable(boatestcase.BoaTestCase):
         self.assertTrue(test_variable_id in method_symbol_table)
 
     def test_declaration_without_type(self):
-        path = self.get_contract_path('DeclarationWithoutType.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, 'DeclarationWithoutType.py')
 
     def test_assignment_with_type(self):
         input = 'unit_test'
@@ -205,8 +204,7 @@ class TestVariable(boatestcase.BoaTestCase):
         self.assertEqual(expected_output, output)
 
     def test_tuple_multiple_assignments(self):
-        path = self.get_contract_path('AssignmentWithTuples.py')
-        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'AssignmentWithTuples.py')
 
     def test_many_assignments(self):
         expected_output = (
@@ -301,12 +299,10 @@ class TestVariable(boatestcase.BoaTestCase):
         self.assertEqual(-140, result)
 
     def test_using_undeclared_variable(self):
-        path = self.get_contract_path('UsingUndeclaredVariable.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, 'UsingUndeclaredVariable.py')
 
     def test_return_undeclared_variable(self):
-        path = self.get_contract_path('ReturnUndeclaredVariable.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, 'ReturnUndeclaredVariable.py')
 
     def test_assign_value_mismatched_type(self):
         string_value = '1'
@@ -323,8 +319,7 @@ class TestVariable(boatestcase.BoaTestCase):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('MismatchedTypeAssignValue.py')
-        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, 'MismatchedTypeAssignValue.py')
         self.assertEqual(expected_output, output)
 
     def test_assign_binary_operation_mismatched_type(self):
@@ -337,8 +332,7 @@ class TestVariable(boatestcase.BoaTestCase):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('MismatchedTypeAssignBinOp.py')
-        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, 'MismatchedTypeAssignBinOp.py')
         self.assertEqual(expected_output, output)
 
     def test_assign_unary_operation_mismatched_type(self):
@@ -352,8 +346,7 @@ class TestVariable(boatestcase.BoaTestCase):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('MismatchedTypeAssignUnOp.py')
-        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, 'MismatchedTypeAssignUnOp.py')
         self.assertEqual(expected_output, output)
 
     def test_assign_mixed_operations_mismatched_type(self):
@@ -376,8 +369,7 @@ class TestVariable(boatestcase.BoaTestCase):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('MismatchedTypeAssignMixedOp.py')
-        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, 'MismatchedTypeAssignMixedOp.py')
         self.assertEqual(expected_output, output)
 
     def test_assign_sequence_get_mismatched_type(self):
@@ -392,21 +384,17 @@ class TestVariable(boatestcase.BoaTestCase):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('MismatchedTypeAssignSequenceGet.py')
-        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, path)
+        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, 'MismatchedTypeAssignSequenceGet.py')
         self.assertEqual(expected_output, output)
 
     def test_assign_sequence_set_mismatched_type(self):
-        path = self.get_contract_path('MismatchedTypeAssignSequenceSet.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MismatchedTypeAssignSequenceSet.py')
 
     def test_aug_assign_mismatched_type(self):
-        path = self.get_contract_path('MismatchedTypeAugAssign.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MismatchedTypeAugAssign.py')
 
     def test_invalid_type_format_mismatched_type(self):
-        path = self.get_contract_path('MismatchedTypeInvalidTypeFormat.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MismatchedTypeInvalidTypeFormat.py')
 
     def test_global_declaration_with_assignment_compile(self):
         expected_output = (
@@ -428,8 +416,7 @@ class TestVariable(boatestcase.BoaTestCase):
         self.assertEqual(10, result)
 
     def test_global_declaration_without_assignment(self):
-        path = self.get_contract_path('GlobalDeclarationWithoutAssignment.py')
-        self.assertCompilerLogs(CompilerError.UnresolvedReference, path)
+        self.assertCompilerLogs(CompilerError.UnresolvedReference, 'GlobalDeclarationWithoutAssignment.py')
 
     def test_global_assignment_with_type_compile(self):
         expected_output = (
@@ -490,8 +477,7 @@ class TestVariable(boatestcase.BoaTestCase):
         self.assertEqual(10, result)
 
     def test_global_tuple_multiple_assignments(self):
-        path = self.get_contract_path('GlobalAssignmentWithTuples.py')
-        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'GlobalAssignmentWithTuples.py')
 
     async def test_global_chained_multiple_assignments(self):
         await self.set_up_contract('GlobalMultipleAssignments.py', compile_if_found=True)
@@ -708,8 +694,7 @@ class TestVariable(boatestcase.BoaTestCase):
             + Opcode.RET
         )
 
-        path = self.get_contract_path('AssignLocalWithArgumentShadowingGlobal.py')
-        output, _ = self.assertCompilerLogs(CompilerWarning.NameShadowing, path)
+        output, _ = self.assertCompilerLogs(CompilerWarning.NameShadowing, 'AssignLocalWithArgumentShadowingGlobal.py')
         self.assertEqual(expected_output, output)
 
     def test_assign_local_shadowing_global_with_arg_value_compile_no_optimization(self):
@@ -774,8 +759,7 @@ class TestVariable(boatestcase.BoaTestCase):
         self.assertEqual(400, result)
 
     def test_assign_starred_variable(self):
-        path = self.get_contract_path('AssignStarredVariable.py')
-        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'AssignStarredVariable.py')
 
     async def test_variables_in_different_scope_with_same_name(self):
         await self.set_up_contract('DifferentScopesWithSameName.py')
@@ -818,12 +802,10 @@ class TestVariable(boatestcase.BoaTestCase):
         self.assertEqual(expected_return, result)
 
     def test_del_variable(self):
-        path = self.get_contract_path('DelVariable.py')
-        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'DelVariable.py')
 
     def test_assign_function(self):
-        path = self.get_contract_path('AssignFunction.py')
-        self.assertCompilerLogs(CompilerError.NotSupportedOperation, path)
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'AssignFunction.py')
 
     async def test_elvis_operator_any_param(self):
         await self.set_up_contract('ElvisOperatorAnyParam.py')

--- a/boa3_test/tests/compiler_tests/test_while.py
+++ b/boa3_test/tests/compiler_tests/test_while.py
@@ -92,8 +92,7 @@ class TestWhile(boatestcase.BoaTestCase):
         self.assertEqual(16, result)
 
     def test_while_mismatched_type_condition(self):
-        path = self.get_contract_path('WhileMismatchedTypeCondition.py')
-        self.assertCompilerLogs(CompilerError.MismatchedTypes, path)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'WhileMismatchedTypeCondition.py')
 
     def test_while_no_condition(self):
         path = self.get_contract_path('WhileNoCondition.py')


### PR DESCRIPTION
**Summary or solution description**
Now users can send relative paths instead of absolute paths when using `assertCompilerLogs`.
It also returns the manifest if there is no error