### PR TITLE
Add RecoverSecp256K1, and change Sha256 and Ripemd160

### DIFF
--- a/boa3/internal/model/builtin/interop/crypto/ripemd160method.py
+++ b/boa3/internal/model/builtin/interop/crypto/ripemd160method.py
@@ -8,5 +8,5 @@ class Ripemd160Method(CryptoLibMethod):
         from boa3.internal.model.type.type import Type
         identifier = 'ripemd160'
         native_identifier = 'ripemd160'
-        args: dict[str, Variable] = {'key': Variable(Type.any)}
+        args: dict[str, Variable] = {'data': Variable(Type.bytes)}
         super().__init__(identifier, native_identifier, args, return_type=Type.bytes)

--- a/boa3/internal/model/builtin/interop/crypto/sha256method.py
+++ b/boa3/internal/model/builtin/interop/crypto/sha256method.py
@@ -7,5 +7,5 @@ class Sha256Method(CryptoLibMethod):
         from boa3.internal.model.type.type import Type
         identifier = 'sha256'
         native_identifier = 'sha256'
-        args: dict[str, Variable] = {'key': Variable(Type.any)}
+        args: dict[str, Variable] = {'data': Variable(Type.bytes)}
         super().__init__(identifier, native_identifier, args, return_type=Type.bytes)

--- a/boa3/internal/model/builtin/native/crypto_lib/__init__.py
+++ b/boa3/internal/model/builtin/native/crypto_lib/__init__.py
@@ -1,0 +1,4 @@
+__all__ = ['RecoverSecp256K1Method',
+           ]
+
+from boa3.internal.model.builtin.native.crypto_lib.recoversecp256k1 import RecoverSecp256K1Method

--- a/boa3/internal/model/builtin/native/crypto_lib/recoversecp256k1.py
+++ b/boa3/internal/model/builtin/native/crypto_lib/recoversecp256k1.py
@@ -1,0 +1,17 @@
+from boa3.internal.model.builtin.interop.nativecontract import CryptoLibMethod
+from boa3.internal.model.variable import Variable
+
+
+class RecoverSecp256K1Method(CryptoLibMethod):
+
+    def __init__(self):
+        from boa3.internal.model.type.type import Type
+
+        identifier = 'recover_secp256k1'
+        syscall = 'recoverSecp256K1'
+        args: dict[str, Variable] = {
+            'message_hash': Variable(Type.bytes),
+            'signature': Variable(Type.bytes),
+        }
+
+        super().__init__(identifier, syscall, args, return_type=Type.optional.build(Type.bytes))

--- a/boa3/internal/model/builtin/native/cryptolibclass.py
+++ b/boa3/internal/model/builtin/native/cryptolibclass.py
@@ -17,9 +17,11 @@ class CryptoLibClass(INativeContractClass):
     def class_methods(self) -> dict[str, Method]:
         # avoid recursive import
         from boa3.internal.model.builtin.interop.interop import Interop
