### PR TITLE
It's necessary to add notify event names on the manifest

### DIFF
--- a/boa3_test/test_sc/interop_test/runtime/NotifyWithDynamicName.py
+++ b/boa3_test/test_sc/interop_test/runtime/NotifyWithDynamicName.py
@@ -4,5 +4,5 @@ from boa3.sc.runtime import notify
 
 
 @public
-def Main():
-    notify(10, 'unit_test')
+def Main(notify_name: str):
+    notify(10, notify_name)

--- a/boa3_test/tests/compiler_tests/test_interop/test_runtime.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_runtime.py
@@ -260,13 +260,16 @@ class TestRuntimeInterop(boatestcase.BoaTestCase):
         self.assertEqual(1, len(event_notifications))
         self.assertEqual(([2, 3, 5, 7],), event_notifications[0].state)
 
+    async def test_notify_with_dynamic_name_run(self):
+        self.assertCompilerLogs(CompilerError.InvalidUsage, 'NotifyWithDynamicName.py')
+
     def test_notify_with_name_compile(self):
         from boa3.internal.model.builtin.interop.interop import Interop
+        unit_test = String('unit_test').to_bytes()
 
         expected_output = (
-            Opcode.INITSLOT
-            + b'\x00\x01'
-            + Opcode.LDARG0
+            Opcode.PUSHDATA1  # 'unit_test
+            + Integer(len(unit_test)).to_byte_array() + unit_test
             + Opcode.PUSH10
             + Opcode.PUSH1
             + Opcode.PACK
@@ -283,7 +286,7 @@ class TestRuntimeInterop(boatestcase.BoaTestCase):
         await self.set_up_contract('NotifyWithName.py')
 
         event_name = 'unit_test'
-        result, notifications = await self.call('Main', [event_name], return_type=None)
+        result, notifications = await self.call('Main', [], return_type=None)
         self.assertIsNone(result)
 
         event_notifications = self.filter_events(notifications,


### PR DESCRIPTION
**Summary or solution description**
You can't emit an event that is not on the manifest.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/3912663cd50d476dfef6bc11e2b441a334442946/boa3_test/test_sc/interop_test/runtime/NotifyWithName.py#L1-L8

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/3912663cd50d476dfef6bc11e2b441a334442946/boa3_test/tests/compiler_tests/test_interop/test_runtime.py#L285-L297

**Platform:**
 - OS: Windows 11 x64
 - Python version: Python 3.11
