### PR TITLE
#86dthh0zp - Update native PolicyContract

### DIFF
--- a/boa3/internal/model/builtin/interop/interop.py
+++ b/boa3/internal/model/builtin/interop/interop.py
@@ -81,6 +81,7 @@ class Interop:
     StorageContextType = StorageContextType.build()
     StorageMapType = StorageMapType.build()
     TransactionType = TransactionType.build()
+    TransactionAttributeType = TransactionAttributeType()
     TriggerType = TriggerType()
     VMStateType = VMStateType.build()
     WitnessCondition = WitnessConditionType.build()
@@ -148,7 +149,9 @@ class Interop:
     GetExecFeeFactor = GetExecFeeFactorMethod()
     GetFeePerByte = GetFeePerByteMethod()
     GetStoragePrice = GetStoragePriceMethod()
+    GetAttributeFee = GetAttributeFeeMethod(TransactionAttributeType)
     IsBlocked = IsBlockedMethod()
+    SetAttributeFee = SetAttributeFeeMethod(TransactionAttributeType)
 
     # Role Interops
     GetDesignatedByRole = GetDesignatedByRoleMethod()

--- a/boa3/internal/model/builtin/interop/policy/__init__.py
+++ b/boa3/internal/model/builtin/interop/policy/__init__.py
@@ -1,10 +1,17 @@
-__all__ = ['GetExecFeeFactorMethod',
-           'GetFeePerByteMethod',
-           'GetStoragePriceMethod',
-           'IsBlockedMethod'
-           ]
+__all__ = [
+    'GetAttributeFeeMethod',
+    'GetExecFeeFactorMethod',
+    'GetFeePerByteMethod',
+    'GetStoragePriceMethod',
+    'IsBlockedMethod',
+    'SetAttributeFeeMethod',
+    'TransactionAttributeType',
+]
 
+from boa3.internal.model.builtin.interop.policy.getattributefeemethod import GetAttributeFeeMethod
 from boa3.internal.model.builtin.interop.policy.getexecfeefactormethod import GetExecFeeFactorMethod
 from boa3.internal.model.builtin.interop.policy.getfeeperbytemethod import GetFeePerByteMethod
 from boa3.internal.model.builtin.interop.policy.getstoragepricemethod import GetStoragePriceMethod
 from boa3.internal.model.builtin.interop.policy.isblockedmethod import IsBlockedMethod
+from boa3.internal.model.builtin.interop.policy.setattributefeemethod import SetAttributeFeeMethod
+from boa3.internal.model.builtin.interop.policy.transactionattributetype import TransactionAttributeType

--- a/boa3/internal/model/builtin/interop/policy/getattributefeemethod.py
+++ b/boa3/internal/model/builtin/interop/policy/getattributefeemethod.py
@@ -1,0 +1,15 @@
+from boa3.internal.model.builtin.interop.nativecontract import PolicyContractMethod
+from boa3.internal.model.builtin.interop.policy.transactionattributetype import TransactionAttributeType
+from boa3.internal.model.variable import Variable
+
+
+class GetAttributeFeeMethod(PolicyContractMethod):
+
+    def __init__(self, tx_attribute_type: TransactionAttributeType):
+        from boa3.internal.model.type.type import Type
+        identifier = 'get_attribute_fee'
+        native_identifier = 'getAttributeFee'
+        args: dict[str, Variable] = {
+            'attribute_type': Variable(tx_attribute_type)
+        }
+        super().__init__(identifier, native_identifier, args, return_type=Type.int)

--- a/boa3/internal/model/builtin/interop/policy/setattributefeemethod.py
+++ b/boa3/internal/model/builtin/interop/policy/setattributefeemethod.py
@@ -1,0 +1,16 @@
+from boa3.internal.model.builtin.interop.nativecontract import PolicyContractMethod
+from boa3.internal.model.builtin.interop.policy.transactionattributetype import TransactionAttributeType
+from boa3.internal.model.variable import Variable
+
+
+class SetAttributeFeeMethod(PolicyContractMethod):
+
+    def __init__(self, tx_attribute_type: TransactionAttributeType):
+        from boa3.internal.model.type.type import Type
+        identifier = 'set_attribute_fee'
+        native_identifier = 'setAttributeFee'
+        args: dict[str, Variable] = {
+            'attribute_type': Variable(tx_attribute_type),
+            'value': Variable(Type.int),
+        }
+        super().__init__(identifier, native_identifier, args, return_type=Type.none)

