### PR TITLE
Allow exception be a valid function return

### DIFF
--- a/boa3/internal/analyser/typeanalyser.py
+++ b/boa3/internal/analyser/typeanalyser.py
@@ -331,7 +331,7 @@ class TypeAnalyser(IAstAnalyser, ast.NodeVisitor):
         else:
 
             has_else_stmt: bool = hasattr(node, 'orelse')
-            has_body_return: bool = any(isinstance(stmt, (ast.Return, ast.Pass)) for stmt in node.body)
+            has_body_return: bool = any(isinstance(stmt, (ast.Return, ast.Pass, ast.Raise)) for stmt in node.body)
             if has_body_return and not has_else_stmt:
                 # if any statement in the function body is a return, all flow has a return
                 return True

--- a/boa3_test/test_sc/function_test/ReturnException.py
+++ b/boa3_test/test_sc/function_test/ReturnException.py
@@ -1,0 +1,8 @@
+from boa3.sc.compiletime import public
+
+
+@public
+def main(x: int) -> bytes:
+    if x == 1:
+        return b'\x01'
+    raise Exception("x must be 1")

--- a/boa3_test/tests/compiler_tests/test_function.py
+++ b/boa3_test/tests/compiler_tests/test_function.py
@@ -1061,6 +1061,17 @@ class TestFunction(boatestcase.BoaTestCase):
         result, _ = await self.call('main', [[1, 2, 3]], return_type=int)
         self.assertEqual(3, result)
 
+    async def test_return_exception(self):
+        await self.set_up_contract('ReturnException.py')
+
+        result, _ = await self.call('main', [1], return_type=bytes)
+        self.assertEqual(b'\x01', result)
+
+        with self.assertRaises(boatestcase.FaultException) as context:
+            await self.call('main', [0], return_type=bytes)
+
+        self.assertRegex(str(context.exception), 'unhandled exception: "x must be 1"')
+
     async def test_call_function_with_same_name_in_different_scopes(self):
         await self.set_up_contract('CallFunctionsWithSameNameInDifferentScopes.py')
 


### PR DESCRIPTION
**Related issue**
close #1287 

**Summary or solution description**
It was not possible to compile a function that had a type hint return but returned an exception

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/c5ec874b80d1edc17c46b152345b7d0f2b6784b0/boa3_test/test_sc/function_test/ReturnException.py#L1-L8

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/c5ec874b80d1edc17c46b152345b7d0f2b6784b0/boa3_test/tests/compiler_tests/test_function.py#L1064-L1073

**Platform:**
 - OS: MacOS 15.5 (24F74)
 - Python version: 3.12
 
**(Optional) Additional context**
Ended up finding another error when working on this issue
