### PR TITLE
#86dt89pje - Refactor test_nep17_contract_interface.py to use BoaConstructor

### DIFF
--- a/boa3_test/tests/compiler_tests/test_interop/test_crypto.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_crypto.py
@@ -1,6 +1,5 @@
 import hashlib
 
-
 from boa3.internal.exception import CompilerError
 from boa3.internal.model.type.type import Type
 from boa3.internal.neo.vm.opcode.Opcode import Opcode

--- a/boa3_test/tests/compiler_tests/test_native/test_cryptolib.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_cryptolib.py
@@ -1,6 +1,5 @@
 import hashlib
 
-
 from boa3.internal import constants
 from boa3.internal.exception import CompilerError
 from boa3.internal.model.type.type import Type

--- a/boa3_test/tests/compiler_tests/test_native/test_neo.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_neo.py
@@ -11,7 +11,6 @@ from neo3.wallet import account
 from boa3.internal import constants
 from boa3.internal.exception import CompilerError
 from boa3_test.tests import annotation, boatestcase
-from boa3_test.tests.boatestcase import FaultException
 
 
 @dataclass

--- a/boa3_test/tests/examples_tests/test_htlc.py
+++ b/boa3_test/tests/examples_tests/test_htlc.py
@@ -5,8 +5,6 @@ from neo3.wallet import account
 
 from boa3.internal import constants
 from boa3.internal.neo.cryptography import hash160
-
-
 from boa3_test.tests import boatestcase
 
 

--- a/boa3_test/tests/stackitem.py
+++ b/boa3_test/tests/stackitem.py
@@ -5,7 +5,6 @@ from neo3.network.payloads import block, transaction, verification
 
 from boa3_test.tests import annotation
 
-
 StackItem = TypeVar(
     'StackItem',
     int,


### PR DESCRIPTION
**Summary or solution description**
 Refactored `test_nep17_contract_interface.py` files to use `BoaTestCase` in place of `BoaTest` for unit testing.