--- a/boa3/internal/model/builtin/interop/policy/transactionattributetype.py
+++ b/boa3/internal/model/builtin/interop/policy/transactionattributetype.py
@@ -1,0 +1,51 @@
+from typing import Any
+
+from boa3.internal.model.symbol import ISymbol
+from boa3.internal.model.type.itype import IType
+from boa3.internal.model.type.primitive.inttype import IntType
+from boa3.internal.neo3.network.payloads.transactionattributetype import TransactionAttributeType as TransactionAttribute
+
+
+class TransactionAttributeType(IntType):
+    """
+    A class used to represent Neo TransactionAttributeType
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._identifier = 'TransactionAttributeType'
+
+    @classmethod
+    def build(cls, value: Any) -> IType:
+        if cls._is_type_of(value):
+            from boa3.internal.model.builtin.interop.interop import Interop
+            return Interop.TransactionAttributeType
+
+    @classmethod
+    def _is_type_of(cls, value: Any):
+        return isinstance(value, (TransactionAttribute, TransactionAttributeType))
+
+    @property
+    def symbols(self) -> dict[str, ISymbol]:
+        """
+        Gets the class symbols of this type
+
+        :return: a dictionary that maps each symbol in the module with its name
+        """
+        from boa3.internal.model.variable import Variable
+
+        _symbols = super().symbols
+        _symbols.update({name: Variable(self) for name in TransactionAttribute.__members__.keys()})
+
+        return _symbols
+
+    def get_value(self, symbol_id) -> Any:
+        """
+        Gets the literal value of a symbol
+
+        :return: the value if this type has this symbol. None otherwise.
+        """
+        if symbol_id in self.symbols:
+            return TransactionAttribute.__members__[symbol_id]
+
+        return None

--- a/boa3/internal/model/builtin/native/policyclass.py
+++ b/boa3/internal/model/builtin/native/policyclass.py
@@ -23,7 +23,9 @@ class PolicyClass(INativeContractClass):
                 'get_fee_per_byte': Interop.GetFeePerByte,
                 'get_exec_fee_factor': Interop.GetExecFeeFactor,
                 'get_storage_price': Interop.GetStoragePrice,
-                'is_blocked': Interop.IsBlocked
+                'get_attribute_fee': Interop.GetAttributeFee,
+                'is_blocked': Interop.IsBlocked,
+                'set_attribute_fee': Interop.SetAttributeFee,
             }
         return super().class_methods
 

--- a/boa3/internal/model/sc/__init__.py
+++ b/boa3/internal/model/sc/__init__.py
@@ -277,7 +277,8 @@ class ContractImports:
             Interop.VMStateType,
             Interop.CallFlagsType,
             Interop.OracleResponseCode,
-            Builtin.NeoAccountState
+            Builtin.NeoAccountState,
+            Interop.TransactionAttributeType,
         ],
     )
     # endregion

--- a/boa3/internal/neo3/network/payloads/transactionattributetype.py
+++ b/boa3/internal/neo3/network/payloads/transactionattributetype.py
@@ -1,0 +1,35 @@
+from enum import IntFlag
+
+
+class TransactionAttributeType(IntFlag):
+    """
+    Represents the TransactionAttributeType for running smart contracts.
+    """
+
+    HIGH_PRIORITY = 0x01
+    """
+    Indicates that the transaction is of high priority.
+    
+    :meta hide-value:
+    """
+
+    ORACLE_RESPONSE = 0x11
+    """
+    Indicates that the transaction is an oracle response
+
+    :meta hide-value:
+    """
+
+    NOT_VALID_BEFORE = 0x20
+    """
+    Indicates that the transaction is not valid before height.
+
+    :meta hide-value:
+    """
+
+    CONFLICTS = 0x21
+    """
+    Indicates that the transaction conflicts with hash.
+
+    :meta hide-value:
+    """

--- a/boa3/sc/contracts/policycontract.py
+++ b/boa3/sc/contracts/policycontract.py
@@ -2,6 +2,7 @@ __all__ = [
     'PolicyContract',
 ]
 
+from boa3.internal.neo3.network.payloads.transactionattributetype import TransactionAttributeType
 from boa3.sc.types import UInt160
 
 
@@ -50,7 +51,20 @@ class PolicyContract:
         >>> PolicyContract.get_storage_price()
         100000
 
-        :return: the snapshot used to read data
+        :return: the storage price
+        :rtype: int
+        """
+        pass
+
+    @classmethod
+    def get_attribute_fee(cls, attribute_type: TransactionAttributeType) -> int:
+        """
+        Gets the fee for attribute.
+
+        >>> PolicyContract.get_attribute_fee(TransactionAttributeType.HIGH_PRIORITY)
+        0
+
+        :return: the fee for attribute
         :rtype: int
         """
         pass
@@ -68,5 +82,16 @@ class PolicyContract:
 
         :return: whether the account is blocked or not
         :rtype: bool
