### PR TITLE
CU-86dtn3pzu - Refactor remaining tests that uses TestRunner

### DIFF
--- a/boa3_test/tests/compiler_tests/test_builtin_method.py
+++ b/boa3_test/tests/compiler_tests/test_builtin_method.py
@@ -883,7 +883,6 @@ class TestBuiltinMethod(boatestcase.BoaTestCase):
 
     async def test_max_int_more_arguments(self):
         await self.set_up_contract('MaxIntMoreArguments.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
 
         numbers = 4, 1, 16, 8, 2
         result, _ = await self.call('main', [], return_type=int)
@@ -1416,7 +1415,6 @@ class TestBuiltinMethod(boatestcase.BoaTestCase):
 
     async def test_super_call_method(self):
         await self.set_up_contract('SuperCallMethod.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
 
         super_method_expected_result = -20
         arg = 20
@@ -1531,7 +1529,6 @@ class TestBuiltinMethod(boatestcase.BoaTestCase):
 
     async def test_int_bytes(self):
         await self.set_up_contract('IntBytes.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
 
         value = b'0b101'
         base = 0

--- a/boa3_test/tests/compiler_tests/test_file_generation.py
+++ b/boa3_test/tests/compiler_tests/test_file_generation.py
@@ -769,18 +769,12 @@ class TestFileGeneration(boatestcase.BoaTestCase):
         with self.assertRaises(NotLoadedException):
             self.compile_and_save(path)
 
-    def test_generation_with_recursive_function(self):
-        path, _ = self.get_deploy_file_paths('test_sc/function_test', 'RecursiveFunction.py')
-
-        from boa3.internal.neo3.vm import VMState
-        from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_generation_with_recursive_function(self):
+        await self.set_up_contract('test_sc/function_test', 'RecursiveFunction.py')
 
         expected = self.fact(57)
-        invoke = runner.call_contract(path, 'main')
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.cli_log)
-        self.assertEqual(expected, invoke.result)
+        result, _ = await self.call('main', return_type=int)
+        self.assertEqual(expected, result)
 
     def fact(self, f: int) -> int:
         if f <= 1:

--- a/boa3_test/tests/compiler_tests/test_list.py
+++ b/boa3_test/tests/compiler_tests/test_list.py
@@ -3,9 +3,7 @@ from boa3.internal.model.type.type import Type
 from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo.vm.type.String import String
-from boa3.internal.neo3.vm import VMState
 from boa3_test.tests import boatestcase
-from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestList(boatestcase.BoaTestCase):
@@ -1100,16 +1098,11 @@ class TestList(boatestcase.BoaTestCase):
         output, _ = self.assertCompile('PopList.py')
         self.assertEqual(expected_output, output)
 
-    def test_list_pop(self):
-        path, _ = self.get_deploy_file_paths('PopList.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_list_pop(self):
+        await self.set_up_contract('PopList.py')
 
-        invoke = (runner.call_contract(path, 'pop_test'))
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        self.assertEqual([1, 2, 3, 4, 5].pop(), invoke.result)
+        result, _ = await self.call('pop_test', [], return_type=int)
+        self.assertEqual([1, 2, 3, 4, 5].pop(), result)
 
     def test_list_pop_without_assignment_compile(self):
         expected_output = (
@@ -1147,18 +1140,13 @@ class TestList(boatestcase.BoaTestCase):
         output, _ = self.assertCompile('PopListWithoutAssignment.py')
         self.assertEqual(expected_output, output)
 
-    def test_list_pop_without_assignment(self):
-        path, _ = self.get_deploy_file_paths('PopListWithoutAssignment.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
-
-        invoke = (runner.call_contract(path, 'pop_test'))
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
+    async def test_list_pop_without_assignment(self):
+        await self.set_up_contract('PopListWithoutAssignment.py')
 
         list_ = [1, 2, 3, 4, 5]
         list_.pop()
-        self.assertEqual(list_, invoke.result)
+        result, _ = await self.call('pop_test', [], return_type=list[int])
+        self.assertEqual(list_, result)
 
     def test_list_pop_literal_argument_compile(self):
         expected_output = (
@@ -1196,16 +1184,12 @@ class TestList(boatestcase.BoaTestCase):
         output, _ = self.assertCompile('PopListLiteralArgument.py')
         self.assertEqual(expected_output, output)
 
-    def test_list_pop_literal_argument(self):
-        path, _ = self.get_deploy_file_paths('PopListLiteralArgument.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_list_pop_literal_argument(self):
+        await self.set_up_contract('PopListLiteralArgument.py')
 
-        invoke = (runner.call_contract(path, 'pop_test'))
 
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        self.assertEqual([1, 2, 3, 4, 5].pop(2), invoke.result)
+        result, _ = await self.call('pop_test', [], return_type=int)
+        self.assertEqual([1, 2, 3, 4, 5].pop(2), result)
 
     def test_list_pop_literal_negative_argument_compile(self):
         expected_output = (
@@ -1244,16 +1228,11 @@ class TestList(boatestcase.BoaTestCase):
         output, _ = self.assertCompile('PopListLiteralNegativeArgument.py')
         self.assertEqual(expected_output, output)
 
-    def test_list_pop_literal_negative_argument(self):
-        path, _ = self.get_deploy_file_paths('PopListLiteralNegativeArgument.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_list_pop_literal_negative_argument(self):
+        await self.set_up_contract('PopListLiteralNegativeArgument.py')
 
-        invoke = (runner.call_contract(path, 'pop_test'))
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        self.assertEqual([1, 2, 3, 4, 5].pop(-2), invoke.result)
+        result, _ = await self.call('pop_test', [], return_type=int)
+        self.assertEqual([1, 2, 3, 4, 5].pop(-2), result)
 
     def test_list_pop_literal_variable_argument_compile(self):
         expected_output = (

--- a/boa3_test/tests/compiler_tests/test_string.py
+++ b/boa3_test/tests/compiler_tests/test_string.py
@@ -3,9 +3,7 @@ from boa3.internal.neo.vm.opcode.Opcode import Opcode
 from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo.vm.type.StackItem import StackItemType
 from boa3.internal.neo.vm.type.String import String
-from boa3.internal.neo3.vm import VMState
 from boa3_test.tests import boatestcase
-from boa3_test.tests.test_drive.testrunner.boa_test_runner import BoaTestRunner
 
 
 class TestString(boatestcase.BoaTestCase):
@@ -1105,17 +1103,12 @@ class TestString(boatestcase.BoaTestCase):
         result, _ = await self.call('main', [start, end], return_type=str)
         self.assertEqual(string[start:end], result)
 
-    def test_f_string_literal(self):
-        path, _ = self.get_deploy_file_paths('FStringLiteral.py')
-        runner = BoaTestRunner(runner_id=self.method_name())
+    async def test_f_string_literal(self):
+        await self.set_up_contract('FStringLiteral.py')
 
-        invoke = runner.call_contract(path, 'main')
         expected_result = "unit test"
-
-        runner.execute()
-        self.assertEqual(VMState.HALT, runner.vm_state, msg=runner.error)
-
-        self.assertEqual(expected_result, invoke.result)
+        result, _ = await self.call('main', [], return_type=str)
+        self.assertEqual(expected_result, result)
 
     async def test_f_string_string_var(self):
         await self.set_up_contract('FStringStringVar.py')


### PR DESCRIPTION
**Summary or solution description**
Removed BoaTestRunner from some tests that don't need it.


**Platform:**
 - OS: Windows 11 x64
 - Python version: Python 3.11
