### PR TITLE
Fix TypeHintMissing error message when functions inside Class were re…

### DIFF
--- a/boa3_test/test_sc/class_test/UserClassClassMethodWithoutReturnType.py
+++ b/boa3_test/test_sc/class_test/UserClassClassMethodWithoutReturnType.py
@@ -1,0 +1,4 @@
+class Example:
+    @classmethod
+    def some_method(cls):
+        return 42

--- a/boa3_test/test_sc/class_test/UserClassInstanceMethodWithoutReturnType.py
+++ b/boa3_test/test_sc/class_test/UserClassInstanceMethodWithoutReturnType.py
@@ -1,0 +1,3 @@
+class Example:
+    def speak(self):
+        return "hello world"

--- a/boa3_test/test_sc/class_test/UserClassStaticMethodWithoutReturnType.py
+++ b/boa3_test/test_sc/class_test/UserClassStaticMethodWithoutReturnType.py
@@ -1,0 +1,4 @@
+class Example:
+    @staticmethod
+    def some_method():
+        return 42

--- a/boa3_test/tests/compiler_tests/test_class.py
+++ b/boa3_test/tests/compiler_tests/test_class.py
@@ -505,3 +505,12 @@ class TestClass(boatestcase.BoaTestCase):
         expected_result = MyNFT('Rectangle', 'Blue', 'Black', 'Small')
         result, _ = await self.call('test', [], return_type=list)
         self.assertObjectEqual(expected_result, result)
+
+    def test_user_class_instance_method_without_return_type(self):
+        self.assertCompilerLogs(CompilerError.TypeHintMissing, 'UserClassInstanceMethodWithoutReturnType.py')
+
+    def test_user_class_static_method_without_return_type(self):
+        self.assertCompilerLogs(CompilerError.TypeHintMissing, 'UserClassStaticMethodWithoutReturnType.py')
+
+    def test_user_class_class_method_without_return_type(self):
+        self.assertCompilerLogs(CompilerError.TypeHintMissing, 'UserClassClassMethodWithoutReturnType.py')


### PR DESCRIPTION
…turning something, but there was no type hint

**Related issue**
#1282

**Summary or solution description**
Previous error message was empty when the type error was inside a function inside a class. 
It also was pointing to the `return` line and column, now it's pointing to the function signature

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/3e27d1b210299a94e8357e92e7e947fa6b94a0ef/boa3_test/test_sc/class_test/UserClassInstanceMethodWithoutReturnType.py#L1-L3

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/3e27d1b210299a94e8357e92e7e947fa6b94a0ef/boa3_test/tests/compiler_tests/test_class.py#L509-L516

**Platform:**
 - OS: macOS 15.5 (24F74)
 - Python version: Python 3.12
