### PR TITLE
Fix sequence insert function when index is greater or equal to sequen…

### DIFF
--- a/boa3_test/test_sc/list_test/ListInsertEmptyList.py
+++ b/boa3_test/test_sc/list_test/ListInsertEmptyList.py
@@ -1,0 +1,9 @@
+from boa3.sc.compiletime import public
+
+
+@public
+def main(index: int, number: int) -> list[int]:
+    empty_list: list[int] = []
+
+    empty_list.insert(index, number)
+    return empty_list

--- a/boa3_test/test_sc/list_test/ListInsertIntNegativeIndex.py
+++ b/boa3_test/test_sc/list_test/ListInsertIntNegativeIndex.py
@@ -5,4 +5,4 @@ from boa3.sc.compiletime import public
 def Main() -> list[int]:
     a = [1, 2, 3]
     a.insert(-2, 4)
-    return a  # expected [1, 2, 4, 3]
+    return a  # expected [1, 4, 2, 3]

--- a/boa3_test/tests/compiler_tests/test_list.py
+++ b/boa3_test/tests/compiler_tests/test_list.py
@@ -1368,6 +1368,37 @@ class TestList(boatestcase.BoaTestCase):
         result, _ = await self.call('Main', [], return_type=list)
         self.assertEqual([1, 2, 4, 3], result)
 
+    async def test_list_insert_empty_list(self):
+        await self.set_up_contract('ListInsertEmptyList.py')
+
+        list_ = []
+        index = 0
+        value = 123
+        result, _ = await self.call('main', [index, value], return_type=list)
+        list_.insert(index, value)
+        self.assertEqual(list_, result)
+
+        list_ = []
+        index = 99
+        value = 123
+        result, _ = await self.call('main', [index, value], return_type=list)
+        list_.insert(index, value)
+        self.assertEqual(list_, result)
+
+        list_ = []
+        index = -1
+        value = 123
+        result, _ = await self.call('main', [index, value], return_type=list)
+        list_.insert(index, value)
+        self.assertEqual(list_, result)
+
+        list_ = []
+        index = -99
+        value = 123
+        result, _ = await self.call('main', [index, value], return_type=list)
+        list_.insert(index, value)
+        self.assertEqual(list_, result)
+
     async def test_list_insert_any_value(self):
         await self.set_up_contract('ListInsertAnyValue.py')
 
@@ -1392,17 +1423,63 @@ class TestList(boatestcase.BoaTestCase):
         list_.insert(pos, value)
         self.assertEqual(list_, result)
 
+        list_ = [1, 2, 3]
+        pos = 4
+        value = '4'
+        result, _ = await self.call('Main', [list_, pos, value], return_type=list)
+        list_.insert(pos, value)
+        self.assertEqual(list_, result)
+
+        list_ = [1, 2, 3]
+        pos = 99
+        value = '4'
+        result, _ = await self.call('Main', [list_, pos, value], return_type=list)
+        list_.insert(pos, value)
+        self.assertEqual(list_, result)
+
+        list_ = [1, 2, 3]
+        pos = -1
+        value = 'zero'
+        result, _ = await self.call('Main', [list_, pos, value], return_type=list)
+        list_.insert(pos, value)
+        self.assertEqual(list_, result)
+
+        list_ = [1, 2, 3]
+        pos = -3
+        value = 'zero'
+        result, _ = await self.call('Main', [list_, pos, value], return_type=list)
+        list_.insert(pos, value)
+        self.assertEqual(list_, result)
+
+        list_ = [1, 2, 3]
+        pos = -4
+        value = 'zero'
+        result, _ = await self.call('Main', [list_, pos, value], return_type=list)
+        list_.insert(pos, value)
+        self.assertEqual(list_, result)
+
+        list_ = [1, 2, 3]
+        pos = -99
+        value = 'zero'
+        result, _ = await self.call('Main', [list_, pos, value], return_type=list)
+        list_.insert(pos, value)
+        self.assertEqual(list_, result)
+
     async def test_list_insert_int_negative_index(self):
         await self.set_up_contract('ListInsertIntNegativeIndex.py')
 
+        list_ = [1, 2, 3]
         result, _ = await self.call('Main', [], return_type=list)
-        self.assertEqual([1, 4, 2, 3], result)
+        list_.insert(-2, 4)
+        self.assertEqual(list_, result)
 
     async def test_list_insert_int_with_builtin(self):
         await self.set_up_contract('ListInsertIntWithBuiltin.py')
 
+        list_ = [1, 2, 3]
         result, _ = await self.call('Main', [], return_type=list)
-        self.assertEqual([1, 2, 4, 3], result)
+        list.insert(list_, 2, 4)
+        self.assertEqual(list_, result)
 
     # endregion
 


### PR DESCRIPTION
…ce length

**Related issue**
close #1288 

**Summary or solution description**
The `list.insert` function was not working properly if you used an index that didn't exist on the original list, e.g. `list_ = []; list_.insert(0, 1) # index 0 doesn't exist because list is empty`

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/8ff93e97868d4cb09cb938babec6d31f329dfa5d/boa3_test/test_sc/list_test/ListInsertEmptyList.py#L1-L9

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/8ff93e97868d4cb09cb938babec6d31f329dfa5d/boa3_test/tests/compiler_tests/test_list.py#L1371-L1386

https://github.com/CityOfZion/neo3-boa/blob/8ff93e97868d4cb09cb938babec6d31f329dfa5d/boa3_test/tests/compiler_tests/test_list.py#L1412-L1424

**Platform:**
 - OS: macOS 15.5 (24F74)
 - Python version: Python 3.12
