### PR TITLE
Fix error when classes with contract decorator are in the same file a…

### DIFF
--- a/boa3/internal/compiler/codegenerator/codegeneratorvisitor.py
+++ b/boa3/internal/compiler/codegenerator/codegeneratorvisitor.py
@@ -9,6 +9,7 @@ from boa3.internal.compiler.codegenerator.generatordata import GeneratorData
 from boa3.internal.compiler.codegenerator.variablegenerationdata import VariableGenerationData
 from boa3.internal.compiler.codegenerator.vmcodemapping import VMCodeMapping
 from boa3.internal.model.builtin.builtin import Builtin
+from boa3.internal.model.builtin.decorator import ContractDecorator
 from boa3.internal.model.builtin.method.builtinmethod import IBuiltinMethod
 from boa3.internal.model.expression import IExpression
 from boa3.internal.model.imports.package import Package
@@ -300,8 +301,9 @@ class VisitorCodeGenerator(IAstAnalyser):
 
             if self._is_generating_initialize:
                 address = self.generator.bytecode_size
-                self.generator.convert_new_empty_array(len(class_symbol.class_variables), class_symbol)
-                self.generator.convert_store_variable(node.name, address)
+                if not any([isinstance(decorator, ContractDecorator) for decorator in class_symbol.decorators]):
+                    self.generator.convert_new_empty_array(len(class_symbol.class_variables), class_symbol)
+                    self.generator.convert_store_variable(node.name, address)
             else:
                 init_method = class_symbol.constructor_method()
                 if isinstance(init_method, Method) and init_method.start_address is None:

--- a/boa3_test/test_sc/contract_interface_test/ContractInterfaceAndClassWithStaticVars.py
+++ b/boa3_test/test_sc/contract_interface_test/ContractInterfaceAndClassWithStaticVars.py
@@ -1,0 +1,24 @@
+from boa3.sc.compiletime import public
+
+
+@public
+def main() -> int:
+    return ExampleStaticVars.value1
+
+
+from boa3.builtin.compile_time import contract
+from boa3.builtin.type import UInt160
+
+
+@contract("0x0123456789abcdef0123456789abcdef01234567")
+class Example:
+    hash: UInt160
+
+    @staticmethod
+    def total() -> int:
+        pass
+
+
+class ExampleStaticVars:
+    value1 = 1
+    value2 = 2

--- a/boa3_test/test_sc/contract_interface_test/ContractInterfaceAndClassWithStaticVars.py
+++ b/boa3_test/test_sc/contract_interface_test/ContractInterfaceAndClassWithStaticVars.py
@@ -1,13 +1,6 @@
-from boa3.sc.compiletime import public
-
-
-@public
-def main() -> int:
-    return ExampleStaticVars.value1
-
-
 from boa3.builtin.compile_time import contract
 from boa3.builtin.type import UInt160
+from boa3.sc.compiletime import public
 
 
 @contract("0x0123456789abcdef0123456789abcdef01234567")
@@ -22,3 +15,8 @@ class Example:
 class ExampleStaticVars:
     value1 = 1
     value2 = 2
+
+
+@public
+def main() -> int:
+    return ExampleStaticVars.value1

--- a/boa3_test/tests/compiler_tests/test_contract_interface.py
+++ b/boa3_test/tests/compiler_tests/test_contract_interface.py
@@ -204,6 +204,14 @@ class TestContractInterface(boatestcase.BoaTestCase):
                        },
                       manifest['permissions'])
 
+    async def test_contract_interface_with_another_class_with_static_variables(self):
+        await self.set_up_contract('ContractInterfaceAndClassWithStaticVars.py',
+                                   compile_if_found=True, debug=True)
+
+        result, _ = await self.call('main', [], return_type=int)
+        self.assertEqual(1, result)
+
+
     async def test_get_hash_on_metadata_run(self):
         await self.set_up_contract('ContractInterfaceGetHashOnMetadata.py')
 


### PR DESCRIPTION
…s classes with static vars

**Summary or solution description**
An error where if you had a class that had the `contract` decorator in the same file as another class that had static variables, the `_initialize` method would be created incorrectly, leading to an `exception="RVCount doesn't match with EvaluationStack"` error when running any method.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/4740507694e54ad2cd76327356f47c805cc2437e/boa3_test/test_sc/contract_interface_test/ContractInterfaceAndClassWithStaticVars.py#L1-L24

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/4740507694e54ad2cd76327356f47c805cc2437e/boa3_test/tests/compiler_tests/test_contract_interface.py#L207-L213

**Platform:**
 - OS: macOS 15.6 (24G84)
 - Python version: Python 3.11
