### PR TITLE
Add StringSplit and StrLen methods from StdLib

### DIFF
--- a/boa3/internal/model/builtin/builtin.py
+++ b/boa3/internal/model/builtin/builtin.py
@@ -40,6 +40,7 @@ class Builtin:
     Print = PrintMethod()
     ScriptHashMethod_ = ScriptHashMethod()
     StrSplit = StrSplitMethod()
+    StrSplitWithoutMaxsplit = StrSplitWithoutMaxsplitMethod()
     Sum = SumMethod()
     ToHexStr = ToHexStrMethod()
 
@@ -147,6 +148,7 @@ class Builtin:
         SequenceReverse,
         StaticMethodDecorator,
         StrSplit,
+        StrSplitWithoutMaxsplit,
         Sum,
         Super,
     ]

--- a/boa3/internal/model/builtin/method/__init__.py
+++ b/boa3/internal/model/builtin/method/__init__.py
@@ -29,6 +29,7 @@ __all__ = ['AbsMethod',
            'StrIntMethod',
            'StrSequenceMethod',
            'StrSplitMethod',
+           'StrSplitWithoutMaxsplitMethod',
            'SumMethod',
            'SuperMethod',
            'ToBoolMethod',
@@ -67,6 +68,7 @@ from boa3.internal.model.builtin.method.strclassmethod import StrClassMethod
 from boa3.internal.model.builtin.method.strintmethod import StrIntMethod
 from boa3.internal.model.builtin.method.strsequencemethod import StrSequenceMethod
 from boa3.internal.model.builtin.method.strsplitmethod import StrSplitMethod
+from boa3.internal.model.builtin.method.strsplitmethod import StrSplitWithoutMaxsplitMethod
 from boa3.internal.model.builtin.method.summethod import SumMethod
 from boa3.internal.model.builtin.method.supermethod import SuperMethod
 from boa3.internal.model.builtin.method.toboolmethod import ToBool as ToBoolMethod

--- a/boa3/internal/model/builtin/method/lenstrmethod.py
+++ b/boa3/internal/model/builtin/method/lenstrmethod.py
@@ -1,0 +1,12 @@
+from boa3.internal.model.builtin.method import LenMethod
+from boa3.internal.model.builtin.native.nativecontract import NativeContract
+from boa3.internal.model.type.itype import IType
+
+
+class LenStrMethod(LenMethod):
+
+    def __init__(self, arg_value: IType | None = None):
+        super().__init__(arg_value)
+
+    def generate_internal_opcodes(self, code_generator):
+        code_generator.convert_builtin_method_call(NativeContract.StdLib.class_methods['str_len'])

--- a/boa3/internal/model/builtin/native/stdlib/__init__.py
+++ b/boa3/internal/model/builtin/native/stdlib/__init__.py
@@ -1,0 +1,6 @@
+__all__ = ['StringSplitMethod',
+           'StrLenMethod',
+           ]
+
+from boa3.internal.model.builtin.native.stdlib.stringsplitmethod import StringSplitMethod
+from boa3.internal.model.builtin.native.stdlib.strlenmethod import StrLenMethod

--- a/boa3/internal/model/builtin/native/stdlib/stringsplitmethod.py
+++ b/boa3/internal/model/builtin/native/stdlib/stringsplitmethod.py
@@ -1,0 +1,39 @@
+import ast
+
+from boa3.internal.model.builtin.interop.nativecontract import StdLibMethod
+from boa3.internal.model.variable import Variable
+
+
+class StringSplitMethod(StdLibMethod):
+
+    def __init__(self):
+        from boa3.internal.model.type.type import Type
+        identifier = 'string_split'
+        syscall = 'stringSplit'
+        args: dict[str, Variable] = {
+            'string': Variable(Type.str),
+            'separator': Variable(Type.str),
+            'remove_empty_entries': Variable(Type.bool),
+        }
+
+        args_default = ast.parse("{0}".format(False)
+                                 ).body[0].value
+
+        super().__init__(identifier, syscall, args, defaults=[args_default], return_type=Type.list.build([Type.str]))
+
+
+class StringSplitWithoutRemoveEmptyEntriesMethod(StdLibMethod):
+
+    def __init__(self):
+        from boa3.internal.model.type.type import Type
+        identifier = 'string_split'
+        syscall = 'stringSplit'
+        args: dict[str, Variable] = {
+            'string': Variable(Type.str),
+            'separator': Variable(Type.str),
+        }
+
+        args_default = ast.parse("{0}".format(False)
+                                 ).body[0].value
+
+        super().__init__(identifier, syscall, args, defaults=[args_default], return_type=Type.list.build([Type.str]))

--- a/boa3/internal/model/builtin/native/stdlib/strlenmethod.py
+++ b/boa3/internal/model/builtin/native/stdlib/strlenmethod.py
@@ -1,0 +1,15 @@
+from boa3.internal.model.builtin.interop.nativecontract import StdLibMethod
+from boa3.internal.model.variable import Variable
+
+
+class StrLenMethod(StdLibMethod):
+
+    def __init__(self):
+        from boa3.internal.model.type.type import Type
+        identifier = 'str_len'
+        syscall = 'strLen'
+        args: dict[str, Variable] = {
+            'string': Variable(Type.str),
+        }
+
+        super().__init__(identifier, syscall, args, return_type=Type.int)

--- a/boa3/internal/model/builtin/native/stdlibclass.py
+++ b/boa3/internal/model/builtin/native/stdlibclass.py
@@ -1,6 +1,7 @@
 from typing import Any, Self
 
 from boa3.internal.model.builtin.interop.nativecontract import StdLibContract
+from boa3.internal.model.builtin.native import stdlib
 from boa3.internal.model.builtin.native.inativecontractclass import INativeContractClass
 from boa3.internal.model.method import Method
 
@@ -34,6 +35,8 @@ class StdLibClass(INativeContractClass):
                 'atoi': Interop.Atoi,
                 'memory_compare': Interop.MemoryCompare,
                 'memory_search': Interop.MemorySearch,
+                'string_split': stdlib.StringSplitMethod(),
+                'str_len': stdlib.StrLenMethod(),
             }
         return super().class_methods
 

