### PR TITLE
#86drpndk1 - Change how to add a method to the permissions

### DIFF
--- a/boa3/builtin/compile_time/__init__.py
+++ b/boa3/builtin/compile_time/__init__.py
@@ -289,7 +289,8 @@ class NeoMetadata:
         if new_group not in self._permissions:
             self._groups.append(new_group)
 
-    def add_permission(self, *, contract: str = IMPORT_WILDCARD, methods: list[str, str] = IMPORT_WILDCARD):
+    def add_permission(self, *, contract: str = IMPORT_WILDCARD,
+                       methods: list[str] | str | tuple[str, ...] = IMPORT_WILDCARD):
         """
         Adds a valid contract and a valid methods to the permissions in the manifest.
 
@@ -315,7 +316,7 @@ class NeoMetadata:
         if not isinstance(contract, str):
             return
 
-        if not isinstance(methods, (str, list)):
+        if not isinstance(methods, (str, list, tuple)):
             return
 
         from boa3.internal.constants import IMPORT_WILDCARD
@@ -326,8 +327,7 @@ class NeoMetadata:
             return
 
         # verifies if methods is a valid value
-        elif ((isinstance(methods, str) and methods != IMPORT_WILDCARD) or
-              (isinstance(methods, list) and any(not isinstance(method, str) for method in methods))):
+        elif isinstance(methods, (tuple, list)) and (any(not isinstance(method, str) for method in methods) or len(methods) == 0):
             return
 
         from boa3.internal import constants
@@ -335,6 +335,17 @@ class NeoMetadata:
             'contract': constants.IMPORT_WILDCARD,
             'methods': constants.IMPORT_WILDCARD,
         }
+
+        # verifies if method contains wildcard
+        if isinstance(methods, (tuple, list)):
+            # if any of the elements in the tuple is the wildcard
+            if constants.IMPORT_WILDCARD in methods:
+                methods = constants.IMPORT_WILDCARD
+            else:
+                methods = list(methods)
+        # if it's a single str and not wildcard, add to a list
+        elif isinstance(methods, str) and methods != constants.IMPORT_WILDCARD:
+            methods = [methods]
 
         if wildcard_permission not in self._permissions:
             new_permission = {

--- a/boa3_test/test_sc/metadata_test/MetadataInfoPermissions.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoPermissions.py
@@ -10,7 +10,7 @@ def permissions_manifest() -> NeoMetadata:
     meta = NeoMetadata()
 
     # the contract needs permission to call this method from any contract
-    meta.add_permission(methods=['onNEP17Payment'])
+    meta.add_permission(methods='onNEP17Payment')
 
     # the contract needs permission to call this method from a specific contract
     meta.add_permission(contract='0x3846a4aa420d9831044396dd3a56011514cd10e3', methods=['get_object'])

--- a/boa3_test/test_sc/metadata_test/MetadataInfoPermissionsEmptyList.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoPermissionsEmptyList.py
@@ -1,0 +1,14 @@
+from boa3.builtin.compile_time import NeoMetadata, public
+
+
+@public
+def main() -> int:
+    return 5
+
+
+def permissions_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+
+    meta.add_permission(contract='*', methods=[])
+
+    return meta

--- a/boa3_test/test_sc/metadata_test/MetadataInfoPermissionsMismatchedType.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoPermissionsMismatchedType.py
@@ -15,13 +15,14 @@ def permissions_manifest() -> NeoMetadata:
     meta.add_permission(methods=b'onNEP17Payment')
     meta.add_permission(methods=123)
     meta.add_permission(methods=True)
-    meta.add_permission(methods='onNEP17Payment')
+    meta.add_permission(methods=(1, 2, 3))
+    meta.add_permission(methods=(b'onNEP17Payment', 123, True))
 
     meta.add_permission(contract=b'12345678901234567890')
     meta.add_permission(contract=123)
     meta.add_permission(contract=True)
     meta.add_permission(contract=['0x3846a4aa420d9831044396dd3a56011514cd10e3'])
 
-    meta.add_permission(contract=123, methods='onNEP17Payment')
+    meta.add_permission(contract=123, methods=b'onNEP17Payment')
 
     return meta

--- a/boa3_test/test_sc/metadata_test/MetadataInfoPermissionsTuple.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoPermissionsTuple.py
@@ -1,0 +1,14 @@
+from boa3.builtin.compile_time import NeoMetadata, public
+
+
+@public
+def main() -> int:
+    return 5
+
+
+def permissions_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+
+    meta.add_permission(contract='*', methods=('total_supply', 'onNEP17Payment'))
+
+    return meta

--- a/boa3_test/test_sc/metadata_test/MetadataInfoPermissionsWildcardList.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoPermissionsWildcardList.py
@@ -1,0 +1,14 @@
+from boa3.builtin.compile_time import NeoMetadata, public
+
+
+@public
+def main() -> int:
+    return 5
+
+
+def permissions_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+
+    meta.add_permission(contract='*', methods=['*', 'onNEP17Payment'])
+
+    return meta

--- a/boa3_test/test_sc/metadata_test/MetadataInfoPermissionsWildcardListSingleElement.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoPermissionsWildcardListSingleElement.py
@@ -1,0 +1,14 @@
+from boa3.builtin.compile_time import NeoMetadata, public
+
+
+@public
+def main() -> int:
+    return 5
+
+
+def permissions_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+
+    meta.add_permission(contract='*', methods=['*'])
+
+    return meta

--- a/boa3_test/test_sc/metadata_test/MetadataInfoPermissionsWildcardTuple.py
+++ b/boa3_test/test_sc/metadata_test/MetadataInfoPermissionsWildcardTuple.py
@@ -1,0 +1,14 @@
+from boa3.builtin.compile_time import NeoMetadata, public
+
+
+@public
+def main() -> int:
+    return 5
+
+
+def permissions_manifest() -> NeoMetadata:
+    meta = NeoMetadata()
+
+    meta.add_permission(contract='*', methods=('*', 'onNEP17Payment'))
+
+    return meta

--- a/boa3_test/tests/compiler_tests/test_metadata.py
+++ b/boa3_test/tests/compiler_tests/test_metadata.py
@@ -438,6 +438,23 @@ class TestMetadata(boatestcase.BoaTestCase):
         self.assertIsInstance(manifest['permissions'], list)
         self.assertEqual(len(manifest['permissions']), 0)
 
+    def test_metadata_info_permissions_empty_list(self):
+        path = self.get_contract_path('MetadataInfoPermissionsEmptyList.py')
+        output, manifest = self.compile_and_save(path)
+
+        self.assertIn('permissions', manifest)
+        self.assertIsInstance(manifest['permissions'], list)
+        self.assertEqual(len(manifest['permissions']), 0)
+
+    def test_metadata_info_permissions_tuple(self):
+        path = self.get_contract_path('MetadataInfoPermissionsTuple.py')
+        output, manifest = self.compile_and_save(path)
+
+        self.assertIn('permissions', manifest)
+        self.assertIsInstance(manifest['permissions'], list)
+        self.assertEqual(len(manifest['permissions']), 1)
+        self.assertIn({"contract": "*", "methods": ['total_supply', 'onNEP17Payment']}, manifest['permissions'])
+
     async def test_metadata_info_permissions_wildcard(self):
         path = self.get_contract_path('MetadataInfoPermissionsWildcard.py')
         output, manifest = self.compile_and_save(path)
@@ -451,6 +468,33 @@ class TestMetadata(boatestcase.BoaTestCase):
 
         result, _ = await self.call('main', [], return_type=int)
         self.assertEqual(result, 100_000_000)    # NEO total supply
+
+    async def test_metadata_info_permissions_wildcard_list_single_element(self):
+        path = self.get_contract_path('MetadataInfoPermissionsWildcardListSingleElement.py')
+        output, manifest = self.compile_and_save(path)
+
+        self.assertIn('permissions', manifest)
+        self.assertIsInstance(manifest['permissions'], list)
+        self.assertEqual(len(manifest['permissions']), 1)
+        self.assertIn({"contract": "*", "methods": "*"}, manifest['permissions'])
+
+    async def test_metadata_info_permissions_wildcard_list(self):
+        path = self.get_contract_path('MetadataInfoPermissionsWildcardList.py')
+        output, manifest = self.compile_and_save(path)
+
+        self.assertIn('permissions', manifest)
+        self.assertIsInstance(manifest['permissions'], list)
+        self.assertEqual(len(manifest['permissions']), 1)
+        self.assertIn({"contract": "*", "methods": "*"}, manifest['permissions'])
+
+    async def test_metadata_info_permissions_wildcard_tuple(self):
+        path = self.get_contract_path('MetadataInfoPermissionsWildcardTuple.py')
+        output, manifest = self.compile_and_save(path)
+
+        self.assertIn('permissions', manifest)
+        self.assertIsInstance(manifest['permissions'], list)
+        self.assertEqual(len(manifest['permissions']), 1)
+        self.assertIn({"contract": "*", "methods": "*"}, manifest['permissions'])
 
     def test_metadata_info_permissions_native_contract(self):
         path = self.get_contract_path('MetadataInfoPermissionsNativeContract.py')


### PR DESCRIPTION
**Summary or solution description**
This issue changes the `add_permission` function from `NeoMetadata` to accept methods in the form of lists and tuples, including handling of wildcard when present in such iterables.