### PR TITLE
#86drtepaj - Verify if type annotation using the literal types instea…

### DIFF
--- a/boa3_test/examples/amm.py
+++ b/boa3_test/examples/amm.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Union
+from typing import Any, Union
 
 from boa3.builtin.compile_time import CreateNewEvent, NeoMetadata, public
 from boa3.builtin.contract import Nep17TransferEvent, abort
@@ -298,7 +298,7 @@ def get_token_b() -> UInt160:
 
 
 @public
-def get_reserves() -> List[int]:
+def get_reserves() -> list[int]:
     """
     Returns how many token_a and token_b tokens are in the pool.
 
@@ -309,7 +309,7 @@ def get_reserves() -> List[int]:
 
 
 @public
-def add_liquidity(amount_token_a_desired: int, amount_token_b_desired: int, amount_token_a_min: int, amount_token_b_min: int, user_address: UInt160) -> List[int]:
+def add_liquidity(amount_token_a_desired: int, amount_token_b_desired: int, amount_token_a_min: int, amount_token_b_min: int, user_address: UInt160) -> list[int]:
     """
     Adds liquidity to the pool, minting AMM tokens in the process.
 
@@ -453,7 +453,7 @@ def quote(amount_token1: int, reserve_token1: int, reserve_token2: int) -> int:
 
 
 @public
-def remove_liquidity(liquidity: int, amount_token_a_min: int, amount_token_b_min: int, user_address: UInt160) -> List[int]:
+def remove_liquidity(liquidity: int, amount_token_a_min: int, amount_token_b_min: int, user_address: UInt160) -> list[int]:
     """
     Remove liquidity from the pool, burning the AMM token in the process and giving token_a and token_b back to the user.
 
@@ -481,7 +481,7 @@ def remove_liquidity(liquidity: int, amount_token_a_min: int, amount_token_b_min
     return amount
 
 
-def burn(liquidity: int, user_address: UInt160) -> List[int]:
+def burn(liquidity: int, user_address: UInt160) -> list[int]:
     """
     Burns AMM tokens, this function will be called by `remove_liquidity()`.
 

--- a/boa3_test/examples/ico.py
+++ b/boa3_test/examples/ico.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Union
+from typing import Any, Union
 
 from boa3.builtin.compile_time import NeoMetadata, public
 from boa3.builtin.contract import Nep17TransferEvent, abort
@@ -466,7 +466,7 @@ def approve(originator: UInt160, to_address: UInt160, amount: int) -> bool:
 
 
 @public
-def kyc_register(addresses: List[UInt160]) -> int:
+def kyc_register(addresses: list[UInt160]) -> int:
     """
     Includes the given addresses to the kyc whitelist
 
@@ -485,7 +485,7 @@ def kyc_register(addresses: List[UInt160]) -> int:
 
 
 @public
-def kyc_remove(addresses: List[UInt160]) -> int:
+def kyc_remove(addresses: list[UInt160]) -> int:
     """
     Removes the given addresses from the kyc whitelist
 

--- a/boa3_test/examples/nep11_non_divisible.py
+++ b/boa3_test/examples/nep11_non_divisible.py
@@ -3,7 +3,7 @@
 # with further instructions on how to modify and use it.
 # ------------------------------------------------------------------------------------------------------------------------
 
-from typing import Any, Dict, List, Union, cast
+from typing import Any, Union, cast
 
 from boa3.builtin.compile_time import CreateNewEvent, NeoMetadata, public
 from boa3.builtin.contract import abort
@@ -305,7 +305,7 @@ def tokens() -> Iterator:
 
 
 @public(safe=True)
-def properties(tokenId: bytes) -> Dict[Any, Any]:
+def properties(tokenId: bytes) -> dict[Any, Any]:
     """
     Get the properties of a token.
 
@@ -318,7 +318,7 @@ def properties(tokenId: bytes) -> Dict[Any, Any]:
     """
     metaBytes = cast(str, get_meta(tokenId))
     expect(len(metaBytes) != 0, 'No metadata available for token')
-    metaObject = cast(Dict[str, str], json_deserialize(metaBytes))
+    metaObject = cast(dict[str, str], json_deserialize(metaBytes))
 
     return metaObject
 
@@ -378,7 +378,7 @@ def internal_deploy(owner: UInt160):
     storage.put_bool(PAUSED, False)
     storage.put_int(TOKEN_COUNT, 0)
 
-    auth: List[UInt160] = []
+    auth: list[UInt160] = []
     auth.append(owner)
     serialized = serialize(auth)
     storage.put(AUTH_ADDRESSES, serialized)

--- a/boa3_test/test_sc/any_test/AnyList.py
+++ b/boa3_test/test_sc/any_test/AnyList.py
@@ -1,8 +1,8 @@
-from typing import Any, List
+from typing import Any
 
 from boa3.builtin.compile_time import public
 
 
 @public
 def Main():
-    a: List[Any] = [True, 1, 'ok']
+    a: list[Any] = [True, 1, 'ok']

--- a/boa3_test/test_sc/any_test/AnyTuple.py
+++ b/boa3_test/test_sc/any_test/AnyTuple.py
@@ -1,8 +1,8 @@
-from typing import Any, Tuple
+from typing import Any
 
 from boa3.builtin.compile_time import public
 
 
 @public
 def Main():
-    a: Tuple[Any, Any, Any] = (True, 1, 'ok')
+    a: tuple[Any, Any, Any] = (True, 1, 'ok')

--- a/boa3_test/test_sc/arithmetic_test/ListAddition.py
+++ b/boa3_test/test_sc/arithmetic_test/ListAddition.py
@@ -1,23 +1,23 @@
-from typing import Any, List
+from typing import Any
 
 from boa3.builtin.compile_time import public
 
 
 @public
-def add_any(a: List[Any], b: List[Any]) -> List[Any]:
+def add_any(a: list[Any], b: list[Any]) -> list[Any]:
     return a + b
 
 
 @public
-def add_int(a: List[int], b: List[int]) -> List[int]:
+def add_int(a: list[int], b: list[int]) -> list[int]:
     return a + b
 
 
 @public
-def add_bool(a: List[bool], b: List[bool]) -> List[bool]:
+def add_bool(a: list[bool], b: list[bool]) -> list[bool]:
     return a + b
 
 
 @public
-def add_str(a: List[str], b: List[str]) -> List[str]:
+def add_str(a: list[str], b: list[str]) -> list[str]:
     return a + b

--- a/boa3_test/test_sc/built_in_methods_test/AppendTooFewParameters.py
+++ b/boa3_test/test_sc/built_in_methods_test/AppendTooFewParameters.py
@@ -1,7 +1,4 @@
-from typing import List
-
-
-def Main(op: str, args: list) -> List[int]:
+def Main(op: str, args: list) -> list[int]:
     a = [1, 2, 3]
     list.append(a)
     return a

--- a/boa3_test/test_sc/built_in_methods_test/AppendTooManyParameters.py
+++ b/boa3_test/test_sc/built_in_methods_test/AppendTooManyParameters.py
@@ -1,7 +1,4 @@
-from typing import List
-
-
-def Main(op: str, args: list) -> List[int]:
+def Main(op: str, args: list) -> list[int]:
     a = [1, 2, 3]
     a.append(4, 5)
     return a

--- a/boa3_test/test_sc/built_in_methods_test/AppendTuple.py
+++ b/boa3_test/test_sc/built_in_methods_test/AppendTuple.py
@@ -1,7 +1,4 @@
-from typing import Tuple
-
-
-def Main(op: str, args: list) -> Tuple[int]:
+def Main(op: str, args: list) -> tuple[int]:
     a = (1, 2, 3)
     a.append(4)  # compiler error - cannot append values to a tuple
     return a

--- a/boa3_test/test_sc/built_in_methods_test/BoolDict.py
+++ b/boa3_test/test_sc/built_in_methods_test/BoolDict.py
@@ -1,8 +1,8 @@
-from typing import Any, Dict
+from typing import Any
 
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(x: Dict[Any, Any]) -> bool:
+def main(x: dict[Any, Any]) -> bool:
     return bool(x)

--- a/boa3_test/test_sc/built_in_methods_test/BoolList.py
+++ b/boa3_test/test_sc/built_in_methods_test/BoolList.py
@@ -1,8 +1,8 @@
-from typing import Any, List
+from typing import Any
 
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(x: List[Any]) -> bool:
+def main(x: list[Any]) -> bool:
     return bool(x)

--- a/boa3_test/test_sc/built_in_methods_test/ClearTooFewParameters.py
+++ b/boa3_test/test_sc/built_in_methods_test/ClearTooFewParameters.py
@@ -1,7 +1,4 @@
-from typing import List
-
-
-def Main(op: str, args: list) -> List[int]:
+def Main(op: str, args: list) -> list[int]:
     a = [1, 2, 3]
     list.clear()
     return a

--- a/boa3_test/test_sc/built_in_methods_test/ClearTooManyParameters.py
+++ b/boa3_test/test_sc/built_in_methods_test/ClearTooManyParameters.py
@@ -1,7 +1,4 @@
-from typing import List
-
-
-def Main(op: str, args: list) -> List[int]:
+def Main(op: str, args: list) -> list[int]:
     a = [1, 2, 3]
     a.clear(a)
     return a

--- a/boa3_test/test_sc/built_in_methods_test/ClearTuple.py
+++ b/boa3_test/test_sc/built_in_methods_test/ClearTuple.py
@@ -1,7 +1,4 @@
-from typing import Tuple
-
-
-def Main(op: str, args: list) -> Tuple[int]:
+def Main(op: str, args: list) -> tuple[int]:
     a = (1, 2, 3)
     a.clear()
     return a

--- a/boa3_test/test_sc/built_in_methods_test/CountListAnyType.py
+++ b/boa3_test/test_sc/built_in_methods_test/CountListAnyType.py
@@ -1,16 +1,16 @@
-from typing import Any, List, Tuple
+from typing import Any
 
 from boa3.builtin.compile_time import public
 
 
 @public
-def main() -> Tuple[int, int, int, int]:
-    a: List[Any] = [[b'unit', b'unit'], [123, 123], [True, False], [True, False], [b'unit', 'test'], 'not list']
+def main() -> tuple[int, int, int, int]:
+    a: list[Any] = [[b'unit', b'unit'], [123, 123], [True, False], [True, False], [b'unit', 'test'], 'not list']
 
     count1 = a.count([b'unit', 'test'])
     count2 = a.count([123, 123])
     count3 = a.count([True, False])
     count4 = a.count(['random value', 'random value', 'random value'])
 
-    b: Tuple[int, int, int, int] = (count1, count2, count3, count4)
+    b: tuple[int, int, int, int] = (count1, count2, count3, count4)
     return b

--- a/boa3_test/test_sc/built_in_methods_test/CountListDifferentPrimitiveTypes.py
+++ b/boa3_test/test_sc/built_in_methods_test/CountListDifferentPrimitiveTypes.py
@@ -1,10 +1,8 @@
-from typing import Tuple
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def main() -> Tuple[int, int, int]:
+def main() -> tuple[int, int, int]:
     a = [b'unit', 'test', b'unit', b'unit', 123, 123, True, False]
-    b: Tuple[int, int, int] = (a.count(b'unit'), a.count('test'), a.count(123))
+    b: tuple[int, int, int] = (a.count(b'unit'), a.count('test'), a.count(123))
     return b

--- a/boa3_test/test_sc/built_in_methods_test/CountListOnlySequences.py
+++ b/boa3_test/test_sc/built_in_methods_test/CountListOnlySequences.py
@@ -1,16 +1,16 @@
-from typing import Any, List, Tuple
+from typing import Any
 
 from boa3.builtin.compile_time import public
 
 
 @public
-def main() -> Tuple[int, int, int, int]:
-    a: List[List[Any]] = [[b'unit', b'unit'], [123, 123], [True, False], [True, False], [b'unit', 'test']]
+def main() -> tuple[int, int, int, int]:
+    a: list[list[Any]] = [[b'unit', b'unit'], [123, 123], [True, False], [True, False], [b'unit', 'test']]
 
     count1 = a.count([b'unit', 'test'])
     count2 = a.count([123, 123])
     count3 = a.count([True, False])
     count4 = a.count(['random value', 'random value', 'random value'])
 
-    b: Tuple[int, int, int, int] = (count1, count2, count3, count4)
+    b: tuple[int, int, int, int] = (count1, count2, count3, count4)
     return b

--- a/boa3_test/test_sc/built_in_methods_test/CountTupleDifferentNonPrimitiveTypes.py
+++ b/boa3_test/test_sc/built_in_methods_test/CountTupleDifferentNonPrimitiveTypes.py
@@ -1,15 +1,15 @@
-from typing import Any, Tuple
+from typing import Any
 
 from boa3.builtin.compile_time import public
 
 
 @public
-def main() -> Tuple[int, int, int]:
-    a: Tuple[Any] = ([b'unit', 'test'], [b'unit', b'unit'], [123, 123], [True, False], [True, False])
+def main() -> tuple[int, int, int]:
+    a: tuple[Any] = ([b'unit', 'test'], [b'unit', b'unit'], [123, 123], [True, False], [True, False])
 
     count1 = a.count([b'unit', 'test'])
     count2 = a.count([123, 123])
     count3 = a.count([True, False])
 
-    b: Tuple[int, int, int] = (count1, count2, count3)
+    b: tuple[int, int, int] = (count1, count2, count3)
     return b

--- a/boa3_test/test_sc/built_in_methods_test/CountTupleDifferentTypes.py
+++ b/boa3_test/test_sc/built_in_methods_test/CountTupleDifferentTypes.py
@@ -1,10 +1,8 @@
-from typing import Tuple
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def main() -> Tuple[int, int, int]:
+def main() -> tuple[int, int, int]:
     a = (b'unit', 'test', b'unit', b'unit', 123, 123, True, False)