+        """
+        pass
+
+    @classmethod
+    def set_attribute_fee(cls, attribute_type: TransactionAttributeType, value: int) -> None:
+        """
+        Sets the fee for attribute. You need to sign the transaction using a committee member, otherwise, this function
+        will throw an error.
+
+        >>> PolicyContract.set_attribute_fee(TransactionAttributeType.HIGH_PRIORITY, 10)
+        None
         """
         pass

--- a/boa3/sc/types/__init__.py
+++ b/boa3/sc/types/__init__.py
@@ -40,7 +40,8 @@ __all__ = [
     'VMState',
     'CallFlags',
     'OracleResponseCode',
-    'NeoAccountState'
+    'NeoAccountState',
+    'TransactionAttributeType',
 ]
 
 from typing import Any
@@ -53,6 +54,7 @@ from boa3.internal.neo3.contracts.findoptions import FindOptions
 from boa3.internal.neo3.contracts.namedcurve import NamedCurve
 from boa3.internal.neo3.contracts.native import Role
 from boa3.internal.neo3.network.payloads import OracleResponseCode
+from boa3.internal.neo3.network.payloads.transactionattributetype import TransactionAttributeType
 from boa3.internal.neo3.network.payloads.verification import WitnessScope, WitnessRuleAction, WitnessConditionType
 from boa3.internal.neo3.vm import VMState
 

--- a/boa3_test/test_sc/native_test/policy/GetAttributeFee.py
+++ b/boa3_test/test_sc/native_test/policy/GetAttributeFee.py
@@ -1,0 +1,8 @@
+from boa3.sc.compiletime import public
+from boa3.sc.contracts import PolicyContract
+from boa3.sc.types import TransactionAttributeType
+
+
+@public
+def main(tx_att: TransactionAttributeType) -> int:
+    return PolicyContract.get_attribute_fee(tx_att)

--- a/boa3_test/test_sc/native_test/policy/SetAttributeFee.py
+++ b/boa3_test/test_sc/native_test/policy/SetAttributeFee.py
@@ -1,0 +1,13 @@
+from boa3.sc.compiletime import public
+from boa3.sc.contracts import PolicyContract
+from boa3.sc.types import TransactionAttributeType
+
+
+@public
+def main(tx_att: TransactionAttributeType, value: int):
+    PolicyContract.set_attribute_fee(tx_att, value)
+
+
+@public
+def get_tx_attr(tx_att: TransactionAttributeType) -> int:
+    return PolicyContract.get_attribute_fee(tx_att)

--- a/boa3_test/tests/compiler_tests/test_native/test_policy.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_policy.py
@@ -4,6 +4,8 @@ from neo3.core import types
 
 from boa3.internal import constants
 from boa3.internal.exception import CompilerError, CompilerWarning
+from neo3.network.payloads import verification
+from boa3.internal.neo3.network.payloads.transactionattributetype import TransactionAttributeType
 from boa3_test.tests import boatestcase
 
 
@@ -39,6 +41,37 @@ class TestPolicyContract(boatestcase.BoaTestCase):
         expected = types.UInt160(constants.POLICY_SCRIPT)
         result, _ = await self.call('main', [], return_type=types.UInt160)
         self.assertEqual(expected, result)
+
+    async def test_get_attribute_fee(self):
+        await self.set_up_contract('GetAttributeFee.py')
+
+        result, _ = await self.call('main', [TransactionAttributeType.HIGH_PRIORITY], return_type=int)
+        self.assertIsInstance(result, int)
+
+        with self.assertRaises(boatestcase.FaultException) as context:
+            await self.call('main', [19999999], return_type=int)
+        self.assertRegex(str(context.exception), 'bigint does not fit into uint8')
+
+        with self.assertRaises(boatestcase.FaultException) as context:
+            await self.call('main', [20], return_type=int)
+        self.assertRegex(str(context.exception), 'invalid attribute type: 20')
+
+    async def test_set_attribute_fee(self):
+        await self.set_up_contract('SetAttributeFee.py')
+
+        signer = verification.Signer(
+            self.genesis.script_hash,
+            verification.WitnessScope.GLOBAL
+        )
+        result, _ = await self.call('main', [TransactionAttributeType.HIGH_PRIORITY, 100],
+                                    return_type=None, signers=[signer], signing_accounts=[self.genesis])
+
+        result, _ = await self.call('get_tx_attr', [TransactionAttributeType.HIGH_PRIORITY], return_type=int)
+        self.assertEqual(result, 100)
+
+        with self.assertRaises(boatestcase.FaultException) as context:
+            await self.call('main', [TransactionAttributeType.HIGH_PRIORITY, 100], return_type=int)
+        self.assertRegex(str(context.exception), 'invalid committee signature')
 
     async def test_get_exec_fee_factor(self):
         await self.set_up_contract('GetExecFeeFactor.py')


### PR DESCRIPTION
**Summary or solution description**
Added `get_attribute_fee` and `set_attribute_fee` to the `PolicyContract` from `boa3.sc.contracts`.
Added `TransactionAttributeType` to `boa3.sc.types`

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/50bf881206b2f370d569be897251fa3c3368ada0/boa3_test/test_sc/native_test/policy/SetAttributeFee.py#L1-L13

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/50bf881206b2f370d569be897251fa3c3368ada0/boa3_test/tests/compiler_tests/test_native/test_policy.py#L45-L74

**Platform:**
 - OS: Windows 11 x64
 - Python version: Python 3.11
