### PR TITLE
Add construtor for some Neo enum types

### DIFF
--- a/boa3/internal/model/builtin/interop/blockchain/vmstatetype.py
+++ b/boa3/internal/model/builtin/interop/blockchain/vmstatetype.py
@@ -1,7 +1,11 @@
 from typing import Any, Self
 
+from boa3.internal.model.builtin.method import IBuiltinMethod
+from boa3.internal.model.expression import IExpression
+from boa3.internal.model.method import Method
 from boa3.internal.model.symbol import ISymbol
 from boa3.internal.model.type.primitive.inttype import IntType
+from boa3.internal.model.variable import Variable
 from boa3.internal.neo3.vm import VMState
 
 
@@ -52,5 +56,32 @@ class VMStateType(IntType):
 
         return None
 
+    def constructor_method(self) -> Method | None:
+        if self._constructor is None:
+            self._constructor: Method = VMStateMethod(self)
+        return self._constructor
+
 
 _VMState = VMStateType()
+
+
+class VMStateMethod(IBuiltinMethod):
+
+    def __init__(self, return_type: VMStateType):
+        from boa3.internal.model.type.type import Type
+        identifier = '-VMState__init__'
+        args: dict[str, Variable] = {
+            'x': Variable(Type.int)
+        }
+        super().__init__(identifier, args, return_type=return_type)
+
+    def validate_parameters(self, *params: IExpression) -> bool:
+        return len(params) == 1
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> str | None:
+        return None

--- a/boa3/internal/model/builtin/interop/blockchain/witnessconditionenumtype.py
+++ b/boa3/internal/model/builtin/interop/blockchain/witnessconditionenumtype.py
@@ -1,7 +1,11 @@
 from typing import Any, Self
 
+from boa3.internal.model.builtin.method import IBuiltinMethod
+from boa3.internal.model.expression import IExpression
+from boa3.internal.model.method import Method
 from boa3.internal.model.symbol import ISymbol
 from boa3.internal.model.type.primitive.inttype import IntType
+from boa3.internal.model.variable import Variable
 from boa3.internal.neo3.network.payloads.verification import WitnessConditionType as WitnessCondition
 
 
@@ -52,5 +56,32 @@ class WitnessConditionType(IntType):
 
         return None
 
+    def constructor_method(self) -> Method | None:
+        if self._constructor is None:
+            self._constructor: Method = WitnessConditionEnumMethod(self)
+        return self._constructor
+
 
 _WitnessConditionType = WitnessConditionType()
+
+
+class WitnessConditionEnumMethod(IBuiltinMethod):
+
+    def __init__(self, return_type: WitnessConditionType):
+        from boa3.internal.model.type.type import Type
+        identifier = '-WitnessConditionType__init__'
+        args: dict[str, Variable] = {
+            'x': Variable(Type.int)
+        }
+        super().__init__(identifier, args, return_type=return_type)
+
+    def validate_parameters(self, *params: IExpression) -> bool:
+        return len(params) == 1
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> str | None:
+        return None

--- a/boa3/internal/model/builtin/interop/blockchain/witnessruleactiontype.py
+++ b/boa3/internal/model/builtin/interop/blockchain/witnessruleactiontype.py
@@ -1,7 +1,11 @@
 from typing import Any, Self
 
+from boa3.internal.model.builtin.method import IBuiltinMethod
+from boa3.internal.model.expression import IExpression
+from boa3.internal.model.method import Method
 from boa3.internal.model.symbol import ISymbol
 from boa3.internal.model.type.primitive.inttype import IntType
+from boa3.internal.model.variable import Variable
 from boa3.internal.neo3.network.payloads.verification import WitnessRuleAction
 
 
@@ -52,5 +56,32 @@ class WitnessRuleActionType(IntType):
 
         return None
 
+    def constructor_method(self) -> Method | None:
+        if self._constructor is None:
+            self._constructor: Method = WitnessRuleActionMethod(self)
+        return self._constructor
+
 
 _WitnessRuleAction = WitnessRuleActionType()
+
+
+class WitnessRuleActionMethod(IBuiltinMethod):
+
+    def __init__(self, return_type: WitnessRuleActionType):
+        from boa3.internal.model.type.type import Type
+        identifier = '-WitnessRuleAction__init__'
+        args: dict[str, Variable] = {
+            'x': Variable(Type.int)
+        }
+        super().__init__(identifier, args, return_type=return_type)
+
+    def validate_parameters(self, *params: IExpression) -> bool:
+        return len(params) == 1
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> str | None:
+        return None

--- a/boa3/internal/model/builtin/interop/blockchain/witnessscopeenumtype.py
+++ b/boa3/internal/model/builtin/interop/blockchain/witnessscopeenumtype.py
@@ -1,7 +1,11 @@
 from typing import Any, Self
 
+from boa3.internal.model.builtin.method import IBuiltinMethod
+from boa3.internal.model.expression import IExpression
+from boa3.internal.model.method import Method
 from boa3.internal.model.symbol import ISymbol
 from boa3.internal.model.type.primitive.inttype import IntType
+from boa3.internal.model.variable import Variable
 from boa3.internal.neo3.network.payloads.verification import WitnessScope
 
 
@@ -52,5 +56,32 @@ class WitnessScopeType(IntType):
 
         return None
 
+    def constructor_method(self) -> Method | None:
+        if self._constructor is None:
+            self._constructor: Method = WitnessScopeMethod(self)
+        return self._constructor
+
 
 _WitnessScope = WitnessScopeType()
+
+
+class WitnessScopeMethod(IBuiltinMethod):
+
+    def __init__(self, return_type: WitnessScopeType):
+        from boa3.internal.model.type.type import Type
+        identifier = '-WitnessScope__init__'
+        args: dict[str, Variable] = {
+            'x': Variable(Type.int)
+        }
+        super().__init__(identifier, args, return_type=return_type)
+
+    def validate_parameters(self, *params: IExpression) -> bool:
+        return len(params) == 1
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> str | None:
+        return None