-    b: Tuple[int, int, int] = (a.count(b'unit'), a.count('test'), a.count(123))
+    b: tuple[int, int, int] = (a.count(b'unit'), a.count('test'), a.count(123))
     return b

--- a/boa3_test/test_sc/built_in_methods_test/ExtendTooFewParameters.py
+++ b/boa3_test/test_sc/built_in_methods_test/ExtendTooFewParameters.py
@@ -1,7 +1,7 @@
-from typing import Any, List
+from typing import Any
 
 
-def Main(op: str, args: list) -> List[Any]:
+def Main(op: str, args: list) -> list[Any]:
     a = [1, 2, 3]
     list.extend((4, 5, 6))
     return a

--- a/boa3_test/test_sc/built_in_methods_test/ExtendTooManyParameters.py
+++ b/boa3_test/test_sc/built_in_methods_test/ExtendTooManyParameters.py
@@ -1,7 +1,7 @@
-from typing import Any, List
+from typing import Any
 
 
-def Main(op: str, args: list) -> List[Any]:
+def Main(op: str, args: list) -> list[Any]:
     a = [1, 2, 3]
     a.extend(4, 5, 6)
     return a

--- a/boa3_test/test_sc/built_in_methods_test/ExtendTuple.py
+++ b/boa3_test/test_sc/built_in_methods_test/ExtendTuple.py
@@ -1,7 +1,4 @@
-from typing import Tuple
-
-
-def Main(op: str, args: list) -> Tuple[int]:
+def Main(op: str, args: list) -> tuple[int]:
     a = (1, 2, 3)
     a.extend([4, 5, 6])  # compiler error - tuples are immutables
     return a

--- a/boa3_test/test_sc/built_in_methods_test/ListAny.py
+++ b/boa3_test/test_sc/built_in_methods_test/ListAny.py
@@ -1,32 +1,32 @@
-from typing import Any, Dict, List, Union
+from typing import Any, Union
 
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(x: Any) -> List[Any]:
+def main(x: Any) -> list[Any]:
     return list(x)
 
 
-def verify_union_types_1(x: Union[int, str, bytes]) -> List[int]:
+def verify_union_types_1(x: Union[int, str, bytes]) -> list[int]:
     return list(x)
 
 
-def verify_union_types_2(x: Union[int, str]) -> List[str]:
+def verify_union_types_2(x: Union[int, str]) -> list[str]:
     return list(x)
 
 
-def verify_union_types_3(x: Union[List[int], str]) -> List[Union[str, int]]:
+def verify_union_types_3(x: Union[list[int], str]) -> list[Union[str, int]]:
     return list(x)
 
 
-def verify_union_types_4(x: Union[List[int], str]) -> List[Union[int, str]]:
+def verify_union_types_4(x: Union[list[int], str]) -> list[Union[int, str]]:
     return list(x)
 
 
-def verify_union_types_5(x: Union[Dict[str, bytes], int]) -> List[str]:
+def verify_union_types_5(x: Union[dict[str, bytes], int]) -> list[str]:
     return list(x)
 
 
-def verify_union_types_6(x: Union[Dict[str, bytes], List[bytes], str, bytes]) -> List[str, int, bytes]:
+def verify_union_types_6(x: Union[dict[str, bytes], list[bytes], str, bytes]) -> list[str, int, bytes]:
     return list(x)

--- a/boa3_test/test_sc/built_in_methods_test/ListBytes.py
+++ b/boa3_test/test_sc/built_in_methods_test/ListBytes.py
@@ -1,12 +1,10 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(x: bytes) -> List[int]:
+def main(x: bytes) -> list[int]:
     return list(x)
 
 
-def verify_return() -> List[int]:
+def verify_return() -> list[int]:
     return list(b'123')

--- a/boa3_test/test_sc/built_in_methods_test/ListBytesMismatchedReturnType.py
+++ b/boa3_test/test_sc/built_in_methods_test/ListBytesMismatchedReturnType.py
@@ -1,5 +1,2 @@
-from typing import List
-
-
-def main() -> List[bytes]:
+def main() -> list[bytes]:
     return list(b'123')

--- a/boa3_test/test_sc/built_in_methods_test/ListBytesString.py
+++ b/boa3_test/test_sc/built_in_methods_test/ListBytesString.py
@@ -1,10 +1,10 @@
-from typing import List, Union
+from typing import Union
 
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(x: Union[bytes, str]) -> List[Union[int, str]]:
+def main(x: Union[bytes, str]) -> list[Union[int, str]]:
     a = 'unit test'
     b = b'unit test'
 

--- a/boa3_test/test_sc/built_in_methods_test/ListDefault.py
+++ b/boa3_test/test_sc/built_in_methods_test/ListDefault.py
@@ -1,8 +1,8 @@
-from typing import Any, List
+from typing import Any
 
 from boa3.builtin.compile_time import public
 
 
 @public
-def main() -> List[Any]:
+def main() -> list[Any]:
     return list()

--- a/boa3_test/test_sc/built_in_methods_test/ListMapping.py
+++ b/boa3_test/test_sc/built_in_methods_test/ListMapping.py
@@ -1,26 +1,26 @@
-from typing import Any, List, Mapping
+from typing import Any, Mapping
 
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(x: Mapping) -> List[Any]:
+def main(x: Mapping) -> list[Any]:
     return list(x)
 
 
-def verify_return_type_int() -> List[int]:
+def verify_return_type_int() -> list[int]:
     return list(
         {1: '123', 2: '4', 45: '123', 123: '00'}
     )
 
 
-def verify_return_type_str() -> List[str]:
+def verify_return_type_str() -> list[str]:
     return list(
         {'1': 123, '2': '4', '45': '123', '123': 00}
     )
 
 
-def verify_return_type_bytes() -> List[bytes]:
+def verify_return_type_bytes() -> list[bytes]:
     return list(
         {b'1': 123, b'2': '4', b'45': '123', b'123': 00}
     )

--- a/boa3_test/test_sc/built_in_methods_test/ListMappingMismatchedReturnType.py
+++ b/boa3_test/test_sc/built_in_methods_test/ListMappingMismatchedReturnType.py
@@ -1,7 +1,4 @@
-from typing import List
-
-
-def main() -> List[str]:
+def main() -> list[str]:
     return list(
         {'123': 00, 123: 123}
     )

--- a/boa3_test/test_sc/built_in_methods_test/ListSequence.py
+++ b/boa3_test/test_sc/built_in_methods_test/ListSequence.py
@@ -1,15 +1,15 @@
-from typing import Any, List, Sequence
+from typing import Any, Sequence
 
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(x: Sequence) -> List[Any]:
+def main(x: Sequence) -> list[Any]:
     return list(x)
 
 
 @public
-def verify_list_unchanged(x: List[Any]) -> List[Any]:
+def verify_list_unchanged(x: list[Any]) -> list[Any]:
     new_list = list(x)
 
     x[0] = x[1]
@@ -17,13 +17,13 @@ def verify_list_unchanged(x: List[Any]) -> List[Any]:
     return new_list
 
 
-def verify_return_type_int() -> List[int]:
+def verify_return_type_int() -> list[int]:
     return list([123, 45, 512, 1265, 76134, 121])
 
 
-def verify_return_type_str() -> List[str]:
+def verify_return_type_str() -> list[str]:
     return list(['unit', 'test', 'aaa', ''])
 
 
-def verify_return_type_bytes() -> List[bytes]:
+def verify_return_type_bytes() -> list[bytes]:
     return list([b'unit', b'test', b'aaa', b''])

--- a/boa3_test/test_sc/built_in_methods_test/ListSequenceMismatchedReturnType.py
+++ b/boa3_test/test_sc/built_in_methods_test/ListSequenceMismatchedReturnType.py
@@ -1,5 +1,2 @@
-from typing import List
-
-
-def main() -> List[str]:
+def main() -> list[str]:
     return list([123, 456, '1234', b'123'])

--- a/boa3_test/test_sc/built_in_methods_test/ListString.py
+++ b/boa3_test/test_sc/built_in_methods_test/ListString.py
@@ -1,8 +1,6 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(x: str) -> List[str]:
+def main(x: str) -> list[str]:
     return list(x)

--- a/boa3_test/test_sc/built_in_methods_test/ListStringMismatchedReturnType.py
+++ b/boa3_test/test_sc/built_in_methods_test/ListStringMismatchedReturnType.py
@@ -1,5 +1,2 @@
-from typing import List
-
-
-def main() -> List[int]:
+def main() -> list[int]:
     return list('123')

--- a/boa3_test/test_sc/built_in_methods_test/ReverseTooFewParameters.py
+++ b/boa3_test/test_sc/built_in_methods_test/ReverseTooFewParameters.py
@@ -1,7 +1,4 @@
-from typing import List
-
-
-def Main() -> List[int]:
-    a: List[int] = [1, 2, 3]
+def Main() -> list[int]:
+    a: list[int] = [1, 2, 3]
     list.reverse()
     return a

--- a/boa3_test/test_sc/built_in_methods_test/ReverseTooManyParameters.py
+++ b/boa3_test/test_sc/built_in_methods_test/ReverseTooManyParameters.py
@@ -1,7 +1,4 @@
-from typing import List
-
-
-def Main() -> List[int]:
-    a: List[int] = [1, 2, 3]
+def Main() -> list[int]:
+    a: list[int] = [1, 2, 3]
     a.reverse(a)
     return a

--- a/boa3_test/test_sc/built_in_methods_test/ReverseTuple.py
+++ b/boa3_test/test_sc/built_in_methods_test/ReverseTuple.py
@@ -1,7 +1,4 @@
-from typing import Tuple
-
-
-def Main() -> Tuple[int]:
-    a: Tuple[int] = (1, 2, 3)
+def Main() -> tuple[int]:
+    a: tuple[int] = (1, 2, 3)
     a.reverse()
     return a

--- a/boa3_test/test_sc/built_in_methods_test/StrSplit.py
+++ b/boa3_test/test_sc/built_in_methods_test/StrSplit.py
@@ -1,8 +1,6 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(string: str, sep: str, maxsplit: int) -> List[str]:
+def main(string: str, sep: str, maxsplit: int) -> list[str]:
     return string.split(sep, maxsplit)

--- a/boa3_test/test_sc/built_in_methods_test/StrSplitMaxsplitDefault.py
+++ b/boa3_test/test_sc/built_in_methods_test/StrSplitMaxsplitDefault.py
@@ -1,8 +1,6 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(string: str, sep: str) -> List[str]:
+def main(string: str, sep: str) -> list[str]:
     return string.split(sep)

--- a/boa3_test/test_sc/built_in_methods_test/StrSplitSeparatorDefault.py
+++ b/boa3_test/test_sc/built_in_methods_test/StrSplitSeparatorDefault.py
@@ -1,8 +1,6 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(string: str) -> List[str]:
+def main(string: str) -> list[str]:
     return string.split()

--- a/boa3_test/test_sc/built_in_methods_test/Sum.py
+++ b/boa3_test/test_sc/built_in_methods_test/Sum.py
@@ -1,8 +1,6 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(x: List[int]) -> int:
+def main(x: list[int]) -> int:
     return sum(x)

--- a/boa3_test/test_sc/built_in_methods_test/SumTooFewParameters.py
+++ b/boa3_test/test_sc/built_in_methods_test/SumTooFewParameters.py
@@ -1,5 +1,2 @@
-from typing import List
-
-
-def main(x: List[int], start: int) -> int:
+def main(x: list[int], start: int) -> int:
     return sum()

--- a/boa3_test/test_sc/built_in_methods_test/SumTooManyParameters.py
+++ b/boa3_test/test_sc/built_in_methods_test/SumTooManyParameters.py
@@ -1,5 +1,2 @@
-from typing import List
-
-
-def main(x: List[int], start: int) -> int:
+def main(x: list[int], start: int) -> int:
     return sum(x, start, 10)

--- a/boa3_test/test_sc/built_in_methods_test/SumWithStart.py
+++ b/boa3_test/test_sc/built_in_methods_test/SumWithStart.py
@@ -1,8 +1,6 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(x: List[int], start: int) -> int:
+def main(x: list[int], start: int) -> int:
     return sum(x, start)

--- a/boa3_test/test_sc/bytes_test/BytearrayFromListOfInt.py
+++ b/boa3_test/test_sc/bytes_test/BytearrayFromListOfInt.py
@@ -1,8 +1,6 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def create_bytearray(int_list: List[int]) -> bytearray:
+def create_bytearray(int_list: list[int]) -> bytearray:
     return bytearray(int_list)  # not supported yet

--- a/boa3_test/test_sc/bytes_test/JoinBytesMethodWithDictionary.py
+++ b/boa3_test/test_sc/bytes_test/JoinBytesMethodWithDictionary.py
@@ -1,8 +1,8 @@
-from typing import Any, Dict
+from typing import Any
 
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(string: bytes, dictionary: Dict[bytes, Any]) -> bytes:
+def main(string: bytes, dictionary: dict[bytes, Any]) -> bytes:
     return string.join(dictionary)

--- a/boa3_test/test_sc/class_test/NotificationGetVariables.py
+++ b/boa3_test/test_sc/class_test/NotificationGetVariables.py
@@ -1,25 +1,25 @@
-from typing import Any, List
+from typing import Any
 
 from boa3.builtin.compile_time import public
 from boa3.builtin.interop.runtime import Notification, executing_script_hash, get_notifications, notify
 
 
 @public
-def script_hash(args: List[Any]) -> bytes:
+def script_hash(args: list[Any]) -> bytes:
     return notification(args).script_hash
 
 
 @public
-def event_name(args: List[Any]) -> str:
+def event_name(args: list[Any]) -> str:
     return notification(args).event_name
 
 
 @public
-def state(args: List[Any]) -> Any:
+def state(args: list[Any]) -> Any:
     return notification(args).state
 
 
-def notification(args: List[Any]) -> Notification:
+def notification(args: list[Any]) -> Notification:
     for x in args:
         notify(x)
 

