### PR TITLE
#86dt89kf4 - Refactor BoaCliTest on cli_tests to use BoaConstructor

### DIFF
--- a/boa3_test/tests/cli_tests/cli_test.py
+++ b/boa3_test/tests/cli_tests/cli_test.py
@@ -1,8 +1,3 @@
-from boa3_test.tests.boa_test import (BoaTest,  # needs to be the first import to avoid circular imports
-                                      _COMPILER_LOCK as LOCK,
-                                      _LOGGING_LOCK as LOG_LOCK
-                                      )
-
 __all__ = [
     'BoaCliTest',
 ]
@@ -12,10 +7,14 @@ import io
 from contextlib import redirect_stdout, redirect_stderr
 
 from boa3.cli import main
+from boa3_test.tests import boatestcase
+from boa3_test.tests.boatestcase import (_COMPILER_LOCK as LOCK,
+                                         _LOGGING_LOCK as LOG_LOCK
+                                         )
 from boa3_test.tests.cli_tests import utils
 
 
-class BoaCliTest(BoaTest, abc.ABC):
+class BoaCliTest(boatestcase.BoaTestCase, abc.ABC):
     default_folder = 'test_cli'
 
     EXIT_CODE_SUCCESS = 0

--- a/boa3_test/tests/cli_tests/test_cli.py
+++ b/boa3_test/tests/cli_tests/test_cli.py
@@ -1,6 +1,5 @@
-from boa3_test.tests.cli_tests.cli_test import BoaCliTest  # needs to be the first import to avoid circular imports
-
 from boa3.internal import constants
+from boa3_test.tests.cli_tests.cli_test import BoaCliTest
 from boa3_test.tests.cli_tests.utils import neo3_boa_cli
 
 


### PR DESCRIPTION
**Summary or solution description**
 Refactored `tests/cli_tests` files to use `BoaTestCase` in place of `BoaTest` for unit testing.