+        from boa3.internal.model.builtin.native.crypto_lib import RecoverSecp256K1Method
 
         if len(self._class_methods) == 0:
             self._class_methods = {
+                'recover_secp256k1': RecoverSecp256K1Method(),
                 'murmur32': Interop.Murmur32,
                 'sha256': Interop.Sha256,
                 'ripemd160': Interop.Ripemd160,

--- a/boa3/sc/contracts/cryptolib.py
+++ b/boa3/sc/contracts/cryptolib.py
@@ -2,8 +2,6 @@ __all__ = [
     'CryptoLib'
 ]
 
-from typing import Any
-
 from boa3.sc.types import ECPoint, UInt160, NamedCurveHash, IBls12381
 
 
@@ -35,36 +33,30 @@ class CryptoLib:
         pass
 
     @classmethod
-    def sha256(cls, key: Any) -> bytes:
+    def sha256(cls, data: bytes) -> bytes:
         """
         Encrypts a key using SHA-256.
 
-        >>> CryptoLib.sha256('unit test')
+        >>> CryptoLib.sha256(b'unit test')
         b'\\xdau1>J\\xc2W\\xf8LN\\xfb2\\x0f\\xbd\\x01\\x1cr@<\\xf5\\x93<\\x90\\xd2\\xe3\\xb8$\\xd6H\\x96\\xf8\\x9a'
 
-        >>> CryptoLib.sha256(10)
-        b'\\x9c\\x82r\\x01\\xb9@\\x19\\xb4/\\x85pk\\xc4\\x9cY\\xff\\x84\\xb5`M\\x11\\xca\\xaf\\xb9\\n\\xb9HV\\xc4\\xe1\\xddz'
-
-        :param key: the key to be encrypted
-        :type key: Any
+        :param data: the data to be encrypted
+        :type data: bytes
         :return: a byte value that represents the encrypted key
         :rtype: bytes
         """
         pass
 
     @classmethod
-    def ripemd160(cls, key: Any) -> bytes:
+    def ripemd160(cls, data: bytes) -> bytes:
         """
         Encrypts a key using RIPEMD-160.
 
-        >>> CryptoLib.ripemd160('unit test')
+        >>> CryptoLib.ripemd160(b'unit test')
         b'H\\x8e\\xef\\xf4Zh\\x89:\\xe6\\xf1\\xdc\\x08\\xdd\\x8f\\x01\\rD\\n\\xbdH'
 
-        >>> CryptoLib.ripemd160(10)
-        b'\\xc0\\xda\\x02P8\\xed\\x83\\xc6\\x87\\xdd\\xc40\\xda\\x98F\\xec\\xb9\\x7f9\\x98'
-
-        :param key: the key to be encrypted
-        :type key: Any
+        :param data: the data to be encrypted
+        :type data: Any
         :return: a byte value that represents the encrypted key
         :rtype: bytes
         """

--- a/boa3/sc/contracts/cryptolib.py
+++ b/boa3/sc/contracts/cryptolib.py
@@ -16,6 +16,29 @@ class CryptoLib:
     hash: UInt160
 
     @classmethod
+    def recover_secp256k1(cls, message_hash: bytes, signature: bytes) -> bytes | None:
+        """
+        Recovers the public key from a secp256k1 signature in a single byte array format.
+
+        >>> CryptoLib.recover_secp256k1(
+        ...     bytes.fromhex('5ae8317d34d1e595e3fa7247db80c0af4320cce1116de187f8f7e2e099c0d8d0'),
+        ...     bytes.fromhex('45c0b7f8c09a9e1f1cea0c25785594427b6bf8f9f878a8af0b1abbb48e16d0920d8becd0c220f67c51217eecfd7184ef0732481c843857e6bc7fc095c4f6b78801')
+        ... )
+        b'\x03J\x07\x1e\x8an\x10\xaa\xda+\x8c\xf3\x9f\xa3\xb5\xfb4\x00\xb0N\x99\xea\x8a\xe6L\xee\xa1\xa9w\xdb\xea\xf5\xd5'
+
+        >>> CryptoLib.recover_secp256k1(b'unit test', b'wrong signature')
+        None
+
+        :param message_hash: the hash of the message that was signed
+        :type message_hash: bytes
+        :param signature: the 65-byte signature in format: r[32] + s[32] + v[1]. 64-bytes for eip-2098, where v must be 27 or 28
+        :type signature: bytes
+        :return: the recovered public key in compressed format, or None if recovery fails.
+        :rtype: bytes
+        """
+        pass
+
+    @classmethod
     def murmur32(cls, data: bytes, seed: int) -> bytes:
         """
         Computes the hash value for the specified byte array using the murmur32 algorithm.

--- a/boa3_test/test_sc/function_test/ModuleMethodBoa2Test1.py
+++ b/boa3_test/test_sc/function_test/ModuleMethodBoa2Test1.py
@@ -1,7 +1,7 @@
 from boa3.sc.compiletime import public
 from boa3.sc.contracts import CryptoLib
 
-MYSHA = CryptoLib.sha256('abc')
+MYSHA = CryptoLib.sha256(b'abc')
 
 
 @public
@@ -9,7 +9,7 @@ def main() -> bool:
 
     m = 3
 
-    j2 = CryptoLib.sha256('abc')
+    j2 = CryptoLib.sha256(b'abc')
 
     j3 = MYSHA
 

--- a/boa3_test/test_sc/if_test/IfOpCallBoa2Test.py
+++ b/boa3_test/test_sc/if_test/IfOpCallBoa2Test.py
@@ -14,10 +14,10 @@ def main(operation: str, a: Any, b: Any) -> Any:
     elif operation == 'omax' and isinstance(a, int) and isinstance(b, int):
         return max(a, b)
 
-    elif operation == 'sha256':
+    elif operation == 'sha256' and isinstance(a, bytes):
         return CryptoLib.sha256(a)
 
-    elif operation == 'hash160':
+    elif operation == 'hash160' and isinstance(a, bytes):
         return hash160(a)
 
     return 'unknown'

--- a/boa3_test/test_sc/native_test/cryptolib/RecoverSecp256K1.py
+++ b/boa3_test/test_sc/native_test/cryptolib/RecoverSecp256K1.py
@@ -1,0 +1,7 @@
+from boa3.sc.compiletime import public
+from boa3.sc.contracts import CryptoLib
+
+
+@public
+def main(message_hash: bytes, signature: bytes) -> bytes | None:
+    return CryptoLib.recover_secp256k1(message_hash, signature)

--- a/boa3_test/test_sc/native_test/cryptolib/Ripemd160Int.py
+++ b/boa3_test/test_sc/native_test/cryptolib/Ripemd160Int.py
@@ -1,7 +1,5 @@
-from boa3.sc.compiletime import public
 from boa3.sc.contracts import CryptoLib
 
 
-@public
 def Main() -> bytes:
     return CryptoLib.ripemd160(10)

--- a/boa3_test/test_sc/native_test/cryptolib/Ripemd160Str.py
+++ b/boa3_test/test_sc/native_test/cryptolib/Ripemd160Str.py
@@ -1,7 +1,5 @@
-from boa3.sc.compiletime import public
 from boa3.sc.contracts import CryptoLib
 
 
-@public
 def Main(test: str) -> bytes:
     return CryptoLib.ripemd160(test)

--- a/boa3_test/test_sc/native_test/cryptolib/Sha256Bool.py
+++ b/boa3_test/test_sc/native_test/cryptolib/Sha256Bool.py
@@ -1,7 +1,5 @@
-from boa3.sc.compiletime import public
 from boa3.sc.contracts import CryptoLib
 
 
-@public
 def Main() -> bytes:
     return CryptoLib.sha256(True)

--- a/boa3_test/test_sc/native_test/cryptolib/Sha256Int.py
+++ b/boa3_test/test_sc/native_test/cryptolib/Sha256Int.py
@@ -1,7 +1,5 @@
-from boa3.sc.compiletime import public
 from boa3.sc.contracts import CryptoLib
 
 
-@public
 def Main() -> bytes:
     return CryptoLib.sha256(10)

--- a/boa3_test/test_sc/native_test/cryptolib/Sha256Str.py
+++ b/boa3_test/test_sc/native_test/cryptolib/Sha256Str.py
@@ -1,7 +1,5 @@
-from boa3.sc.compiletime import public
 from boa3.sc.contracts import CryptoLib
 
 
-@public
 def Main(test: str) -> bytes:
     return CryptoLib.sha256(test)

--- a/boa3_test/tests/compiler_tests/test_if.py
+++ b/boa3_test/tests/compiler_tests/test_if.py
@@ -531,10 +531,10 @@ class TestIf(boatestcase.BoaTestCase):
 
         from boa3.internal.neo.cryptography import sha256, hash160
         from boa3.internal.neo.vm.type.String import String
-        result, _ = await self.call('main', ['sha256', 'abc', 4], return_type=bytes)
+        result, _ = await self.call('main', ['sha256', b'abc', 4], return_type=bytes)
         self.assertEqual(sha256(String('abc').to_bytes()), result)
 
-        result, _ = await self.call('main', ['hash160', 'abc', 4], return_type=bytes)
+        result, _ = await self.call('main', ['hash160', b'abc', 4], return_type=bytes)
         self.assertEqual(hash160(String('abc').to_bytes()), result)
 
     async def test_boa2_test_many_elif(self):

--- a/boa3_test/tests/compiler_tests/test_native/test_cryptolib.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_cryptolib.py
@@ -33,29 +33,13 @@ class TestCryptoLibClass(boatestcase.BoaTestCase):
         self.assertEqual(constants.CRYPTO_SCRIPT, result)
 
     async def test_ripemd160_str(self):
-        await self.set_up_contract('Ripemd160Str.py')
-
-        expected_result = hashlib.new('ripemd160', b'unit test')
-        result, _ = await self.call('Main', ['unit test'], return_type=bytes)
-        self.assertEqual(expected_result.digest(), result)
-
-        expected_result = hashlib.new('ripemd160', b'')
-        result, _ = await self.call('Main', [''], return_type=bytes)
-        self.assertEqual(expected_result.digest(), result)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'Ripemd160Str.py')
 
     async def test_ripemd160_int(self):
-        await self.set_up_contract('Ripemd160Int.py')
-
-        expected_result = hashlib.new('ripemd160', Integer(10).to_byte_array())
-        result, _ = await self.call('Main', [], return_type=bytes)
-        self.assertEqual(expected_result.digest(), result)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'Ripemd160Int.py')
 
     async def test_ripemd160_bool(self):
-        await self.set_up_contract('Ripemd160Bool.py')
-
-        expected_result = hashlib.new('ripemd160', Integer(1).to_byte_array())
-        result, _ = await self.call('Main', [], return_type=bytes)
-        self.assertEqual(expected_result.digest(), result)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'Ripemd160Bool.py')
 
     async def test_ripemd160_bytes(self):
         await self.set_up_contract('Ripemd160Bytes.py')
@@ -71,29 +55,13 @@ class TestCryptoLibClass(boatestcase.BoaTestCase):
         self.assertCompilerLogs(CompilerError.UnfilledArgument, 'Ripemd160TooFewArguments.py')
 
     async def test_sha256_str(self):
-        await self.set_up_contract('Sha256Str.py')
-
-        expected_result = hashlib.sha256(b'unit test')
-        result, _ = await self.call('Main', ['unit test'], return_type=bytes)
-        self.assertEqual(expected_result.digest(), result)
-
-        expected_result = hashlib.sha256(b'')
-        result, _ = await self.call('Main', [''], return_type=bytes)
-        self.assertEqual(expected_result.digest(), result)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'Sha256Str.py')
 
     async def test_sha256_int(self):
-        await self.set_up_contract('Sha256Int.py')
-
-        expected_result = hashlib.sha256(Integer(10).to_byte_array())
-        result, _ = await self.call('Main', [], return_type=bytes)
-        self.assertEqual(expected_result.digest(), result)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'Sha256Int.py')
 
     async def test_sha256_bool(self):
-        await self.set_up_contract('Sha256Bool.py')
-
-        expected_result = hashlib.sha256(Integer(1).to_byte_array())
-        result, _ = await self.call('Main', [], return_type=bytes)
-        self.assertEqual(expected_result.digest(), result)
+        self.assertCompilerLogs(CompilerError.MismatchedTypes, 'Sha256Bool.py')
 
     async def test_sha256_bytes(self):
         await self.set_up_contract('Sha256Bytes.py')

--- a/boa3_test/tests/compiler_tests/test_native/test_cryptolib.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_cryptolib.py
@@ -374,25 +374,33 @@ class TestCryptoLibClass(boatestcase.BoaTestCase):
         await self.set_up_contract('RecoverSecp256K1.py')
 
         result, _ = await self.call('main', [b'unit test', b'wrong signature'], return_type=None)
-        self.assertEqual(None, result)
+        self.assertIsNone(result)
 
+        # Test values taken from Neo Project tests
+        # https://github.com/neo-project/neo/blob/9b9be47357e9065de524005755212ed54c3f6a11/tests/Neo.UnitTests/Cryptography/UT_Crypto.cs#L99
         message_hash = bytes.fromhex('5ae8317d34d1e595e3fa7247db80c0af4320cce1116de187f8f7e2e099c0d8d0')
         signature = bytes.fromhex(
-            "45c0b7f8c09a9e1f1cea0c25785594427b6bf8f9f878a8af0b1abbb48e16d0920d8becd0c220f67c51217eecfd7184ef0732481c843857e6bc7fc095c4f6b78801")
+            "45c0b7f8c09a9e1f1cea0c25785594427b6bf8f9f878a8af0b1abbb48e16d092" +
+            "0d8becd0c220f67c51217eecfd7184ef0732481c843857e6bc7fc095c4f6b78801"
+        )
         public_key = bytes.fromhex('034a071e8a6e10aada2b8cf39fa3b5fb3400b04e99ea8ae64ceea1a977dbeaf5d5')
         result, _ = await self.call('main', [message_hash, signature], return_type=bytes)
         self.assertEqual(public_key, result)
 
         message_hash = bytes.fromhex('586052916fb6f746e1d417766cceffbe1baf95579bab67ad49addaaa6e798862')
         signature = bytes.fromhex(
-            "4e0ea79d4a476276e4b067facdec7460d2c98c8a65326a6e5c998fd7c65061140e45aea5034af973410e65cf97651b3f2b976e3fc79c6a93065ed7cb69a2ab5a01")
+            "4e0ea79d4a476276e4b067facdec7460d2c98c8a65326a6e5c998fd7c6506114" +
+            "0e45aea5034af973410e65cf97651b3f2b976e3fc79c6a93065ed7cb69a2ab5a01"
+        )
         public_key = bytes.fromhex('02dbf1f4092deb3cfd4246b2011f7b24840bc5dbedae02f28471ce5b3bfbf06e71')
         result, _ = await self.call('main', [message_hash, signature], return_type=bytes)
         self.assertEqual(public_key, result)
 
         message_hash = bytes.fromhex('c36d0ecf4bfd178835c97aae7585f6a87de7dfa23cc927944f99a8d60feff68b')
         signature = bytes.fromhex(
-            "f25b86e1d8a11d72475b3ed273b0781c7d7f6f9e1dae0dd5d3ee9b84f3fab89163d9c4e1391de077244583e9a6e3d8e8e1f236a3bf5963735353b93b1a3ba93500")
+            "f25b86e1d8a11d72475b3ed273b0781c7d7f6f9e1dae0dd5d3ee9b84f3fab891" +
+            "63d9c4e1391de077244583e9a6e3d8e8e1f236a3bf5963735353b93b1a3ba93500"
+        )
         public_key = bytes.fromhex('03414549fd05bfb7803ae507ff86b99becd36f8d66037a7f5ba612792841d42eb9')
         result, _ = await self.call('main', [message_hash, signature], return_type=bytes)
         self.assertEqual(public_key, result)

--- a/boa3_test/tests/compiler_tests/test_native/test_cryptolib.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_cryptolib.py
@@ -369,3 +369,30 @@ class TestCryptoLibClass(boatestcase.BoaTestCase):
         for named_curve_hash in NamedCurveHash:
             result, _ = await self.call('main', [named_curve_hash], return_type=int)
             self.assertEqual(~named_curve_hash, result)
+
+    async def test_recover_secp256k1(self):
+        await self.set_up_contract('RecoverSecp256K1.py')
+
+        result, _ = await self.call('main', [b'unit test', b'wrong signature'], return_type=None)
+        self.assertEqual(None, result)
+
+        message_hash = bytes.fromhex('5ae8317d34d1e595e3fa7247db80c0af4320cce1116de187f8f7e2e099c0d8d0')
+        signature = bytes.fromhex(
+            "45c0b7f8c09a9e1f1cea0c25785594427b6bf8f9f878a8af0b1abbb48e16d0920d8becd0c220f67c51217eecfd7184ef0732481c843857e6bc7fc095c4f6b78801")
+        public_key = bytes.fromhex('034a071e8a6e10aada2b8cf39fa3b5fb3400b04e99ea8ae64ceea1a977dbeaf5d5')
+        result, _ = await self.call('main', [message_hash, signature], return_type=bytes)
+        self.assertEqual(public_key, result)
+
+        message_hash = bytes.fromhex('586052916fb6f746e1d417766cceffbe1baf95579bab67ad49addaaa6e798862')
+        signature = bytes.fromhex(
+            "4e0ea79d4a476276e4b067facdec7460d2c98c8a65326a6e5c998fd7c65061140e45aea5034af973410e65cf97651b3f2b976e3fc79c6a93065ed7cb69a2ab5a01")
+        public_key = bytes.fromhex('02dbf1f4092deb3cfd4246b2011f7b24840bc5dbedae02f28471ce5b3bfbf06e71')
+        result, _ = await self.call('main', [message_hash, signature], return_type=bytes)
+        self.assertEqual(public_key, result)
+
+        message_hash = bytes.fromhex('c36d0ecf4bfd178835c97aae7585f6a87de7dfa23cc927944f99a8d60feff68b')
+        signature = bytes.fromhex(
+            "f25b86e1d8a11d72475b3ed273b0781c7d7f6f9e1dae0dd5d3ee9b84f3fab89163d9c4e1391de077244583e9a6e3d8e8e1f236a3bf5963735353b93b1a3ba93500")
+        public_key = bytes.fromhex('03414549fd05bfb7803ae507ff86b99becd36f8d66037a7f5ba612792841d42eb9')
+        result, _ = await self.call('main', [message_hash, signature], return_type=bytes)
+        self.assertEqual(public_key, result)


### PR DESCRIPTION
**Related issue**
#1302 

**Summary or solution description**
- Add RecoverSecp256K1 from CryptoLib;
- Change Sha256 and Ripemd160 to only accept `bytes` parameters
    - Those methods initially accepted [all types of parameters](https://github.com/neo-project/neo/blob/604541c91b3151ee40a8613cb8534ebc0540fd27/src/neo/SmartContract/ApplicationEngine.Crypto.cs#L21), 
    - but it was changed to only [accept `byte[]`](https://github.com/neo-project/neo/blob/d555af07b2888df3dc9d2b6238a122a8c98fbaa1/src/neo/SmartContract/Native/CryptoLib.cs#L27).

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/54df40641d5321d5e768f3dfac39a8005ad86946/boa3_test/test_sc/native_test/cryptolib/RecoverSecp256K1.py#L1-L7

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/54df40641d5321d5e768f3dfac39a8005ad86946/boa3_test/tests/compiler_tests/test_native/test_cryptolib.py#L373-L398
https://github.com/CityOfZion/neo3-boa/blob/54df40641d5321d5e768f3dfac39a8005ad86946/boa3_test/tests/compiler_tests/test_native/test_cryptolib.py#L35-L71

**Platform:**
 - OS: MacOS 15.6 (24G84)
 - Python version:  Python 3.13