### PR TITLE
Fix document build warnings

### DIFF
--- a/docs/source/auto-package/boa3/builtin/interop/blockchain/boa3-builtin-interop-blockchain.rst
+++ b/docs/source/auto-package/boa3/builtin/interop/blockchain/boa3-builtin-interop-blockchain.rst
@@ -8,5 +8,7 @@ Subpackages
 -----------
 .. automodule:: boa3.builtin.interop.blockchain.block
 .. automodule:: boa3.builtin.interop.blockchain.signer
+    :no-index:
 .. automodule:: boa3.builtin.interop.blockchain.transaction
 .. automodule:: boa3.builtin.interop.blockchain.vmstate
+    :no-index:

--- a/docs/source/auto-package/boa3/builtin/interop/contract/boa3-builtin-interop-contract.rst
+++ b/docs/source/auto-package/boa3/builtin/interop/contract/boa3-builtin-interop-contract.rst
@@ -7,5 +7,7 @@ contract
 Subpackages
 -----------
 .. automodule:: boa3.builtin.interop.contract.callflagstype
+    :no-index:
 .. automodule:: boa3.builtin.interop.contract.contract
 .. automodule:: boa3.builtin.interop.contract.contractmanifest
+    :no-index:

--- a/docs/source/auto-package/boa3/builtin/interop/crypto/boa3-builtin-interop-crypto.rst
+++ b/docs/source/auto-package/boa3/builtin/interop/crypto/boa3-builtin-interop-crypto.rst
@@ -7,3 +7,4 @@ crypto
 Subpackages
 -----------
 .. automodule:: boa3.builtin.interop.crypto.namedcurve
+    :no-index:

--- a/docs/source/auto-package/boa3/builtin/interop/role/boa3-builtin-interop-role.rst
+++ b/docs/source/auto-package/boa3/builtin/interop/role/boa3-builtin-interop-role.rst
@@ -7,3 +7,4 @@ role
 Subpackages
 -----------
 .. automodule:: boa3.builtin.interop.role.roletype
+    :no-index:

--- a/docs/source/auto-package/boa3/builtin/interop/runtime/boa3-builtin-interop-runtime.rst
+++ b/docs/source/auto-package/boa3/builtin/interop/runtime/boa3-builtin-interop-runtime.rst
@@ -8,3 +8,4 @@ Subpackages
 -----------
 .. automodule:: boa3.builtin.interop.runtime.notification
 .. automodule:: boa3.builtin.interop.runtime.triggertype
+    :no-index:

--- a/docs/source/auto-package/boa3/builtin/interop/storage/boa3-builtin-interop-storage.rst
+++ b/docs/source/auto-package/boa3/builtin/interop/storage/boa3-builtin-interop-storage.rst
@@ -7,5 +7,6 @@ storage
 Subpackages
 -----------
 .. automodule:: boa3.builtin.interop.storage.findoptions
+    :no-index:
 .. automodule:: boa3.builtin.interop.storage.storagecontext
 .. automodule:: boa3.builtin.interop.storage.storagemap

--- a/docs/source/auto-package/boa3/builtin/vm/boa3-builtin-vm.rst
+++ b/docs/source/auto-package/boa3/builtin/vm/boa3-builtin-vm.rst
@@ -2,6 +2,7 @@ vm
 ==
 
 .. automodule:: boa3.builtin.vm
+    :no-index:
     :no-undoc-members:
     :exclude-members: _member_type_
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -210,4 +210,4 @@ latex_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/', None)}

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -211,8 +211,9 @@ Boa3.compile_and_save('path/to/your/file.py')
 Check out [Neo3-boa tutorials](https://developers.neo.org/tutorials/tags/neo-3-boa) on [Neo Developer](https://developers.neo.org/).
 
 For an extensive collection of examples:
-- [Smart contract examples](../../boa3_test/examples)
-- [Features tests](../../boa3_test/test_sc)
+- [Smart contract examples](https://github.com/CityOfZion/neo3-boa/tree/master/boa3_test/examples)
+- [Features tests](https://github.com/CityOfZion/neo3-boa/tree/master/boa3_test/test_sc)
+
 
 For reference of boa3 smart contract package utilities, take a look at [Package Reference](https://dojo.coz.io/neo3/boa/auto-package/package-reference.html) from boa3 documentation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,9 @@ test = [
 ]
 docs = [
     'autodocsumm>=0.2.12',
-    'myst-parser==1.0.0',
-    'Sphinx==5.0.0',
-    'sphinx-rtd-theme==1.2.1',
+    'myst-parser==4.0.1',
+    'Sphinx==8.2.3',
+    'sphinx-rtd-theme==3.0.2',
 ]
 
 [project.urls]


### PR DESCRIPTION
1. Due to the new import structure it would throw warnings like the following
> /home/erik/code/neo3-boa/boa3/sc/types/__init__.py:docstring of boa3.internal.neo3.network.payloads.verification.WitnessConditionType:1: WARNING: duplicate object description of boa3.internal.neo3.network.payloads.verification.WitnessConditionType, other instance in auto-package/boa3/builtin/interop/blockchain/boa3-builtin-interop-blockchain, use :no-index: for one of them

I initially hoped that upgrading the dependencies would do something, but that was not the fix. However, I decided to keep those changes as it is not that bad to be on the latest versions

2. There were 2 more warnings related to linking to the contract examples
> /home/erik/code/neo3-boa/docs/source/getting-started.md:214: WARNING: 'myst' cross-reference target not found: '../../boa3_test/examples' [myst.xref_missing]
/home/erik/code/neo3-boa/docs/source/getting-started.md:215: WARNING: 'myst' cross-reference target not found: '../../boa3_test/test_sc' [myst.xref_missing]

I tried various suggestions like using the `linkify` myst-extension, using `{.external}` and what not. They all did not work. So I just converted them to direct links to the github repo as the goal is to not spent too much time on resolving all this.