--- a/boa3/internal/model/builtin/interop/contract/callflagstype.py
+++ b/boa3/internal/model/builtin/interop/contract/callflagstype.py
@@ -1,8 +1,12 @@
 from typing import Any
 
+from boa3.internal.model.builtin.method import IBuiltinMethod
+from boa3.internal.model.expression import IExpression
+from boa3.internal.model.method import Method
 from boa3.internal.model.symbol import ISymbol
 from boa3.internal.model.type.itype import IType
 from boa3.internal.model.type.primitive.inttype import IntType
+from boa3.internal.model.variable import Variable
 from boa3.internal.neo3.contracts import CallFlags
 
 
@@ -53,5 +57,32 @@ class CallFlagsType(IntType):
 
         return None
 
+    def constructor_method(self) -> Method | None:
+        if self._constructor is None:
+            self._constructor: Method = CallFlagsMethod(self)
+        return self._constructor
+
 
 _CallFlags = CallFlagsType()
+
+
+class CallFlagsMethod(IBuiltinMethod):
+
+    def __init__(self, return_type: CallFlagsType):
+        from boa3.internal.model.type.type import Type
+        identifier = '-CallFlags__init__'
+        args: dict[str, Variable] = {
+            'x': Variable(Type.int)
+        }
+        super().__init__(identifier, args, return_type=return_type)
+
+    def validate_parameters(self, *params: IExpression) -> bool:
+        return len(params) == 1
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> str | None:
+        return None

--- a/boa3/internal/model/builtin/interop/contract/contractmanifest/contractparametertype.py
+++ b/boa3/internal/model/builtin/interop/contract/contractmanifest/contractparametertype.py
@@ -1,8 +1,12 @@
 from typing import Any
 
+from boa3.internal.model.builtin.method import IBuiltinMethod
+from boa3.internal.model.expression import IExpression
+from boa3.internal.model.method import Method
 from boa3.internal.model.symbol import ISymbol
 from boa3.internal.model.type.itype import IType
 from boa3.internal.model.type.primitive.inttype import IntType
+from boa3.internal.model.variable import Variable
 
 
 class ContractParameterType(IntType):
@@ -57,5 +61,32 @@ class ContractParameterType(IntType):
 
         return None
 
+    def constructor_method(self) -> Method | None:
+        if self._constructor is None:
+            self._constructor: Method = ContractParameterTypeMethod(self)
+        return self._constructor
+
 
 _ContractParameterType = ContractParameterType()
+
+
+class ContractParameterTypeMethod(IBuiltinMethod):
+
+    def __init__(self, return_type: ContractParameterType):
+        from boa3.internal.model.type.type import Type
+        identifier = '-ContractParameterType__init__'
+        args: dict[str, Variable] = {
+            'x': Variable(Type.int)
+        }
+        super().__init__(identifier, args, return_type=return_type)
+
+    def validate_parameters(self, *params: IExpression) -> bool:
+        return len(params) == 1
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> str | None:
+        return None

--- a/boa3/internal/model/builtin/interop/crypto/namedcurvehashtype.py
+++ b/boa3/internal/model/builtin/interop/crypto/namedcurvehashtype.py
@@ -1,8 +1,12 @@
 from typing import Any
 
+from boa3.internal.model.builtin.method import IBuiltinMethod
+from boa3.internal.model.expression import IExpression
+from boa3.internal.model.method import Method
 from boa3.internal.model.symbol import ISymbol
 from boa3.internal.model.type.itype import IType
 from boa3.internal.model.type.primitive.inttype import IntType
+from boa3.internal.model.variable import Variable
 from boa3.internal.neo3.contracts.namedcurvehash import NamedCurveHash
 
 
@@ -49,5 +53,32 @@ class NamedCurveHashType(IntType):
 
         return None
 
+    def constructor_method(self) -> Method | None:
+        if self._constructor is None:
+            self._constructor: Method = NamedCurveHashMethod(self)
+        return self._constructor
+
 
 _NamedCurve = NamedCurveHashType()
+
+
+class NamedCurveHashMethod(IBuiltinMethod):
+
+    def __init__(self, return_type: NamedCurveHashType):
+        from boa3.internal.model.type.type import Type
+        identifier = '-NamedCurveHash__init__'
+        args: dict[str, Variable] = {
+            'x': Variable(Type.int)
+        }
+        super().__init__(identifier, args, return_type=return_type)
+
+    def validate_parameters(self, *params: IExpression) -> bool:
+        return len(params) == 1
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> str | None:
+        return None

--- a/boa3/internal/model/builtin/interop/oracle/oracleresponsecodetype.py
+++ b/boa3/internal/model/builtin/interop/oracle/oracleresponsecodetype.py
@@ -1,8 +1,12 @@
 from typing import Any
 
+from boa3.internal.model.builtin.method import IBuiltinMethod
+from boa3.internal.model.expression import IExpression
+from boa3.internal.model.method import Method
 from boa3.internal.model.symbol import ISymbol
 from boa3.internal.model.type.itype import IType
 from boa3.internal.model.type.primitive.inttype import IntType
+from boa3.internal.model.variable import Variable
 from boa3.internal.neo3.contracts.native import Role
 from boa3.internal.neo3.network.payloads import OracleResponseCode
 
@@ -50,5 +54,32 @@ class OracleResponseCodeType(IntType):
 
         return None
 
+    def constructor_method(self) -> Method | None:
+        if self._constructor is None:
+            self._constructor: Method = OracleResponseCodeMethod(self)
+        return self._constructor
+
 
 _OracleResponseCode = OracleResponseCodeType()
