### PR TITLE
public decorator signature is misleading

### DIFF
--- a/boa3/builtin/compile_time/__init__.py
+++ b/boa3/builtin/compile_time/__init__.py
@@ -39,7 +39,7 @@ def CreateNewEvent(arguments: list[tuple[str, type]] = [], event_name: str = '')
 
 
 @deprecated(details='This module is deprecated. Use boa3.sc.compiletime instead')
-def public(name: str = None, safe: bool = True, *args, **kwargs):
+def public(name: str = None, safe: bool = False, *args, **kwargs):
     """
     This decorator identifies which methods should be included in the abi file. Adding this decorator to a function
     means it could be called externally.

--- a/boa3/sc/compiletime/__init__.py
+++ b/boa3/sc/compiletime/__init__.py
@@ -8,7 +8,7 @@ __all__ = [
 from typing import Any
 
 
-def public(name: str = None, safe: bool = True, *args, **kwargs):
+def public(name: str = None, safe: bool = False, *args, **kwargs):
     """
     This decorator identifies which methods should be included in the abi file. Adding this decorator to a function
     means it could be called externally.


### PR DESCRIPTION
**Related issue**
 #1222

**Summary or solution description**
Fixing the wrong default value on the `safe` parameter at the `public` decorator

**Platform:**
 - OS: Windows 11 x64
 - Python version: Python 3.11
