### PR TITLE
CU-86drpndnn - Throw a compilation error when variable type declaration doesn't match the assigned value type

### DIFF
--- a/boa3/internal/analyser/moduleanalyser.py
+++ b/boa3/internal/analyser/moduleanalyser.py
@@ -1115,7 +1115,16 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
 
         self._check_annotation_type(ann_assign.annotation, ann_assign)
 
-        # TODO: check if the annotated type and the value type are the same #86a1ctmwy
+        if isinstance(ann_assign.value, ast.Constant):
+            annotation_type = self.get_type(ann_assign.value)
+            if not var_type.is_type_of(annotation_type):
+                self._log_error(
+                    CompilerError.MismatchedTypes(line=ann_assign.value.lineno,
+                                                  col=ann_assign.value.col_offset,
+                                                  expected_type_id=var_type.identifier,
+                                                  actual_type_id=annotation_type.identifier)
+                )
+
         return self.assign_value(var_id, var_type,
                                  source_node=ann_assign,
                                  assignment=ann_assign.value is not None,

--- a/boa3_test/tests/compiler_tests/test_bytes.py
+++ b/boa3_test/tests/compiler_tests/test_bytes.py
@@ -492,20 +492,7 @@ class TestBytes(boatestcase.BoaTestCase):
         self.assertEqual(b'\x01', result)
 
     def test_byte_array_literal_value(self):
-        data = b'\x01\x02\x03'
-        expected_output = (
-            Opcode.INITSLOT     # function signature
-            + b'\x01'
-            + b'\x00'
-            + Opcode.PUSHDATA1  # a = bytearray(b'\x01\x02\x03')
-            + Integer(len(data)).to_byte_array(min_length=1)
-            + data
-            + Opcode.STLOC0
-            + Opcode.RET        # return
-        )
-
-        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, 'BytearrayLiteral.py')
-        self.assertEqual(expected_output, output)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'BytearrayLiteral.py')
 
     def test_byte_array_default_compile(self):
         expected_output = (

--- a/boa3_test/tests/compiler_tests/test_variable.py
+++ b/boa3_test/tests/compiler_tests/test_variable.py
@@ -303,22 +303,7 @@ class TestVariable(boatestcase.BoaTestCase):
         self.assertCompilerLogs(CompilerError.UnresolvedReference, 'ReturnUndeclaredVariable.py')
 
     def test_assign_value_mismatched_type(self):
-        string_value = '1'
-        byte_input = String(string_value).to_bytes()
-
-        expected_output = (
-            Opcode.INITSLOT
-            + b'\x01'
-            + b'\x00'
-            + Opcode.PUSHDATA1  # a = '1'
-            + Integer(len(byte_input)).to_byte_array()
-            + byte_input
-            + Opcode.STLOC0
-            + Opcode.RET
-        )
-
-        output, _ = self.assertCompilerLogs(CompilerWarning.TypeCasting, 'MismatchedTypeAssignValue.py')
-        self.assertEqual(expected_output, output)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'MismatchedTypeAssignValue.py')
 
     def test_assign_binary_operation_mismatched_type(self):
         expected_output = (


### PR DESCRIPTION
**Summary or solution description**
When assigning a variable and defining the type of said as a constant (like a number or hardcoded string) of a different type, it should throw an error.

**Platform:**
 - OS: Windows 10 x64
 - Python version: Python 3.11
 