### PR TITLE
CU-86dthh0nm - Update NeoToken native contract

### DIFF
--- a/boa3/internal/model/builtin/native/neo_contract_methods/__init__.py
+++ b/boa3/internal/model/builtin/native/neo_contract_methods/__init__.py
@@ -3,8 +3,10 @@ __all__ = ['GetAccountStateMethod',
            'GetCandidatesMethod',
            'GetCandidateVoteMethod',
            'GetCommitteeMethod',
+           'GetCommitteeAddressMethod',
            'GetGasPerBlockMethod',
            'GetNextBlockValidatorsMethod',
+           'GetRegisterPriceMethod',
            'RegisterCandidateMethod',
            'UnclaimedGasMethod',
            'UnregisterCandidateMethod',
@@ -17,8 +19,10 @@ from boa3.internal.model.builtin.native.neo_contract_methods.getallcandidatesmet
 from boa3.internal.model.builtin.native.neo_contract_methods.getcandidatesmethod import GetCandidatesMethod
 from boa3.internal.model.builtin.native.neo_contract_methods.getcandidatevotemethod import GetCandidateVoteMethod
 from boa3.internal.model.builtin.native.neo_contract_methods.getcommitteemethod import GetCommitteeMethod
+from boa3.internal.model.builtin.native.neo_contract_methods.getcommitteeaddressmethod import GetCommitteeAddressMethod
 from boa3.internal.model.builtin.native.neo_contract_methods.getgasperblockmethod import GetGasPerBlockMethod
 from boa3.internal.model.builtin.native.neo_contract_methods.getnextblockvalidators import GetNextBlockValidatorsMethod
+from boa3.internal.model.builtin.native.neo_contract_methods.getregisterpricemethod import GetRegisterPriceMethod
 from boa3.internal.model.builtin.native.neo_contract_methods.registercandidatemethod import RegisterCandidateMethod
 from boa3.internal.model.builtin.native.neo_contract_methods.unclaimedgasmethod import UnclaimedGasMethod
 from boa3.internal.model.builtin.native.neo_contract_methods.unregistercandidatemethod import UnregisterCandidateMethod

--- a/boa3/internal/model/builtin/native/neo_contract_methods/getcommitteeaddressmethod.py
+++ b/boa3/internal/model/builtin/native/neo_contract_methods/getcommitteeaddressmethod.py
@@ -1,0 +1,13 @@
+from boa3.internal.model.builtin.interop.nativecontract import NeoContractMethod
+from boa3.internal.model.variable import Variable
+
+
+class GetCommitteeAddressMethod(NeoContractMethod):
+
+    def __init__(self):
+        from boa3.internal.model.type.collection.sequence.uint160type import UInt160Type
+
+        identifier = 'get_committee_address'
+        native_identifier = 'getCommitteeAddress'
+        args: dict[str, Variable] = {}
+        super().__init__(identifier, native_identifier, args, return_type=UInt160Type.build())

--- a/boa3/internal/model/builtin/native/neo_contract_methods/getregisterpricemethod.py
+++ b/boa3/internal/model/builtin/native/neo_contract_methods/getregisterpricemethod.py
@@ -1,0 +1,13 @@
+from boa3.internal.model.builtin.interop.nativecontract import NeoContractMethod
+from boa3.internal.model.variable import Variable
+
+
+class GetRegisterPriceMethod(NeoContractMethod):
+
+    def __init__(self):
+        from boa3.internal.model.type.type import Type
+
+        identifier = 'get_register_price'
+        native_identifier = 'getRegisterPrice'
+        args: dict[str, Variable] = {}
+        super().__init__(identifier, native_identifier, args, return_type=Type.int)

--- a/boa3/internal/model/builtin/native/neoclass.py
+++ b/boa3/internal/model/builtin/native/neoclass.py
@@ -19,12 +19,12 @@ class NeoClass(INativeContractClass):
         # avoid recursive import
         from boa3.internal.model.builtin.native.nep17_methods import (BalanceOfMethod, DecimalsMethod, SymbolMethod,
                                                                       TotalSupplyMethod, TransferMethod)
-        from boa3.internal.model.builtin.native.neo_contract_methods import (GetAccountStateMethod, GetAllCandidatesMethod,
-                                                                             GetCandidatesMethod, GetCandidateVoteMethod,
-                                                                             GetCommitteeMethod, GetGasPerBlockMethod,
-                                                                             GetNextBlockValidatorsMethod,
-                                                                             RegisterCandidateMethod, UnclaimedGasMethod,
-                                                                             UnregisterCandidateMethod, UnVoteMethod, VoteMethod)
+        from boa3.internal.model.builtin.native.neo_contract_methods import (
+            GetAccountStateMethod, GetAllCandidatesMethod, GetCandidatesMethod, GetCandidateVoteMethod,
+            GetCommitteeMethod, GetGasPerBlockMethod, GetNextBlockValidatorsMethod, GetRegisterPriceMethod,
+            RegisterCandidateMethod, UnclaimedGasMethod, UnregisterCandidateMethod, UnVoteMethod, VoteMethod,
+            GetCommitteeAddressMethod
+        )
         from boa3.internal.model.builtin.contract import NeoAccountStateType
 
         if len(self._class_methods) == 0:
@@ -40,8 +40,10 @@ class NeoClass(INativeContractClass):
                 'get_candidates': GetCandidatesMethod(),
                 'get_candidate_vote': GetCandidateVoteMethod(),
                 'get_committee': GetCommitteeMethod(),
+                'get_committee_address': GetCommitteeAddressMethod(),
                 'get_gas_per_block': GetGasPerBlockMethod(),
                 'get_next_block_validators': GetNextBlockValidatorsMethod(),
+                'get_register_price': GetRegisterPriceMethod(),
                 'register_candidate': RegisterCandidateMethod(),
                 'unclaimed_gas': UnclaimedGasMethod(),
                 'unregister_candidate': UnregisterCandidateMethod(),

--- a/boa3/sc/contracts/neotoken.py
+++ b/boa3/sc/contracts/neotoken.py
@@ -260,6 +260,32 @@ class NeoToken:
         pass
 
     @classmethod
+    def get_committee_address(cls) -> UInt160:
+        """
+        Gets the address of the committee.
+
+        >>> NeoToken.get_committee_address()
+        UInt160(0x9273d3c792bce5eab4daac1c3ffdc1e83c4237f7)
+
+        :return: the address of the committee
+        :rtype: UInt160
+        """
+        pass
+
+    @classmethod
+    def get_register_price(cls) -> int:
+        """
+        Gets the fees to be paid to register as a candidate.
+
+        >>> NeoToken.get_register_price()
+        100000000000
+
+        :return: the amount of the fees
+        :rtype: int
+        """
+        pass
+
+    @classmethod
     def get_next_block_validators(cls) -> list[ECPoint]:
         """
         Gets validators list of the next block.

--- a/boa3_test/test_sc/native_test/neo/GetCommitteeAddress.py
+++ b/boa3_test/test_sc/native_test/neo/GetCommitteeAddress.py
@@ -1,0 +1,8 @@
+from boa3.sc.compiletime import public
+from boa3.sc.contracts import NeoToken
+from boa3.sc.types import UInt160
+
+
+@public
+def main() -> UInt160:
+    return NeoToken.get_committee_address()

--- a/boa3_test/test_sc/native_test/neo/GetRegisterPrice.py
+++ b/boa3_test/test_sc/native_test/neo/GetRegisterPrice.py
@@ -1,0 +1,7 @@
+from boa3.sc.compiletime import public
+from boa3.sc.contracts import NeoToken
+
+
+@public
+def main() -> int:
+    return NeoToken.get_register_price()

--- a/boa3_test/tests/compiler_tests/test_native/test_neo.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_neo.py
@@ -11,6 +11,7 @@ from neo3.wallet import account
 
 from boa3.internal import constants
 from boa3.internal.exception import CompilerError, CompilerWarning
+from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3_test.tests import annotation, boatestcase
 
 
@@ -74,6 +75,11 @@ class TestNeoClass(boatestcase.BoaTestCase):
     async def get_gas_per_block(cls) -> int:
         async with noderpc.NeoRpcClient(cls.node.facade.rpc_host):
             return await cls.node.facade.test_invoke(NeoToken().get_gas_per_block())
+
+    @classmethod
+    async def get_register_price(cls) -> int:
+        async with noderpc.NeoRpcClient(cls.node.facade.rpc_host):
+            return await cls.node.facade.test_invoke(NeoToken().candidate_registration_price())
 
     async def test_get_hash(self):
         await self.set_up_contract('GetHash.py')
@@ -579,3 +585,19 @@ class TestNeoClass(boatestcase.BoaTestCase):
             self.assertIsNone(result[2])
             self.assertGreaterEqual(result[3], 0)
         self.assertRegex(str(context.exception), "item is not of type 'StackItemType.ARRAY' but of type 'StackItemType.STRUCT'")
+
+    async def test_get_committee_address(self):
+        expected_output = (
+            Opcode.CALLT + b'\x00\x00'
+            + Opcode.RET
+        )
+
+        output, _ = self.assertCompile('GetCommitteeAddress.py')
+        self.assertEqual(expected_output, output)
+
+    async def test_get_register_price(self):
+        await self.set_up_contract('GetRegisterPrice.py')
+
+        register_price = await self.get_register_price()
+        result, _ = await self.call('main', [], return_type=int)
+        self.assertEqual(register_price, result)


### PR DESCRIPTION
**Summary or solution description**
Added `get_committee_address` and `get_register_price` to the NeoToken native contract interface at `boa3.sc.contracts`

**How to Reproduce**
```python
from boa3.sc.compiletime import public
from boa3.sc.contracts import NeoToken


@public
def main() -> int:
    return NeoToken.get_register_price()
```

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/570584a03508d808c4b37633206bce2b6c805f80/boa3_test/tests/compiler_tests/test_native/test_neo.py#L589-L603

**Platform:**
 - OS: Windows 11 x64
 - Python version: Python 3.11

**(Optional) Additional context**
Couldn't test the `get_committee_address` method with the current neo-go config, so it's just checking the opcode and it was invoked on the testnet.