### PR TITLE
#86dtb6tt0 - Change the usage of `typing` collections to use `collections.abc` and update the tests accordingly

### DIFF
--- a/boa3/boa3.py
+++ b/boa3/boa3.py
@@ -11,9 +11,14 @@ class Boa3:
     """
 
     @staticmethod
-    def compile(path: str, root_folder: str = None, log_level: str = None,
-                env: str = None, fail_fast: bool = True,
-                optimize: bool = True) -> bytes:
+    def compile(
+            path: str,
+            root_folder: str = None,
+            log_level: str = None,
+            env: str = None,
+            fail_fast: bool = True,
+            optimize: bool = True
+    ) -> bytes:
         """
         Load a Python file to be compiled but don't write the result into a file
 
@@ -33,10 +38,17 @@ class Boa3:
                                   )
 
     @staticmethod
-    def compile_and_save(path: str, output_path: str = None, root_folder: str = None,
-                         show_errors: bool = True, log_level: str = None,
-                         debug: bool = False, env: str = None, fail_fast: bool = True,
-                         optimize: bool = True):
+    def compile_and_save(
+            path: str,
+            output_path: str = None,
+            root_folder: str = None,
+            show_errors: bool = True,
+            log_level: str = None,
+            debug: bool = False,
+            env: str = None,
+            fail_fast: bool = True,
+            optimize: bool = True
+    ):
         """
         Load a Python file to be compiled and save the result into the files.
         By default, the resultant .nef file is saved in the same folder of the

--- a/boa3/internal/analyser/analyser.py
+++ b/boa3/internal/analyser/analyser.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
-
 import ast
+from typing import Self
 
 from boa3.builtin.compile_time import NeoMetadata
 from boa3.internal import constants
@@ -56,11 +55,18 @@ class Analyser:
                           if project_root is not None and os.path.isdir(project_root)
                           else path)
 
-    @staticmethod
-    def analyse(path: str, log: bool = False, fail_fast: bool = False,
-                imported_files: dict[str, Analyser] | None = None,
-                import_stack: list[str] | None = None,
-                root: str = None, env: str = None, compiler_entry: bool = False) -> Analyser:
+    @classmethod
+    def analyse(
+            cls,
+            path: str,
+            log: bool = False,
+            fail_fast: bool = False,
+            imported_files: dict[str, Self] | None = None,
+            import_stack: list[str] | None = None,
+            root: str = None,
+            env: str = None,
+            compiler_entry: bool = False
+    ) -> Self:
         """
         Analyses the syntax of the Python code
 
@@ -116,7 +122,7 @@ class Analyser:
     def env(self) -> str:
         return self._env
 
-    def copy(self) -> Analyser:
+    def copy(self) -> Self:
         copied = Analyser(ast_tree=self.ast_tree, path=self.path, project_root=self.root,
                           env=self._env, log=self._log, fail_fast=self._fail_fast)
 
@@ -146,7 +152,7 @@ class Analyser:
         return not type_analyser.has_errors
 
     def __analyse_modules(self,
-                          imported_files: dict[str, Analyser] | None = None,
+                          imported_files: dict[str, Self] | None = None,
                           import_stack: list[str] | None = None) -> bool:
         """
         Validates the symbols and constructs the symbol table of the ast tree
@@ -246,5 +252,5 @@ class Analyser:
 
         self._included_imported_files = True
 
-    def get_imports(self) -> list[Analyser]:
+    def get_imports(self) -> list[Self]:
         return list(self._imported_files.values())

--- a/boa3/internal/analyser/importanalyser.py
+++ b/boa3/internal/analyser/importanalyser.py
@@ -146,8 +146,17 @@ class ImportAnalyser(IAstAnalyser):
             self.is_builtin_import = True
             return
 
-        if (os.path.commonpath([self.path, constants.BOA_PACKAGE_PATH]) != constants.BOA_PACKAGE_PATH or
-                ('boa3' in path and constants.PATH_SEPARATOR.join(path[path.index('boa3'):]).startswith('boa3/builtin'))):
+        def is_boa_package() -> bool:
+            common_path = os.path.commonpath([self.path, constants.BOA_PACKAGE_PATH])
+            if common_path == constants.BOA_PACKAGE_PATH:
+                return True
+            if 'boa3' not in path:
+                return False
+
+            boa_path = path[path.index('boa3'):]
+            return len(boa_path) > 1 and boa_path[1] in ('builtin', 'sc')
+
+        if not is_boa_package():
             # doesn't analyse boa3.builtin packages that aren't included in the imports.compilerbuiltin as an user module
             import re
 

--- a/boa3/internal/analyser/model/optimizer/Operation.py
+++ b/boa3/internal/analyser/model/optimizer/Operation.py
@@ -1,7 +1,6 @@
-from __future__ import annotations
-
 import ast
 from enum import Enum, auto
+from typing import Self
 
 from boa3.internal.model.operation.operation import IOperation
 from boa3.internal.model.operation.operator import Operator
@@ -20,7 +19,7 @@ class Operation(Enum):
         return self._symmetric
 
     @classmethod
-    def get_operation(cls, op: ast.operator | IOperation) -> Operation | None:
+    def get_operation(cls, op: ast.operator | IOperation) -> Self | None:
         op = op.operator if isinstance(op, IOperation) else op
         if op is Operator.Plus or isinstance(op, (ast.Add, ast.UAdd)):
             return cls.Add

--- a/boa3/internal/analyser/model/optimizer/__init__.py
+++ b/boa3/internal/analyser/model/optimizer/__init__.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 
 class ScopeValue:
@@ -9,14 +7,14 @@ class ScopeValue:
         self._assigned_variables: set[str] = set()
         self._parent_scope: ScopeValue | None = None
 
-    def new_scope(self) -> ScopeValue:
+    def new_scope(self) -> Self:
         scope = ScopeValue()
         scope._values = self._values.copy()
         scope._assigned_variables = self._assigned_variables.copy()
         scope._parent_scope = self
         return scope
 
-    def previous_scope(self) -> ScopeValue | None:
+    def previous_scope(self) -> Self | None:
         return self._parent_scope
 
     def update_values(self, *scopes, is_loop_scope: bool = False):
@@ -91,6 +89,10 @@ class UndefinedType:
     @property
     def identifier(self) -> str:
         return 'undefined'
+
+    @property
+    def is_deprecated(self) -> bool:
+        return False
 
 
 Undefined = UndefinedType()

--- a/boa3/internal/analyser/model/symbolscope.py
+++ b/boa3/internal/analyser/model/symbolscope.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+from typing import Self
 
 from boa3.internal.model.symbol import ISymbol
 
@@ -11,7 +11,7 @@ class SymbolScope:
     def symbols(self) -> dict[str, ISymbol]:
         return self._symbols.copy()
 
-    def copy(self) -> SymbolScope:
+    def copy(self) -> Self:
         return SymbolScope(self._symbols)
 
     def include_symbol(self, symbol_id: str, symbol: ISymbol, reassign_original: bool = True):

--- a/boa3/internal/compiler/codegenerator/engine/executionscript.py
+++ b/boa3/internal/compiler/codegenerator/engine/executionscript.py
@@ -1,9 +1,8 @@
-from __future__ import annotations
-
 __all__ = [
     'ExecutionScript'
 ]
 
+from typing import Self
 
 from boa3.internal.compiler.codegenerator.vmcodemapping import VMCodeMapping
 from boa3.internal.neo.vm.VMCode import VMCode
@@ -21,7 +20,7 @@ class ExecutionScript:
         self._tokens = tokens
 
     @classmethod
-    def from_code_map(cls, instance: VMCodeMapping) -> ExecutionScript:
+    def from_code_map(cls, instance: VMCodeMapping) -> Self:
         obj = ExecutionScript(instance.code_map, instance._method_tokens.to_list())
         return obj
 

--- a/boa3/internal/compiler/codegenerator/engine/istack.py
+++ b/boa3/internal/compiler/codegenerator/engine/istack.py
@@ -1,7 +1,5 @@
-from __future__ import annotations
-
 import abc
-from typing import TypeVar
+from typing import TypeVar, Self
 
 T = TypeVar("T")
 
@@ -21,7 +19,7 @@ class IStack(abc.ABC):
     def clear(self):
         return self._stack.clear()
 
-    def copy(self) -> IStack:
+    def copy(self) -> Self:
         new_stack = self.__class__(*self._default_constructor_args())
         new_stack._stack = self._stack.copy()
         return new_stack

--- a/boa3/internal/compiler/codegenerator/engine/stackmemento.py
+++ b/boa3/internal/compiler/codegenerator/engine/stackmemento.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 __all__ = [
     'StackMemento',
     'NeoStack'
@@ -9,6 +7,15 @@ from boa3.internal.compiler.codegenerator.engine.istack import IStack
 from boa3.internal.compiler.codegenerator.vmcodemapping import VMCodeMapping
 from boa3.internal.model.type.itype import IType
 from boa3.internal.neo.vm.VMCode import VMCode
+
+
+class NeoStack(IStack):
+    def __init__(self):
+        from boa3.internal.model.type.itype import IType
+        super().__init__(stack_type=IType)
+
+    def _default_constructor_args(self) -> tuple:
+        return tuple()
 
 
 class StackMemento:
@@ -105,12 +112,3 @@ class StackMemento:
             self._current_stack = stack
 
         return stack.reverse(start, end, rotate=rotate)
-
-
-class NeoStack(IStack):
-    def __init__(self):
-        from boa3.internal.model.type.itype import IType
-        super().__init__(stack_type=IType)
-
-    def _default_constructor_args(self) -> tuple:
-        return tuple()

--- a/boa3/internal/compiler/codegenerator/generatordata.py
+++ b/boa3/internal/compiler/codegenerator/generatordata.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
-
 import ast
+from typing import Self
 
 from boa3.internal.model.expression import IExpression
 from boa3.internal.model.identifiedsymbol import IdentifiedSymbol
@@ -28,13 +27,16 @@ class GeneratorData:
         self.symbol_id: str | None = symbol_id
         self.type: IType | None = result_type
         self.index: int | None = index
-        self.origin_object_type: ISymbol | None = origin_object_type
+        self.origin_object_type: IType | None = origin_object_type
         self.already_generated: bool = already_generated
 
-    def copy(self, new_origin: ast.AST | None = None) -> GeneratorData:
-        return GeneratorData(new_origin if isinstance(new_origin, ast.AST) else self.node,
-                             self.symbol_id,
-                             self.symbol,
-                             self.type,
-                             self.index,
-                             self.already_generated)
+    def copy(self, new_origin: ast.AST | None = None) -> Self:
+        return GeneratorData(
+            origin_node=new_origin if isinstance(new_origin, ast.AST) else self.node,
+            symbol_id=self.symbol_id,
+            symbol=self.symbol,
+            result_type=self.type,
+            index=self.index,
+            origin_object_type=self.origin_object_type,
+            already_generated=self.already_generated
+        )

--- a/boa3/internal/compiler/codegenerator/vmcodemapping.py
+++ b/boa3/internal/compiler/codegenerator/vmcodemapping.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+from typing import Self
 
 from boa3.internal.compiler.codegenerator.methodtokencollection import MethodTokenCollection
 from boa3.internal.compiler.codegenerator.vmcodemap import VMCodeMap
@@ -14,7 +14,7 @@ class VMCodeMapping:
     """
     This class is responsible for managing the Neo VM instruction during the bytecode generation.
     """
-    _instance: VMCodeMapping = None
+    _instance: Self = None
 
     @classmethod
     def instance(cls):

--- a/boa3/internal/compiler/compiledmetadata.py
+++ b/boa3/internal/compiler/compiledmetadata.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+from typing import Self
 
 from boa3.builtin.compile_time import NeoMetadata
 from boa3.internal import constants
@@ -9,7 +9,7 @@ class CompiledMetadata:
     _instance = None
 
     @classmethod
-    def instance(cls) -> CompiledMetadata:
+    def instance(cls) -> Self:
         if cls._instance is None:
             cls._instance = cls()
         return cls._instance

--- a/boa3/internal/constants.py
+++ b/boa3/internal/constants.py
@@ -19,7 +19,7 @@ SYS_VERSION = platform.python_version()
 BOA_VERSION = _actual_boa_version  # for logging only
 BOA_LOGGING_NAME = 'neo3-boa-log'
 COMPILER_VERSION = BOA_VERSION
-BOA_PACKAGE_PATH = os.path.abspath(f'{__file__}/..')
+BOA_PACKAGE_PATH = os.path.abspath(f'{__file__}/../..')
 DEFAULT_CONTRACT_ENVIRONMENT = 'mainnet'
 
 locale.setlocale(locale.LC_ALL, '')

--- a/boa3/internal/model/builtin/builtinsymbol.py
+++ b/boa3/internal/model/builtin/builtinsymbol.py
@@ -1,13 +1,12 @@
-from __future__ import annotations
-
 from abc import ABC
+from typing import Self
 
 from boa3.internal.model.identifiedsymbol import IdentifiedSymbol
 
 
 class IBuiltinSymbol(IdentifiedSymbol, ABC):
 
-    def build(self, *args, **kwargs) -> IBuiltinSymbol:
+    def build(self, *args, **kwargs) -> Self:
         """
         Creates a symbol instance with the given value as self
 

