### PR TITLE
Add GetContractById method from ContractManagement native contract

### DIFF
--- a/boa3/internal/model/builtin/native/contract_management/__init__.py
+++ b/boa3/internal/model/builtin/native/contract_management/__init__.py
@@ -1,4 +1,6 @@
-__all__ = ['HasMethod',
+__all__ = ['GetContractByIdMethod',
+           'HasMethod',
            ]
 
+from boa3.internal.model.builtin.native.contract_management.getcontractbyid import GetContractByIdMethod
 from boa3.internal.model.builtin.native.contract_management.hasmethod import HasMethod

--- a/boa3/internal/model/builtin/native/contract_management/getcontractbyid.py
+++ b/boa3/internal/model/builtin/native/contract_management/getcontractbyid.py
@@ -1,0 +1,17 @@
+from boa3.internal.model.builtin.interop.contract import ContractType
+from boa3.internal.model.builtin.interop.nativecontract import ContractManagementMethod
+from boa3.internal.model.variable import Variable
+
+
+class GetContractByIdMethod(ContractManagementMethod):
+
+    def __init__(self, contract_type: ContractType):
+        from boa3.internal.model.type.type import Type
+
+        identifier = 'get_contract_by_id'
+        syscall = 'getContractById'
+        args: dict[str, Variable] = {
+            'contract_id': Variable(Type.int),
+        }
+
+        super().__init__(identifier, syscall, args, return_type=contract_type)

--- a/boa3/internal/model/builtin/native/contractmanagementclass.py
+++ b/boa3/internal/model/builtin/native/contractmanagementclass.py
@@ -19,11 +19,12 @@ class ContractManagementClass(INativeContractClass):
         from boa3.internal.model.builtin.interop.interop import Interop
 
         if len(self._class_methods) == 0:
-            from boa3.internal.model.builtin.native.contract_management import HasMethod
+            from boa3.internal.model.builtin.native.contract_management import HasMethod, GetContractByIdMethod
 
             self._class_methods = {
                 'get_minimum_deployment_fee': Interop.GetMinimumDeploymentFee,
                 'get_contract': Interop.GetContract,
+                'get_contract_by_id': GetContractByIdMethod(Interop.ContractType),
                 'has_method': HasMethod(),
                 'deploy': Interop.CreateContract,
                 'update': Interop.UpdateContract,

--- a/boa3/sc/contracts/contractmanagement.py
+++ b/boa3/sc/contracts/contractmanagement.py
@@ -66,6 +66,39 @@ class ContractManagement:
         pass
 
     @classmethod
+    def get_contract_by_id(cls, contract_id: int) -> Contract | None:
+        """
+        Gets a contract with a given ID. If the script hash is not associated with a smart contract, then it will
+        return None.
+
+        >>> ContractManagement.get_contract_by_id(-6)    # GAS ID
+        {
+            'id': -6,
+            'update_counter': 0,
+            'hash': b'\\xcfv\\xe2\\x8b\\xd0\\x06,JG\\x8e\\xe3Ua\\x01\\x13\\x19\\xf3\\xcf\\xa4\\xd2',
+            'nef': b'NEF3neo-core-v3.0\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00#\\x10A\\x1a\\xf7{g@\\x10A\\x1a\\xf7{g@\\x10A\\x1a\\xf7{g@\\x10A\\x1a\\xf7{g@\\x10A\\x1a\\xf7{g@QA\\xc7\\x9e',
+            'manifest': {
+                'name': 'GasToken',
+                'group': [],
+                'supported_standards': ['NEP-17'],
+                'abi': [[['balanceOf', [['account', 20]], 17, 0, True], ['decimals', [], 17, 7, True], ['symbol', [], 19, 14, True], ['totalSupply', [], 17, 21, True], ['transfer', [['from', 20], ['to', 20], ['amount', 17], ['data', 0]], 16, 28, False]], [['Transfer', [['from', 20], ['to', 20], ['amount', 17]]]]],
+                'permissions': [[None, None]],
+                'trusts': [],
+                'extras': 'null'
+            },
+        }
+
+        >>> ContractManagement.get_contract_by_id(99999)
+        None
+
+        :param contract_id: a contract id
+        :type contract_id: int
+        :return: a contract
+        :rtype: boa3.sc.type.Contract
+        """
+        pass
+
+    @classmethod
     def has_method(cls, hash: UInt160, method: str, parameter_count: int) -> bool:
         """
         Check if a method exists in a contract.

--- a/boa3_test/test_sc/native_test/contractmanagement/GetContractById.py
+++ b/boa3_test/test_sc/native_test/contractmanagement/GetContractById.py
@@ -1,0 +1,8 @@
+from boa3.sc.compiletime import public
+from boa3.sc.contracts import ContractManagement
+from boa3.sc.types import Contract
+
+
+@public
+def main(contract_id: int) -> Contract | None:
+    return ContractManagement.get_contract_by_id(contract_id)

--- a/boa3_test/tests/compiler_tests/test_native/test_contract_management.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_contract_management.py
@@ -269,3 +269,17 @@ class TestContractManagementContract(boatestcase.BoaTestCase):
         self.assertEqual(call_hash, result[2])
         self.assertEqual(nef, result[3])
         self.assertEqual(manifest, result[4])
+
+    async def test_get_contract_by_id(self):
+        await self.set_up_contract('GetContractById.py')
+
+        invalid_contract_id = 999
+        result, _ = await self.call('main', [invalid_contract_id], return_type=None)
+        self.assertIsNone(result)
+
+        gas_contract_id = -6
+        result, _ = await self.call('main', [gas_contract_id], return_type=annotation.Contract)
+        self.assertEqual(5, len(result))
+        self.assertEqual(gas_contract_id, result[0])  # contract id
+        self.assertEqual(0, result[1])  # update counter
+        self.assertEqual(types.UInt160(constants.GAS_SCRIPT), result[2])  # contract hash


### PR DESCRIPTION
**Summary or solution description**
Added GetContractById method from ContractManagement native contract. Related to #1302

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/5f4a161e310a0d8be12737503e3d7456fdedb68b/boa3_test/test_sc/native_test/contractmanagement/GetContractById.py#L1-L8

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/5f4a161e310a0d8be12737503e3d7456fdedb68b/boa3_test/tests/compiler_tests/test_native/test_contract_management.py#L273-L285

**Platform:**
 - OS: Macos 15.6 (24G84)
  - Python version:  Python 3.13

**(Optional) Additional context**
While working on this issue, I've realised that there is a [single folder that has one native method](https://github.com/CityOfZion/neo3-boa/tree/master/boa3/internal/model/builtin/native/contract_management) inside it (`hasMethod`) and added the `GetContractById` there too.

@ixje Do you think I should move the other native methods to the `boa3/internal/model/builtin/native/` folder too?

For example:[ `Update`](https://github.com/CityOfZion/neo3-boa/blob/5f4a161e310a0d8be12737503e3d7456fdedb68b/boa3/internal/model/builtin/interop/contract/updatemethod.py) is in `boa3/internal/model/builtin/interop/contract/updatemethod.py`, but should've been in `boa3/internal/model/builtin/native/contract_management/updatemethod.py`
While [log](https://github.com/CityOfZion/neo3-boa/blob/a501316f332058744eacbe127ff105f91fa6aedd/boa3/internal/model/builtin/interop/runtime/logmethod.py#L9) is in `boa3/internal/model/builtin/interop/runtime/logmethod.py` and should be kept there because it's a syscall