+
+
+class OracleResponseCodeMethod(IBuiltinMethod):
+
+    def __init__(self, return_type: OracleResponseCodeType):
+        from boa3.internal.model.type.type import Type
+        identifier = '-OracleResponseCode__init__'
+        args: dict[str, Variable] = {
+            'x': Variable(Type.int)
+        }
+        super().__init__(identifier, args, return_type=return_type)
+
+    def validate_parameters(self, *params: IExpression) -> bool:
+        return len(params) == 1
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> str | None:
+        return None

--- a/boa3/internal/model/builtin/interop/policy/transactionattributetype.py
+++ b/boa3/internal/model/builtin/interop/policy/transactionattributetype.py
@@ -1,9 +1,14 @@
 from typing import Any
 
+from boa3.internal.model.builtin.method import IBuiltinMethod
+from boa3.internal.model.expression import IExpression
+from boa3.internal.model.method import Method
 from boa3.internal.model.symbol import ISymbol
 from boa3.internal.model.type.itype import IType
 from boa3.internal.model.type.primitive.inttype import IntType
-from boa3.internal.neo3.network.payloads.transactionattributetype import TransactionAttributeType as TransactionAttribute
+from boa3.internal.model.variable import Variable
+from boa3.internal.neo3.network.payloads.transactionattributetype import \
+    TransactionAttributeType as TransactionAttribute
 
 
 class TransactionAttributeType(IntType):
@@ -48,4 +53,31 @@ class TransactionAttributeType(IntType):
         if symbol_id in self.symbols:
             return TransactionAttribute.__members__[symbol_id]
 
+        return None
+
+    def constructor_method(self) -> Method | None:
+        if self._constructor is None:
+            self._constructor: Method = TransactionAttributeMethod(self)
+        return self._constructor
+
+
+class TransactionAttributeMethod(IBuiltinMethod):
+
+    def __init__(self, return_type: TransactionAttributeType):
+        from boa3.internal.model.type.type import Type
+        identifier = '-TransactionAttributeType__init__'
+        args: dict[str, Variable] = {
+            'x': Variable(Type.int)
+        }
+        super().__init__(identifier, args, return_type=return_type)
+
+    def validate_parameters(self, *params: IExpression) -> bool:
+        return len(params) == 1
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> str | None:
         return None

--- a/boa3/internal/model/builtin/interop/role/roletype.py
+++ b/boa3/internal/model/builtin/interop/role/roletype.py
@@ -1,8 +1,12 @@
 from typing import Any
 
+from boa3.internal.model.builtin.method import IBuiltinMethod
+from boa3.internal.model.expression import IExpression
+from boa3.internal.model.method import Method
 from boa3.internal.model.symbol import ISymbol
 from boa3.internal.model.type.itype import IType
 from boa3.internal.model.type.primitive.inttype import IntType
+from boa3.internal.model.variable import Variable
 from boa3.internal.neo3.contracts.native import Role
 
 
@@ -49,5 +53,32 @@ class RoleType(IntType):
 
         return None
 
+    def constructor_method(self) -> Method | None:
+        if self._constructor is None:
+            self._constructor: Method = RoleMethod(self)
+        return self._constructor
+
 
 _Role = RoleType()
+
+
+class RoleMethod(IBuiltinMethod):
+
+    def __init__(self, return_type: RoleType):
+        from boa3.internal.model.type.type import Type
+        identifier = '-Role__init__'
+        args: dict[str, Variable] = {
+            'x': Variable(Type.int)
+        }
+        super().__init__(identifier, args, return_type=return_type)
+
+    def validate_parameters(self, *params: IExpression) -> bool:
+        return len(params) == 1
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> str | None:
+        return None

--- a/boa3/internal/model/builtin/interop/runtime/triggertype.py
+++ b/boa3/internal/model/builtin/interop/runtime/triggertype.py
@@ -1,8 +1,12 @@
 from typing import Any
 
+from boa3.internal.model.builtin.method import IBuiltinMethod
+from boa3.internal.model.expression import IExpression
+from boa3.internal.model.method import Method
 from boa3.internal.model.symbol import ISymbol
 from boa3.internal.model.type.itype import IType
 from boa3.internal.model.type.primitive.inttype import IntType
+from boa3.internal.model.variable import Variable
 from boa3.internal.neo3.contracts import TriggerType as Trigger
 
 
@@ -52,4 +56,30 @@ class TriggerType(IntType):
         if symbol_id in self.symbols:
             return Trigger.__members__[symbol_id]
 
+        return None
+
+    def constructor_method(self) -> Method | None:
+        if self._constructor is None:
+            self._constructor: Method = TriggerTypeMethod(self)
+        return self._constructor
+
+class TriggerTypeMethod(IBuiltinMethod):
+
+    def __init__(self, return_type: TriggerType):
+        from boa3.internal.model.type.type import Type
+        identifier = '-TriggerType__init__'
+        args: dict[str, Variable] = {
+            'x': Variable(Type.int)
+        }
+        super().__init__(identifier, args, return_type=return_type)
+
+    def validate_parameters(self, *params: IExpression) -> bool:
+        return len(params) == 1
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> str | None:
         return None

--- a/boa3/internal/model/builtin/interop/storage/findoptionstype.py
+++ b/boa3/internal/model/builtin/interop/storage/findoptionstype.py
@@ -1,8 +1,12 @@
 from typing import Any
 
+from boa3.internal.model.builtin.method import IBuiltinMethod
+from boa3.internal.model.expression import IExpression
+from boa3.internal.model.method import Method
 from boa3.internal.model.symbol import ISymbol
 from boa3.internal.model.type.itype import IType
 from boa3.internal.model.type.primitive.inttype import IntType
+from boa3.internal.model.variable import Variable
 from boa3.internal.neo3.contracts.findoptions import FindOptions
 
 