--- a/boa3_test/test_sc/class_test/NotificationSetVariables.py
+++ b/boa3_test/test_sc/class_test/NotificationSetVariables.py
@@ -1,4 +1,4 @@
-from typing import Any, Tuple
+from typing import Any
 
 from boa3.builtin.compile_time import public
 from boa3.builtin.interop.runtime import Notification
@@ -20,7 +20,7 @@ def event_name(event: str) -> str:
 
 
 @public
-def state(obj: Tuple[Any, ...]) -> Any:
+def state(obj: tuple[Any, ...]) -> Any:
     x = Notification()
     x.state = obj
     return x.state

--- a/boa3_test/test_sc/class_test/UserClassWithClassMethodWithVararg.py
+++ b/boa3_test/test_sc/class_test/UserClassWithClassMethodWithVararg.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
@@ -12,5 +10,5 @@ class Example:
 
 
 @public
-def call_by_class_name(arg: List[int]) -> int:
+def call_by_class_name(arg: list[int]) -> int:
     return Example.some_method(*arg)

--- a/boa3_test/test_sc/class_test/UserClassWithStaticMethodWithVararg.py
+++ b/boa3_test/test_sc/class_test/UserClassWithStaticMethodWithVararg.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
@@ -12,5 +10,5 @@ class Example:
 
 
 @public
-def call_by_class_name(arg: List[int]) -> int:
+def call_by_class_name(arg: list[int]) -> int:
     return Example.some_method(*arg)

--- a/boa3_test/test_sc/dict_test/AnyValueDict.py
+++ b/boa3_test/test_sc/dict_test/AnyValueDict.py
@@ -1,11 +1,11 @@
-from typing import Any, Dict
+from typing import Any
 
 from boa3.builtin.compile_time import public
 
 
 @public
 def Main():
