### PR TITLE
update boa-test-constructor dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dev = [
     'twine>=1.10.0',
 ]
 test = [
-    'boa-test-constructor==0.3.0',
+    'boa-test-constructor==0.3.1',
 ]
 docs = [
     'myst-parser==1.0.0',


### PR DESCRIPTION
**Related issue**
GhostMarket reported a problem with using the test framework because their contract is named `GhostMarket.NFT.py` and it would fail to find the manifest due to incorrect stripping of the extension (it included `.NFT`)

**Summary or solution description**
It is fixed in the new version of the test framework