--- a/boa3/internal/model/builtin/contract/neoaccountstatetype.py
+++ b/boa3/internal/model/builtin/contract/neoaccountstatetype.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.internal.model.expression import IExpression
@@ -61,7 +59,7 @@ class NeoAccountStateType(ClassArrayType):
         return self._constructor
 
     @classmethod
-    def build(cls, value: Any = None) -> NeoAccountStateType:
+    def build(cls, value: Any = None) -> Self:
         if value is None or cls._is_type_of(value):
             return _NeoAccountState
 

--- a/boa3/internal/model/builtin/internal/innerdeploymethod.py
+++ b/boa3/internal/model/builtin/internal/innerdeploymethod.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
-
 import ast
+from typing import Self
 
 from boa3.internal import constants
 from boa3.internal.model import set_internal_call
@@ -14,7 +13,7 @@ from boa3.internal.model.variable import Variable
 class InnerDeployMethod(IInternalMethod):
 
     @classmethod
-    def instance(cls) -> InnerDeployMethod:
+    def instance(cls) -> Self:
         return _INNER_DEPLOY_METHOD
 
     def __init__(self):
@@ -41,7 +40,7 @@ class InnerDeployMethod(IInternalMethod):
     def _args_on_stack(self) -> int:
         return len(self.args)
 
-    def copy(self) -> InnerDeployMethod:
+    def copy(self) -> Self:
         return InnerDeployMethod()
 
     @classmethod

--- a/boa3/internal/model/builtin/internal/internalmethod.py
+++ b/boa3/internal/model/builtin/internal/internalmethod.py
@@ -1,7 +1,6 @@
-from __future__ import annotations
-
 import abc
 import ast
+from typing import Self
 
 from boa3.internal.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.internal.model.symbol import ISymbol
@@ -23,7 +22,7 @@ class IInternalMethod(IBuiltinMethod, abc.ABC):
 
     @classmethod
     @abc.abstractmethod
-    def instance(cls) -> IInternalMethod:
+    def instance(cls) -> Self:
         pass
 
     @classmethod

--- a/boa3/internal/model/builtin/interop/blockchain/blocktype.py
+++ b/boa3/internal/model/builtin/interop/blockchain/blocktype.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.internal.model.expression import IExpression
@@ -67,7 +65,7 @@ class BlockType(ClassArrayType):
         return self._constructor
 
     @classmethod
-    def build(cls, value: Any = None) -> BlockType:
+    def build(cls, value: Any = None) -> Self:
         if value is None or cls._is_type_of(value):
             return _Block
 

--- a/boa3/internal/model/builtin/interop/blockchain/signertype.py
+++ b/boa3/internal/model/builtin/interop/blockchain/signertype.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.internal.model.expression import IExpression
@@ -65,7 +63,7 @@ class SignerType(ClassArrayType):
         return self._constructor
 
     @classmethod
-    def build(cls, value: Any = None) -> SignerType:
+    def build(cls, value: Any = None) -> Self:
         if value is None or cls._is_type_of(value):
             return _Signer
 

--- a/boa3/internal/model/builtin/interop/blockchain/transactiontype.py
+++ b/boa3/internal/model/builtin/interop/blockchain/transactiontype.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.internal.model.expression import IExpression
@@ -64,7 +62,7 @@ class TransactionType(ClassArrayType):
         return self._constructor
 
     @classmethod
-    def build(cls, value: Any = None) -> TransactionType:
+    def build(cls, value: Any = None) -> Self:
         if value is None or cls._is_type_of(value):
             return _Transaction
 

--- a/boa3/internal/model/builtin/interop/blockchain/vmstatetype.py
+++ b/boa3/internal/model/builtin/interop/blockchain/vmstatetype.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.model.symbol import ISymbol
 from boa3.internal.model.type.primitive.inttype import IntType
@@ -21,7 +19,7 @@ class VMStateType(IntType):
         return VMState.NONE
 
     @classmethod
-    def build(cls, value: Any = None) -> VMStateType:
+    def build(cls, value: Any = None) -> Self:
         if value is None or cls._is_type_of(value):
             return _VMState
 

--- a/boa3/internal/model/builtin/interop/blockchain/witnessconditionenumtype.py
+++ b/boa3/internal/model/builtin/interop/blockchain/witnessconditionenumtype.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.model.symbol import ISymbol
 from boa3.internal.model.type.primitive.inttype import IntType
@@ -21,7 +19,7 @@ class WitnessConditionType(IntType):
         return WitnessCondition.BOOLEAN
 
     @classmethod
-    def build(cls, value: Any = None) -> WitnessConditionType:
+    def build(cls, value: Any = None) -> Self:
         if value is None or cls._is_type_of(value):
             return _WitnessConditionType
 

--- a/boa3/internal/model/builtin/interop/blockchain/witnessconditiontype.py
+++ b/boa3/internal/model/builtin/interop/blockchain/witnessconditiontype.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.internal.model.expression import IExpression
@@ -55,7 +53,7 @@ class WitnessConditionType(ClassArrayType):
         return self._constructor
 
     @classmethod
-    def build(cls, value: Any = None) -> WitnessConditionType:
+    def build(cls, value: Any = None) -> Self:
         if value is None or cls._is_type_of(value):
             return _WitnessCondition
 

--- a/boa3/internal/model/builtin/interop/blockchain/witnessruleactiontype.py
+++ b/boa3/internal/model/builtin/interop/blockchain/witnessruleactiontype.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.model.symbol import ISymbol
 from boa3.internal.model.type.primitive.inttype import IntType
@@ -21,7 +19,7 @@ class WitnessRuleActionType(IntType):
         return WitnessRuleAction.DENY
 
     @classmethod
-    def build(cls, value: Any = None) -> WitnessRuleActionType:
+    def build(cls, value: Any = None) -> Self:
         if value is None or cls._is_type_of(value):
             return _WitnessRuleAction
 

--- a/boa3/internal/model/builtin/interop/blockchain/witnessruletype.py
+++ b/boa3/internal/model/builtin/interop/blockchain/witnessruletype.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.internal.model.expression import IExpression
@@ -57,7 +55,7 @@ class WitnessRuleType(ClassArrayType):
         return self._constructor
 
     @classmethod
-    def build(cls, value: Any = None) -> WitnessRuleType:
+    def build(cls, value: Any = None) -> Self:
         if value is None or cls._is_type_of(value):
             return _WitnessRule
 

--- a/boa3/internal/model/builtin/interop/blockchain/witnessscopeenumtype.py
+++ b/boa3/internal/model/builtin/interop/blockchain/witnessscopeenumtype.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.model.symbol import ISymbol
 from boa3.internal.model.type.primitive.inttype import IntType
@@ -21,7 +19,7 @@ class WitnessScopeType(IntType):
         return WitnessScope.NONE
 
     @classmethod
-    def build(cls, value: Any = None) -> WitnessScopeType:
+    def build(cls, value: Any = None) -> Self:
         if value is None or cls._is_type_of(value):
             return _WitnessScope
 

--- a/boa3/internal/model/builtin/interop/contract/contractmanifest/contractabitype.py
+++ b/boa3/internal/model/builtin/interop/contract/contractmanifest/contractabitype.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.model.method import Method
 from boa3.internal.model.property import Property
@@ -55,7 +53,7 @@ class ContractAbiType(ClassStructType):
         return self._constructor
 
     @classmethod
-    def build(cls, value: Any = None) -> ContractAbiType:
+    def build(cls, value: Any = None) -> Self:
         if value is None or cls._is_type_of(value):
             return _ContractAbi
 

--- a/boa3/internal/model/builtin/interop/contract/contractmanifest/contracteventdescriptortype.py
+++ b/boa3/internal/model/builtin/interop/contract/contractmanifest/contracteventdescriptortype.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.model.method import Method
 from boa3.internal.model.property import Property
@@ -53,7 +51,7 @@ class ContractEventDescriptorType(ClassStructType):
         return self._constructor
 
     @classmethod
-    def build(cls, value: Any = None) -> ContractEventDescriptorType:
+    def build(cls, value: Any = None) -> Self:
         if value is None or cls._is_type_of(value):
             return _ContractEventDescriptor
 

--- a/boa3/internal/model/builtin/interop/contract/contractmanifest/contractgrouptype.py
+++ b/boa3/internal/model/builtin/interop/contract/contractmanifest/contractgrouptype.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.model.method import Method
 from boa3.internal.model.property import Property
@@ -52,7 +50,7 @@ class ContractGroupType(ClassStructType):
         return self._constructor
 
     @classmethod
-    def build(cls, value: Any = None) -> ContractGroupType:
+    def build(cls, value: Any = None) -> Self:
         if value is None or cls._is_type_of(value):
             return _ContractGroup
 

--- a/boa3/internal/model/builtin/interop/contract/contractmanifest/contractmanifesttype.py
+++ b/boa3/internal/model/builtin/interop/contract/contractmanifest/contractmanifesttype.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.model.method import Method
 from boa3.internal.model.property import Property
@@ -57,7 +55,7 @@ class ContractManifestType(ClassStructType):
         return self._constructor
 
     @classmethod
-    def build(cls, value: Any = None) -> ContractManifestType:
+    def build(cls, value: Any = None) -> Self:
         if value is None or cls._is_type_of(value):
             return _ContractManifest
 

--- a/boa3/internal/model/builtin/interop/contract/contractmanifest/contractmethoddescriptortype.py
+++ b/boa3/internal/model/builtin/interop/contract/contractmanifest/contractmethoddescriptortype.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.model.method import Method
 from boa3.internal.model.property import Property
@@ -57,7 +55,7 @@ class ContractMethodDescriptorType(ClassStructType):
         return self._constructor
 
     @classmethod
-    def build(cls, value: Any = None) -> ContractMethodDescriptorType:
+    def build(cls, value: Any = None) -> Self:
         if value is None or cls._is_type_of(value):
             return _ContractMethodDescriptor
 

--- a/boa3/internal/model/builtin/interop/contract/contractmanifest/contractparameterdefinitiontype.py
+++ b/boa3/internal/model/builtin/interop/contract/contractmanifest/contractparameterdefinitiontype.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.model.method import Method
 from boa3.internal.model.property import Property
@@ -52,7 +50,7 @@ class ContractParameterDefinitionType(ClassStructType):
         return self._constructor
 
     @classmethod
-    def build(cls, value: Any = None) -> ContractParameterDefinitionType:
+    def build(cls, value: Any = None) -> Self:
         if value is None or cls._is_type_of(value):
             return _ContractParameterDefinition
 

--- a/boa3/internal/model/builtin/interop/contract/contractmanifest/contractpermissiondescriptortype.py
+++ b/boa3/internal/model/builtin/interop/contract/contractmanifest/contractpermissiondescriptortype.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.model.method import Method
 from boa3.internal.model.property import Property
@@ -53,7 +51,7 @@ class ContractPermissionDescriptorType(ClassStructType):
         return self._constructor
 
     @classmethod
-    def build(cls, value: Any = None) -> ContractPermissionDescriptorType:
+    def build(cls, value: Any = None) -> Self:
         if value is None or cls._is_type_of(value):
             return _ContractPermissionDescriptor
 

--- a/boa3/internal/model/builtin/interop/contract/contractmanifest/contractpermissiontype.py
+++ b/boa3/internal/model/builtin/interop/contract/contractmanifest/contractpermissiontype.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.model.method import Method
 from boa3.internal.model.property import Property
@@ -51,7 +49,7 @@ class ContractPermissionType(ClassArrayType):
         return self._constructor
 
     @classmethod
-    def build(cls, value: Any = None) -> ContractPermissionType:
+    def build(cls, value: Any = None) -> Self:
         if value is None or cls._is_type_of(value):
             return _ContractPermission
 