@@ -52,4 +56,34 @@ class FindOptionsType(IntType):
         if symbol_id in self.symbols and symbol_id in FindOptions.__members__:
             return FindOptions.__members__[symbol_id]
 
+        return None
+
+    def constructor_method(self) -> Method | None:
+        if self._constructor is None:
+            self._constructor: Method = FindOptionsMethod(self)
+        return self._constructor
+
+
+class FindOptionsMethod(IBuiltinMethod):
+
+    def __init__(self, return_type: FindOptionsType):
+        from boa3.internal.model.type.type import Type
+        identifier = '-FindOptions__init__'
+        args: dict[str, Variable] = {
+            'x': Variable(Type.int)
+        }
+        super().__init__(identifier, args, return_type=return_type)
+
+    def validate_parameters(self, *params: IExpression) -> bool:
+        return len(params) == 1
+
+    def generate_internal_opcodes(self, code_generator):
+        pass
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> str | None:
         return None

--- a/boa3/internal/model/type/neo/opcodetype.py
+++ b/boa3/internal/model/type/neo/opcodetype.py
@@ -1,8 +1,12 @@
 from typing import Any
 
+from boa3.internal.model.builtin.method import IBuiltinMethod
+from boa3.internal.model.expression import IExpression
+from boa3.internal.model.method import Method
 from boa3.internal.model.symbol import ISymbol
 from boa3.internal.model.type.itype import IType
 from boa3.internal.model.type.primitive.bytestype import BytesType
+from boa3.internal.model.variable import Variable
 
 
 class OpcodeType(BytesType):
@@ -56,5 +60,32 @@ class OpcodeType(BytesType):
 
         return None
 
+    def constructor_method(self) -> Method | None:
+        if self._constructor is None:
+            self._constructor: Method = OpcodeMethod(self)
+        return self._constructor
+
 
 _Opcode = OpcodeType()
+
+
+class OpcodeMethod(IBuiltinMethod):
+
+    def __init__(self, return_type: OpcodeType):
+        from boa3.internal.model.type.type import Type
+        identifier = '-Opcode__init__'
+        args: dict[str, Variable] = {
+            'x': Variable(Type.bytes)
+        }
+        super().__init__(identifier, args, return_type=return_type)
+
+    def validate_parameters(self, *params: IExpression) -> bool:
+        return len(params) == 1
+
+    @property
+    def _args_on_stack(self) -> int:
+        return len(self.args)
+
+    @property
+    def _body(self) -> str | None:
+        return None

--- a/boa3_test/test_sc/interop_test/runtime/TriggerTypeInstantiate.py
+++ b/boa3_test/test_sc/interop_test/runtime/TriggerTypeInstantiate.py
@@ -1,0 +1,7 @@
+from boa3.sc.compiletime import public
+from boa3.sc.types import TriggerType
+
+
+@public
+def main(x: int) -> TriggerType:
+    return TriggerType(x)

--- a/boa3_test/test_sc/interop_test/storage/FindOptionsInstantiate.py
+++ b/boa3_test/test_sc/interop_test/storage/FindOptionsInstantiate.py
@@ -1,0 +1,7 @@
+from boa3.sc.compiletime import public
+from boa3.sc.types import FindOptions
+
+
+@public
+def main(x: int) -> FindOptions:
+    return FindOptions(x)

--- a/boa3_test/test_sc/native_test/cryptolib/NamedCurveHashInstantiate.py
+++ b/boa3_test/test_sc/native_test/cryptolib/NamedCurveHashInstantiate.py
@@ -1,0 +1,8 @@
+from boa3.sc.compiletime import public
+from boa3.sc.types import NamedCurveHash
+
+
+@public
+def main(x: int) -> NamedCurveHash:
+    curve = NamedCurveHash(x)
+    return curve

--- a/boa3_test/test_sc/native_test/oracle/OracleResponseCodeInstantiate.py
+++ b/boa3_test/test_sc/native_test/oracle/OracleResponseCodeInstantiate.py
@@ -1,0 +1,7 @@
+from boa3.sc.compiletime import public
+from boa3.sc.types import OracleResponseCode
+
+
+@public
+def main(x: int) -> OracleResponseCode:
+    return OracleResponseCode(x)

--- a/boa3_test/test_sc/native_test/policy/TransactionAttributeTypeInstantiate.py
+++ b/boa3_test/test_sc/native_test/policy/TransactionAttributeTypeInstantiate.py
@@ -1,0 +1,7 @@
+from boa3.sc.compiletime import public
+from boa3.sc.types import TransactionAttributeType
+
+
+@public
+def main(x: int) -> TransactionAttributeType:
+    return TransactionAttributeType(x)

--- a/boa3_test/test_sc/native_test/rolemanagement/RoleInstantiate.py
+++ b/boa3_test/test_sc/native_test/rolemanagement/RoleInstantiate.py
@@ -1,0 +1,7 @@
+from boa3.sc.compiletime import public
+from boa3.sc.types import Role
+
+
+@public
+def main(x: int) -> Role:
+    return Role(x)

--- a/boa3_test/test_sc/neo_type_test/CallFlagsInstantiate.py
+++ b/boa3_test/test_sc/neo_type_test/CallFlagsInstantiate.py
@@ -1,0 +1,7 @@
+from boa3.sc.compiletime import public
+from boa3.sc.types import CallFlags
+
+
+@public
+def main(x: int) -> CallFlags:
+    return CallFlags(x)

--- a/boa3_test/test_sc/neo_type_test/ContractParameterTypeInstantiate.py
+++ b/boa3_test/test_sc/neo_type_test/ContractParameterTypeInstantiate.py
@@ -1,0 +1,7 @@
+from boa3.sc.compiletime import public
+from boa3.sc.types import ContractParameterType
+
+
+@public
+def main(x: int) -> ContractParameterType:
+    return ContractParameterType(x)

