### PR TITLE
#86drpnca2 - Compilation error when trying to attribute an operation directly into the value of a dictionary

### DIFF
--- a/boa3_test/test_sc/dict_test/DictValueWithMethodReturn.py
+++ b/boa3_test/test_sc/dict_test/DictValueWithMethodReturn.py
@@ -1,0 +1,21 @@
+from typing import Any
+
+from boa3.builtin.compile_time import public
+from boa3.builtin.interop import runtime
+from boa3.builtin.nativecontract.stdlib import StdLib
+
+
+@public
+def symbol() -> str:
+    return "test"
+
+
+def get_id() -> str:
+    return StdLib.itoa(runtime.get_random())
+
+
+@public
+def Main() -> Any:
+    token_id = get_id()
+    first_token = {"id": token_id, "name": (symbol() + token_id)}
+    return first_token

--- a/boa3_test/tests/compiler_tests/test_dict.py
+++ b/boa3_test/tests/compiler_tests/test_dict.py
@@ -592,3 +592,24 @@ class TestDict(boatestcase.BoaTestCase):
 
     def test_del_dict_pair(self):
         self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'DelPair.py')
+
+    async def test_dict_value_with_method_return(self):
+        await self.set_up_contract('DictValueWithMethodReturn.py')
+
+        symbol, _ = await self.call('symbol', return_type=str)
+        self.assertGreater(len(symbol), 0)
+
+        result, _ = await self.call('Main', [], return_type=dict[str, str], signing_accounts=[self.genesis])
+        self.assertIn('id', result)
+
+        token_id = result['id']
+        expected = {"id": token_id, "name": (symbol + token_id)}
+        self.assertEqual(expected, result)
+
+        result, _ = await self.call('Main', [], return_type=dict[str, str])
+        self.assertIn('id', result)
+        self.assertNotEqual(result['id'], token_id)
+
+        token_id = result['id']
+        expected = {"id": token_id, "name": (symbol + token_id)}
+        self.assertEqual(expected, result)


### PR DESCRIPTION
**Summary or solution description**
Couldn't reproduce the bug, I think it was fixed in other issues. Included in the unit tests to make sure it works properly.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/14586f005b856f5ebd83a0094ae48a453cb83558/boa3_test/test_sc/dict_test/DictValueWithMethodReturn.py#L9-L21

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/14586f005b856f5ebd83a0094ae48a453cb83558/boa3_test/tests/compiler_tests/test_dict.py#L596-L615