--- a/boa3/internal/model/builtin/interop/contract/contracttype.py
+++ b/boa3/internal/model/builtin/interop/contract/contracttype.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.internal.model.expression import IExpression
@@ -61,7 +59,7 @@ class ContractType(ClassArrayType):
         return self._constructor
 
     @classmethod
-    def build(cls, value: Any = None) -> ContractType:
+    def build(cls, value: Any = None) -> Self:
         if value is None or cls._is_type_of(value):
             return _Contract
 

--- a/boa3/internal/model/builtin/interop/contractgethashmethod.py
+++ b/boa3/internal/model/builtin/interop/contractgethashmethod.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import ast
 from abc import ABC
 

--- a/boa3/internal/model/builtin/interop/iterator/iteratortype.py
+++ b/boa3/internal/model/builtin/interop/iterator/iteratortype.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.model.builtin.interop.interopinterfacetype import InteropInterfaceType
 from boa3.internal.model.method import Method
@@ -49,7 +47,7 @@ class IteratorType(InteropInterfaceType, ICollectionType):
         return self._origin_collection.is_valid_key(key_type)
 
     @classmethod
-    def build(cls, value: Any = None) -> IteratorType:
+    def build(cls, value: Any = None) -> Self:
         if isinstance(value, ICollectionType):
             return IteratorType(value)
         else:

--- a/boa3/internal/model/builtin/interop/runtime/notificationtype.py
+++ b/boa3/internal/model/builtin/interop/runtime/notificationtype.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.internal.model.expression import IExpression
@@ -58,7 +56,7 @@ class NotificationType(ClassArrayType):
         return self._constructor
 
     @classmethod
-    def build(cls, value: Any = None) -> NotificationType:
+    def build(cls, value: Any = None) -> Self:
         if value is None or cls._is_type_of(value):
             return _Notification
 

--- a/boa3/internal/model/builtin/method/builtinmethod.py
+++ b/boa3/internal/model/builtin/method/builtinmethod.py
@@ -1,8 +1,6 @@
-from __future__ import annotations
-
 import ast
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.model.builtin.builtincallable import IBuiltinCallable
 from boa3.internal.model.method import Method
@@ -198,7 +196,7 @@ class IBuiltinMethod(IBuiltinCallable, Method, ABC):
         """
         return None
 
-    def build(self, value: Any) -> IBuiltinMethod:
+    def build(self, value: Any) -> Self:
         """
         Creates a method instance with the given value as self
 

--- a/boa3/internal/model/builtin/native/contractmanagementclass.py
+++ b/boa3/internal/model/builtin/native/contractmanagementclass.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.model.builtin.interop.nativecontract import ContractManagement
 from boa3.internal.model.builtin.native.inativecontractclass import INativeContractClass
@@ -34,7 +32,7 @@ class ContractManagementClass(INativeContractClass):
         return super().class_methods
 
     @classmethod
-    def build(cls, value: Any = None) -> ContractManagementClass:
+    def build(cls, value: Any = None) -> Self:
         if value is None or cls._is_type_of(value):
             return _ContractManagement
 

--- a/boa3/internal/model/builtin/native/cryptolibclass.py
+++ b/boa3/internal/model/builtin/native/cryptolibclass.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.model.builtin.interop.nativecontract import CryptoLibContract
 from boa3.internal.model.builtin.native.inativecontractclass import INativeContractClass
@@ -36,7 +34,7 @@ class CryptoLibClass(INativeContractClass):
         return super().class_methods
 
     @classmethod
-    def build(cls, value: Any = None) -> CryptoLibClass:
+    def build(cls, value: Any = None) -> Self:
         if value is None or cls._is_type_of(value):
             return _CryptoLib
 

--- a/boa3/internal/model/builtin/native/gasclass.py
+++ b/boa3/internal/model/builtin/native/gasclass.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.constants import GAS_SCRIPT
 from boa3.internal.model.builtin.interop.contract import GasToken
@@ -33,7 +31,7 @@ class GasClass(INativeContractClass):
         return super().class_methods
 
     @classmethod
-    def build(cls, value: Any = None) -> GasClass:
+    def build(cls, value: Any = None) -> Self:
         if value is None or cls._is_type_of(value):
             return _Gas
 

--- a/boa3/internal/model/builtin/native/ledgerclass.py
+++ b/boa3/internal/model/builtin/native/ledgerclass.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.model.builtin.interop.nativecontract import LedgerContract
 from boa3.internal.model.builtin.native.inativecontractclass import INativeContractClass
@@ -33,7 +31,7 @@ class LedgerClass(INativeContractClass):
         return super().class_methods
 
     @classmethod
-    def build(cls, value: Any = None) -> LedgerClass:
+    def build(cls, value: Any = None) -> Self:
         if value is None or cls._is_type_of(value):
             return _Ledger
 

--- a/boa3/internal/model/builtin/native/neoclass.py
+++ b/boa3/internal/model/builtin/native/neoclass.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.constants import NEO_SCRIPT
 from boa3.internal.model.builtin.interop.contract import NeoToken
@@ -53,7 +51,7 @@ class NeoClass(INativeContractClass):
         return super().class_methods
 
     @classmethod
-    def build(cls, value: Any = None) -> NeoClass:
+    def build(cls, value: Any = None) -> Self:
         if value is None or cls._is_type_of(value):
             return _Neo
 

--- a/boa3/internal/model/builtin/native/oracleclass.py
+++ b/boa3/internal/model/builtin/native/oracleclass.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.model.builtin.interop.nativecontract import OracleContract
 from boa3.internal.model.builtin.native.inativecontractclass import INativeContractClass
@@ -29,7 +27,7 @@ class OracleClass(INativeContractClass):
         return super().class_methods
 
     @classmethod
-    def build(cls, value: Any = None) -> OracleClass:
+    def build(cls, value: Any = None) -> Self:
         if value is None or cls._is_type_of(value):
             return _Oracle
 

--- a/boa3/internal/model/builtin/native/policyclass.py
+++ b/boa3/internal/model/builtin/native/policyclass.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.model.builtin.interop.nativecontract import PolicyContract
 from boa3.internal.model.builtin.native.inativecontractclass import INativeContractClass
@@ -30,7 +28,7 @@ class PolicyClass(INativeContractClass):
         return super().class_methods
 
     @classmethod
-    def build(cls, value: Any = None) -> PolicyClass:
+    def build(cls, value: Any = None) -> Self:
         if value is None or cls._is_type_of(value):
             return _Policy
 

--- a/boa3/internal/model/builtin/native/rolemanagementclass.py
+++ b/boa3/internal/model/builtin/native/rolemanagementclass.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.model.builtin.interop.nativecontract import RoleManagement
 from boa3.internal.model.builtin.native.inativecontractclass import INativeContractClass
@@ -27,7 +25,7 @@ class RoleManagementClass(INativeContractClass):
         return super().class_methods
 
     @classmethod
-    def build(cls, value: Any = None) -> RoleManagementClass:
+    def build(cls, value: Any = None) -> Self:
         if value is None or cls._is_type_of(value):
             return _RoleManagement
 

--- a/boa3/internal/model/builtin/native/stdlibclass.py
+++ b/boa3/internal/model/builtin/native/stdlibclass.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.model.builtin.interop.nativecontract import StdLibContract
 from boa3.internal.model.builtin.native.inativecontractclass import INativeContractClass
@@ -40,7 +38,7 @@ class StdLibClass(INativeContractClass):
         return super().class_methods
 
     @classmethod
-    def build(cls, value: Any = None) -> StdLibClass:
+    def build(cls, value: Any = None) -> Self:
         if value is None or cls._is_type_of(value):
             return _StdLib
 

--- a/boa3/internal/model/callable.py
+++ b/boa3/internal/model/callable.py
@@ -1,7 +1,6 @@
-from __future__ import annotations
-
 import ast
 from abc import ABC
+from typing import Self
 
 from boa3.internal.model import set_internal_call
 from boa3.internal.model.expression import IExpression
@@ -25,7 +24,7 @@ class Callable(IExpression, ABC):
                  kwargs: dict[str, Variable] | None = None,
                  defaults: list[ast.AST] = None,
                  return_type: IType = Type.none, is_public: bool = False,
-                 decorators: list[Callable] = None,
+                 decorators: list[Self] = None,
                  external_name: str = None,
                  is_safe: bool = False,
                  origin_node: ast.AST | None = None,

--- a/boa3/internal/model/debuginstruction.py
+++ b/boa3/internal/model/debuginstruction.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
-
 import ast
+from typing import Self
 
 from boa3.internal.neo.vm.VMCode import VMCode
 
@@ -24,7 +23,7 @@ class DebugInstruction:
                                             self.code)
 
     @classmethod
-    def build(cls, ast_node: ast.AST, bytecode: VMCode) -> DebugInstruction:
+    def build(cls, ast_node: ast.AST, bytecode: VMCode) -> Self:
         end_line: int = ast_node.end_lineno if hasattr(ast_node, 'end_lineno') else ast_node.lineno
         end_col: int = ast_node.end_col_offset + 1 if hasattr(ast_node, 'end_lineno') else ast_node.col_offset
         return cls(bytecode, ast_node.lineno, ast_node.col_offset, end_line, end_col)

--- a/boa3/internal/model/expression.py
+++ b/boa3/internal/model/expression.py
@@ -28,7 +28,7 @@ class IExpression(ISymbol):
     def is_deprecated(self) -> bool:
         return self._deprecated
 
-    def deprecate(self):
+    def deprecate(self, new_location: str = None):
         self._deprecated = True
 
     @property

--- a/boa3/internal/model/identifiedsymbol.py
+++ b/boa3/internal/model/identifiedsymbol.py
@@ -10,9 +10,10 @@ class IdentifiedSymbol(ISymbol, ABC):
     :return: the resulting type when the expression is evaluated
     """
 
-    def __init__(self, identifier: str, deprecated: bool = False):
+    def __init__(self, identifier: str, deprecated: bool = False, new_location: str = None):
         self._identifier: str = identifier
         self._deprecated: bool = deprecated
+        self._new_location: str = new_location
 
     @property
     def identifier(self) -> str:
@@ -36,5 +37,11 @@ class IdentifiedSymbol(ISymbol, ABC):
     def is_deprecated(self) -> bool:
         return self._deprecated
 
-    def deprecate(self):
+    def deprecate(self, new_location: str = None):
         self._deprecated = True
+        if new_location is not None:
+            self._new_location = new_location
+
+    @property
+    def new_location(self) -> str | None:
+        return self._new_location

--- a/boa3/internal/model/imports/compilerbuiltin.py
+++ b/boa3/internal/model/imports/compilerbuiltin.py
@@ -1,10 +1,10 @@
-from __future__ import annotations
-
 __all__ = [
     'get_package',
     'get_internal_symbol',
     'CompilerBuiltin'
 ]
+
+from typing import Self
 
 from boa3.internal import constants
 from boa3.internal.model.builtin.builtin import Builtin, BoaPackage
@@ -16,7 +16,7 @@ from boa3.internal.model.imports.package import Package
 from boa3.internal.model.sc import ContractImports, BoaSCPackage
 from boa3.internal.model.symbol import ISymbol
 from boa3.internal.model.type.math import Math
-from boa3.internal.model.type.typeutils import TypeUtils
+from boa3.internal.model.type.typeutils import TypeUtils, TypingPackage
 
 
 def get_package(package_full_path: str) -> Package | None:
@@ -31,7 +31,7 @@ class CompilerBuiltin:
     _instance = None
 
     @classmethod
-    def instance(cls) -> CompilerBuiltin:
+    def instance(cls) -> Self:
         if cls._instance is None:
             cls._instance = cls()
         return cls._instance
@@ -40,7 +40,8 @@ class CompilerBuiltin:
         self.packages: list[Package] = []
         self._events: list[Event] = []
 
-        self._generate_builtin_package('typing', TypeUtils.get_types_from_typing_lib())
+        self._generate_builtin_package('typing', TypeUtils.package_symbols(TypingPackage.Typing))
+        self._generate_builtin_package('collections', TypeUtils.package_symbols(TypingPackage.Collections))
         self._generate_builtin_package('math', Math.get_methods_from_math_lib())
 
         self._generate_builtin_package('boa3.sc.types', ContractImports.package_symbols(BoaSCPackage.Types))

--- a/boa3/internal/model/imports/importsymbol.py
+++ b/boa3/internal/model/imports/importsymbol.py
@@ -71,7 +71,7 @@ class Import(ISymbol):
     def is_deprecated(self) -> bool:
         return False
 
-    def deprecate(self):
+    def deprecate(self, new_location: str = None):
         return
 
 

--- a/boa3/internal/model/module.py
+++ b/boa3/internal/model/module.py
@@ -44,7 +44,7 @@ class Module(ISymbol):
     def is_deprecated(self) -> bool:
         return self._deprecated
 
-    def deprecate(self):
+    def deprecate(self, new_location: str = None):
         self._deprecated = True
 
     def include_variable(self, var_id: str, var: Variable):

--- a/boa3/internal/model/operation/binary/binaryoperation.py
+++ b/boa3/internal/model/operation/binary/binaryoperation.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
-
 from abc import ABC, abstractmethod
+from typing import Self
 
 from boa3.internal.model.operation.operation import IOperation
 from boa3.internal.model.type.itype import IType
@@ -46,14 +45,14 @@ class BinaryOperation(IOperation, ABC):
         pass
 
     @classmethod
-    def build(cls, *operands: IType) -> BinaryOperation | None:
+    def build(cls, *operands: IType) -> Self | None:
         if len(operands) == 1:
             return cls._build_with_left_arg(operands[0])
         if len(operands) == 2:
             return cls._build_with_two_args(operands[0], operands[1])
 
     @classmethod
-    def _build_with_left_arg(cls, left: IType) -> BinaryOperation | None:
+    def _build_with_left_arg(cls, left: IType) -> Self | None:
         """
         Creates a binary operation with the given operands types
 