--- a/boa3_test/test_sc/neo_type_test/VMStateInstantiate.py
+++ b/boa3_test/test_sc/neo_type_test/VMStateInstantiate.py
@@ -1,0 +1,7 @@
+from boa3.sc.compiletime import public
+from boa3.sc.types import VMState
+
+
+@public
+def main(x: int) -> VMState:
+    return VMState(x)

--- a/boa3_test/test_sc/neo_type_test/opcode/OpcodeInstantiate.py
+++ b/boa3_test/test_sc/neo_type_test/opcode/OpcodeInstantiate.py
@@ -1,0 +1,7 @@
+from boa3.sc.compiletime import public
+from boa3.sc.types import Opcode
+
+
+@public
+def main(opcode: bytes) -> Opcode:
+    return Opcode(opcode)

--- a/boa3_test/test_sc/neo_type_test/witness/WitnessConditionTypeInstantiate.py
+++ b/boa3_test/test_sc/neo_type_test/witness/WitnessConditionTypeInstantiate.py
@@ -1,0 +1,7 @@
+from boa3.sc.compiletime import public
+from boa3.sc.types import WitnessConditionType
+
+
+@public
+def main(x: int) -> WitnessConditionType:
+    return WitnessConditionType(x)

--- a/boa3_test/test_sc/neo_type_test/witness/WitnessRuleActionInstantiate.py
+++ b/boa3_test/test_sc/neo_type_test/witness/WitnessRuleActionInstantiate.py
@@ -1,0 +1,7 @@
+from boa3.sc.compiletime import public
+from boa3.sc.types import WitnessRuleAction
+
+
+@public
+def main(x: int) -> WitnessRuleAction:
+    return WitnessRuleAction(x)

--- a/boa3_test/test_sc/neo_type_test/witness/WitnessScopeInstantiate.py
+++ b/boa3_test/test_sc/neo_type_test/witness/WitnessScopeInstantiate.py
@@ -1,0 +1,7 @@
+from boa3.sc.compiletime import public
+from boa3.sc.types import WitnessScope
+
+
+@public
+def main(x: int) -> WitnessScope:
+    return WitnessScope(x)

--- a/boa3_test/tests/compiler_tests/test_interop/test_runtime.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_runtime.py
@@ -957,3 +957,24 @@ class TestRuntimeInterop(boatestcase.BoaTestCase):
         )
         result, _ = await self.call('compare_scope', [verification.WitnessScope.GLOBAL], return_type=bool, signers=[signer])
         self.assertEqual(True, result)
+
+    async def test_trigger_type_instantiate(self):
+        await self.set_up_contract('TriggerTypeInstantiate.py')
+
+        result, _ = await self.call('main', [TriggerType.ON_PERSIST], return_type=int)
+        self.assertEqual(TriggerType.ON_PERSIST, result)
+
+        result, _ = await self.call('main', [TriggerType.POST_PERSIST], return_type=int)
+        self.assertEqual(TriggerType.POST_PERSIST, result)
+
+        result, _ = await self.call('main', [TriggerType.SYSTEM], return_type=int)
+        self.assertEqual(TriggerType.SYSTEM, result)
+
+        result, _ = await self.call('main', [TriggerType.VERIFICATION], return_type=int)
+        self.assertEqual(TriggerType.VERIFICATION, result)
+
+        result, _ = await self.call('main', [TriggerType.APPLICATION], return_type=int)
+        self.assertEqual(TriggerType.APPLICATION, result)
+
+        result, _ = await self.call('main', [TriggerType.ALL], return_type=int)
+        self.assertEqual(TriggerType.ALL, result)

--- a/boa3_test/tests/compiler_tests/test_interop/test_storage.py
+++ b/boa3_test/tests/compiler_tests/test_interop/test_storage.py
@@ -853,3 +853,34 @@ class TestStorageInterop(boatestcase.BoaTestCase):
 
     def test_find_options_mismatched_type(self):
         self.assertCompilerLogs(CompilerError.MismatchedTypes, 'FindOptionsMismatchedType.py')
+
+    async def test_find_options_instantiate(self):
+        await self.set_up_contract('FindOptionsInstantiate.py')
+
+        result, _ = await self.call('main', [FindOptions.NONE], return_type=int)
+        self.assertEqual(FindOptions.NONE, result)
+
+        result, _ = await self.call('main', [FindOptions.KEYS_ONLY], return_type=int)
+        self.assertEqual(FindOptions.KEYS_ONLY, result)
+
+        result, _ = await self.call('main', [FindOptions.REMOVE_PREFIX], return_type=int)
+        self.assertEqual(FindOptions.REMOVE_PREFIX, result)
+
+        result, _ = await self.call('main', [FindOptions.VALUES_ONLY], return_type=int)
+        self.assertEqual(FindOptions.VALUES_ONLY, result)
+
+        result, _ = await self.call('main', [FindOptions.DESERIALIZE_VALUES], return_type=int)
+        self.assertEqual(FindOptions.DESERIALIZE_VALUES, result)
+
+        result, _ = await self.call('main', [FindOptions.PICK_FIELD_0], return_type=int)
+        self.assertEqual(FindOptions.PICK_FIELD_0, result)
+
+        result, _ = await self.call('main', [FindOptions.PICK_FIELD_1], return_type=int)
+        self.assertEqual(FindOptions.PICK_FIELD_1, result)
+
+        result, _ = await self.call('main', [FindOptions.BACKWARDS], return_type=int)
+        self.assertEqual(FindOptions.BACKWARDS, result)
+
+        result, _ = await self.call('main', [FindOptions.KEYS_ONLY | FindOptions.REMOVE_PREFIX], return_type=int)
+        self.assertEqual(FindOptions.KEYS_ONLY | FindOptions.REMOVE_PREFIX, result)
+