-    a: Dict[int, Any] = {
+    a: dict[int, Any] = {
         1: True,
         2: 4,
         3: 'nine'

--- a/boa3_test/test_sc/dict_test/CopyDictBuiltinCall.py
+++ b/boa3_test/test_sc/dict_test/CopyDictBuiltinCall.py
@@ -1,11 +1,11 @@
-from typing import Any, Dict, Tuple
+from typing import Any
 
 from boa3.builtin.compile_time import public
 
 
 @public
-def copy_dict(dict_: Dict[Any, Any], key: Any, value: Any) -> Tuple[Dict[Any, Any], Dict[Any, Any]]:
-    dict_copy = Dict.copy(dict_)
+def copy_dict(dict_: dict[Any, Any], key: Any, value: Any) -> tuple[dict[Any, Any], dict[Any, Any]]:
+    dict_copy = dict.copy(dict_)
 
     dict_copy[key] = value
 

--- a/boa3_test/test_sc/dict_test/DictAnyKeyAndValue.py
+++ b/boa3_test/test_sc/dict_test/DictAnyKeyAndValue.py
@@ -1,4 +1,4 @@
-from typing import List, cast
+from typing import cast
 
 from boa3.builtin.compile_time import public
 
@@ -18,7 +18,7 @@ def main() -> int:
 
     value1: int = d['fcall']
 
-    return value1 + cast(List[int], d['c'])[3]
+    return value1 + cast(list[int], d['c'])[3]
 
 
 def mymethod(a: int, b: int) -> int:

--- a/boa3_test/test_sc/dict_test/DictBoa2Test1.py
+++ b/boa3_test/test_sc/dict_test/DictBoa2Test1.py
@@ -1,11 +1,11 @@
-from typing import Any, Dict
+from typing import Any
 
 from boa3.builtin.compile_time import public
 
 
 @public
-def main() -> Dict[Any, int]:
-    d: Dict[Any, int] = {}
+def main() -> dict[Any, int]:
+    d: dict[Any, int] = {}
     d['a'] = 4
     d[13] = 3
 

--- a/boa3_test/test_sc/dict_test/DictBoa2Test2.py
+++ b/boa3_test/test_sc/dict_test/DictBoa2Test2.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 from boa3.builtin.compile_time import public
 
@@ -6,7 +6,7 @@ from boa3.builtin.compile_time import public
 @public
 def Main() -> int:
 
-    d: Dict[Any, int] = {}
+    d: dict[Any, int] = {}
 
     d['a'] = 4
     d[13] = 3

--- a/boa3_test/test_sc/dict_test/DictBoa2Test4.py
+++ b/boa3_test/test_sc/dict_test/DictBoa2Test4.py
@@ -1,4 +1,4 @@
-from typing import List, cast
+from typing import cast
 
 from boa3.builtin.compile_time import public
 
@@ -18,7 +18,7 @@ def main() -> int:
     }
 
     j4: int = d['mcalll']
-    return j4 + cast(List[int], d['z'])[3]
+    return j4 + cast(list[int], d['z'])[3]
 
 
 def mymethod(a: int, b: int) -> int:

--- a/boa3_test/test_sc/dict_test/DictBoa2Test6ShouldNotCompile.py
+++ b/boa3_test/test_sc/dict_test/DictBoa2Test6ShouldNotCompile.py
@@ -1,10 +1,10 @@
-from typing import Any, Dict
+from typing import Any
 
 from boa3.builtin.compile_time import public
 
 
 @public
-def main() -> Dict[Any, int]:
+def main() -> dict[Any, int]:
 
     q = 3
 

--- a/boa3_test/test_sc/dict_test/DictCopy.py
+++ b/boa3_test/test_sc/dict_test/DictCopy.py
@@ -1,10 +1,10 @@
-from typing import Any, Dict, List
+from typing import Any
 
 from boa3.builtin.compile_time import public
 
 
 @public
-def copy_dict(dict_: Dict[Any, Any]) -> List[Dict[Any, Any]]:
+def copy_dict(dict_: dict[Any, Any]) -> list[dict[Any, Any]]:
     dict_copy = dict_.copy()
     dict_copy['unit'] = 'test'
     return [dict_, dict_copy]

--- a/boa3_test/test_sc/dict_test/DictGetValue.py
+++ b/boa3_test/test_sc/dict_test/DictGetValue.py
@@ -1,8 +1,6 @@
-from typing import Dict
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def Main(a: Dict[int, str]) -> str:
+def Main(a: dict[int, str]) -> str:
     return a[0]  # raises runtime error if the dict doesn't contain this key

--- a/boa3_test/test_sc/dict_test/DictOfDict.py
+++ b/boa3_test/test_sc/dict_test/DictOfDict.py
@@ -1,11 +1,9 @@
-from typing import Dict
-
 from boa3.builtin.compile_time import public
 
 
 @public
 def Main():
-    a: Dict[int, Dict[int, bool]] = {
+    a: dict[int, dict[int, bool]] = {
         1: {
             14: False,
             12: True,

--- a/boa3_test/test_sc/dict_test/DictPop.py
+++ b/boa3_test/test_sc/dict_test/DictPop.py
@@ -1,10 +1,10 @@
-from typing import Any, Dict, Tuple
+from typing import Any
 
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(dict_: Dict[Any, Any], key: Any) -> Tuple[Dict[Any, Any], Any]:
+def main(dict_: dict[Any, Any], key: Any) -> tuple[dict[Any, Any], Any]:
     value = dict_.pop(key)
     new_dict_and_value = (dict_, value)
     return new_dict_and_value

--- a/boa3_test/test_sc/dict_test/DictPopDefault.py
+++ b/boa3_test/test_sc/dict_test/DictPopDefault.py
@@ -1,10 +1,10 @@
-from typing import Any, Dict, Tuple
+from typing import Any
 
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(dict_: Dict[Any, Any], key: Any, default: Any) -> Tuple[Dict[Any, Any], Any]:
+def main(dict_: dict[Any, Any], key: Any, default: Any) -> tuple[dict[Any, Any], Any]:
     value = dict_.pop(key, default)
     new_dict_and_value = (dict_, value)
     return new_dict_and_value

--- a/boa3_test/test_sc/dict_test/DictSetValue.py
+++ b/boa3_test/test_sc/dict_test/DictSetValue.py
@@ -1,9 +1,7 @@
-from typing import Dict
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def Main(a: Dict[int, str]) -> Dict[int, str]:
+def Main(a: dict[int, str]) -> dict[int, str]:
     a[0] = 'ok'
     return a

--- a/boa3_test/test_sc/dict_test/EmptyDictAssignment.py
+++ b/boa3_test/test_sc/dict_test/EmptyDictAssignment.py
@@ -1,8 +1,6 @@
-from typing import Dict
-
 from boa3.builtin.compile_time import public
 
 
 @public
 def Main():
-    a: Dict[int, int] = {}
+    a: dict[int, int] = {}

--- a/boa3_test/test_sc/dict_test/KeysDict.py
+++ b/boa3_test/test_sc/dict_test/KeysDict.py
@@ -1,10 +1,10 @@
-from typing import Dict, Sequence
+from typing import Sequence
 
 from boa3.builtin.compile_time import public
 
 
 @public
 def Main() -> Sequence[str]:
-    a: Dict[str, int] = {'one': 1, 'two': 2, 'three': 3}
+    a: dict[str, int] = {'one': 1, 'two': 2, 'three': 3}
     b = a.keys()  # expected ['one', 'two', 'three']
     return b

--- a/boa3_test/test_sc/dict_test/MismatchedTypeDictGetValue.py
+++ b/boa3_test/test_sc/dict_test/MismatchedTypeDictGetValue.py
@@ -1,5 +1,2 @@
-from typing import Dict
-
-
-def Main(a: Dict[str, int]) -> int:
+def Main(a: dict[str, int]) -> int:
     return a[0]  # raises runtime error if the dict doesn't contain this key

--- a/boa3_test/test_sc/dict_test/MismatchedTypeDictSetValue.py
+++ b/boa3_test/test_sc/dict_test/MismatchedTypeDictSetValue.py
@@ -1,6 +1,3 @@
-from typing import Dict
-
-
-def Main(a: Dict[int, str]) -> Dict[int, str]:
+def Main(a: dict[int, str]) -> dict[int, str]:
     a[0] = True
     return a

--- a/boa3_test/test_sc/dict_test/MismatchedTypeKeysDict.py
+++ b/boa3_test/test_sc/dict_test/MismatchedTypeKeysDict.py
@@ -1,10 +1,10 @@
-from typing import Dict, Sequence, Tuple
+from typing import Sequence
 
 from boa3.builtin.compile_time import public
 
 
 @public
 def Main() -> Sequence[str]:
-    a: Dict[str, int] = {'one': 1, 'two': 2, 'three': 3}
-    b: Tuple[str, ...] = a.keys()
+    a: dict[str, int] = {'one': 1, 'two': 2, 'three': 3}
+    b: tuple[str, ...] = a.keys()
     return b

--- a/boa3_test/test_sc/dict_test/MismatchedTypeValuesDict.py
+++ b/boa3_test/test_sc/dict_test/MismatchedTypeValuesDict.py
@@ -1,10 +1,10 @@
-from typing import Dict, Sequence, Tuple
+from typing import Sequence
 
 from boa3.builtin.compile_time import public
 
 
 @public
 def Main() -> Sequence[int]:
-    a: Dict[str, int] = {'one': 1, 'two': 2, 'three': 3}
-    b: Tuple[int, ...] = a.values()
+    a: dict[str, int] = {'one': 1, 'two': 2, 'three': 3}
+    b: tuple[int, ...] = a.values()
     return b

--- a/boa3_test/test_sc/dict_test/TypeHintAssignment.py
+++ b/boa3_test/test_sc/dict_test/TypeHintAssignment.py
@@ -1,8 +1,6 @@
-from typing import Dict
-
 from boa3.builtin.compile_time import public
 
 
 @public
 def Main():
-    a: Dict[int, int] = {1: 15, 2: 14, 3: 13}
+    a: dict[int, int] = {1: 15, 2: 14, 3: 13}

--- a/boa3_test/test_sc/dict_test/ValuesDict.py
+++ b/boa3_test/test_sc/dict_test/ValuesDict.py
@@ -1,10 +1,10 @@
-from typing import Dict, Sequence
+from typing import Sequence
 
 from boa3.builtin.compile_time import public
 
 
 @public
 def Main() -> Sequence[int]:
-    a: Dict[str, int] = {'one': 1, 'two': 2, 'three': 3}
+    a: dict[str, int] = {'one': 1, 'two': 2, 'three': 3}
     b = a.values()  # expected [1, 2, 3]
     return b

--- a/boa3_test/test_sc/for_test/ForElse.py
+++ b/boa3_test/test_sc/for_test/ForElse.py
@@ -1,12 +1,10 @@
-from typing import Tuple
-
 from boa3.builtin.compile_time import public
 
 
 @public
 def Main() -> int:
     a: int = 0
-    sequence: Tuple[int, int, int] = (3, 5, 15)
+    sequence: tuple[int, int, int] = (3, 5, 15)
 
     for x in sequence:
         a = a + x

--- a/boa3_test/test_sc/for_test/ForWithContractInterface.py
+++ b/boa3_test/test_sc/for_test/ForWithContractInterface.py
@@ -1,11 +1,9 @@
-from typing import List
-
 from boa3.builtin.compile_time import public, contract
 
 
 @public
-def main(number: int) -> List[int]:
-    result_list: List[int] = []
+def main(number: int) -> list[int]:
+    result_list: list[int] = []
     for x in range(number):
         idx: int = AnotherContract.return_zero()
         result_list.append(idx)

--- a/boa3_test/test_sc/for_test/NestedFor.py
+++ b/boa3_test/test_sc/for_test/NestedFor.py
@@ -1,12 +1,10 @@
-from typing import Tuple
-
 from boa3.builtin.compile_time import public
 
 
 @public
 def Main() -> int:
     a: int = 0
-    sequence: Tuple[int, int, int] = (3, 5, 15)
+    sequence: tuple[int, int, int] = (3, 5, 15)
 
     for x in sequence:
         for y in sequence:

--- a/boa3_test/test_sc/function_test/CallFunctionsWithSameNameInDifferentScopes.py
+++ b/boa3_test/test_sc/function_test/CallFunctionsWithSameNameInDifferentScopes.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 from boa3.builtin.compile_time import public
 
 
@@ -15,7 +13,7 @@ def test() -> int:
 
 
 @public
-def result() -> Tuple[int, int]:
+def result() -> tuple[int, int]:
     a = Example.test()
     b = test()
     c = (a, b)

--- a/boa3_test/test_sc/function_test/EmptyListReturn.py
+++ b/boa3_test/test_sc/function_test/EmptyListReturn.py
@@ -1,8 +1,6 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def Main() -> List[int]:
+def Main() -> list[int]:
     return []

--- a/boa3_test/test_sc/function_test/FunctionWithArgAsArg.py
+++ b/boa3_test/test_sc/function_test/FunctionWithArgAsArg.py
@@ -1,10 +1,8 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(a: List[int], value: int) -> int:
+def main(a: list[int], value: int) -> int:
     var = return_same(a.index(value))
 
     return var

--- a/boa3_test/test_sc/function_test/FunctionWithArgsAsArg.py
+++ b/boa3_test/test_sc/function_test/FunctionWithArgsAsArg.py
@@ -1,10 +1,8 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(a: List[int], value: int, start: int, end: int) -> int:
+def main(a: list[int], value: int, start: int, end: int) -> int:
     var = return_same(a.index(value, start, end))
 
     return var

--- a/boa3_test/test_sc/function_test/FunctionWithDefaultArgument.py
+++ b/boa3_test/test_sc/function_test/FunctionWithDefaultArgument.py
@@ -1,10 +1,8 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def Main() -> List[int]:
+def Main() -> list[int]:
     x = add(1, 2, 3)
     y = add(5, 6)
     return [x, y]

--- a/boa3_test/test_sc/function_test/FunctionWithDictionaryUnpackingOperator.py
+++ b/boa3_test/test_sc/function_test/FunctionWithDictionaryUnpackingOperator.py
@@ -1,13 +1,13 @@
-from typing import Any, Dict
+from typing import Any
 
 from boa3.builtin.compile_time import public
 
 
 @public
-def function_with_unpacking(**kwargs: Dict[Any, Any]) -> int:  # not sure if Dict is the best type
+def function_with_unpacking(**kwargs: dict[Any, Any]) -> int:  # not sure if Dict is the best type
     return len(kwargs)
 
 
 @public
-def main(dictionary: Dict[str, int]) -> int:
+def main(dictionary: dict[str, int]) -> int:
     return function_with_unpacking(**dictionary)

--- a/boa3_test/test_sc/function_test/FunctionsWithDuplicatedName.py
+++ b/boa3_test/test_sc/function_test/FunctionsWithDuplicatedName.py
@@ -1,14 +1,12 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 from boa3.builtin.type import UInt160
 
 
 @public
-def func_no_arg_with_return_array() -> List[int]:
+def func_no_arg_with_return_array() -> list[int]:
     return [1, 2]
 
 
 @public
-def func_no_arg_with_return_array() -> List[UInt160]:
+def func_no_arg_with_return_array() -> list[UInt160]:
     return [UInt160(b'\x01' * 20), UInt160(b'\x02' * 20)]

--- a/boa3_test/test_sc/function_test/MethodBoa2Test3.py
+++ b/boa3_test/test_sc/function_test/MethodBoa2Test3.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
@@ -25,5 +23,5 @@ def add(a: int, b: int, c: int, d: int, e: int) -> int:
     return result
 
 
-def get_first_item(array_item: List[int]) -> int:
+def get_first_item(array_item: list[int]) -> int:
     return array_item[0]

--- a/boa3_test/test_sc/function_test/MultipleFunctionLargeCall.py
+++ b/boa3_test/test_sc/function_test/MultipleFunctionLargeCall.py
@@ -1,12 +1,12 @@
-from typing import Any, List
+from typing import Any
 
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(operation: str, arg: List[int]) -> Any:
+def main(operation: str, arg: list[int]) -> Any:
     if operation == 'calculate' and len(arg) >= 2:
-        operands: List[int] = []
+        operands: list[int] = []
         i = 1
         while i < len(arg):
             operands.append(arg[i])
@@ -17,7 +17,7 @@ def main(operation: str, arg: List[int]) -> Any:
 
 
 @public
-def calculate(op_id: int, operands: List[int]) -> Any:
+def calculate(op_id: int, operands: list[int]) -> Any:
     op = get_operation(op_id)
     result: Any
     if len(operands) <= 0:

--- a/boa3_test/test_sc/function_test/NoneFunctionChangingValuesWithReturn.py
+++ b/boa3_test/test_sc/function_test/NoneFunctionChangingValuesWithReturn.py
@@ -1,15 +1,13 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
-def return_none(a: List[int]) -> None:
+def return_none(a: list[int]) -> None:
     a.append(10)
     return None
 
 
 @public
-def main() -> List[int]:
+def main() -> list[int]:
     a = [2, 4, 6, 8]
     return_none(a)
     return a

--- a/boa3_test/test_sc/function_test/NoneFunctionChangingValuesWithoutReturn.py
+++ b/boa3_test/test_sc/function_test/NoneFunctionChangingValuesWithoutReturn.py
@@ -1,14 +1,12 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
-def return_none(a: List[int]) -> None:
+def return_none(a: list[int]) -> None:
     a.append(10)
 
 
 @public
-def main() -> List[int]:
+def main() -> list[int]:
     a = [2, 4, 6, 8]
     return_none(a)
     return a

--- a/boa3_test/test_sc/function_test/ReturnFor.py
+++ b/boa3_test/test_sc/function_test/ReturnFor.py
@@ -1,10 +1,8 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def Main(iterator: List[int]) -> int:
+def Main(iterator: list[int]) -> int:
     for value in iterator:
         return value
     else:

--- a/boa3_test/test_sc/function_test/ReturnForElseMissing.py
+++ b/boa3_test/test_sc/function_test/ReturnForElseMissing.py
@@ -1,7 +1,4 @@
-from typing import List
-
-
-def Main(iterator: List[int]) -> int:
+def Main(iterator: list[int]) -> int:
     for value in iterator:
         return value
     else:

--- a/boa3_test/test_sc/function_test/ReturnForOnlyOnElse.py
+++ b/boa3_test/test_sc/function_test/ReturnForOnlyOnElse.py
@@ -1,10 +1,8 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def Main(iterator: List[int]) -> int:
+def Main(iterator: list[int]) -> int:
     x = 0
     for value in iterator:
         x += value

--- a/boa3_test/test_sc/function_test/ReturnStarredArgumentCount.py
+++ b/boa3_test/test_sc/function_test/ReturnStarredArgumentCount.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
@@ -9,5 +7,5 @@ def fun_with_starred(*args: int) -> int:
 
 
 @public
-def main(list_with_args: List[int]) -> int:
+def main(list_with_args: list[int]) -> int:
     return fun_with_starred(*list_with_args)

--- a/boa3_test/test_sc/generation_test/GenerationWithMultipleFlows.py
+++ b/boa3_test/test_sc/generation_test/GenerationWithMultipleFlows.py
@@ -1,10 +1,8 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def Main(operation: str, args: List[int]) -> int:
+def Main(operation: str, args: list[int]) -> int:
     if len(args) < 2:
         return 0
     a: int = args[0]

--- a/boa3_test/test_sc/generation_test/GenerationWithUserModuleImports.py
+++ b/boa3_test/test_sc/generation_test/GenerationWithUserModuleImports.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 from boa3.builtin.interop.runtime import Notification
 from boa3.builtin.type import UInt160
@@ -7,5 +5,5 @@ from boa3_test.test_sc.interop_test.runtime.GetNotifications import with_param
 
 
 @public
-def main(args: list, key: UInt160) -> List[Notification]:
+def main(args: list, key: UInt160) -> list[Notification]:
     return with_param(args, key)

--- a/boa3_test/test_sc/generation_test/GenerationWithUserModuleNameImports.py
+++ b/boa3_test/test_sc/generation_test/GenerationWithUserModuleNameImports.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 from boa3.builtin.interop.runtime import Notification
 from boa3.builtin.type import UInt160
@@ -7,5 +5,5 @@ from boa3_test.test_sc.interop_test.runtime import GetNotifications
 
 
 @public
-def main(args: list, key: UInt160) -> List[Notification]:
+def main(args: list, key: UInt160) -> list[Notification]:
     return GetNotifications.with_param(args, key)

--- a/boa3_test/test_sc/generation_test/ManifestTypeHintMapsArraysUnionHint.py
+++ b/boa3_test/test_sc/generation_test/ManifestTypeHintMapsArraysUnionHint.py
@@ -1,10 +1,10 @@
-from typing import List, Dict, Union
+from typing import Union
 
 from boa3.builtin.compile_time import public
 
 
 @public
-def Main(var: Dict[str, List[bool]]) -> List[Union[Dict[str, int], str, bool]]:
+def Main(var: dict[str, list[bool]]) -> list[Union[dict[str, int], str, bool]]:
     if var:
         return []
     return []

--- a/boa3_test/test_sc/generation_test/project_path/GenerationWithUserModuleImportsFromProjectRoot.py
+++ b/boa3_test/test_sc/generation_test/project_path/GenerationWithUserModuleImportsFromProjectRoot.py
@@ -1,5 +1,3 @@
-from typing import List
-
 # only compile if pass boa3_test/test_sc/generation_test as project root
 from GenerationWithUserModuleImports import with_param
 
@@ -9,5 +7,5 @@ from boa3.builtin.type import UInt160
 
 
 @public
-def main(args: list, key: UInt160) -> List[Notification]:
+def main(args: list, key: UInt160) -> list[Notification]:
     return with_param(args, key)

--- a/boa3_test/test_sc/if_test/IfElseMultipleIsInstanceConditionWithUnionVariable.py
+++ b/boa3_test/test_sc/if_test/IfElseMultipleIsInstanceConditionWithUnionVariable.py
@@ -1,10 +1,10 @@
-from typing import List, Union
+from typing import Union
 
 from boa3.builtin.compile_time import public
 
 
 @public
-def example(value: Union[List[bytes], int, bytes]) -> int:
+def example(value: Union[list[bytes], int, bytes]) -> int:
     if isinstance(value, (list, bytes)):
         x = value if isinstance(value, bytes) else (b'\x00' if len(value) == 0 else value[0])
         return len(x)

--- a/boa3_test/test_sc/import_test/FromImportAll.py
+++ b/boa3_test/test_sc/import_test/FromImportAll.py
@@ -5,7 +5,7 @@ from boa3_test.test_sc.import_test.FromImportTyping import *
 
 @public
 def call_imported_method() -> list:
-    a: List[Any] = EmptyList()
+    a: list[Any] = EmptyList()
     return a
 
 

--- a/boa3_test/test_sc/import_test/FromImportNotExistingMethod.py
+++ b/boa3_test/test_sc/import_test/FromImportNotExistingMethod.py
@@ -1,9 +1,9 @@
-from typing import Any, Dict
+from typing import Any
 
 from boa3.builtin.compile_time import public
 from package_with_import import Module as imported_module
 
 
 @public
-def get_token_json(token_id: bytes) -> Dict[str, Any]:
+def get_token_json(token_id: bytes) -> dict[str, Any]:
     return imported_module.get_token_json(token_id)  # this method doesn't exist in the imported module

--- a/boa3_test/test_sc/import_test/FromImportTyping.py
+++ b/boa3_test/test_sc/import_test/FromImportTyping.py
@@ -1,11 +1,11 @@
-from typing import Any, List
+from typing import Any
 
 from boa3.builtin.compile_time import \
     public as public_method  # alias to not change other tests when executing lint process
 
 
 @public_method
-def EmptyList() -> List[Any]:
+def EmptyList() -> list[Any]:
     return []
 
 

--- a/boa3_test/test_sc/import_test/FromImportTypingWithAlias.py
+++ b/boa3_test/test_sc/import_test/FromImportTypingWithAlias.py
@@ -1,8 +1,8 @@
-from typing import Any as Bar, List as Foo
+from typing import Any as Bar
 
 from boa3.builtin.compile_time import public
 
 
 @public
-def EmptyList() -> Foo[Bar]:
+def EmptyList() -> list[Bar]:
     return []

--- a/boa3_test/test_sc/import_test/FromImportUserModule.py
+++ b/boa3_test/test_sc/import_test/FromImportUserModule.py
@@ -1,4 +1,4 @@
-from typing import Any, List
+from typing import Any
 
 from boa3.builtin.compile_time import public
 from boa3_test.test_sc.import_test.FromImportTyping import EmptyList
@@ -6,5 +6,5 @@ from boa3_test.test_sc.import_test.FromImportTyping import EmptyList
 
 @public
 def Main() -> list:
-    a: List[Any] = EmptyList()
+    a: list[Any] = EmptyList()
     return a

--- a/boa3_test/test_sc/import_test/FromImportUserModuleFromRootAndFileDir.py
+++ b/boa3_test/test_sc/import_test/FromImportUserModuleFromRootAndFileDir.py
@@ -1,4 +1,4 @@
-from typing import Any, List
+from typing import Any
 
 from boa3.builtin.compile_time import public
 from boa3_test.test_sc.import_test.FromImportTyping import EmptyList as RootImportedFunction
@@ -7,11 +7,11 @@ from package_with_import.Module import EmptyList as FileDirImportedFunction
 
 @public
 def call_imported_from_root() -> list:
-    a: List[Any] = RootImportedFunction()
+    a: list[Any] = RootImportedFunction()
     return a
 
 
 @public
 def call_imported_from_file_dir() -> list:
-    a: List[Any] = FileDirImportedFunction()
+    a: list[Any] = FileDirImportedFunction()
     return a

--- a/boa3_test/test_sc/import_test/FromImportUserModuleWithAlias.py
+++ b/boa3_test/test_sc/import_test/FromImportUserModuleWithAlias.py
@@ -1,4 +1,4 @@
-from typing import Any, List
+from typing import Any
 
 from boa3.builtin.compile_time import public
 from boa3_test.test_sc.import_test.FromImportTyping import EmptyList as NewList
@@ -6,5 +6,5 @@ from boa3_test.test_sc.import_test.FromImportTyping import EmptyList as NewList
 
 @public
 def Main() -> list:
-    a: List[Any] = NewList()
+    a: list[Any] = NewList()
     return a

--- a/boa3_test/test_sc/import_test/FromImportVariable.py
+++ b/boa3_test/test_sc/import_test/FromImportVariable.py
@@ -1,9 +1,9 @@
-from typing import Any, List
+from typing import Any
 
 from boa3.builtin.compile_time import public
 from boa3_test.test_sc.import_test.FromImportTyping import empty_list
 
 
 @public
-def Main() -> List[Any]:
+def Main() -> list[Any]:
     return empty_list

--- a/boa3_test/test_sc/import_test/FromImportWithGlobalVariables.py
+++ b/boa3_test/test_sc/import_test/FromImportWithGlobalVariables.py
@@ -1,4 +1,4 @@
-from typing import Any, List
+from typing import Any
 
 from boa3.builtin.compile_time import public
 from boa3_test.test_sc.import_test.FromImportTyping import EmptyList
@@ -7,5 +7,5 @@ a = EmptyList()
 
 
 @public
-def Main() -> List[Any]:
+def Main() -> list[Any]:
     return a

--- a/boa3_test/test_sc/import_test/ImportModuleWithInit.py
+++ b/boa3_test/test_sc/import_test/ImportModuleWithInit.py
@@ -5,7 +5,7 @@ from boa3_test.test_sc.import_test.package_with_import import Module
 
 @public
 def call_imported_method() -> list:
-    a: Module.List[Module.Any] = Module.EmptyList()
+    a: list[Module.Any] = Module.EmptyList()
     return a
 
 

--- a/boa3_test/test_sc/import_test/ImportModuleWithoutInit.py
+++ b/boa3_test/test_sc/import_test/ImportModuleWithoutInit.py
@@ -5,7 +5,7 @@ from boa3_test.test_sc.import_test.sample_package.package import another_module,
 
 @public
 def call_imported_method() -> dict:
-    a: another_module.Dict[another_module.Any, another_module.Any] = another_module.EmptyDict()
+    a: dict[another_module.Any, another_module.Any] = another_module.EmptyDict()
     return a
 
 

--- a/boa3_test/test_sc/import_test/ImportNotExistingMethod.py
+++ b/boa3_test/test_sc/import_test/ImportNotExistingMethod.py
@@ -1,9 +1,9 @@
-from typing import Any, Dict
+from typing import Any
 
 import FromImportAll as imported_module
 from boa3.builtin.compile_time import public
 
 
 @public
-def get_token_json(token_id: bytes) -> Dict[str, Any]:
+def get_token_json(token_id: bytes) -> dict[str, Any]:
     return imported_module.get_token_json(token_id)  # this method doesn't exist in the imported module

--- a/boa3_test/test_sc/import_test/ImportUserModule.py
+++ b/boa3_test/test_sc/import_test/ImportUserModule.py
@@ -1,9 +1,9 @@
-from typing import Any, List
+from typing import Any
 
 import boa3_test.test_sc.import_test.FromImportTyping
 from boa3.builtin.compile_time import public
 
 
 @public
-def Main() -> List[Any]:
+def Main() -> list[Any]:
     return boa3_test.test_sc.import_test.FromImportTyping.EmptyList()

--- a/boa3_test/test_sc/import_test/ImportUserModuleWithAlias.py
+++ b/boa3_test/test_sc/import_test/ImportUserModuleWithAlias.py
@@ -1,9 +1,9 @@
-from typing import Any, List
+from typing import Any
 
 import boa3_test.test_sc.import_test.FromImportTyping as UserModule
 from boa3.builtin.compile_time import public
 
 
 @public
-def Main() -> List[Any]:
+def Main() -> list[Any]:
     return UserModule.EmptyList()

--- a/boa3_test/test_sc/import_test/ImportUserModuleWithNotImportedSymbols.py
+++ b/boa3_test/test_sc/import_test/ImportUserModuleWithNotImportedSymbols.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 from boa3.builtin.interop.runtime import Notification
 from boa3.builtin.type import UInt160
@@ -7,5 +5,5 @@ from boa3_test.test_sc.interop_test.runtime.GetNotifications import with_param
 
 
 @public
-def main(args: list, key: UInt160) -> List[Notification]:
+def main(args: list, key: UInt160) -> list[Notification]:
     return with_param(args, key)

--- a/boa3_test/test_sc/import_test/NotImportedBuiltinFromTypingInSubscript.py
+++ b/boa3_test/test_sc/import_test/NotImportedBuiltinFromTypingInSubscript.py
@@ -1,5 +1,2 @@
-from typing import Dict
-
-
-def Main(a: Dict[Any, Any]):  # Any is not imported
+def Main(a: dict[Any, Any]):  # Any is not imported
     b = a

--- a/boa3_test/test_sc/import_test/package_with_import/Module.py
+++ b/boa3_test/test_sc/import_test/package_with_import/Module.py
@@ -1,7 +1,7 @@
-from typing import Any, List
+from typing import Any
 
 
-def EmptyList() -> List[Any]:
+def EmptyList() -> list[Any]:
     return []
 
 

--- a/boa3_test/test_sc/import_test/sample_package/package/another_module.py
+++ b/boa3_test/test_sc/import_test/sample_package/package/another_module.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 empty_dict = {}
 

--- a/boa3_test/test_sc/interop_test/contract/CreateMultisigAccount.py
+++ b/boa3_test/test_sc/interop_test/contract/CreateMultisigAccount.py
@@ -1,10 +1,8 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 from boa3.builtin.interop.contract import create_multisig_account
 from boa3.builtin.type import ECPoint, UInt160
 
 
 @public
-def main(minimum_sigs: int, public_keys: List[ECPoint]) -> UInt160:
+def main(minimum_sigs: int, public_keys: list[ECPoint]) -> UInt160:
     return create_multisig_account(minimum_sigs, public_keys)

--- a/boa3_test/test_sc/interop_test/contract/CreateMultisigAccountTooManyArguments.py
+++ b/boa3_test/test_sc/interop_test/contract/CreateMultisigAccountTooManyArguments.py
@@ -1,8 +1,8 @@
-from typing import Any, List
+from typing import Any
 
 from boa3.builtin.interop.contract import create_multisig_account
 from boa3.builtin.type import ECPoint, UInt160
 
 
-def main(minimum_sigs: int, public_keys: List[ECPoint], arg: Any) -> UInt160:
+def main(minimum_sigs: int, public_keys: list[ECPoint], arg: Any) -> UInt160:
     return create_multisig_account(minimum_sigs, public_keys, arg)

--- a/boa3_test/test_sc/interop_test/crypto/CheckMultisig.py
+++ b/boa3_test/test_sc/interop_test/crypto/CheckMultisig.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 from boa3.builtin.interop.crypto import check_multisig
 from boa3.builtin.type import ECPoint
@@ -7,7 +5,7 @@ from boa3.builtin.type import ECPoint
 
 @public
 def main() -> bool:
-    pubkeys: List[ECPoint] = [ECPoint(b'\x03\xcd\xb0g\xd90\xfdZ\xda\xa6\xc6\x85E\x01`D\xaa\xdd\xecd\xba9\xe5H%\x0e\xae\xa5Q\x17.S\\'),
+    pubkeys: list[ECPoint] = [ECPoint(b'\x03\xcd\xb0g\xd90\xfdZ\xda\xa6\xc6\x85E\x01`D\xaa\xdd\xecd\xba9\xe5H%\x0e\xae\xa5Q\x17.S\\'),
                               ECPoint(b'\x03l\x841\xccx\xb31w\xa6\x0bK\xcc\x02\xba\xf6\r\x05\xfe\xe5\x03\x8es9\xd3\xa6\x88\xe3\x94\xc2\xcb\xd8C')]
-    signatures: List[bytes] = [b'wrongsignature1', b'wrongsignature2']
+    signatures: list[bytes] = [b'wrongsignature1', b'wrongsignature2']
     return check_multisig(pubkeys, signatures)

--- a/boa3_test/test_sc/interop_test/runtime/GetNotifications.py
+++ b/boa3_test/test_sc/interop_test/runtime/GetNotifications.py
@@ -1,4 +1,4 @@
-from typing import Any, List
+from typing import Any
 
 from boa3.builtin.compile_time import public
 from boa3.builtin.interop.runtime import Notification, get_notifications, notify
@@ -6,17 +6,17 @@ from boa3.builtin.type import UInt160
 
 
 @public
-def with_param(args: List[Any], key: UInt160) -> List[Notification]:
+def with_param(args: list[Any], key: UInt160) -> list[Notification]:
     notify_args(args)
     return get_notifications(key)
 
 
 @public
-def without_param(args: List[Any]) -> List[Notification]:
+def without_param(args: list[Any]) -> list[Notification]:
     notify_args(args)
     return get_notifications()
 
 
-def notify_args(args: List[Any]):
+def notify_args(args: list[Any]):
     for x in args:
         notify(x)

--- a/boa3_test/test_sc/list_test/ClearList.py
+++ b/boa3_test/test_sc/list_test/ClearList.py
@@ -1,10 +1,8 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def Main(op: str, args: list) -> List[int]:
+def Main(op: str, args: list) -> list[int]:
     a = [1, 2, 3]
     a.clear()
     return a

--- a/boa3_test/test_sc/list_test/CopyListBuiltinCall.py
+++ b/boa3_test/test_sc/list_test/CopyListBuiltinCall.py
@@ -1,11 +1,11 @@
-from typing import Any, List, Tuple
+from typing import Any
 
 from boa3.builtin.compile_time import public
 
 
 @public
-def copy_list(list_: List[Any], value: Any) -> Tuple[List[Any], List[Any]]:
-    list_copy = List.copy(list_)
+def copy_list(list_: list[Any], value: Any) -> tuple[list[Any], list[Any]]:
+    list_copy = list.copy(list_)
 
     list_copy.append(value)
 

--- a/boa3_test/test_sc/list_test/EmptyListAssignment.py
+++ b/boa3_test/test_sc/list_test/EmptyListAssignment.py
@@ -1,8 +1,6 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
 def Main():
-    a: List[int] = []
+    a: list[int] = []

--- a/boa3_test/test_sc/list_test/IndexList.py
+++ b/boa3_test/test_sc/list_test/IndexList.py
@@ -1,8 +1,8 @@
-from typing import Any, List
+from typing import Any
 
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(a: List[Any], value: Any, start: int, end: int) -> int:
+def main(a: list[Any], value: Any, start: int, end: int) -> int:
     return a.index(value, start, end)

--- a/boa3_test/test_sc/list_test/IndexListBool.py
+++ b/boa3_test/test_sc/list_test/IndexListBool.py
@@ -1,8 +1,6 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(a: List[bool], value: bool) -> int:
+def main(a: list[bool], value: bool) -> int:
     return a.index(value)

--- a/boa3_test/test_sc/list_test/IndexListDefaults.py
+++ b/boa3_test/test_sc/list_test/IndexListDefaults.py
@@ -1,8 +1,8 @@
-from typing import Any, List
+from typing import Any
 
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(a: List[Any], value: Any) -> int:
+def main(a: list[Any], value: Any) -> int:
     return a.index(value)

--- a/boa3_test/test_sc/list_test/IndexListEndDefault.py
+++ b/boa3_test/test_sc/list_test/IndexListEndDefault.py
@@ -1,8 +1,8 @@
-from typing import Any, List
+from typing import Any
 
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(a: List[Any], value: Any, start: int) -> int:
+def main(a: list[Any], value: Any, start: int) -> int:
     return a.index(value, start)

--- a/boa3_test/test_sc/list_test/IndexListInt.py
+++ b/boa3_test/test_sc/list_test/IndexListInt.py
@@ -1,8 +1,6 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(a: List[int], value: int) -> int:
+def main(a: list[int], value: int) -> int:
     return a.index(value)

--- a/boa3_test/test_sc/list_test/IndexListStr.py
+++ b/boa3_test/test_sc/list_test/IndexListStr.py
@@ -1,8 +1,6 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(a: List[str], value: str) -> int:
+def main(a: list[str], value: str) -> int:
     return a.index(value)

--- a/boa3_test/test_sc/list_test/ListAppendAnyValue.py
+++ b/boa3_test/test_sc/list_test/ListAppendAnyValue.py
@@ -1,10 +1,10 @@
-from typing import Any, List
+from typing import Any
 
 from boa3.builtin.compile_time import public
 
 
 @public
-def Main() -> List[Any]:
-    a: List[Any] = [1, 2, 3]
+def Main() -> list[Any]:
+    a: list[Any] = [1, 2, 3]
     a.append('4')
     return a

--- a/boa3_test/test_sc/list_test/ListAppendBoa2Test.py
+++ b/boa3_test/test_sc/list_test/ListAppendBoa2Test.py
@@ -1,11 +1,11 @@
-from typing import Any, List
+from typing import Any
 
 from boa3.builtin.compile_time import public
 
 
 @public
 def main() -> Any:
-    m: List[Any] = [1, 2, 2]
+    m: list[Any] = [1, 2, 2]
     m.append(7)
     q = [6, 7]
     l = 'howdy'

--- a/boa3_test/test_sc/list_test/ListAppendInClassVariable.py
+++ b/boa3_test/test_sc/list_test/ListAppendInClassVariable.py
@@ -1,14 +1,12 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 class SomeClass:
     def __init__(self):
-        self._some_list: List[int] = [1, 2, 3]
+        self._some_list: list[int] = [1, 2, 3]
 
     @property
-    def inner_list(self) -> List[int]:
+    def inner_list(self) -> list[int]:
         return self._some_list
 
     def append(self, value: int) -> bool:

--- a/boa3_test/test_sc/list_test/ListAppendIntValue.py
+++ b/boa3_test/test_sc/list_test/ListAppendIntValue.py
@@ -1,10 +1,8 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def Main() -> List[int]:
+def Main() -> list[int]:
     a = [1, 2, 3]
     a.append(4)
     return a

--- a/boa3_test/test_sc/list_test/ListAppendIntWithBuiltin.py
+++ b/boa3_test/test_sc/list_test/ListAppendIntWithBuiltin.py
@@ -1,10 +1,8 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def Main() -> List[int]:
+def Main() -> list[int]:
     a = [1, 2, 3]
     list.append(a, 4)
     return a

--- a/boa3_test/test_sc/list_test/ListCopy.py
+++ b/boa3_test/test_sc/list_test/ListCopy.py
@@ -1,10 +1,10 @@
-from typing import Any, List
+from typing import Any
 
 from boa3.builtin.compile_time import public
 
 
 @public
-def copy_list(_list: List[Any], value: Any) -> List[List[Any]]:
+def copy_list(_list: list[Any], value: Any) -> list[list[Any]]:
     list_copy = _list.copy()
 
     list_copy.append(value)
@@ -14,7 +14,7 @@ def copy_list(_list: List[Any], value: Any) -> List[List[Any]]:
 
 
 @public
-def attribution(_list: List[Any], value: Any) -> bool:
+def attribution(_list: list[Any], value: Any) -> bool:
     list_not_copy = _list
 
     list_not_copy.append(value)

--- a/boa3_test/test_sc/list_test/ListCopyBool.py
+++ b/boa3_test/test_sc/list_test/ListCopyBool.py
@@ -1,10 +1,8 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def copy_bool_list(_list: List[bool], value: bool) -> List[List[bool]]:
+def copy_bool_list(_list: list[bool], value: bool) -> list[list[bool]]:
     list_copy = _list.copy()
 
     list_copy.append(value)

--- a/boa3_test/test_sc/list_test/ListCopyBytes.py
+++ b/boa3_test/test_sc/list_test/ListCopyBytes.py
@@ -1,10 +1,8 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def copy_bytes_list(_list: List[bytes], value: bytes) -> List[List[bytes]]:
+def copy_bytes_list(_list: list[bytes], value: bytes) -> list[list[bytes]]:
     list_copy = _list.copy()
 
     list_copy.append(value)

--- a/boa3_test/test_sc/list_test/ListCopyInt.py
+++ b/boa3_test/test_sc/list_test/ListCopyInt.py
@@ -1,10 +1,8 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def copy_int_list(_list: List[int], value: int) -> List[List[int]]:
+def copy_int_list(_list: list[int], value: int) -> list[list[int]]:
     list_copy = _list.copy()
 
     list_copy.append(value)

--- a/boa3_test/test_sc/list_test/ListCopyStr.py
+++ b/boa3_test/test_sc/list_test/ListCopyStr.py
@@ -1,10 +1,8 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def copy_str_list(_list: List[str], value: str) -> List[List[str]]:
+def copy_str_list(_list: list[str], value: str) -> list[list[str]]:
     list_copy = _list.copy()
 
     list_copy.append(value)

--- a/boa3_test/test_sc/list_test/ListExtendAnyValue.py
+++ b/boa3_test/test_sc/list_test/ListExtendAnyValue.py
@@ -1,10 +1,10 @@
-from typing import Any, List
+from typing import Any
 
 from boa3.builtin.compile_time import public
 
 
 @public
-def Main() -> List[Any]:
-    a: List[Any] = [1, 2, 3]
+def Main() -> list[Any]:
+    a: list[Any] = [1, 2, 3]
     a.extend(('4', 5, True))
     return a  # expected [1, 2, 3, '4', 5, True]

--- a/boa3_test/test_sc/list_test/ListExtendTupleValue.py
+++ b/boa3_test/test_sc/list_test/ListExtendTupleValue.py
@@ -1,10 +1,8 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def Main() -> List[int]:
+def Main() -> list[int]:
     a = [1, 2, 3]
     a.extend((4, 5, 6))
     return a  # expected [1, 2, 3, 4, 5, 6]

--- a/boa3_test/test_sc/list_test/ListExtendWithBuiltin.py
+++ b/boa3_test/test_sc/list_test/ListExtendWithBuiltin.py
@@ -1,10 +1,8 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def Main() -> List[int]:
+def Main() -> list[int]:
     a = [1, 2, 3]
     list.extend(a, [4, 5, 6])
     return a  # expected [1, 2, 3, 4, 5, 6]

--- a/boa3_test/test_sc/list_test/ListGetValue.py
+++ b/boa3_test/test_sc/list_test/ListGetValue.py
@@ -1,8 +1,6 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def Main(a: List[int]) -> int:
+def Main(a: list[int]) -> int:
     return a[0]  # raises runtime error if the list is empty

--- a/boa3_test/test_sc/list_test/ListGetValueNegativeIndex.py
+++ b/boa3_test/test_sc/list_test/ListGetValueNegativeIndex.py
@@ -1,8 +1,6 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def Main(a: List[int]) -> int:
+def Main(a: list[int]) -> int:
     return a[-1]  # raises runtime error if the list is empty

--- a/boa3_test/test_sc/list_test/ListInsertAnyValue.py
+++ b/boa3_test/test_sc/list_test/ListInsertAnyValue.py
@@ -1,9 +1,9 @@
-from typing import Any, List
+from typing import Any
 
 from boa3.builtin.compile_time import public
 
 
 @public
-def Main(a: List[Any], pos: int, value: Any) -> List[Any]:
+def Main(a: list[Any], pos: int, value: Any) -> list[Any]:
     a.insert(pos, value)
     return a

--- a/boa3_test/test_sc/list_test/ListInsertIntNegativeIndex.py
+++ b/boa3_test/test_sc/list_test/ListInsertIntNegativeIndex.py
@@ -1,10 +1,8 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def Main() -> List[int]:
+def Main() -> list[int]:
     a = [1, 2, 3]
     a.insert(-2, 4)
     return a  # expected [1, 2, 4, 3]

--- a/boa3_test/test_sc/list_test/ListInsertIntValue.py
+++ b/boa3_test/test_sc/list_test/ListInsertIntValue.py
@@ -1,10 +1,8 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def Main() -> List[int]:
+def Main() -> list[int]:
     a = [1, 2, 3]
     a.insert(2, 4)
     return a  # expected [1, 2, 4, 3]

--- a/boa3_test/test_sc/list_test/ListInsertIntWithBuiltin.py
+++ b/boa3_test/test_sc/list_test/ListInsertIntWithBuiltin.py
@@ -1,10 +1,8 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def Main() -> List[int]:
+def Main() -> list[int]:
     a = [1, 2, 3]
     list.insert(a, 2, 4)
     return a  # expected [1, 2, 4, 3]

--- a/boa3_test/test_sc/list_test/ListMultipleExpressionsInLine.py
+++ b/boa3_test/test_sc/list_test/ListMultipleExpressionsInLine.py
@@ -1,9 +1,7 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def Main(items1: List[int]) -> int:
+def Main(items1: list[int]) -> int:
     items2 = [False, '1', 2, 3, '4']; value = items1[0]; count = value + len(items2)
     return count

--- a/boa3_test/test_sc/list_test/ListOfList.py
+++ b/boa3_test/test_sc/list_test/ListOfList.py
@@ -1,8 +1,6 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def Main(a: List[List[int]]) -> int:
+def Main(a: list[list[int]]) -> int:
     return a[0][0]

--- a/boa3_test/test_sc/list_test/ListRemoveBoa2Test.py
+++ b/boa3_test/test_sc/list_test/ListRemoveBoa2Test.py
@@ -1,10 +1,8 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def main() -> List[int]:
+def main() -> list[int]:
     m = [16, 2, 3, 4]
     m.pop(1)
     return m

--- a/boa3_test/test_sc/list_test/ListRemoveIntValue.py
+++ b/boa3_test/test_sc/list_test/ListRemoveIntValue.py
@@ -1,10 +1,8 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def Main() -> List[int]:
+def Main() -> list[int]:
     a = [10, 20, 30]
     a.remove(20)
     return a  # expected [10, 30]

--- a/boa3_test/test_sc/list_test/ListRemoveIntWithBuiltin.py
+++ b/boa3_test/test_sc/list_test/ListRemoveIntWithBuiltin.py
@@ -1,10 +1,8 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def Main() -> List[int]:
+def Main() -> list[int]:
     a = [10, 20, 30]
     list.remove(a, 30)
     return a  # expected [10, 20]

--- a/boa3_test/test_sc/list_test/ListRemoveValue.py
+++ b/boa3_test/test_sc/list_test/ListRemoveValue.py
@@ -1,9 +1,7 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def Main(a: List[int], value: int) -> List[int]:
+def Main(a: list[int], value: int) -> list[int]:
     a.remove(value)
     return a

--- a/boa3_test/test_sc/list_test/ListSetValue.py
+++ b/boa3_test/test_sc/list_test/ListSetValue.py
@@ -1,9 +1,7 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def Main(a: List[int]) -> list:
+def Main(a: list[int]) -> list:
     a[0] = 1
     return a

--- a/boa3_test/test_sc/list_test/ListSetValueNegativeIndex.py
+++ b/boa3_test/test_sc/list_test/ListSetValueNegativeIndex.py
@@ -1,9 +1,7 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def Main(a: List[int]) -> list:
+def Main(a: list[int]) -> list:
     a[-1] = 1
     return a

--- a/boa3_test/test_sc/list_test/ListTypeHintAssignment.py
+++ b/boa3_test/test_sc/list_test/ListTypeHintAssignment.py
@@ -1,8 +1,6 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
 def Main():
-    a: List[int] = [1, 2, 3]
+    a: list[int] = [1, 2, 3]

--- a/boa3_test/test_sc/list_test/ListWithEmptyTypedDict.py
+++ b/boa3_test/test_sc/list_test/ListWithEmptyTypedDict.py
@@ -1,8 +1,6 @@
-from typing import List, Dict
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def Main() -> List[Dict[str, bool]]:
+def Main() -> list[dict[str, bool]]:
     return [{}]

--- a/boa3_test/test_sc/list_test/MismatchedTypeListAppendWithBuiltin.py
+++ b/boa3_test/test_sc/list_test/MismatchedTypeListAppendWithBuiltin.py
@@ -1,7 +1,4 @@
-from typing import List
-
-
-def Main(op: str, args: list) -> List[int]:
+def Main(op: str, args: list) -> list[int]:
     a = [1, 2, 3]
     list.append(a, [a])  # expecting int value to append
     return a

--- a/boa3_test/test_sc/list_test/MismatchedTypeListExtendTupleValue.py
+++ b/boa3_test/test_sc/list_test/MismatchedTypeListExtendTupleValue.py
@@ -1,7 +1,4 @@
-from typing import List
-
-
-def Main(op: str, args: list) -> List[int]:
+def Main(op: str, args: list) -> list[int]:
     a = [1, 2, 3]
     a.extend(('4', '5', '6'))
     return a

--- a/boa3_test/test_sc/list_test/MismatchedTypeListExtendValue.py
+++ b/boa3_test/test_sc/list_test/MismatchedTypeListExtendValue.py
@@ -1,7 +1,4 @@
-from typing import List
-
-
-def Main(op: str, args: list) -> List[int]:
+def Main(op: str, args: list) -> list[int]:
     a = [1, 2, 3]
     a.extend(4)
     return a

--- a/boa3_test/test_sc/list_test/MismatchedTypeListExtendWithBuiltin.py
+++ b/boa3_test/test_sc/list_test/MismatchedTypeListExtendWithBuiltin.py
@@ -1,7 +1,4 @@
-from typing import List
-
-
-def Main(op: str, args: list) -> List[int]:
+def Main(op: str, args: list) -> list[int]:
     a = [1, 2, 3]
     list.extend(a, 4)
     return a

--- a/boa3_test/test_sc/list_test/MismatchedTypeListGetValue.py
+++ b/boa3_test/test_sc/list_test/MismatchedTypeListGetValue.py
@@ -1,5 +1,2 @@
-from typing import List
-
-
-def Main(a: List[int]) -> int:
+def Main(a: list[int]) -> int:
     return a[0][0]  # expecting sequence[sequence[]], but receiver sequence[int]

--- a/boa3_test/test_sc/list_test/MismatchedTypeListIndex.py
+++ b/boa3_test/test_sc/list_test/MismatchedTypeListIndex.py
@@ -1,5 +1,2 @@
-from typing import List
-
-
-def Main(a: List[str]) -> str:
+def Main(a: list[str]) -> str:
     return a['0']  # expecting int index

--- a/boa3_test/test_sc/list_test/ReverseBoa2Test.py
+++ b/boa3_test/test_sc/list_test/ReverseBoa2Test.py
@@ -1,10 +1,10 @@
-from typing import Any, List
+from typing import Any
 
 from boa3.builtin.compile_time import public
 
 
 @public
-def main() -> List[Any]:
+def main() -> list[Any]:
     m = [1, 2, 4, 'blah']
     m.reverse()
     return m

--- a/boa3_test/test_sc/list_test/ReverseList.py
+++ b/boa3_test/test_sc/list_test/ReverseList.py
@@ -1,10 +1,8 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def Main() -> List[int]:
-    a: List[int] = [1, 2, 3]
+def Main() -> list[int]:
+    a: list[int] = [1, 2, 3]
     a.reverse()
     return a

--- a/boa3_test/test_sc/list_test/SetListIntoListSlice.py
+++ b/boa3_test/test_sc/list_test/SetListIntoListSlice.py
@@ -1,10 +1,8 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def main() -> List[int]:
+def main() -> list[int]:
     a = [1, 2, 3, 4, 5, 6]
     a[:3] = [10]
     return a

--- a/boa3_test/test_sc/logical_test/LogicMismatchedOperandLogicOr.py
+++ b/boa3_test/test_sc/logical_test/LogicMismatchedOperandLogicOr.py
@@ -1,5 +1,2 @@
-from typing import Tuple
-
-
-def Main(a: bool, b: Tuple[str, ...]) -> bool:
+def Main(a: bool, b: tuple[str, ...]) -> bool:
     return a | b

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsByteStringAsBytes.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsByteStringAsBytes.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 from boa3.builtin.compile_time import CreateNewEvent, NeoMetadata, public
 from boa3.builtin.interop.iterator import Iterator
@@ -64,5 +64,5 @@ def tokens() -> Iterator:
 
 
 @public(safe=True)
-def properties(tokenId: bytes) -> Dict[Any, Any]:
+def properties(tokenId: bytes) -> dict[Any, Any]:
     pass

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsByteStringAsStr.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsByteStringAsStr.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 from boa3.builtin.compile_time import CreateNewEvent, NeoMetadata, public
 from boa3.builtin.interop.iterator import Iterator
@@ -64,5 +64,5 @@ def tokens() -> Iterator:
 
 
 @public(safe=True)
-def properties(tokenId: str) -> Dict[Any, Any]:
+def properties(tokenId: str) -> dict[Any, Any]:
     pass

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsMissingImplementationNEP11OptionalMethods.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsMissingImplementationNEP11OptionalMethods.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 from boa3.builtin.compile_time import NeoMetadata, public
 from boa3.builtin.contract import Nep11TransferEvent
@@ -16,7 +16,7 @@ def standards_manifest() -> NeoMetadata:
 
 # this method has the same name as an NEP-11 optional method, but with a different signature
 @public(safe=True)
-def properties(token_id: int) -> Dict[Any, Any]:
+def properties(token_id: int) -> dict[Any, Any]:
     pass
 
 

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsNEP11DivisibleOptionalMethods.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsNEP11DivisibleOptionalMethods.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 from boa3.builtin.compile_time import NeoMetadata, public
 from boa3.builtin.contract import Nep11TransferEvent
@@ -65,5 +65,5 @@ def tokens() -> Iterator:
 
 
 @public(safe=True)
-def properties(token_id: bytes) -> Dict[Any, Any]:
+def properties(token_id: bytes) -> dict[Any, Any]:
     pass

--- a/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsNEP11NonDivisibleOptionalMethods.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoSupportedStandardsNEP11NonDivisibleOptionalMethods.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 from boa3.builtin.compile_time import NeoMetadata, public
 from boa3.builtin.contract import Nep11TransferEvent
@@ -55,5 +55,5 @@ def tokens() -> Iterator:
 
 
 @public(safe=True)
-def properties(token_id: bytes) -> Dict[Any, Any]:
+def properties(token_id: bytes) -> dict[Any, Any]:
     pass

--- a/boa3_test/test_sc/native_test/neo/GetCandidates.py
+++ b/boa3_test/test_sc/native_test/neo/GetCandidates.py
@@ -1,10 +1,8 @@
-from typing import List, Tuple
-
 from boa3.builtin.compile_time import public
 from boa3.builtin.nativecontract.neo import NEO
 from boa3.builtin.type import ECPoint
 
 
 @public
-def main() -> List[Tuple[ECPoint, int]]:
+def main() -> list[tuple[ECPoint, int]]:
     return NEO.get_candidates()

--- a/boa3_test/test_sc/native_test/neo/GetCommittee.py
+++ b/boa3_test/test_sc/native_test/neo/GetCommittee.py
@@ -1,10 +1,8 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 from boa3.builtin.nativecontract.neo import NEO
 from boa3.builtin.type import ECPoint
 
 
 @public
-def main() -> List[ECPoint]:
+def main() -> list[ECPoint]:
     return NEO.get_committee()

--- a/boa3_test/test_sc/native_test/neo/GetNextBlockValidators.py
+++ b/boa3_test/test_sc/native_test/neo/GetNextBlockValidators.py
@@ -1,10 +1,8 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 from boa3.builtin.nativecontract.neo import NEO
 from boa3.builtin.type import ECPoint
 
 
 @public
-def main() -> List[ECPoint]:
+def main() -> list[ECPoint]:
     return NEO.get_next_block_validators()

--- a/boa3_test/test_sc/native_test/oracle/OracleRequestCall.py
+++ b/boa3_test/test_sc/native_test/oracle/OracleRequestCall.py
@@ -1,4 +1,4 @@
-from typing import Any, List
+from typing import Any
 
 from boa3.builtin.compile_time import public
 from boa3.builtin.interop import storage
@@ -23,7 +23,7 @@ def callback_method(requested_url: str, user_data: bytes, code: OracleResponseCo
 
 
 @public
-def get_storage() -> List[Any]:
+def get_storage() -> list[Any]:
     a = storage.get_str(b'pUrl')
     b = storage.get(b'pUser')
     c = storage.get_int(b'pCode')

--- a/boa3_test/test_sc/optional_test/OptionalArgumentInsideDict.py
+++ b/boa3_test/test_sc/optional_test/OptionalArgumentInsideDict.py
@@ -1,8 +1,8 @@
-from typing import Optional, Dict
+from typing import Optional
 
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(a: Dict[str, Optional[int]]) -> dict:
+def main(a: dict[str, Optional[int]]) -> dict:
     return a

--- a/boa3_test/test_sc/python_operation_test/DictMembershipMismatchedType.py
+++ b/boa3_test/test_sc/python_operation_test/DictMembershipMismatchedType.py
@@ -1,8 +1,6 @@
-from typing import Dict
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(value: int, some_dict: Dict[str, int]) -> bool:
+def main(value: int, some_dict: dict[str, int]) -> bool:
     return value in some_dict

--- a/boa3_test/test_sc/python_operation_test/ListMembershipMismatchedType.py
+++ b/boa3_test/test_sc/python_operation_test/ListMembershipMismatchedType.py
@@ -1,8 +1,6 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(value: int, some_list: List[str]) -> bool:
+def main(value: int, some_list: list[str]) -> bool:
     return value not in some_list

--- a/boa3_test/test_sc/python_operation_test/TupleMembershipMismatchedType.py
+++ b/boa3_test/test_sc/python_operation_test/TupleMembershipMismatchedType.py
@@ -1,8 +1,6 @@
-from typing import Tuple
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(value: bytes, some_tuple: Tuple[str]) -> bool:
+def main(value: bytes, some_tuple: tuple[str]) -> bool:
     return value in some_tuple

--- a/boa3_test/test_sc/python_operation_test/TypedDictBuiltinTypeIn.py
+++ b/boa3_test/test_sc/python_operation_test/TypedDictBuiltinTypeIn.py
@@ -1,9 +1,7 @@
-from typing import Dict
-
 from boa3.builtin.compile_time import public
 from boa3.builtin.interop.storage.findoptions import FindOptions
 
 
 @public
-def main(value: FindOptions, some_dict: Dict[FindOptions, str]) -> bool:
+def main(value: FindOptions, some_dict: dict[FindOptions, str]) -> bool:
     return value in some_dict

--- a/boa3_test/test_sc/python_operation_test/TypedDictBuiltinTypeNotIn.py
+++ b/boa3_test/test_sc/python_operation_test/TypedDictBuiltinTypeNotIn.py
@@ -1,9 +1,7 @@
-from typing import Dict
-
 from boa3.builtin.compile_time import public
 from boa3.builtin.interop.storage.findoptions import FindOptions
 
 
 @public
-def main(value: FindOptions, some_dict: Dict[FindOptions, str]) -> bool:
+def main(value: FindOptions, some_dict: dict[FindOptions, str]) -> bool:
     return value not in some_dict

--- a/boa3_test/test_sc/python_operation_test/TypedDictIn.py
+++ b/boa3_test/test_sc/python_operation_test/TypedDictIn.py
@@ -1,8 +1,6 @@
-from typing import Dict
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(value: int, some_dict: Dict[int, str]) -> bool:
+def main(value: int, some_dict: dict[int, str]) -> bool:
     return value in some_dict

--- a/boa3_test/test_sc/python_operation_test/TypedDictNotIn.py
+++ b/boa3_test/test_sc/python_operation_test/TypedDictNotIn.py
@@ -1,8 +1,6 @@
-from typing import Dict
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(value: int, some_dict: Dict[int, str]) -> bool:
+def main(value: int, some_dict: dict[int, str]) -> bool:
     return value not in some_dict

--- a/boa3_test/test_sc/python_operation_test/TypedListBuiltinTypeIn.py
+++ b/boa3_test/test_sc/python_operation_test/TypedListBuiltinTypeIn.py
@@ -1,9 +1,7 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 from boa3.builtin.interop.storage.findoptions import FindOptions
 
 
 @public
-def main(value: FindOptions, some_list: List[FindOptions]) -> bool:
+def main(value: FindOptions, some_list: list[FindOptions]) -> bool:
     return value in some_list

--- a/boa3_test/test_sc/python_operation_test/TypedListBuiltinTypeNotIn.py
+++ b/boa3_test/test_sc/python_operation_test/TypedListBuiltinTypeNotIn.py
@@ -1,9 +1,7 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 from boa3.builtin.interop.storage.findoptions import FindOptions
 
 
 @public
-def main(value: FindOptions, some_list: List[FindOptions]) -> bool:
+def main(value: FindOptions, some_list: list[FindOptions]) -> bool:
     return value not in some_list

--- a/boa3_test/test_sc/python_operation_test/TypedListIn.py
+++ b/boa3_test/test_sc/python_operation_test/TypedListIn.py
@@ -1,8 +1,6 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(value: int, some_list: List[int]) -> bool:
+def main(value: int, some_list: list[int]) -> bool:
     return value in some_list

--- a/boa3_test/test_sc/python_operation_test/TypedListNotIn.py
+++ b/boa3_test/test_sc/python_operation_test/TypedListNotIn.py
@@ -1,8 +1,6 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(value: int, some_list: List[int]) -> bool:
+def main(value: int, some_list: list[int]) -> bool:
     return value not in some_list

--- a/boa3_test/test_sc/python_operation_test/TypedTupleBuiltinTypeIn.py
+++ b/boa3_test/test_sc/python_operation_test/TypedTupleBuiltinTypeIn.py
@@ -1,9 +1,7 @@
-from typing import Tuple
-
 from boa3.builtin.compile_time import public
 from boa3.builtin.interop.storage.findoptions import FindOptions
 
 
 @public
-def main(value: FindOptions, some_tuple: Tuple[FindOptions]) -> bool:
+def main(value: FindOptions, some_tuple: tuple[FindOptions]) -> bool:
     return value in some_tuple

--- a/boa3_test/test_sc/python_operation_test/TypedTupleBuiltinTypeNotIn.py
+++ b/boa3_test/test_sc/python_operation_test/TypedTupleBuiltinTypeNotIn.py
@@ -1,9 +1,7 @@
-from typing import Tuple
-
 from boa3.builtin.compile_time import public
 from boa3.builtin.interop.storage.findoptions import FindOptions
 
 
 @public
-def main(value: FindOptions, some_tuple: Tuple[FindOptions]) -> bool:
+def main(value: FindOptions, some_tuple: tuple[FindOptions]) -> bool:
     return value not in some_tuple

--- a/boa3_test/test_sc/python_operation_test/TypedTupleIn.py
+++ b/boa3_test/test_sc/python_operation_test/TypedTupleIn.py
@@ -1,8 +1,6 @@
-from typing import Tuple
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(value: int, some_tuple: Tuple[int]) -> bool:
+def main(value: int, some_tuple: tuple[int]) -> bool:
     return value in some_tuple

--- a/boa3_test/test_sc/python_operation_test/TypedTupleNotIn.py
+++ b/boa3_test/test_sc/python_operation_test/TypedTupleNotIn.py
@@ -1,8 +1,6 @@
-from typing import Tuple
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(value: int, some_tuple: Tuple[int]) -> bool:
+def main(value: int, some_tuple: tuple[int]) -> bool:
     return value not in some_tuple

--- a/boa3_test/test_sc/relational_test/ListEqualityWithSlice.py
+++ b/boa3_test/test_sc/relational_test/ListEqualityWithSlice.py
@@ -1,8 +1,6 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(a: List[str], b: str) -> bool:
+def main(a: list[str], b: str) -> bool:
     return a[0] == b

--- a/boa3_test/test_sc/relational_test/ListIdentity.py
+++ b/boa3_test/test_sc/relational_test/ListIdentity.py
@@ -1,17 +1,15 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
 def with_attribution() -> bool:
-    a: List[int] = [1, 2, 3]
+    a: list[int] = [1, 2, 3]
     b = a
     return a is b
 
 
 @public
 def without_attribution() -> bool:
-    a: List[int] = [1, 2, 3]
-    b: List[int] = [1, 2, 3]
+    a: list[int] = [1, 2, 3]
+    b: list[int] = [1, 2, 3]
     return a is b

--- a/boa3_test/test_sc/relational_test/ListNotIdentity.py
+++ b/boa3_test/test_sc/relational_test/ListNotIdentity.py
@@ -1,17 +1,15 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
 def with_attribution() -> bool:
-    a: List[int] = [1, 2, 3]
+    a: list[int] = [1, 2, 3]
     b = a
     return a is not b
 
 
 @public
 def without_attribution() -> bool:
-    a: List[int] = [1, 2, 3]
-    b: List[int] = [1, 2, 3]
+    a: list[int] = [1, 2, 3]
+    b: list[int] = [1, 2, 3]
     return a is not b

--- a/boa3_test/test_sc/relational_test/MixedIdentity.py
+++ b/boa3_test/test_sc/relational_test/MixedIdentity.py
@@ -1,10 +1,8 @@
-from typing import List, Tuple
-
 from boa3.builtin.compile_time import public
 
 
 @public
 def mixed() -> bool:
-    a: List[int] = [1, 2, 3]
-    b: Tuple[str, str] = ('unit', 'test')
+    a: list[int] = [1, 2, 3]
+    b: tuple[str, str] = ('unit', 'test')
     return a is b

--- a/boa3_test/test_sc/relational_test/TupleIdentity.py
+++ b/boa3_test/test_sc/relational_test/TupleIdentity.py
@@ -1,17 +1,15 @@
-from typing import Tuple
-
 from boa3.builtin.compile_time import public
 
 
 @public
 def with_attribution() -> bool:
-    a: Tuple[int, int, int] = (1, 2, 3)
+    a: tuple[int, int, int] = (1, 2, 3)
     b = a
     return a is b
 
 
 @public
 def without_attribution() -> bool:
-    a: Tuple[int, int, int] = (1, 2, 3)
-    b: Tuple[int, int, int] = (1, 2, 3)
+    a: tuple[int, int, int] = (1, 2, 3)
+    b: tuple[int, int, int] = (1, 2, 3)
     return a is b

--- a/boa3_test/test_sc/relational_test/TupleNotIdentity.py
+++ b/boa3_test/test_sc/relational_test/TupleNotIdentity.py
@@ -1,17 +1,15 @@
-from typing import Tuple
-
 from boa3.builtin.compile_time import public
 
 
 @public
 def with_attribution() -> bool:
-    a: Tuple[int, int, int] = (1, 2, 3)
+    a: tuple[int, int, int] = (1, 2, 3)
     b = a
     return a is not b
 
 
 @public
 def without_attribution() -> bool:
-    a: Tuple[int, int, int] = (1, 2, 3)
-    b: Tuple[int, int, int] = (1, 2, 3)
+    a: tuple[int, int, int] = (1, 2, 3)
+    b: tuple[int, int, int] = (1, 2, 3)
     return a is not b

--- a/boa3_test/test_sc/reversed_test/ReversedList.py
+++ b/boa3_test/test_sc/reversed_test/ReversedList.py
@@ -1,8 +1,8 @@
-from typing import Any, List
+from typing import Any
 
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(a: List[Any]) -> reversed:
+def main(a: list[Any]) -> reversed:
     return reversed(a)

--- a/boa3_test/test_sc/reversed_test/ReversedTuple.py
+++ b/boa3_test/test_sc/reversed_test/ReversedTuple.py
@@ -1,8 +1,6 @@
-from typing import Tuple
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(a: Tuple) -> reversed:
+def main(a: tuple) -> reversed:
     return reversed(a)

--- a/boa3_test/test_sc/string_test/ConcatBoa2Test2.py
+++ b/boa3_test/test_sc/string_test/ConcatBoa2Test2.py
@@ -1,17 +1,17 @@
-from typing import List, Union
+from typing import Union
 
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(operation: str, args: List[str]) -> Union[str, bool]:
+def main(operation: str, args: list[str]) -> Union[str, bool]:
     if operation == 'concat':
         return do_concat(args)
     else:
         return False
 
 
-def do_concat(args: List[str]) -> Union[str, bool]:
+def do_concat(args: list[str]) -> Union[str, bool]:
     if len(args) > 1:
         a = args[0]
         b = args[1]

--- a/boa3_test/test_sc/string_test/FStringSequenceVar.py
+++ b/boa3_test/test_sc/string_test/FStringSequenceVar.py
@@ -1,9 +1,7 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(a: List) -> str:
+def main(a: list) -> str:
     fstring = f"F-string: {a}"
     return fstring

--- a/boa3_test/test_sc/string_test/FStringUserClassVar.py
+++ b/boa3_test/test_sc/string_test/FStringUserClassVar.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 

--- a/boa3_test/test_sc/string_test/JoinStringMethodWithDictionary.py
+++ b/boa3_test/test_sc/string_test/JoinStringMethodWithDictionary.py
@@ -1,8 +1,8 @@
-from typing import Any, Dict
+from typing import Any
 
 from boa3.builtin.compile_time import public
 
 
 @public
-def main(string: str, dictionary: Dict[str, Any]) -> str:
+def main(string: str, dictionary: dict[str, Any]) -> str:
     return string.join(dictionary)

--- a/boa3_test/test_sc/tuple_test/MultipleExpressionsInLine.py
+++ b/boa3_test/test_sc/tuple_test/MultipleExpressionsInLine.py
@@ -1,9 +1,7 @@
-from typing import Tuple
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def Main(items1: Tuple[int, ...]) -> int:
+def Main(items1: tuple[int, ...]) -> int:
     items2 = ('a', 'b', 'c', 'd'); value = items1[0]; count = value + len(items2)
     return count

--- a/boa3_test/test_sc/tuple_test/TupleGetValue.py
+++ b/boa3_test/test_sc/tuple_test/TupleGetValue.py
@@ -1,8 +1,6 @@
-from typing import Tuple
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def Main(a: Tuple[int, ...]) -> int:
+def Main(a: tuple[int, ...]) -> int:
     return a[0]

--- a/boa3_test/test_sc/tuple_test/TupleGetValueMismatchedType.py
+++ b/boa3_test/test_sc/tuple_test/TupleGetValueMismatchedType.py
@@ -1,5 +1,2 @@
-from typing import Tuple
-
-
-def Main(a: Tuple[int, ...]) -> int:
+def Main(a: tuple[int, ...]) -> int:
     return a[0][0]

--- a/boa3_test/test_sc/tuple_test/TupleGetValueTypedTuple.py
+++ b/boa3_test/test_sc/tuple_test/TupleGetValueTypedTuple.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 from boa3.builtin.compile_time import public
 
 

--- a/boa3_test/test_sc/tuple_test/TupleIndexMismatchedType.py
+++ b/boa3_test/test_sc/tuple_test/TupleIndexMismatchedType.py
@@ -1,5 +1,2 @@
-from typing import Tuple
-
-
-def Main(a: Tuple[int, ...]) -> int:
+def Main(a: tuple[int, ...]) -> int:
     return a['0']

--- a/boa3_test/test_sc/tuple_test/TupleOfTuple.py
+++ b/boa3_test/test_sc/tuple_test/TupleOfTuple.py
@@ -1,8 +1,6 @@
-from typing import Tuple
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def Main(a: Tuple[Tuple[int, ...], ...]) -> int:
+def Main(a: tuple[tuple[int, ...], ...]) -> int:
     return a[0][0]

--- a/boa3_test/test_sc/tuple_test/TupleSetValue.py
+++ b/boa3_test/test_sc/tuple_test/TupleSetValue.py
@@ -1,6 +1,3 @@
-from typing import Tuple
-
-
-def Main(a: Tuple[int, ...]) -> int:
+def Main(a: tuple[int, ...]) -> int:
     a[0] = 1
     return 1

--- a/boa3_test/test_sc/typing_test/CastInsideIf.py
+++ b/boa3_test/test_sc/typing_test/CastInsideIf.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, cast
+from typing import Any, cast
 
 from boa3.builtin.compile_time import public
 from boa3.builtin.interop.json import json_deserialize
@@ -8,13 +8,13 @@ from boa3.builtin.interop.json import json_deserialize
 def main() -> str:
     # compilable
     data_xy = '{"type":"skin"}'
-    data: Dict[str, Any] = json_deserialize(data_xy)
+    data: dict[str, Any] = json_deserialize(data_xy)
     type_ = cast(str, data['type'])
 
     # not compilable
     if type_ == "skin":
         data_xy = '{"type":"body"}'
-        data: Dict[str, Any] = json_deserialize(data_xy)
+        data: dict[str, Any] = json_deserialize(data_xy)
         type_ = cast(str, data['type'])  # compile error on this line
 
     return type_

--- a/boa3_test/test_sc/typing_test/CastToDict.py
+++ b/boa3_test/test_sc/typing_test/CastToDict.py
@@ -1,9 +1,9 @@
-from typing import Any, Dict, cast
+from typing import Any, cast
 
 from boa3.builtin.compile_time import public
 
 
 @public
-def Main(value: Any) -> Dict[Any, Any]:
+def Main(value: Any) -> dict[Any, Any]:
     x = cast(dict, value)
     return x

--- a/boa3_test/test_sc/typing_test/CastToList.py
+++ b/boa3_test/test_sc/typing_test/CastToList.py
@@ -1,9 +1,9 @@
-from typing import Any, List, cast
+from typing import Any, cast
 
 from boa3.builtin.compile_time import public
 
 
 @public
-def Main(value: Any) -> List[Any]:
+def Main(value: Any) -> list[Any]:
     x = cast(list, value)
     return x

--- a/boa3_test/test_sc/typing_test/CastToTypedDict.py
+++ b/boa3_test/test_sc/typing_test/CastToTypedDict.py
@@ -1,9 +1,9 @@
-from typing import Any, Dict, cast
+from typing import Any, cast
 
 from boa3.builtin.compile_time import public
 
 
 @public
 def Main(value: Any) -> int:
-    x = cast(Dict[str, int], value)
+    x = cast(dict[str, int], value)
     return x['example']

--- a/boa3_test/test_sc/typing_test/CastToTypedList.py
+++ b/boa3_test/test_sc/typing_test/CastToTypedList.py
@@ -1,9 +1,9 @@
-from typing import Any, List, cast
+from typing import Any, cast
 
 from boa3.builtin.compile_time import public
 
 
 @public
 def Main(value: Any) -> int:
-    x = cast(List[int], value)
+    x = cast(list[int], value)
     return x[0]

--- a/boa3_test/test_sc/variable_test/GetGlobalValueWrittenAfter.py
+++ b/boa3_test/test_sc/variable_test/GetGlobalValueWrittenAfter.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 a = 0
@@ -11,7 +9,7 @@ f = 5
 
 
 @public
-def Main() -> List[int]:
+def Main() -> list[int]:
     return [a, b, c, d, e, f, g, h]
 
 

--- a/boa3_test/test_sc/variable_test/ListGlobalAssignment.py
+++ b/boa3_test/test_sc/variable_test/ListGlobalAssignment.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 a = [1, 2, 3, 4]
@@ -7,7 +5,7 @@ a = [1, 2, 3, 4]
 
 class Test:
     @classmethod
-    def get_global(cls) -> List[int]:
+    def get_global(cls) -> list[int]:
         return a
 
 
@@ -17,16 +15,16 @@ def append_to_global(value: int):
 
 
 @public
-def get_from_global() -> List[int]:
+def get_from_global() -> list[int]:
     return a
 
 
 @public
-def get_from_class() -> List[int]:
+def get_from_class() -> list[int]:
     return Test.get_global()
 
 
 @public
-def get_from_class_without_assigning() -> List[int]:
+def get_from_class_without_assigning() -> list[int]:
     Test.get_global()
     return []

--- a/boa3_test/test_sc/variable_test/ManyGlobalAssignments.py
+++ b/boa3_test/test_sc/variable_test/ManyGlobalAssignments.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from boa3.builtin.compile_time import public
 
 a = 0
@@ -13,5 +11,5 @@ h = 7
 
 
 @public
-def Main() -> List[int]:
+def Main() -> list[int]:
     return [a, b, c, d, e, f, g, h]

--- a/boa3_test/test_sc/variable_test/MismatchedTypeAssignSequenceGet.py
+++ b/boa3_test/test_sc/variable_test/MismatchedTypeAssignSequenceGet.py
@@ -1,8 +1,6 @@
-from typing import Tuple
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def Main(a: Tuple[int]):
+def Main(a: tuple[int]):
     b: str = a[0]

--- a/boa3_test/test_sc/variable_test/MismatchedTypeAssignSequenceSet.py
+++ b/boa3_test/test_sc/variable_test/MismatchedTypeAssignSequenceSet.py
@@ -1,5 +1,2 @@
-from typing import Tuple
-
-
-def Main(a: Tuple[int]):
+def Main(a: tuple[int]):
     a[0] = '1'

--- a/boa3_test/test_sc/variable_test/MismatchedTypeInvalidTypeFormat.py
+++ b/boa3_test/test_sc/variable_test/MismatchedTypeInvalidTypeFormat.py
@@ -1,8 +1,6 @@
-# from typing import List
-
 from boa3.builtin.compile_time import public
 
 
 @public
-def Main(a: [int]) -> [int]:  # should be List[int] instead of [int]
+def Main(a: [int]) -> [int]:  # should be list[int] instead of [int]
     return a

--- a/boa3_test/tests/compiler_tests/test_variable.py
+++ b/boa3_test/tests/compiler_tests/test_variable.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from boa3.internal.compiler.compiler import Compiler
 from boa3.internal.exception import CompilerError, CompilerWarning
 from boa3.internal.model.method import Method
@@ -31,7 +29,7 @@ class TestVariable(boatestcase.BoaTestCase):
         from boa3_test.tests.boa_test import _COMPILER_LOCK as LOCK
         with LOCK:
             compiler_output = compiler.compile(path)
-            main_symbol_table: Dict[str, ISymbol] = self.get_compiler_analyser(compiler).symbol_table
+            main_symbol_table: dict[str, ISymbol] = self.get_compiler_analyser(compiler).symbol_table
 
         self.assertEqual(expected_compiler_output, compiler_output)
 
@@ -42,7 +40,7 @@ class TestVariable(boatestcase.BoaTestCase):
         self.assertIsInstance(main_symbol_table[test_method_id], Method)
         method: Method = main_symbol_table[test_method_id]
 
-        method_symbol_table: Dict[str, Variable] = method.symbols
+        method_symbol_table: dict[str, Variable] = method.symbols
         # the variable is local to this method, so it should be in the method symbol table
         self.assertTrue(test_variable_id in method_symbol_table)
 


### PR DESCRIPTION
**Summary or solution description**
Changed the usage of deprecated methods from `typing`, specifically `List`, `Dict` and `Tuple`, to use the native implementations.
`Sequence`, `Union`, `Optional` and `Mapping` will be changed in different issues