@@ -64,7 +63,7 @@ class BinaryOperation(IOperation, ABC):
         return cls(left)
 
     @classmethod
-    def _build_with_two_args(cls, left: IType, right: IType) -> BinaryOperation | None:
+    def _build_with_two_args(cls, left: IType, right: IType) -> Self | None:
         """
         Creates a binary operation with the given operands types
 

--- a/boa3/internal/model/operation/operation.py
+++ b/boa3/internal/model/operation/operation.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
-
 from abc import ABC, abstractmethod
+from typing import Self
 
 from boa3.internal.model.operation.operator import Operator
 from boa3.internal.model.symbol import ISymbol
@@ -49,7 +48,7 @@ class IOperation(ISymbol, ABC):
     def is_deprecated(self) -> bool:
         return self._deprecated
 
-    def deprecate(self):
+    def deprecate(self, new_location: str = None):
         self._deprecated = True
 
     @property
@@ -105,7 +104,7 @@ class IOperation(ISymbol, ABC):
 
     @classmethod
     @abstractmethod
-    def build(cls, *operands: IType) -> IOperation | None:
+    def build(cls, *operands: IType) -> Self | None:
         """
         Creates an operation with the given operands types
 

--- a/boa3/internal/model/operation/operator.py
+++ b/boa3/internal/model/operation/operator.py
@@ -1,7 +1,6 @@
-from __future__ import annotations
-
 import ast
 from enum import Enum
+from typing import Self
 
 
 class Operator(str, Enum):
@@ -41,7 +40,7 @@ class Operator(str, Enum):
     NotIn = 'not in'
 
     @classmethod
-    def get_operation(cls, node: ast.operator) -> Operator | None:
+    def get_operation(cls, node: ast.operator) -> Self | None:
         operators: dict[type[ast.operator], Operator] = {
             ast.Add: Operator.Plus,
             ast.Sub: Operator.Minus,

--- a/boa3/internal/model/operation/unary/unaryoperation.py
+++ b/boa3/internal/model/operation/unary/unaryoperation.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
-
 from abc import ABC, abstractmethod
+from typing import Self
 
 from boa3.internal.model.operation.operation import IOperation
 from boa3.internal.model.type.itype import IType
@@ -36,7 +35,7 @@ class UnaryOperation(IOperation, ABC):
         pass
 
     @classmethod
-    def build(cls, operand: IType) -> UnaryOperation | None:
+    def build(cls, operand: IType) -> Self | None:
         """
         Creates a unary operation with the given operand type
 

--- a/boa3/internal/model/symbol.py
+++ b/boa3/internal/model/symbol.py
@@ -24,7 +24,7 @@ class ISymbol(ABC):
         return False
 
     @abstractmethod
-    def deprecate(self):
+    def deprecate(self, new_location: str = None):
         """
         Deprecate this symbol
         """

--- a/boa3/internal/model/type/classes/classtype.py
+++ b/boa3/internal/model/type/classes/classtype.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from abc import ABC, abstractmethod
 
 from boa3.internal.compiler.codegenerator import get_bytes_count
@@ -18,7 +16,7 @@ class ClassType(IType, ABC):
     """
 
     def __init__(self, identifier: str, decorators: list = None,
-                 bases: list[ClassType] = None):
+                 bases: list["ClassType"] = None):
         super().__init__(identifier)
 
         if decorators is None:

--- a/boa3/internal/model/type/collection/icollection.py
+++ b/boa3/internal/model/type/collection/icollection.py
@@ -1,8 +1,6 @@
-from __future__ import annotations
-
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.model.type.annotation.uniontype import UnionType
 from boa3.internal.model.type.classes.pythonclass import PythonClass
@@ -144,7 +142,7 @@ class ICollectionType(PythonClass, ABC):
         return values_type
 
     @classmethod
-    def build_collection(cls, *value_type: IType | Iterable) -> ICollectionType:
+    def build_collection(cls, *value_type: IType | Iterable) -> Self:
         """
         Creates a collection type instance with the given value
 

--- a/boa3/internal/model/type/collection/sequence/tupletype.py
+++ b/boa3/internal/model/type/collection/sequence/tupletype.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
-
-from typing import Any, Iterable
+from collections.abc import Iterable
+from typing import Any
 
 from boa3.internal.model.type.collection.sequence.sequencetype import SequenceType
 from boa3.internal.model.type.itype import IType

--- a/boa3/internal/model/type/itype.py
+++ b/boa3/internal/model/type/itype.py
@@ -1,7 +1,5 @@
-from __future__ import annotations
-
 from abc import abstractmethod
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.model.identifiedsymbol import IdentifiedSymbol
 from boa3.internal.model.symbol import ISymbol
@@ -85,7 +83,7 @@ class IType(IdentifiedSymbol):
 
     @classmethod
     @abstractmethod
-    def build(cls, value: Any) -> IType:
+    def build(cls, value: Any) -> Self:
         """
         Creates a type instance with the given value
 
@@ -112,7 +110,7 @@ class IType(IdentifiedSymbol):
         """
         return {}
 
-    def union_type(self, other_type: IType) -> IType:
+    def union_type(self, other_type: "IType") -> "IType":
         """
         Gets a type that is an union of `self` and `other_type`
 
@@ -124,7 +122,7 @@ class IType(IdentifiedSymbol):
         from boa3.internal.model.type.annotation.uniontype import UnionType
         return UnionType.build((self, other_type))
 
-    def except_type(self, other_type: IType) -> IType:
+    def except_type(self, other_type: "IType") -> "IType":
         """
         Gets a type that is type of `self` but is not type of `other_type`.
         If `other_type` is an implementation of `self`, returns `self`
@@ -136,7 +134,7 @@ class IType(IdentifiedSymbol):
         """
         return self
 
-    def intersect_type(self, other_type: IType) -> IType:
+    def intersect_type(self, other_type: "IType") -> "IType":
         """
         Gets a type that is the intersection of `self` but is not type of `other_type`.
         If `other_type` is an implementation of `self`, returns `other_type`

--- a/boa3/internal/model/type/typeutils.py
+++ b/boa3/internal/model/type/typeutils.py
@@ -1,9 +1,17 @@
+import enum
+
 from boa3.internal.model.callable import Callable
 from boa3.internal.model.identifiedsymbol import IdentifiedSymbol
+from boa3.internal.model.imports.package import Package
 from boa3.internal.model.symbol import ISymbol
 from boa3.internal.model.type.annotation.metatype import metaType
 from boa3.internal.model.type.type import Type
 from boa3.internal.model.type.typingmethod.casttypemethod import CastTypeMethod
+
+
+class TypingPackage(str, enum.Enum):
+    Collections = 'collections'
+    Typing = 'typing'
 
 
 class TypeUtils:
@@ -13,6 +21,16 @@ class TypeUtils:
         return {tpe._identifier: tpe for tpe in vars(cls).values() if isinstance(tpe, IBuiltinCallable)}
 
     @classmethod
+    def package_symbols(cls, package: str = None) -> Package | None:
+        if package in TypingPackage.__members__.values():
+            if TypingPackage.Typing not in cls._pkg_tree:
+                cls._pkg_tree[TypingPackage.Typing] = Package(
+                    identifier=TypingPackage.Typing,
+                    other_symbols=cls.get_types_from_typing_lib()
+                )
+            return cls._pkg_tree[package]
+
+    @classmethod
     def get_types_from_typing_lib(cls) -> dict[str, ISymbol]:
         import typing
         from types import FunctionType
@@ -20,16 +38,32 @@ class TypeUtils:
         type_symbols: dict[str, ISymbol] = {}
         all_types: list[str] = typing.__all__
 
+        deprecated_builtins = [
+            'List', 'Dict', 'Tuple'
+        ]
+        deprecated_collections = list(cls._pkg_tree[TypingPackage.Collections].inner_packages['abc'].symbols)
+
         for t_id in all_types:
             attr = getattr(typing, t_id)
+            type_symbol = None
             if not isinstance(attr, FunctionType):
                 type_id: str = t_id if t_id in Type.all_types() else t_id.lower()
                 if type_id in Type.all_types():
-                    type_symbols[t_id] = Type.all_types()[type_id]
+                    type_symbol = Type.all_types()[type_id]
             else:
                 function_id: str = t_id if t_id in cls.all_functions() else t_id.lower()
                 if function_id in cls.all_functions():
-                    type_symbols[t_id] = cls.all_functions()[function_id]
+                    type_symbol = cls.all_functions()[function_id]
+
+            if isinstance(type_symbol, ISymbol):
+                if t_id in deprecated_builtins:
+                    type_symbol = type_symbol.clone()
+                    type_symbol.deprecate(t_id.lower())
+                elif t_id in deprecated_collections:
+                    type_symbol = type_symbol.clone()
+                    type_symbol.deprecate(f'{TypingPackage.Collections.value}.abc.{t_id}')
+
+                type_symbols[t_id] = type_symbol
 
         return type_symbols
 
@@ -44,3 +78,15 @@ class TypeUtils:
 
     symbols_for_internal_validation = {symbol.identifier: symbol
                                        for symbol in _internal_validation_symbols}
+
+    _pkg_tree: dict[TypingPackage, Package] = {
+        TypingPackage.Collections: Package.create_package(
+            package_id=f'{TypingPackage.Collections.value}.abc',
+            symbols={
+                'Collection': Type.collection,
+                'Mapping': Type.mapping,
+                'MutableSequence': Type.mutableSequence,
+                'Sequence': Type.sequence,
+            }
+        )
+    }

--- a/boa3/internal/model/variable.py
+++ b/boa3/internal/model/variable.py
@@ -1,7 +1,5 @@
-from __future__ import annotations
-
 import ast
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.model.expression import IExpression
 from boa3.internal.model.type.itype import IType
@@ -32,7 +30,7 @@ class Variable(IExpression):
         self._origin_variable: Variable | None = None
         self._first_assign_value: Any = Undefined
 
-    def copy(self) -> Variable:
+    def copy(self) -> Self:
         var = Variable(self._var_type, self._origin_node)
         var.is_reassigned = self.is_reassigned
         var._first_assign_value = self._first_assign_value

--- a/boa3/internal/neo/contracts/neffile.py
+++ b/boa3/internal/neo/contracts/neffile.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+from typing import Self
 
 from boa3.internal import constants
 from boa3.internal.neo.contracts import NEF
@@ -54,7 +54,7 @@ class NefFile:
         return result
 
     @classmethod
-    def deserialize(cls, bts: bytes) -> NefFile:
+    def deserialize(cls, bts: bytes) -> Self:
         """
         Deserialize the NefFile object
 

--- a/boa3/internal/neo/smart_contract/notification.py
+++ b/boa3/internal/neo/smart_contract/notification.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.neo import to_hex_str
 from boa3.internal.neo.utils import stack_item_from_json
@@ -29,7 +27,7 @@ class Notification:
         return self._value
 
     @classmethod
-    def from_json(cls, json: dict[str, Any], *args, **kwargs) -> Notification:
+    def from_json(cls, json: dict[str, Any], *args, **kwargs) -> Self:
         """
         Creates a Notification object from a json.
 

--- a/boa3/internal/neo/vm/VMCode.py
+++ b/boa3/internal/neo/vm/VMCode.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+from typing import Self
 
 from boa3.internal.neo.vm.opcode import OpcodeHelper
 from boa3.internal.neo.vm.opcode.Opcode import Opcode
@@ -85,7 +85,7 @@ class VMCode:
         return self.info.opcode
 
     @property
-    def target(self) -> VMCode:
+    def target(self) -> Self:
         """
         Gets the target code of this code
 