--- a/boa3_test/tests/compiler_tests/test_native/test_cryptolib.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_cryptolib.py
@@ -371,3 +371,18 @@ class TestCryptoLibClass(boatestcase.BoaTestCase):
 
     def test_bls12_381_serialize_mismatched_type(self):
         self.assertCompilerLogs(CompilerError.MismatchedTypes, 'Bls12381SerializeMismatchedType.py')
+
+    async def test_get_named_curve_hash(self):
+        await self.set_up_contract('NamedCurveHashInstantiate.py')
+
+        result, _ = await self.call('main', [NamedCurveHash.SECP256K1SHA256], return_type=int)
+        self.assertEqual(NamedCurveHash.SECP256K1SHA256, result)
+
+        result, _ = await self.call('main', [NamedCurveHash.SECP256R1SHA256], return_type=int)
+        self.assertEqual(NamedCurveHash.SECP256R1SHA256, result)
+
+        result, _ = await self.call('main', [NamedCurveHash.SECP256K1KECCAK256], return_type=int)
+        self.assertEqual(NamedCurveHash.SECP256K1KECCAK256, result)
+
+        result, _ = await self.call('main', [NamedCurveHash.SECP256R1KECCAK256], return_type=int)
+        self.assertEqual(NamedCurveHash.SECP256R1KECCAK256, result)

--- a/boa3_test/tests/compiler_tests/test_native/test_oracle.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_oracle.py
@@ -9,6 +9,7 @@ from neo3.wallet import account
 from boa3.internal import constants
 from boa3.internal.exception import CompilerError, CompilerWarning
 from boa3.internal.neo.vm.opcode.Opcode import Opcode
+from boa3.internal.neo3.network.payloads import OracleResponseCode
 from boa3_test.tests import boatestcase
 
 
@@ -415,3 +416,36 @@ class TestNativeContracts(boatestcase.BoaTestCase):
 
         result, _ = await self.call('main', [], return_type=int)
         self.assertGreater(result, 0)
+
+    async def test_oracle_response_code_instantiate(self):
+        await self.set_up_contract('OracleResponseCodeInstantiate.py')
+
+        result, _ = await self.call('main', [OracleResponseCode.SUCCESS], return_type=int)
+        self.assertEqual(OracleResponseCode.SUCCESS, result)
+
+        result, _ = await self.call('main', [OracleResponseCode.PROTOCOL_NOT_SUPPORTED], return_type=int)
+        self.assertEqual(OracleResponseCode.PROTOCOL_NOT_SUPPORTED, result)
+
+        result, _ = await self.call('main', [OracleResponseCode.CONSENSUS_UNREACHABLE], return_type=int)
+        self.assertEqual(OracleResponseCode.CONSENSUS_UNREACHABLE, result)
+
+        result, _ = await self.call('main', [OracleResponseCode.NOT_FOUND], return_type=int)
+        self.assertEqual(OracleResponseCode.NOT_FOUND, result)
+
+        result, _ = await self.call('main', [OracleResponseCode.TIME_OUT], return_type=int)
+        self.assertEqual(OracleResponseCode.TIME_OUT, result)
+
+        result, _ = await self.call('main', [OracleResponseCode.FORBIDDEN], return_type=int)
+        self.assertEqual(OracleResponseCode.FORBIDDEN, result)
+
+        result, _ = await self.call('main', [OracleResponseCode.RESPONSE_TOO_LARGE], return_type=int)
+        self.assertEqual(OracleResponseCode.RESPONSE_TOO_LARGE, result)
+
+        result, _ = await self.call('main', [OracleResponseCode.INSUFFICIENT_FUNDS], return_type=int)
+        self.assertEqual(OracleResponseCode.INSUFFICIENT_FUNDS, result)
+
+        result, _ = await self.call('main', [OracleResponseCode.CONTENT_TYPE_NOT_SUPPORTED], return_type=int)
+        self.assertEqual(OracleResponseCode.CONTENT_TYPE_NOT_SUPPORTED, result)
+
+        result, _ = await self.call('main', [OracleResponseCode.ERROR], return_type=int)
+        self.assertEqual(OracleResponseCode.ERROR, result)

--- a/boa3_test/tests/compiler_tests/test_native/test_policy.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_policy.py
@@ -121,3 +121,18 @@ class TestPolicyContract(boatestcase.BoaTestCase):
 
     def test_is_blocked_too_few_parameters(self):
         self.assertCompilerLogs(CompilerError.UnfilledArgument, 'IsBlockedTooFewArguments.py')
+
+    async def test_transaction_attribute_instantiate(self):
+        await self.set_up_contract('TransactionAttributeTypeInstantiate.py')
+
+        result, _ = await self.call('main', [TransactionAttributeType.HIGH_PRIORITY], return_type=int)
+        self.assertEqual(TransactionAttributeType.HIGH_PRIORITY, result)
+
+        result, _ = await self.call('main', [TransactionAttributeType.ORACLE_RESPONSE], return_type=int)
+        self.assertEqual(TransactionAttributeType.ORACLE_RESPONSE, result)
+
+        result, _ = await self.call('main', [TransactionAttributeType.NOT_VALID_BEFORE], return_type=int)
+        self.assertEqual(TransactionAttributeType.NOT_VALID_BEFORE, result)
+
+        result, _ = await self.call('main', [TransactionAttributeType.CONFLICTS], return_type=int)
+        self.assertEqual(TransactionAttributeType.CONFLICTS, result)

--- a/boa3_test/tests/compiler_tests/test_native/test_rolemanagement.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_rolemanagement.py
@@ -3,6 +3,7 @@ from neo3.core import types
 from boa3.internal import constants
 from boa3.internal.exception import CompilerError, CompilerWarning
 from boa3.internal.neo.vm.opcode.Opcode import Opcode
