### PR TITLE
Script container

### DIFF
--- a/boa3/internal/analyser/moduleanalyser.py
+++ b/boa3/internal/analyser/moduleanalyser.py
@@ -18,6 +18,7 @@ from boa3.internal.model.builtin.builtin import Builtin
 from boa3.internal.model.builtin.compile_time.neometadatatype import MetadataTypeSingleton
 from boa3.internal.model.builtin.decorator import ContractDecorator
 from boa3.internal.model.builtin.decorator.builtindecorator import IBuiltinDecorator
+from boa3.internal.model.builtin.interop.runtime import ScriptContainerProperty
 from boa3.internal.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.internal.model.callable import Callable
 from boa3.internal.model.decorator import IDecorator
@@ -1431,6 +1432,8 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
         value: ISymbol = self.get_symbol(value_id) if value_id is not None else self.visit(attribute.value)
 
         if isinstance(value, Variable):
+            value = value.type
+        elif isinstance(value, ScriptContainerProperty):
             value = value.type
 
         attribute_symbol = None

--- a/boa3/internal/compiler/codegenerator/codegeneratorvisitor.py
+++ b/boa3/internal/compiler/codegenerator/codegeneratorvisitor.py
@@ -126,7 +126,7 @@ class VisitorCodeGenerator(IAstAnalyser):
             result = self.visit(node)
 
             if not result.already_generated and result.symbol_id is not None:
-                if isinstance(node, ast.Attribute):
+                if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Attribute):
                     self.visit_to_generate(node.value)
 
                 if self.is_exception_name(result.symbol_id):

--- a/boa3/internal/compiler/codegenerator/codegeneratorvisitor.py
+++ b/boa3/internal/compiler/codegenerator/codegeneratorvisitor.py
@@ -126,6 +126,9 @@ class VisitorCodeGenerator(IAstAnalyser):
             result = self.visit(node)
 
             if not result.already_generated and result.symbol_id is not None:
+                if isinstance(node, ast.Attribute):
+                    self.visit_to_generate(node.value)
+
                 if self.is_exception_name(result.symbol_id):
                     self.generator.convert_new_exception()
                 else:

--- a/boa3_test/test_sc/interop_test/runtime/ScriptContainerHash.py
+++ b/boa3_test/test_sc/interop_test/runtime/ScriptContainerHash.py
@@ -1,0 +1,8 @@
+from boa3.builtin.compile_time import public
+from boa3.builtin.type import UInt256
+from boa3.builtin.interop.runtime import script_container
+
+
+@public
+def main() -> UInt256:
+    return script_container.hash

--- a/boa3_test/test_sc/interop_test/runtime/ScriptContainerHash2.py
+++ b/boa3_test/test_sc/interop_test/runtime/ScriptContainerHash2.py
@@ -1,0 +1,7 @@
+from boa3.builtin.compile_time import public
+from boa3.builtin.type import UInt256
+from boa3.builtin.interop import runtime
+
+@public
+def main() -> UInt256:
+    return runtime.script_container.hash

--- a/boa3_test/tests/compiler_tests/test_interop/test_runtime.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_runtime.py
@@ -890,3 +890,16 @@ class TestRuntimeInterop(boatestcase.BoaTestCase):
                                     return_type=int
                                     )
         self.assertEqual(expected_result, result)
+
+    async def test_script_container_hash(self):
+        # test https://github.com/CityOfZion/neo3-boa/issues/1273
+        # both import styles must work
+        await self.set_up_contract('ScriptContainerHash.py')
+
+        result, _ = await self.call('main', [], return_type=types.UInt256)
+        self.assertIsInstance(result, types.UInt256)
+
+        await self.set_up_contract('ScriptContainerHash2.py')
+        result, _ = await self.call('main', [], return_type=types.UInt256)
+        self.assertIsInstance(result, types.UInt256)
+


### PR DESCRIPTION
**Related issue**
fix #1273 

**Summary or solution description**
`script_container` is the only module attribute of the interop package that returns a class with more properties. The module analyser is changed to allow to capture the class properties.

In the case of importing the `runtime` module and trying to do
```python
x = runtime.script_container.hash
```
The code generator failed to generate code for getting the `script_container` and only generated code for picking the `hash` property. It now recursively generates for all attributes instead of just the first as the AST looks as follows
```python
                Assign(
                    targets=[
                        Name(id='x', ctx=Store())],
                    value=Attribute(
                        value=Attribute(
                            value=Name(id='runtime', ctx=Load()),
                            attr='script_container',
                            ctx=Load()),
                        attr='hash',
                        ctx=Load())),
```