--- a/boa3/internal/neo/vm/opcode/Opcode.py
+++ b/boa3/internal/neo/vm/opcode/Opcode.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from enum import Enum
 
 

--- a/boa3/internal/neo/vm/opcode/OpcodeHelper.py
+++ b/boa3/internal/neo/vm/opcode/OpcodeHelper.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from boa3.internal.constants import FOUR_BYTES_MAX_VALUE
 from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3.internal.neo.vm.type.Integer import Integer

--- a/boa3/internal/neo/vm/opcode/OpcodeInformation.py
+++ b/boa3/internal/neo/vm/opcode/OpcodeInformation.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+from typing import Self
 
 from boa3.internal.neo.vm.opcode.Opcode import Opcode
 
@@ -27,7 +27,7 @@ class OpcodeInformation:
             stack_items = 0
         self.stack_items: int = stack_items
 
-    def get_large(self) -> OpcodeInformation | None:
+    def get_large(self) -> Self | None:
         large_op = self.opcode.get_large
         if large_op is None:
             return None

--- a/boa3/internal/neo/vm/type/AbiType.py
+++ b/boa3/internal/neo/vm/type/AbiType.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
-
 from enum import Enum
+from typing import Self
 
 
 class AbiType(str, Enum):
@@ -18,8 +17,8 @@ class AbiType(str, Enum):
     Any = 'Any'
     Void = 'Void'
 
-    @staticmethod
-    def union(abi_types: list[AbiType]) -> AbiType:
+    @classmethod
+    def union(cls, abi_types: list[Self]) -> Self:
         if len(abi_types) == 0:
             return AbiType.Any
 

--- a/boa3/internal/neo/vm/type/StackItem.py
+++ b/boa3/internal/neo/vm/type/StackItem.py
@@ -1,7 +1,5 @@
-from __future__ import annotations
-
 from enum import Enum
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo.vm.type.String import String
@@ -19,15 +17,15 @@ class StackItemType(bytes, Enum):
     Map = b'\x48'
     InteropInterface = b'\x60'
 
-    @staticmethod
-    def get_stack_item_type(stack_item_type: str) -> StackItemType:
+    @classmethod
+    def get_stack_item_type(cls, stack_item_type: str) -> Self:
         try:
             return StackItemType[stack_item_type]
         except BaseException:
             return StackItemType.Any
 
-    @staticmethod
-    def union(stack_item_types: list[StackItemType]) -> StackItemType:
+    @classmethod
+    def union(cls, stack_item_types: list[Self]) -> Self:
         if len(stack_item_types) == 0:
             return StackItemType.Any
 

--- a/boa3/internal/neo3/core/serialization.py
+++ b/boa3/internal/neo3/core/serialization.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import abc
 import struct
 import sys
@@ -9,56 +7,6 @@ from typing import Any, TypeVar
 ISerializable_T = TypeVar('ISerializable_T', bound='ISerializable')
 
 __all__ = ['ISerializable', 'BinaryReader', 'BinaryWriter']
-
-
-class ISerializable(abc.ABC):
-    """
-    An interface like class supporting NEO's network serialization protocol.
-    """
-
-    @abc.abstractmethod
-    def serialize(self, writer: BinaryWriter) -> None:
-        """
-        Serialize the object into a binary stream.
-
-        Args:
-            writer: instance.
-        """
-
-    @abc.abstractmethod
-    def deserialize(self, reader: BinaryReader) -> None:
-        """
-        Deserialize the object from a binary stream.
-
-        Args:
-            reader: instance.
-        """
-
-    @classmethod
-    def deserialize_from_bytes(cls: type[ISerializable_T], data: bytes | bytearray) -> ISerializable_T:
-        """
-        Parse data into an object instance.
-
-        Args:
-            data: hex escaped bytes.
-
-        Returns:
-            a deserialized instance of the class.
-        """
-        with BinaryReader(data) as br:
-            payload = cls()
-            payload.deserialize(br)
-            return payload
-
-    def to_array(self) -> bytes:
-        """ Serialize the object into a bytearray."""
-        with BinaryWriter() as bw:
-            self.serialize(bw)
-            return bw._stream.getvalue()
-
-    @abc.abstractmethod
-    def __len__(self):
-        """ Return the length of the object in number of bytes."""
 
 
 class BinaryReader(object):
@@ -727,3 +675,53 @@ class BinaryWriter(object):
         Get the raw bytes from the underlying stream.
         """
         return self._stream.getvalue()
+
+
+class ISerializable(abc.ABC):
+    """
+    An interface like class supporting NEO's network serialization protocol.
+    """
+
+    @abc.abstractmethod
+    def serialize(self, writer: BinaryWriter) -> None:
+        """
+        Serialize the object into a binary stream.
+
+        Args:
+            writer: instance.
+        """
+
+    @abc.abstractmethod
+    def deserialize(self, reader: BinaryReader) -> None:
+        """
+        Deserialize the object from a binary stream.
+
+        Args:
+            reader: instance.
+        """
+
+    @classmethod
+    def deserialize_from_bytes(cls: type[ISerializable_T], data: bytes | bytearray) -> ISerializable_T:
+        """
+        Parse data into an object instance.
+
+        Args:
+            data: hex escaped bytes.
+
+        Returns:
+            a deserialized instance of the class.
+        """
+        with BinaryReader(data) as br:
+            payload = cls()
+            payload.deserialize(br)
+            return payload
+
+    def to_array(self) -> bytes:
+        """ Serialize the object into a bytearray."""
+        with BinaryWriter() as bw:
+            self.serialize(bw)
+            return bw._stream.getvalue()
+
+    @abc.abstractmethod
+    def __len__(self):
+        """ Return the length of the object in number of bytes."""

--- a/boa3/internal/neo3/core/types/biginteger.py
+++ b/boa3/internal/neo3/core/types/biginteger.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
-
 from decimal import Decimal, localcontext
+from typing import Self
 
 
 class BigInteger(int):
@@ -9,7 +8,7 @@ class BigInteger(int):
     """
 
     @classmethod
-    def ZERO(cls: type[BigInteger]) -> BigInteger:
+    def ZERO(cls: type[Self]) -> Self:
         """
         Returns:
             An instance initialized to zero.
@@ -17,7 +16,7 @@ class BigInteger(int):
         return cls(0)
 
     @classmethod
-    def ONE(cls: type[BigInteger]) -> BigInteger:
+    def ONE(cls: type[Self]) -> Self:
         """
         Returns:
             An instance initialized to one.
@@ -25,7 +24,7 @@ class BigInteger(int):
         return cls(1)
 
     @classmethod
-    def frombytes(cls: type[BigInteger], bytes: bytes) -> BigInteger:
+    def frombytes(cls: type[Self], bytes: bytes) -> Self:
         """
         Return the BigInteger represented by the given array of bytes.
 

--- a/boa3/internal/neo3/core/types/uint.py
+++ b/boa3/internal/neo3/core/types/uint.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
-
 import binascii
+from typing import Self
 
 from boa3.internal.neo import to_hex_str
 from boa3.internal.neo3.core import serialization
@@ -134,7 +133,7 @@ class UInt160(_UIntBase):
         super(UInt160, self).__init__(num_bytes=self._BYTE_LEN, data=data)
 
     @classmethod
-    def deserialize_from_bytes(cls: type[UInt160], data: bytes) -> UInt160:
+    def deserialize_from_bytes(cls: type[Self], data: bytes) -> Self:
         """
         Parse data into an object instance.
 
@@ -149,7 +148,7 @@ class UInt160(_UIntBase):
         return cls(data[:cls._BYTE_LEN])
 
     @classmethod
-    def from_string(cls: type[UInt160], value: str) -> UInt160:
+    def from_string(cls: type[Self], value: str) -> Self:
         """
         Try to parse a string into an instance.
 
@@ -172,7 +171,7 @@ class UInt160(_UIntBase):
         return cls(data=reversed_data)
 
     @classmethod
-    def zero(cls: type[UInt160]) -> UInt160:
+    def zero(cls: type[Self]) -> Self:
         """
         Returns:
             An instance initialized to zero.
@@ -211,7 +210,7 @@ class UInt256(_UIntBase):
         super(UInt256, self).__init__(num_bytes=self._BYTE_LEN, data=data)
 
     @classmethod
-    def deserialize_from_bytes(cls: type[UInt256], data: bytes) -> UInt256:
+    def deserialize_from_bytes(cls: type[Self], data: bytes) -> Self:
         """
         Parse data into an object instance.
 
@@ -226,7 +225,7 @@ class UInt256(_UIntBase):
         return cls(data[:cls._BYTE_LEN])
 
     @classmethod
-    def from_string(cls: type[UInt256], value: str) -> UInt256:
+    def from_string(cls: type[Self], value: str) -> Self:
         """
         Try to parse a string into an instance.
 
@@ -249,7 +248,7 @@ class UInt256(_UIntBase):
         return cls(data=reversed_data)
 
     @classmethod
-    def zero(cls: type[UInt256]) -> UInt256:
+    def zero(cls: type[Self]) -> Self:
         """
         Returns:
             An instance initialized to zero.

--- a/boa3/internal/neo3/vm/vmstate.py
+++ b/boa3/internal/neo3/vm/vmstate.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from enum import IntEnum
 
 

--- a/boa3/sc/storage/storagecontext.py
+++ b/boa3/sc/storage/storagecontext.py
@@ -1,9 +1,8 @@
-from __future__ import annotations
-
 __all__ = [
     'StorageContext'
 ]
 
+from typing import Self
 
 from boa3.sc.storage.storagemap import StorageMap
 
@@ -30,7 +29,7 @@ class StorageContext:
         """
         pass
 