+from boa3.internal.neo3.contracts.native import Role
 from boa3_test.tests import boatestcase
 
 
@@ -41,3 +42,15 @@ class TestRoleManagementClass(boatestcase.BoaTestCase):
 
     def test_get_designated_by_role_too_few_parameters(self):
         self.assertCompilerLogs(CompilerError.UnfilledArgument, 'GetDesignatedByRoleTooFewArguments.py')
+
+    async def test_role_instantiate(self):
+        await self.set_up_contract('RoleInstantiate.py')
+
+        result, _ = await self.call('main', [Role.STATE_VALIDATOR], return_type=int)
+        self.assertEqual(Role.STATE_VALIDATOR, result)
+
+        result, _ = await self.call('main', [Role.ORACLE], return_type=int)
+        self.assertEqual(Role.ORACLE, result)
+
+        result, _ = await self.call('main', [Role.NEO_FS_ALPHABET_NODE], return_type=int)
+        self.assertEqual(Role.NEO_FS_ALPHABET_NODE, result)

--- a/boa3_test/tests/compiler_tests/test_neo_types.py
+++ b/boa3_test/tests/compiler_tests/test_neo_types.py
@@ -1,7 +1,11 @@
 from neo3.core import cryptography, types
 
 from boa3.internal.exception import CompilerError, CompilerWarning
+from boa3.internal.neo.vm.type.ContractParameterType import ContractParameterType
 from boa3.internal.neo.vm.type.Integer import Integer
+from boa3.internal.neo3.contracts import CallFlags
+from boa3.internal.neo3.network.payloads.verification import WitnessScope, WitnessRuleAction, WitnessConditionType
+from boa3.internal.neo3.vm import VMState
 from boa3_test.tests import boatestcase
 
 
@@ -313,6 +317,13 @@ class TestNeoTypes(boatestcase.BoaTestCase):
         result, _ = await self.call('opcode_mult', [multiplier], return_type=bytes)
         self.assertEqual(Opcode.NOP * multiplier, result)
 
+    async def test_opcode_instantiate(self):
+        from boa3.internal.neo.vm.opcode.Opcode import Opcode
+        await self.set_up_contract('opcode', 'OpcodeInstantiate.py')
+
+        result, _ = await self.call('main', [Opcode.AND], return_type=bytes)
+        self.assertEqual(Opcode.AND, result)
+
     # endregion
 
     # region IsInstance Neo Types
@@ -470,5 +481,165 @@ class TestNeoTypes(boatestcase.BoaTestCase):
 
         result, _ = await self.call('is_ecpoint', [42], return_type=bool)
         self.assertEqual(False, result)