--- a/boa3/internal/model/type/primitive/strtype.py
+++ b/boa3/internal/model/type/primitive/strtype.py
@@ -33,7 +33,7 @@ class StrType(IByteStringType):
                             ]
 
         for instance_method in instance_methods:
-            self._instance_methods[instance_method.raw_identifier] = instance_method.build(self)
+            self._instance_methods[instance_method.identifier] = instance_method.build(self)
 
         self._instance_methods[constants.INIT_METHOD_ID] = Builtin.StrBytes
 

--- a/boa3/sc/contracts/stdlib.py
+++ b/boa3/sc/contracts/stdlib.py
@@ -299,3 +299,48 @@ class StdLib:
         :rtype: int
         """
         pass
+
+    @classmethod
+    def string_split(cls, string: str, separator: str, remove_empty_entries: bool = False) -> list[str]:
+        """
+        Searches for a given value in a given memory.
+
+        >>> StdLib.string_split('abc,def,ghi', ',')
+        ['abc', 'def', 'ghi']
+
+        >>> StdLib.string_split('abc,def,ghi,,', ',')
+        ['abc', 'def', 'ghi', '', '']
+
+        >>> StdLib.string_split('abc,def,ghi,,', ',', True)
+        ['abc', 'def', 'ghi']
+
+        :param string: the string to be split
+        :type string: str
+        :param separator: the seperator character used to split the string
+        :type separator: str
+        :param remove_empty_entries: whether it should include empty strings in the list
+        :type remove_empty_entries: bool
+
+        :return: a list of substrings split by the given separator
+        :rtype: list[str]
+        """
+        pass
+
+    @classmethod
+    def str_len(cls, string: str) -> int:
+        """
+        Gets the length of a string. Works with Unicode strings.utf
+
+        >>> StdLib.str_len('abcdefghijklmnopqrstuvwxyz')
+        26
+
+        >>> StdLib.str_len('😀')
+        1
+
+        :param string: the string to get the length of
+        :type string: str
+
+        :return: the length of the string
+        :rtype: list[str]
+        """
+        pass

--- a/boa3_test/test_sc/native_test/stdlib/StrLen.py
+++ b/boa3_test/test_sc/native_test/stdlib/StrLen.py
@@ -1,0 +1,7 @@
+from boa3.sc.compiletime import public
+from boa3.sc.contracts import StdLib
+
+
+@public
+def main(string: str) -> int:
+    return StdLib.str_len(string)

--- a/boa3_test/test_sc/native_test/stdlib/StringSplit.py
+++ b/boa3_test/test_sc/native_test/stdlib/StringSplit.py
@@ -1,0 +1,7 @@
+from boa3.sc.compiletime import public
+from boa3.sc.contracts import StdLib
+
+
+@public
+def main(string: str, separator: str) -> list[str]:
+    return StdLib.string_split(string, separator)

--- a/boa3_test/test_sc/native_test/stdlib/StringSplitRemoveEmptyEntries.py
+++ b/boa3_test/test_sc/native_test/stdlib/StringSplitRemoveEmptyEntries.py
@@ -1,0 +1,7 @@
+from boa3.sc.compiletime import public
+from boa3.sc.contracts import StdLib
+
+
+@public
+def main(string: str, separator: str, remove_empty_entries: bool) -> list[str]:
+    return StdLib.string_split(string, separator, remove_empty_entries)

--- a/boa3_test/tests/compiler_tests/test_builtin_method.py
+++ b/boa3_test/tests/compiler_tests/test_builtin_method.py
@@ -81,7 +81,7 @@ class TestBuiltinMethod(boatestcase.BoaTestCase):
             + Opcode.PUSHDATA1            # push the bytes
             + Integer(len(byte_input)).to_byte_array()
             + byte_input
-            + Opcode.SIZE
+            + Opcode.CALLT + b'\x00\x00'
             + Opcode.RET
         )
 
@@ -1095,6 +1095,27 @@ class TestBuiltinMethod(boatestcase.BoaTestCase):
 
     # region str split test
 
+    async def test_str_split_opcodes(self):
+        expected_output_start = (
+                Opcode.INITSLOT
+                + b'\x00'
+                + b'\x03'
+                + Opcode.LDARG1
+                + Opcode.LDARG2
+                + Opcode.LDARG0
+                + Opcode.PUSH2
+                + Opcode.PICK
+                + Opcode.SWAP
+                + Opcode.CALLT + b'\x00\x00'
+                + Opcode.OVER
+                + Opcode.PUSH0
+                + Opcode.JMPLT
+                + Integer(25).to_byte_array(signed=True, min_length=1)
+        )
+
+        output, _ = self.assertCompile('StrSplit.py')
+        self.assertStartsWith(output, expected_output_start)
+
     async def test_str_split(self):
         await self.set_up_contract('StrSplit.py')
 
@@ -1126,6 +1147,20 @@ class TestBuiltinMethod(boatestcase.BoaTestCase):
         result, _ = await self.call('main', [string, separator, maxsplit], return_type=list)
         self.assertEqual(expected_result, result)
 
+    async def test_str_split_maxsplit_default_opcodes(self):
+        expected_output = (
+                Opcode.INITSLOT
+                + b'\x00'
+                + b'\x02'
+                + Opcode.LDARG1
+                + Opcode.LDARG0
+                + Opcode.CALLT + b'\x00\x00'
+                + Opcode.RET
+        )
+
+        output, _ = self.assertCompile('StrSplitMaxsplitDefault.py')
+        self.assertEqual(expected_output, output)
+
     async def test_str_split_maxsplit_default(self):
         await self.set_up_contract('StrSplitMaxsplitDefault.py')
 
@@ -1140,6 +1175,23 @@ class TestBuiltinMethod(boatestcase.BoaTestCase):
         expected_result = string.split(separator)
         result, _ = await self.call('main', [string, separator], return_type=list)
         self.assertEqual(expected_result, result)
+
+    async def test_str_split_default_opcodes(self):
+        default_separator = String(' ').to_bytes()
+        expected_output = (
+                Opcode.INITSLOT
+                + b'\x00'
+                + b'\x01'
+                + Opcode.PUSHDATA1
+                + Integer(len(default_separator)).to_byte_array(min_length=1)
+                + default_separator
+                + Opcode.LDARG0
+                + Opcode.CALLT + b'\x00\x00'
+                + Opcode.RET
+        )
+
+        output, _ = self.assertCompile('StrSplitSeparatorDefault.py')
+        self.assertEqual(expected_output, output)
 
     async def test_str_split_default(self):
         await self.set_up_contract('StrSplitSeparatorDefault.py')

--- a/boa3_test/tests/compiler_tests/test_native/test_stdlib.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_stdlib.py
@@ -658,3 +658,27 @@ class TestStdlibClass(boatestcase.BoaTestCase):
         value = 'string'
         result, _ = await self.call('main', [value], return_type=str)
         self.assertEqual(value, result)
+
+    async def test_string_split(self):
+        await self.set_up_contract('StringSplit.py')
+
+        string = 'abc,def,ghi'
+        separator = ','
+        result, _ = await self.call('main', [string, separator], return_type=list[str])
+        self.assertEqual(string.split(separator), result)
+
+        string = 'abc,def,ghi,,'
+        separator = ','
+        result, _ = await self.call('main', [string, separator], return_type=list[str])
+        self.assertEqual(string.split(separator), result)
+
+    async def test_str_len(self):
+        await self.set_up_contract('StrLen.py')
+
+        string = 'abcdefghijklmnopqrstuvwxyz'
+        result, _ = await self.call('main', [string], return_type=int)
+        self.assertEqual(len(string), result)
+
+        string = '😀'
+        result, _ = await self.call('main', [string], return_type=int)
+        self.assertEqual(len(string), result)


### PR DESCRIPTION
**Related issue**
close #1302 

**Summary or solution description**
- Added StringSplit and StrLen to Boa3
- Changed a little bit how `'string'.split()` and `len('string')` works internally
    - If you are using `len` with a string argument, then it will use StdLib, otherwise it will use `Opcode.SIZE`
        - Using `Opcode.SIZE` on a string would sometimes return an incorrect length, because some string characters would consist of 2 or more bytes, e.g., "Φ" (`b'\xce\xa6'`) would have size 2 instead of 1
    - If you are using `split` with 1 or 2 arguments, then it will use just StdLib, otherwise it will also concatenate the strings back into one when exceeding maxSplit arg. 

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/c83666a17fa01c3326362bdc46ac976183aa4aee/boa3_test/test_sc/native_test/stdlib/StrLen.py#L1-L7
https://github.com/CityOfZion/neo3-boa/blob/c83666a17fa01c3326362bdc46ac976183aa4aee/boa3_test/test_sc/native_test/stdlib/StringSplit.py#L1-L7

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/c83666a17fa01c3326362bdc46ac976183aa4aee/boa3_test/tests/compiler_tests/test_native/test_stdlib.py#L662-L684


**Platform:**
 - OS: MacOS 15.6 (24G84)
 - Python version:  Python 3.13
