### PR TITLE
ci: fix setuptools deprecation warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,13 +3,12 @@ name = 'neo3-boa'
 description = 'A Python compiler for the Neo3 Virtual Machine'
 readme = 'README.md'
 requires-python = '>= 3.11,< 3.13'
-license = {file = 'LICENSE' }
+license = 'MIT'
 keywords = ['compiler', 'NEO', '.nef', 'blockchain', 'smartcontract', 'development', 'dApp']
 classifiers = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',
     'Topic :: Software Development :: Build Tools',
-    'License :: OSI Approved :: Apache Software License',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
 ]
@@ -49,6 +48,8 @@ changelog = 'https://github.com/CityOfZion/neo3-boa/blob/master/CHANGELOG.md'
 neo3-boa = 'boa3.cli:main'
 install_cpm = 'boa3.cpm:main'
 
+[tool.setuptools]
+license-files = ["LICENSE"]
 
 [tool.setuptools.packages.find]
 exclude = ['boa3_test.tests.*_tests*']
@@ -63,7 +64,6 @@ boa3 = ['py.typed']
 
 [tool.setuptools.dynamic]
 version = { attr = 'boa3.__version__' }
-
 
 [tool.bumpversion]
 current_version = '1.3.0'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ description = 'A Python compiler for the Neo3 Virtual Machine'
 readme = 'README.md'
 requires-python = '>= 3.11,< 3.13'
 license = 'MIT'
+license-files = ["LICENSE"]
 keywords = ['compiler', 'NEO', '.nef', 'blockchain', 'smartcontract', 'development', 'dApp']
 classifiers = [
     'Development Status :: 5 - Production/Stable',
@@ -47,9 +48,6 @@ changelog = 'https://github.com/CityOfZion/neo3-boa/blob/master/CHANGELOG.md'
 [project.scripts]
 neo3-boa = 'boa3.cli:main'
 install_cpm = 'boa3.cpm:main'
-
-[tool.setuptools]
-license-files = ["LICENSE"]
 
 [tool.setuptools.packages.find]
 exclude = ['boa3_test.tests.*_tests*']


### PR DESCRIPTION
The last release showed 2 warnings in CI

```
/tmp/build-env-5woftfi1/lib/python3.11/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
!!

        ********************************************************************************
        Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

        By 2026-Feb-18, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
```
and
```
  corresp(dist, value, root_dir)
/tmp/build-env-5woftfi1/lib/python3.11/site-packages/setuptools/config/_apply_pyprojecttoml.py:61: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: Apache Software License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
```

This resolves those warnings