-    def as_read_only(self) -> StorageContext:
+    def as_read_only(self) -> Self:
         """
         Converts the specified storage context to a new readonly storage context.
 

--- a/boa3_test/test_drive/model/network/payloads/oracleresponse.py
+++ b/boa3_test/test_drive/model/network/payloads/oracleresponse.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3_test.test_drive.model.network.payloads.transactionattribute import TransactionAttribute, \
     TransactionAttributeType
@@ -24,8 +22,8 @@ class OracleResponse(TransactionAttribute):
 
         return json_response
 
-    @staticmethod
-    def from_json(json: dict[str, Any]) -> OracleResponse:
+    @classmethod
+    def from_json(cls, json: dict[str, Any]) -> Self:
         oracle_response: OracleResponse = OracleResponse(json['id'], json['code'], json['result'])
 
         return oracle_response

--- a/boa3_test/test_drive/model/network/payloads/signer.py
+++ b/boa3_test/test_drive/model/network/payloads/signer.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.neo import from_hex_str, to_hex_str
 from boa3.internal.neo3.core.types import UInt160
@@ -34,7 +32,7 @@ class Signer:
         }
 
     @classmethod
-    def from_json(cls, json: dict[str, Any]) -> Signer:
+    def from_json(cls, json: dict[str, Any]) -> Self:
         account_hex = json['account']
         account = UInt160(from_hex_str(account_hex))
         scopes = WitnessScope.get_from_neo_name(json['scopes']) if 'scopes' in json else WitnessScope.CalledByEntry

--- a/boa3_test/test_drive/model/network/payloads/testblock.py
+++ b/boa3_test/test_drive/model/network/payloads/testblock.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.neo import from_hex_str
 from boa3.internal.neo3.core.types import UInt256
@@ -35,7 +33,7 @@ class TestBlock:
         return json_block
 
     @classmethod
-    def from_json(cls, json: dict[str, Any], *args, **kwargs) -> TestBlock:
+    def from_json(cls, json: dict[str, Any], *args, **kwargs) -> Self:
         block = object.__new__(cls)
 
         if 'index' in json:

--- a/boa3_test/test_drive/model/network/payloads/testtransaction.py
+++ b/boa3_test/test_drive/model/network/payloads/testtransaction.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.neo import from_hex_str, utils
 from boa3.internal.neo3.core.types import UInt256
@@ -44,7 +42,7 @@ class TestTransaction:
         }
 
     @classmethod
-    def from_json(cls, json: dict[str, Any], *args, **kwargs) -> TestTransaction:
+    def from_json(cls, json: dict[str, Any], *args, **kwargs) -> Self:
         import base64
 
         if 'hash' in json and isinstance(json['hash'], str):
@@ -120,7 +118,7 @@ class TransactionExecution:
         return self._notifications.copy()
 
     @classmethod
-    def from_json(cls, json: dict[str, Any], contract_collection: ContractCollection = None) -> TransactionExecution:
+    def from_json(cls, json: dict[str, Any], contract_collection: ContractCollection = None) -> Self:
         tx_exec = cls()
 
         tx_exec._trigger = TriggerType[json['trigger']]

--- a/boa3_test/test_drive/model/network/payloads/transactionattribute.py
+++ b/boa3_test/test_drive/model/network/payloads/transactionattribute.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 
 class TransactionAttributeType:
@@ -19,8 +17,8 @@ class TransactionAttribute:
             'type': self._type,
         }
 
-    @staticmethod
-    def from_json(json: dict[str, Any]) -> TransactionAttribute:
+    @classmethod
+    def from_json(cls, json: dict[str, Any]) -> Self:
         if json['type'] == TransactionAttributeType.ORACLE_RESPONSE:
             from boa3_test.test_drive.model.network.payloads.oracleresponse import OracleResponse
             tx_attr = OracleResponse.from_json(json)

--- a/boa3_test/test_drive/model/network/payloads/witness.py
+++ b/boa3_test/test_drive/model/network/payloads/witness.py
@@ -1,7 +1,5 @@
-from __future__ import annotations
-
 import base64
-from typing import Any
+from typing import Any, Self
 
 
 class Witness:
@@ -25,7 +23,7 @@ class Witness:
         }
 
     @classmethod
-    def from_json(cls, json: dict[str, Any]) -> Witness:
+    def from_json(cls, json: dict[str, Any]) -> Self:
         invocation = base64.b64decode(json['invocation'])
         verification = base64.b64decode(json['verification'])
         return cls(invocation, verification)

--- a/boa3_test/test_drive/model/network/payloads/witnessscope.py
+++ b/boa3_test/test_drive/model/network/payloads/witnessscope.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
-
 import enum
+from typing import Self
 
 
 class WitnessScope(enum.IntEnum):
@@ -31,8 +30,8 @@ class WitnessScope(enum.IntEnum):
         else:
             return self.name
 
-    @staticmethod
-    def get_from_neo_name(neo_name: str) -> WitnessScope:
+    @classmethod
+    def get_from_neo_name(cls, neo_name: str) -> Self:
         if neo_name == 'None':
             return WitnessScope._None
         elif neo_name != WitnessScope._None.name:

--- a/boa3_test/test_drive/model/smart_contract/triggertype.py
+++ b/boa3_test/test_drive/model/smart_contract/triggertype.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
-
 import enum
+from typing import Self
 
 
 class TriggerType(enum.IntEnum):
@@ -25,6 +24,6 @@ class TriggerType(enum.IntEnum):
     def neo_name(self) -> str:
         return self.name
 
-    @staticmethod
-    def get_from_neo_name(neo_name: str) -> TriggerType:
+    @classmethod
+    def get_from_neo_name(cls, neo_name: str) -> Self:
         return TriggerType[neo_name]

--- a/boa3_test/test_drive/model/wallet/account.py
+++ b/boa3_test/test_drive/model/wallet/account.py
@@ -1,7 +1,5 @@
-from __future__ import annotations
-
 import abc
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.neo3.core.types import UInt160
 from boa3_test.test_drive.model.wallet import utils
@@ -47,7 +45,7 @@ class Account(abc.ABC):
 
     @classmethod
     @abc.abstractmethod
-    def from_json(cls, json: dict[str, Any]) -> Account:
+    def from_json(cls, json: dict[str, Any]) -> Self:
         pass
 
     def get_identifier(self) -> str:

--- a/boa3_test/test_drive/neoxp/model/neoxpaccount.py
+++ b/boa3_test/test_drive/neoxp/model/neoxpaccount.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.neo3.core.types import UInt160
 from boa3_test.test_drive.model.wallet import utils
@@ -18,9 +18,11 @@ class NeoExpressAccount(Account):
         return utils.address_from_script_hash(self._script_hash.to_array(), self._version)
 
     @classmethod
-    def from_json(cls, json: dict[str, Any]) -> Account:
+    def from_json(cls, json: dict[str, Any]) -> Self:
         address = json['script-hash']
         label = json['label']
-        account = NeoExpressAccount(script_hash=UInt160(utils.address_to_script_hash(address)),
-                                    label=label)
+        account = NeoExpressAccount(
+            script_hash=UInt160(utils.address_to_script_hash(address)),
+            label=label
+        )
         return account

--- a/boa3_test/test_drive/testrunner/blockchain/block.py
+++ b/boa3_test/test_drive/testrunner/blockchain/block.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.neo3.core.types import UInt256
 from boa3_test.test_drive.model.network.payloads.testblock import TestBlock
@@ -74,10 +72,10 @@ class TestRunnerBlock(TestBlock):
         return json_block
 
     @classmethod
-    def from_json(cls, json: dict[str, Any], *args, **kwargs) -> TestRunnerBlock:
+    def from_json(cls, json: dict[str, Any], *args, **kwargs) -> Self:
         from boa3.internal.neo import from_hex_str
 
-        block: TestRunnerBlock = super().from_json(json)
+        block: Self = super().from_json(json)
 
         if 'neoxp_config' in kwargs:
             neoxp_config = kwargs['neoxp_config']

--- a/boa3_test/test_drive/testrunner/blockchain/log.py
+++ b/boa3_test/test_drive/testrunner/blockchain/log.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.neo import to_hex_str
 from boa3.internal.neo3.core.types import UInt160
@@ -23,7 +21,7 @@ class TestRunnerLog:
         return self._message
 
     @classmethod
-    def from_json(cls, json: dict[str, Any]) -> TestRunnerLog:
+    def from_json(cls, json: dict[str, Any]) -> Self:
         """
         Creates a Log object from a json.
 

--- a/boa3_test/test_drive/testrunner/blockchain/notification.py
+++ b/boa3_test/test_drive/testrunner/blockchain/notification.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.neo.smart_contract.notification import Notification
 from boa3.internal.neo3.core.types import UInt160
@@ -19,8 +19,13 @@ class TestRunnerNotification(Notification):
         return self._contract
 
     @classmethod
-    def from_json(cls, json: dict[str, Any], contract_collection: ContractCollection = None,
-                  *args, **kwargs) -> Notification:
+    def from_json(
+            cls,
+            json: dict[str, Any],
+            contract_collection: ContractCollection = None,
+            *args,
+            **kwargs
+    ) -> Self:
 
         result = super().from_json(json)
         if result is None:

--- a/boa3_test/test_drive/testrunner/blockchain/storage.py
+++ b/boa3_test/test_drive/testrunner/blockchain/storage.py
@@ -1,12 +1,74 @@
-from __future__ import annotations
-
 import base64
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo.vm.type.String import String
 from boa3_test.test_drive.model.smart_contract.contractcollection import ContractCollection
 from boa3_test.test_drive.model.smart_contract.testcontract import TestContract
+
+
+class StorageKey:
+    def __init__(self, key: bytes):
+        self._key: bytes = key
+
+    @classmethod
+    def from_json(cls, json: str) -> Self:
+        decoded: bytes = base64.b64decode(json)
+        return cls(decoded)
+
+    def as_str(self) -> str:
+        return String.from_bytes(self._key)
+
+    def as_bytes(self) -> bytes:
+        return self._key
+
+    def __str__(self):
+        return self.as_str()
+
+    def __repr__(self):
+        return str(self)
+
+    def __hash__(self) -> int:
+        return self._key.__hash__()
+
+    def __eq__(self, other) -> bool:
+        return (other == self.as_bytes()
+                or other == self.as_str()
+                or (isinstance(other, StorageKey) and self._key == other._key))
+
+
+class StorageItem:
+    def __init__(self, value: bytes):
+        self._value: bytes = value
+
+    @classmethod
+    def from_json(cls, json: str) -> Self:
+        decoded: bytes = base64.b64decode(json)
+        return cls(decoded)
+
+    def as_bytes(self) -> bytes:
+        return self._value
+
+    def as_str(self) -> str:
+        return String.from_bytes(self._value)
+
+    def as_int(self) -> int:
+        return Integer.from_bytes(self._value)
+
+    def __str__(self) -> str:
+        return self._value.__str__()
+
+    def __repr__(self):
+        return str(self)
+
+    def __hash__(self) -> int:
+        return self._value.__hash__()
+
+    def __eq__(self, other) -> bool:
+        return (other == self.as_bytes()
+                or other == self.as_int()
+                or other == self.as_str()
+                or (isinstance(other, StorageItem) and self._value == other._value))
 
 
 class TestRunnerStorage:
@@ -31,7 +93,7 @@ class TestRunnerStorage:
         return self._values
 
     @classmethod