+
+    # endregion
+
+    # region Witness
+
+    async def test_witness_scope_instantiate(self):
+        await self.set_up_contract('witness', 'WitnessScopeInstantiate.py')
+
+        result, _ = await self.call('main', [WitnessScope.NONE], return_type=int)
+        self.assertEqual(WitnessScope.NONE, result)
+
+        result, _ = await self.call('main', [WitnessScope.CALLED_BY_ENTRY], return_type=int)
+        self.assertEqual(WitnessScope.CALLED_BY_ENTRY, result)
+
+        result, _ = await self.call('main', [WitnessScope.CUSTOM_CONTRACTS], return_type=int)
+        self.assertEqual(WitnessScope.CUSTOM_CONTRACTS, result)
+
+        result, _ = await self.call('main', [WitnessScope.CUSTOM_GROUPS], return_type=int)
+        self.assertEqual(WitnessScope.CUSTOM_GROUPS, result)
+
+        result, _ = await self.call('main', [WitnessScope.WITNESS_RULES], return_type=int)
+        self.assertEqual(WitnessScope.WITNESS_RULES, result)
+
+        result, _ = await self.call('main', [WitnessScope.GLOBAL], return_type=int)
+        self.assertEqual(WitnessScope.GLOBAL, result)
+
+    async def test_witness_rule_action_instantiate(self):
+        await self.set_up_contract('witness', 'WitnessRuleActionInstantiate.py')
+
+        result, _ = await self.call('main', [WitnessRuleAction.DENY], return_type=int)
+        self.assertEqual(WitnessRuleAction.DENY, result)
+
+        result, _ = await self.call('main', [WitnessRuleAction.ALLOW], return_type=int)
+        self.assertEqual(WitnessRuleAction.ALLOW, result)
+
+    async def test_witness_condition_type_action_instantiate(self):
+        await self.set_up_contract('witness', 'WitnessConditionTypeInstantiate.py')
+
+        result, _ = await self.call('main', [WitnessConditionType.BOOLEAN], return_type=int)
+        self.assertEqual(WitnessConditionType.BOOLEAN, result)
+
+        result, _ = await self.call('main', [WitnessConditionType.NOT], return_type=int)
+        self.assertEqual(WitnessConditionType.NOT, result)
+
+        result, _ = await self.call('main', [WitnessConditionType.AND], return_type=int)
+        self.assertEqual(WitnessConditionType.AND, result)
+
+        result, _ = await self.call('main', [WitnessConditionType.OR], return_type=int)
+        self.assertEqual(WitnessConditionType.OR, result)
+
+        result, _ = await self.call('main', [WitnessConditionType.SCRIPT_HASH], return_type=int)
+        self.assertEqual(WitnessConditionType.SCRIPT_HASH, result)
+
+        result, _ = await self.call('main', [WitnessConditionType.GROUP], return_type=int)
+        self.assertEqual(WitnessConditionType.GROUP, result)
+
+        result, _ = await self.call('main', [WitnessConditionType.CALLED_BY_ENTRY], return_type=int)
+        self.assertEqual(WitnessConditionType.CALLED_BY_ENTRY, result)
+
+        result, _ = await self.call('main', [WitnessConditionType.CALLED_BY_CONTRACT], return_type=int)
+        self.assertEqual(WitnessConditionType.CALLED_BY_CONTRACT, result)
+
+        result, _ = await self.call('main', [WitnessConditionType.CALLED_BY_GROUP], return_type=int)
+        self.assertEqual(WitnessConditionType.CALLED_BY_GROUP, result)
+
+    # endregion
+
+    # region VMState
+
+    async def test_vm_state_instantiate(self):
+        await self.set_up_contract('VMStateInstantiate.py')
+
+        result, _ = await self.call('main', [VMState.NONE], return_type=int)
+        self.assertEqual(VMState.NONE, result)
+
+        result, _ = await self.call('main', [VMState.HALT], return_type=int)
+        self.assertEqual(VMState.HALT, result)
+
+        result, _ = await self.call('main', [VMState.FAULT], return_type=int)
+        self.assertEqual(VMState.FAULT, result)
+
+        result, _ = await self.call('main', [VMState.BREAK], return_type=int)
+        self.assertEqual(VMState.BREAK, result)
+
+    # endregion
+
+    # region ContractParameterType
+
+    async def test_contract_parameter_type_instantiate(self):
+        await self.set_up_contract('ContractParameterTypeInstantiate.py')
+
+        result, _ = await self.call('main', [ContractParameterType.Any], return_type=int)
+        self.assertEqual(ContractParameterType.Any, result)
+
+        result, _ = await self.call('main', [ContractParameterType.Boolean], return_type=int)
+        self.assertEqual(ContractParameterType.Boolean, result)
+
+        result, _ = await self.call('main', [ContractParameterType.Integer], return_type=int)
+        self.assertEqual(ContractParameterType.Integer, result)
+
+        result, _ = await self.call('main', [ContractParameterType.ByteArray], return_type=int)
+        self.assertEqual(ContractParameterType.ByteArray, result)
+
+        result, _ = await self.call('main', [ContractParameterType.String], return_type=int)
+        self.assertEqual(ContractParameterType.String, result)
+
+        result, _ = await self.call('main', [ContractParameterType.Hash160], return_type=int)
+        self.assertEqual(ContractParameterType.Hash160, result)
+
+        result, _ = await self.call('main', [ContractParameterType.Hash256], return_type=int)
+        self.assertEqual(ContractParameterType.Hash256, result)
+
+        result, _ = await self.call('main', [ContractParameterType.PublicKey], return_type=int)
+        self.assertEqual(ContractParameterType.PublicKey, result)
+
+        result, _ = await self.call('main', [ContractParameterType.Signature], return_type=int)
+        self.assertEqual(ContractParameterType.Signature, result)
+
+        result, _ = await self.call('main', [ContractParameterType.Array], return_type=int)
+        self.assertEqual(ContractParameterType.Array, result)
+
+        result, _ = await self.call('main', [ContractParameterType.Map], return_type=int)
+        self.assertEqual(ContractParameterType.Map, result)
+
+        result, _ = await self.call('main', [ContractParameterType.InteropInterface], return_type=int)
+        self.assertEqual(ContractParameterType.InteropInterface, result)
+
+        result, _ = await self.call('main', [ContractParameterType.Void], return_type=int)
+        self.assertEqual(ContractParameterType.Void, result)
+
+    # endregion
+
+    # region CallFlags
+
+    async def test_call_flags_instantiate(self):
+        await self.set_up_contract('CallFlagsInstantiate.py')
+
+        result, _ = await self.call('main', [CallFlags.NONE], return_type=int)
+        self.assertEqual(CallFlags.NONE, result)
+
+        result, _ = await self.call('main', [CallFlags.READ_STATES], return_type=int)
+        self.assertEqual(CallFlags.READ_STATES, result)
+
+        result, _ = await self.call('main', [CallFlags.WRITE_STATES], return_type=int)
+        self.assertEqual(CallFlags.WRITE_STATES, result)
+
+        result, _ = await self.call('main', [CallFlags.ALLOW_CALL], return_type=int)
+        self.assertEqual(CallFlags.ALLOW_CALL, result)
+
+        result, _ = await self.call('main', [CallFlags.ALLOW_NOTIFY], return_type=int)
+        self.assertEqual(CallFlags.ALLOW_NOTIFY, result)
+
+        result, _ = await self.call('main', [CallFlags.STATES], return_type=int)
+        self.assertEqual(CallFlags.STATES, result)
+
+        result, _ = await self.call('main', [CallFlags.READ_ONLY], return_type=int)
+        self.assertEqual(CallFlags.READ_ONLY, result)
+
+        result, _ = await self.call('main', [CallFlags.ALL], return_type=int)
+        self.assertEqual(CallFlags.ALL, result)
 
     # endregion


### PR DESCRIPTION
**Related issue**
#1284

**Summary or solution description**
The Enum types on Neo3-boa didn't have a proper constructor, so they wouldn't know their types if they were initialized `NamedCurveHash(22) # this is considered just as an int, instead of a NamedCurveHash`

Classes changed:
- NamedCurveHash
- Opcode
- ContractParameterType
- TriggerType
- FindOptions
- Role
- OracleResponseCode
- TransactionAttributeType
- WitnessScope
- WitnessRuleAction
- WitnessConditionType
- VMState
- CallFlags

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/7b982e5d0a1da90d4a654c2997ee08c2edb8ad56/boa3_test/test_sc/native_test/cryptolib/NamedCurveHashInstantiate.py#L1-L8

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/7b982e5d0a1da90d4a654c2997ee08c2edb8ad56/boa3_test/tests/compiler_tests/test_native/test_cryptolib.py#L375-L388

**Platform:**
 - OS:  macOS 15.5 (24F74)
 - Python version: Python 3.12