-    def from_json(cls, json: dict[str, Any], contracts: ContractCollection = None) -> TestRunnerStorage:
+    def from_json(cls, json: dict[str, Any], contracts: ContractCollection = None) -> Self:
         keys = set(json.keys())
         if not keys.issubset([cls._storage_contract_name_key,
                               cls._storage_contract_hash_key,
@@ -71,67 +133,3 @@ class TestRunnerStorage:
 
     def __repr__(self) -> str:
         return self._values.__repr__()
-
-
-class StorageKey:
-    def __init__(self, key: bytes):
-        self._key: bytes = key
-
-    @classmethod
-    def from_json(cls, json: str) -> StorageKey:
-        decoded: bytes = base64.b64decode(json)
-        return cls(decoded)
-
-    def as_str(self) -> str:
-        return String.from_bytes(self._key)
-
-    def as_bytes(self) -> bytes:
-        return self._key
-
-    def __str__(self):
-        return self.as_str()
-
-    def __repr__(self):
-        return str(self)
-
-    def __hash__(self) -> int:
-        return self._key.__hash__()
-
-    def __eq__(self, other) -> bool:
-        return (other == self.as_bytes()
-                or other == self.as_str()
-                or (isinstance(other, StorageKey) and self._key == other._key))
-
-
-class StorageItem:
-    def __init__(self, value: bytes):
-        self._value: bytes = value
-
-    @classmethod
-    def from_json(cls, json: str) -> StorageItem:
-        decoded: bytes = base64.b64decode(json)
-        return cls(decoded)
-
-    def as_bytes(self) -> bytes:
-        return self._value
-
-    def as_str(self) -> str:
-        return String.from_bytes(self._value)
-
-    def as_int(self) -> int:
-        return Integer.from_bytes(self._value)
-
-    def __str__(self) -> str:
-        return self._value.__str__()
-
-    def __repr__(self):
-        return str(self)
-
-    def __hash__(self) -> int:
-        return self._value.__hash__()
-
-    def __eq__(self, other) -> bool:
-        return (other == self.as_bytes()
-                or other == self.as_int()
-                or other == self.as_str()
-                or (isinstance(other, StorageItem) and self._value == other._value))

--- a/boa3_test/test_drive/testrunner/blockchain/transaction.py
+++ b/boa3_test/test_drive/testrunner/blockchain/transaction.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.neo3.core.types import UInt256
 from boa3_test.test_drive.model.network.payloads.signer import Signer
@@ -66,8 +64,8 @@ class TestRunnerTransaction(TestTransaction):
         return self._witnesses.copy()
 
     @classmethod
-    def from_json(cls, json: dict[str, Any], *args, **kwargs) -> TestRunnerTransaction:
-        tx: TestRunnerTransaction = super().from_json(json)
+    def from_json(cls, json: dict[str, Any], *args, **kwargs) -> Self:
+        tx: Self = super().from_json(json)
 
         if 'neoxp_config' in kwargs:
             neoxp_config = kwargs['neoxp_config']

--- a/boa3_test/test_drive/testrunner/blockchain/transactionlog.py
+++ b/boa3_test/test_drive/testrunner/blockchain/transactionlog.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3_test.test_drive.model.interface.itransactionobject import ITransactionObject
 from boa3_test.test_drive.model.network.payloads.testtransaction import TransactionExecution
@@ -17,7 +15,7 @@ class TestRunnerTransactionLog(ITransactionObject):
         return self._executions.copy()
 
     @classmethod
-    def from_json(cls, json: dict[str, Any], contract_collection: ContractCollection = None) -> TestRunnerTransactionLog:
+    def from_json(cls, json: dict[str, Any], contract_collection: ContractCollection = None) -> Self:
         tx_log = cls()
 
         tx_log._executions = [TransactionExecution.from_json(execution, contract_collection) for execution in json['executions']]

--- a/boa3_test/test_sc/any_test/AnySequenceAssignments.py
+++ b/boa3_test/test_sc/any_test/AnySequenceAssignments.py
@@ -1,4 +1,5 @@
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 from boa3.builtin.compile_time import public
 

--- a/boa3_test/test_sc/any_test/FunctionAnyParam.py
+++ b/boa3_test/test_sc/any_test/FunctionAnyParam.py
@@ -1,4 +1,5 @@
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 from boa3.builtin.compile_time import public
 

--- a/boa3_test/test_sc/any_test/IntSequenceAnyAssignment.py
+++ b/boa3_test/test_sc/any_test/IntSequenceAnyAssignment.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 from boa3.builtin.compile_time import public
 

--- a/boa3_test/test_sc/any_test/SequenceOfAnyIntSequence.py
+++ b/boa3_test/test_sc/any_test/SequenceOfAnyIntSequence.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 from boa3.builtin.compile_time import public
 

--- a/boa3_test/test_sc/any_test/SequenceOfAnySequence.py
+++ b/boa3_test/test_sc/any_test/SequenceOfAnySequence.py
@@ -1,4 +1,5 @@
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 from boa3.builtin.compile_time import public
 

--- a/boa3_test/test_sc/any_test/SequenceOfIntSequence.py
+++ b/boa3_test/test_sc/any_test/SequenceOfIntSequence.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 from boa3.builtin.compile_time import public
 

--- a/boa3_test/test_sc/any_test/StrSequenceAnyAssignment.py
+++ b/boa3_test/test_sc/any_test/StrSequenceAnyAssignment.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 from boa3.builtin.compile_time import public
 

--- a/boa3_test/test_sc/any_test/StrSequenceStrAssignment.py
+++ b/boa3_test/test_sc/any_test/StrSequenceStrAssignment.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 from boa3.builtin.compile_time import public
 

--- a/boa3_test/test_sc/built_in_methods_test/AppendMutableSequence.py
+++ b/boa3_test/test_sc/built_in_methods_test/AppendMutableSequence.py
@@ -1,4 +1,4 @@
-from typing import MutableSequence
+from collections.abc import MutableSequence
 
 from boa3.builtin.compile_time import public
 

--- a/boa3_test/test_sc/built_in_methods_test/AppendMutableSequenceBuiltinCall.py
+++ b/boa3_test/test_sc/built_in_methods_test/AppendMutableSequenceBuiltinCall.py
@@ -1,4 +1,4 @@
-from typing import MutableSequence
+from collections.abc import MutableSequence
 
 from boa3.builtin.compile_time import public
 

--- a/boa3_test/test_sc/built_in_methods_test/AppendSequence.py
+++ b/boa3_test/test_sc/built_in_methods_test/AppendSequence.py
@@ -1,4 +1,5 @@
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 
 def Main(op: str, args: list) -> Sequence[int]:

--- a/boa3_test/test_sc/built_in_methods_test/ClearMutableSequence.py
+++ b/boa3_test/test_sc/built_in_methods_test/ClearMutableSequence.py
@@ -1,4 +1,4 @@
-from typing import MutableSequence
+from collections.abc import MutableSequence
 
 from boa3.builtin.compile_time import public
 

--- a/boa3_test/test_sc/built_in_methods_test/ClearMutableSequenceBuiltinCall.py
+++ b/boa3_test/test_sc/built_in_methods_test/ClearMutableSequenceBuiltinCall.py
@@ -1,4 +1,4 @@
-from typing import MutableSequence
+from collections.abc import MutableSequence
 
 from boa3.builtin.compile_time import public
 

--- a/boa3_test/test_sc/built_in_methods_test/ExtendMutableSequence.py
+++ b/boa3_test/test_sc/built_in_methods_test/ExtendMutableSequence.py
@@ -1,4 +1,4 @@
-from typing import MutableSequence
+from collections.abc import MutableSequence
 
 from boa3.builtin.compile_time import public
 

--- a/boa3_test/test_sc/built_in_methods_test/ExtendMutableSequenceBuiltinCall.py
+++ b/boa3_test/test_sc/built_in_methods_test/ExtendMutableSequenceBuiltinCall.py
@@ -1,4 +1,4 @@
-from typing import MutableSequence
+from collections.abc import MutableSequence
 
 from boa3.builtin.compile_time import public
 

--- a/boa3_test/test_sc/built_in_methods_test/ExtendSequence.py
+++ b/boa3_test/test_sc/built_in_methods_test/ExtendSequence.py
@@ -1,4 +1,5 @@
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 
 def Main(op: str, args: list) -> Sequence[int]:

--- a/boa3_test/test_sc/built_in_methods_test/ListMapping.py
+++ b/boa3_test/test_sc/built_in_methods_test/ListMapping.py
@@ -1,4 +1,5 @@
-from typing import Any, Mapping
+from collections.abc import Mapping
+from typing import Any
 
 from boa3.builtin.compile_time import public
 

--- a/boa3_test/test_sc/built_in_methods_test/ListSequence.py
+++ b/boa3_test/test_sc/built_in_methods_test/ListSequence.py
@@ -1,4 +1,5 @@
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 from boa3.builtin.compile_time import public
 

--- a/boa3_test/test_sc/built_in_methods_test/ReverseMutableSequence.py
+++ b/boa3_test/test_sc/built_in_methods_test/ReverseMutableSequence.py
@@ -1,4 +1,4 @@
-from typing import MutableSequence
+from collections.abc import MutableSequence
 
 from boa3.builtin.compile_time import public
 

--- a/boa3_test/test_sc/built_in_methods_test/ReverseMutableSequenceBuiltinCall.py
+++ b/boa3_test/test_sc/built_in_methods_test/ReverseMutableSequenceBuiltinCall.py
@@ -1,4 +1,4 @@
-from typing import MutableSequence
+from collections.abc import MutableSequence
 
 from boa3.builtin.compile_time import public
 

--- a/boa3_test/test_sc/bytes_test/BytearrayAppendWithMutableSequence.py
+++ b/boa3_test/test_sc/bytes_test/BytearrayAppendWithMutableSequence.py
@@ -1,4 +1,4 @@
-from typing import MutableSequence
+from collections.abc import MutableSequence
 
 from boa3.builtin.compile_time import public
 

--- a/boa3_test/test_sc/bytes_test/JoinBytesMethodWithSequence.py
+++ b/boa3_test/test_sc/bytes_test/JoinBytesMethodWithSequence.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 from boa3.builtin.compile_time import public
 

--- a/boa3_test/test_sc/dict_test/KeysDict.py
+++ b/boa3_test/test_sc/dict_test/KeysDict.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 from boa3.builtin.compile_time import public
 

--- a/boa3_test/test_sc/dict_test/MismatchedTypeKeysDict.py
+++ b/boa3_test/test_sc/dict_test/MismatchedTypeKeysDict.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 from boa3.builtin.compile_time import public
 

--- a/boa3_test/test_sc/dict_test/MismatchedTypeValuesDict.py
+++ b/boa3_test/test_sc/dict_test/MismatchedTypeValuesDict.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 from boa3.builtin.compile_time import public
 

--- a/boa3_test/test_sc/dict_test/ValuesDict.py
+++ b/boa3_test/test_sc/dict_test/ValuesDict.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 from boa3.builtin.compile_time import public
 

--- a/boa3_test/test_sc/range_test/RangeExpectedSequence.py
+++ b/boa3_test/test_sc/range_test/RangeExpectedSequence.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 from boa3.builtin.compile_time import public
 

--- a/boa3_test/test_sc/string_test/JoinStringMethodWithSequence.py
+++ b/boa3_test/test_sc/string_test/JoinStringMethodWithSequence.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 from boa3.builtin.compile_time import public
 

--- a/boa3_test/tests/compiler_tests/test_interop/test_contract.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_contract.py
@@ -1,4 +1,5 @@
 import json
+from typing import Self
 
 from boaconstructor import storage
 from neo3.contracts.contract import CONTRACT_HASHES
@@ -97,7 +98,7 @@ class TestContractInterop(boatestcase.BoaTestCase):
             state: str
 
             @classmethod
-            def from_untyped_notification(cls, n: noderpc.Notification):
+            def from_untyped_notification(cls, n: noderpc.Notification) -> Self:
                 inner_args_types = tuple(cls.__annotations__.values())
                 e = super().from_notification(n, *inner_args_types)
                 return cls(e.contract, e.name, e.state[0])

--- a/boa3_test/tests/compiler_tests/test_native/test_neo.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_neo.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Self
 
 from neo3.api import noderpc
 from neo3.api.wrappers import NeoToken
@@ -20,7 +21,7 @@ class CandidateStateChangedEvent(boatestcase.BoaTestEvent):
     votes: int
 
     @classmethod
-    def from_untyped_notification(cls, n: noderpc.Notification):
+    def from_untyped_notification(cls, n: noderpc.Notification) -> Self:
         inner_args_types = tuple(cls.__annotations__.values())
         e = super().from_notification(n, *inner_args_types)
         return cls(e.contract, e.name, e.state, *e.state)

--- a/boa3_test/tests/compiler_tests/test_native/test_oracle.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_oracle.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Self
 
 from neo3.api import noderpc
 from neo3.contracts.contract import CONTRACT_HASHES
@@ -41,7 +42,7 @@ class OracleRequestEvent(boatestcase.BoaTestEvent):
     filter: str
 
     @classmethod
-    def from_untyped_notification(cls, n: noderpc.Notification):
+    def from_untyped_notification(cls, n: noderpc.Notification) -> Self:
         inner_args_types = tuple(cls.__annotations__.values())
         e = super().from_notification(n, *inner_args_types)
         return cls(e.contract, e.name, e.state, *e.state)
@@ -53,7 +54,7 @@ class OracleResponseEvent(boatestcase.BoaTestEvent):
     original_tx: types.UInt256
 
     @classmethod
-    def from_untyped_notification(cls, n: noderpc.Notification):
+    def from_untyped_notification(cls, n: noderpc.Notification) -> Self:
         inner_args_types = tuple(cls.__annotations__.values())
         e = super().from_notification(n, *inner_args_types)
         return cls(e.contract, e.name, e.state, *e.state)

--- a/boa3_test/tests/compiler_tests/test_while.py
+++ b/boa3_test/tests/compiler_tests/test_while.py
@@ -1,3 +1,5 @@
+from typing import Self
+
 from neo3.api import noderpc
 from neo3.contracts.contract import CONTRACT_HASHES
 from neo3.core import types
@@ -272,7 +274,7 @@ class TestWhile(boatestcase.BoaTestCase):
             fee_amount: int
 
             @classmethod
-            def from_untyped_notification(cls, n: noderpc.Notification):
+            def from_untyped_notification(cls, n: noderpc.Notification) -> Self:
                 inner_args_types = tuple(cls.__annotations__.values())
                 e = super().from_notification(n, tuple[inner_args_types])
                 stack = e.state[0]

--- a/boa3_test/tests/event.py
+++ b/boa3_test/tests/event.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Self
 
 from neo3.api import noderpc
 from neo3.core import types
@@ -11,7 +12,7 @@ class DeployEvent(boatestcase.BoaTestEvent):
     deployed_contract: types.UInt160
 
     @classmethod
-    def from_untyped_notification(cls, n: noderpc.Notification):
+    def from_untyped_notification(cls, n: noderpc.Notification) -> Self:
         inner_args_types = tuple(cls.__annotations__.values())
         e = super().from_notification(n, *inner_args_types)
         return cls(e.contract, e.name, e.state, *e.state)
@@ -22,7 +23,7 @@ class UpdateEvent(boatestcase.BoaTestEvent):
     updated_contract: types.UInt160
 
     @classmethod
-    def from_untyped_notification(cls, n: noderpc.Notification):
+    def from_untyped_notification(cls, n: noderpc.Notification) -> Self:
         inner_args_types = tuple(cls.__annotations__.values())
         e = super().from_notification(n, *inner_args_types)
         return cls(e.contract, e.name, e.state, *e.state)
@@ -33,7 +34,7 @@ class DestroyEvent(boatestcase.BoaTestEvent):
     destroyed_contract: types.UInt160
 
     @classmethod
-    def from_untyped_notification(cls, n: noderpc.Notification):
+    def from_untyped_notification(cls, n: noderpc.Notification) -> Self:
         inner_args_types = tuple(cls.__annotations__.values())
         e = super().from_notification(n, *inner_args_types)
         return cls(e.contract, e.name, e.state, *e.state)

--- a/boa3_test/tests/examples_tests/test_amm.py
+++ b/boa3_test/tests/examples_tests/test_amm.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Self
 
 from neo3.api import noderpc
 from neo3.contracts.contract import CONTRACT_HASHES
@@ -16,7 +17,7 @@ class SyncEvent(boatestcase.BoaTestEvent):
     reserve_token_b: int
 
     @classmethod
-    def from_untyped_notification(cls, n: noderpc.Notification):
+    def from_untyped_notification(cls, n: noderpc.Notification) -> Self:
         inner_args_types = tuple(cls.__annotations__.values())
         e = super().from_notification(n, *inner_args_types)
         return cls(e.contract, e.name, e.state, *e.state)
@@ -29,7 +30,7 @@ class BurnOrMintEvent(boatestcase.BoaTestEvent):
     amount_token_b: int
 
     @classmethod
-    def from_untyped_notification(cls, n: noderpc.Notification):
+    def from_untyped_notification(cls, n: noderpc.Notification) -> Self:
         inner_args_types = tuple(cls.__annotations__.values())
         e = super().from_notification(n, *inner_args_types)
         return cls(e.contract, e.name, e.state, *e.state)
@@ -44,7 +45,7 @@ class SwapEvent(boatestcase.BoaTestEvent):
     amount_token_b_out: int
 
     @classmethod
-    def from_untyped_notification(cls, n: noderpc.Notification):
+    def from_untyped_notification(cls, n: noderpc.Notification) -> Self:
         inner_args_types = tuple(cls.__annotations__.values())
         e = super().from_notification(n, *inner_args_types)
         return cls(e.contract, e.name, e.state, *e.state)

--- a/boa3_test/tests/examples_tests/test_nep11_non_divisible.py
+++ b/boa3_test/tests/examples_tests/test_nep11_non_divisible.py
@@ -1,4 +1,5 @@
 import json
+from typing import Self
 
 from neo3.api import StackItemType
 from neo3.contracts.contract import CONTRACT_HASHES
@@ -384,7 +385,7 @@ class TestNEP11NonDivisibleTemplate(boatestcase.BoaTestCase):
             add: bool
 
             @classmethod
-            def from_untyped_notification(cls, n: noderpc.Notification):
+            def from_untyped_notification(cls, n: noderpc.Notification) -> Self:
                 inner_args_types = tuple(cls.__annotations__.values())
                 e = super().from_notification(n, *inner_args_types)
                 return cls(e.contract, e.name, e.state, *e.state)

--- a/boa3_test/tests/examples_tests/test_wrapped_neo.py
+++ b/boa3_test/tests/examples_tests/test_wrapped_neo.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Self
 
 from neo3.api import noderpc
 from neo3.contracts.contract import CONTRACT_HASHES
@@ -664,7 +665,7 @@ class ApprovalEvent(boatestcase.BoaTestEvent):
     amount: int
 
     @classmethod
-    def from_untyped_notification(cls, n: noderpc.Notification):
+    def from_untyped_notification(cls, n: noderpc.Notification) -> Self:
         inner_args_types = tuple(cls.__annotations__.values())
         e = super().from_notification(n, *inner_args_types)
         return cls(e.contract, e.name, e.state, *e.state)

--- a/boa3_test/tests/test_classes/block.py
+++ b/boa3_test/tests/test_classes/block.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3_test.test_drive.model.network.payloads.testblock import TestBlock
 from boa3_test.tests.test_classes.transaction import Transaction
@@ -45,8 +43,8 @@ class Block(TestBlock):
         return json_block
 
     @classmethod
-    def from_json(cls, json: dict[str, Any]) -> Block:
-        block: Block = super().from_json(json)
+    def from_json(cls, json: dict[str, Any]) -> Self:
+        block: Self = super().from_json(json)
 
         # 'index' and 'timestamp' fields are required
         block._index = int(json['index'])

--- a/boa3_test/tests/test_classes/contract/neoabistruct.py
+++ b/boa3_test/tests/test_classes/contract/neoabistruct.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3_test.tests.test_classes.contract.neoeventstruct import NeoEventStruct
 from boa3_test.tests.test_classes.contract.neomethodstruct import NeoMethodStruct
@@ -12,7 +10,7 @@ class NeoAbiStruct(NeoStruct):
     _events_field = 'events'
 
     @classmethod
-    def from_json(cls, json: dict[str, Any]) -> NeoAbiStruct:
+    def from_json(cls, json: dict[str, Any]) -> Self:
         required_fields = [cls._methods_field,
                            cls._events_field
                            ]

--- a/boa3_test/tests/test_classes/contract/neoeventstruct.py
+++ b/boa3_test/tests/test_classes/contract/neoeventstruct.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3_test.tests.test_classes.contract.neostruct import NeoStruct
 
@@ -10,7 +8,7 @@ class NeoEventStruct(NeoStruct):
     _parameters_field = 'parameters'
 
     @classmethod
-    def from_json(cls, json: dict[str, Any]) -> NeoEventStruct:
+    def from_json(cls, json: dict[str, Any]) -> Self:
         required_fields = [cls._name_field,
                            cls._parameters_field
                            ]

--- a/boa3_test/tests/test_classes/contract/neomanifeststruct.py
+++ b/boa3_test/tests/test_classes/contract/neomanifeststruct.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3_test.tests.test_classes.contract.neoabistruct import NeoAbiStruct
 from boa3_test.tests.test_classes.contract.neopermissionsstruct import NeoPermissionsStruct
@@ -18,7 +16,7 @@ class NeoManifestStruct(NeoStruct):
     _extra_field = 'extra'
 
     @classmethod
-    def from_json(cls, json: dict[str, Any]) -> NeoManifestStruct:
+    def from_json(cls, json: dict[str, Any]) -> Self:
         required_fields = [cls._name_field,
                            cls._groups_field,
                            cls._supported_standards_field,

--- a/boa3_test/tests/test_classes/contract/neomethodstruct.py
+++ b/boa3_test/tests/test_classes/contract/neomethodstruct.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.neo.vm.type.ContractParameterType import ContractParameterType
 from boa3_test.tests.test_classes.contract.neostruct import NeoStruct
@@ -14,7 +12,7 @@ class NeoMethodStruct(NeoStruct):
     _is_safe_field = 'safe'
 
     @classmethod
-    def from_json(cls, json: dict[str, Any]) -> NeoMethodStruct:
+    def from_json(cls, json: dict[str, Any]) -> Self:
         required_fields = [cls._name_field,
                            cls._parameters_field,
                            cls._return_type_field,

--- a/boa3_test/tests/test_classes/contract/neopermissionsstruct.py
+++ b/boa3_test/tests/test_classes/contract/neopermissionsstruct.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.neo3.core.types import UInt160
 from boa3_test.tests.test_classes.contract.neostruct import NeoStruct
@@ -11,7 +9,7 @@ class NeoPermissionsStruct(NeoStruct):
     _methods_fields = 'methods'
 
     @classmethod
-    def from_json(cls, json: dict[str, Any]) -> NeoPermissionsStruct:
+    def from_json(cls, json: dict[str, Any]) -> Self:
         required_fields = [cls._contract_fields,
                            cls._methods_fields
                            ]

--- a/boa3_test/tests/test_classes/contract/neostruct.py
+++ b/boa3_test/tests/test_classes/contract/neostruct.py
@@ -1,14 +1,12 @@
-from __future__ import annotations
-
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, Self
 
 
 class NeoStruct(list, ABC):
 
     @classmethod
     @abstractmethod
-    def from_json(cls, json: dict[str, Any]) -> NeoStruct:
+    def from_json(cls, json: dict[str, Any]) -> Self:
         pass
 
     @classmethod

--- a/boa3_test/tests/test_classes/signer.py
+++ b/boa3_test/tests/test_classes/signer.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from boa3.internal import constants
 from boa3.internal.neo import from_hex_str
 from boa3.internal.neo3.core.types import UInt160

--- a/boa3_test/tests/test_classes/transaction.py
+++ b/boa3_test/tests/test_classes/transaction.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.neo3.vm import VMState, vmstate
 from boa3_test.test_drive.model.network.payloads.testtransaction import TestTransaction
@@ -39,8 +37,8 @@ class Transaction(TestTransaction):
         return json
 
     @classmethod
-    def from_json(cls, json: dict[str, Any]) -> Transaction:
-        tx: Transaction = super().from_json(json)
+    def from_json(cls, json: dict[str, Any]) -> Self:
+        tx: Self = super().from_json(json)
 
         if 'attributes' in json:
             attributes_json = json['attributes']

--- a/boa3_test/tests/test_classes/transactionattribute/oracleresponse.py
+++ b/boa3_test/tests/test_classes/transactionattribute/oracleresponse.py
@@ -1,40 +1,9 @@
-from __future__ import annotations
-
 import base64
 import enum
-from typing import Any
+from typing import Any, Self
 
 from boa3.internal.neo.vm.type.String import String
 from boa3_test.tests.test_classes.transactionattribute import TransactionAttribute, TransactionAttributeType
-
-
-class OracleResponse(TransactionAttribute):
-    def __init__(self, request_id: int, code: OracleResponseCode, result: bytes):
-        super().__init__(TransactionAttributeType.OracleResponse)
-        self._id: int = request_id
-        self._response_code: OracleResponseCode = code
-        self._result: bytes = result
-
-    def to_json(self) -> dict[str, Any]:
-        json = super().to_json()
-        json.update({
-            'id': self._id,
-            'code': self._response_code.value,
-            'result': String.from_bytes(base64.b64encode(self._result))
-        })
-        return json
-
-    @classmethod
-    def from_json(cls, json: dict[str, Any]) -> OracleResponse:
-        return cls(request_id=json['id'],
-                   code=json['code'],
-                   result=base64.b64decode(json['result']))
-
-    def __eq__(self, other) -> bool:
-        return (isinstance(other, OracleResponse)
-                and self._id == other._id
-                and self._response_code == other._response_code
-                and self._result == other._result)
 
 
 class OracleResponseCode(enum.IntEnum):
@@ -64,3 +33,32 @@ class OracleResponseCode(enum.IntEnum):
 
     # Indicates that the request failed due to other errors.
     Error = 0xff
+
+
+class OracleResponse(TransactionAttribute):
+    def __init__(self, request_id: int, code: OracleResponseCode, result: bytes):
+        super().__init__(TransactionAttributeType.OracleResponse)
+        self._id: int = request_id
+        self._response_code: OracleResponseCode = code
+        self._result: bytes = result
+
+    def to_json(self) -> dict[str, Any]:
+        json = super().to_json()
+        json.update({
+            'id': self._id,
+            'code': self._response_code.value,
+            'result': String.from_bytes(base64.b64encode(self._result))
+        })
+        return json
+
+    @classmethod
+    def from_json(cls, json: dict[str, Any]) -> Self:
+        return cls(request_id=json['id'],
+                   code=json['code'],
+                   result=base64.b64decode(json['result']))
+
+    def __eq__(self, other) -> bool:
+        return (isinstance(other, OracleResponse)
+                and self._id == other._id
+                and self._response_code == other._response_code
+                and self._result == other._result)

--- a/boa3_test/tests/test_classes/transactionattribute/transactionattribute.py
+++ b/boa3_test/tests/test_classes/transactionattribute/transactionattribute.py
@@ -1,15 +1,13 @@
-from __future__ import annotations
-
 import abc
-from typing import Any
+from typing import Any, Self
 
-from boa3_test.tests.test_classes import transactionattribute
+from boa3_test.tests.test_classes.transactionattribute import transactionattributetype
 
 
 class TransactionAttribute(abc.ABC):
 
-    def __init__(self, _type: transactionattribute.TransactionAttributeType):
-        self._type: transactionattribute.TransactionAttributeType = _type
+    def __init__(self, _type: transactionattributetype.TransactionAttributeType):
+        self._type: transactionattributetype.TransactionAttributeType = _type
 
     def to_json(self) -> dict[str, Any]:
         return {
@@ -17,7 +15,8 @@ class TransactionAttribute(abc.ABC):
         }
 
     @classmethod
-    def from_json(cls, json: dict[str, Any]) -> TransactionAttribute:
+    @abc.abstractmethod
+    def from_json(cls, json: dict[str, Any]) -> Self:
         tx_type = json['type']
         pass
 

--- a/boa3_test/tests/test_classes/witness.py
+++ b/boa3_test/tests/test_classes/witness.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from boa3_test.test_drive.model.network.payloads.witness import Witness as TestWitness
 
 __all__ = ['Witness']


### PR DESCRIPTION
**Summary or solution description**
Refactor all usages of classes from `collection.abc` that were imported from `typing`.
Also removed all `from __future__ import annotations` that could be replaced by the `typing.Self` annotation
