### PR TITLE
Add endianness and sign to to_int method

### DIFF
--- a/boa3/internal/model/builtin/interop/storage/get/storagegetintmethod.py
+++ b/boa3/internal/model/builtin/interop/storage/get/storagegetintmethod.py
@@ -19,4 +19,4 @@ class StorageGetIntMethod(IStorageGetMethod):
         from boa3.internal.model.type.type import Type
 
         converter = ToInt.build(Type.bytes)
-        code_generator.convert_builtin_method_call(converter)
+        code_generator.convert_builtin_method_call(converter, is_internal=True)

--- a/boa3/internal/model/builtin/interop/storage/getcheck/storagegetintmethod.py
+++ b/boa3/internal/model/builtin/interop/storage/getcheck/storagegetintmethod.py
@@ -19,4 +19,4 @@ class StorageTryGetIntMethod(IStorageTryGetMethod):
         from boa3.internal.model.type.type import Type
 
         converter = ToInt.build(Type.bytes)
-        code_generator.convert_builtin_method_call(converter)
+        code_generator.convert_builtin_method_call(converter, is_internal=True)

--- a/boa3/internal/model/builtin/method/tointmethod.py
+++ b/boa3/internal/model/builtin/method/tointmethod.py
@@ -1,39 +1,81 @@
-from abc import ABC
+import ast
 from typing import Any
 
+from boa3.internal.model import set_internal_call
 from boa3.internal.model.builtin.method.builtinmethod import IBuiltinMethod
-from boa3.internal.model.expression import IExpression
-from boa3.internal.model.identifiedsymbol import IdentifiedSymbol
-from boa3.internal.model.type.itype import IType
 from boa3.internal.model.type.primitive.bytestype import BytesType
 from boa3.internal.model.variable import Variable
+from boa3.internal.model.type.type import Type
+from boa3.internal.neo.vm.opcode.Opcode import Opcode
 
 
-class ToIntMethod(IBuiltinMethod, ABC):
-    def __init__(self, self_type: IType):
+class ToIntMethod(IBuiltinMethod):
+    def __init__(self):
         identifier = 'to_int'
-        if isinstance(self_type, IdentifiedSymbol):
-            identifier = '-{0}_{1}'.format(self_type.identifier, identifier)
 
-        args: dict[str, Variable] = {'self': Variable(self_type)}
-        from boa3.internal.model.type.type import Type
-        super().__init__(identifier, args, return_type=Type.int)
+        args: dict[str, Variable] = {
+            'value': Variable(Type.bytes),
+            'big_endian': Variable(Type.bool),
+            'signed': Variable(Type.bool),
+        }
+        big_endian_default = set_internal_call(ast.parse("{0}".format(True)
+                                                            ).body[0].value)
+        signed_default = set_internal_call(ast.parse("{0}".format(Type.bool.default_value)
+                                                     ).body[0].value)
+
+        super().__init__(identifier, args, defaults=[big_endian_default, signed_default],
+                         return_type=Type.int)
 
     @property
-    def _arg_self(self) -> Variable:
-        return self.args['self']
+    def generation_order(self) -> list[int]:
+        value_index = list(self.args).index('value')
+        big_endian_index = list(self.args).index('big_endian')
+        signed_index = list(self.args).index('signed')
 
-    def validate_parameters(self, *params: IExpression) -> bool:
-        if len(params) != 1:
-            return False
-        return isinstance(params[0], IExpression) and isinstance(params[0].type, BytesType)
+        return [signed_index, value_index, big_endian_index]
+
+    def generate_opcodes(self, code_generator):
+        from boa3.internal.model.builtin.builtin import Builtin
+        from boa3.internal.model.operation.binaryop import BinaryOp
+        # stack: signed, value, big_endian
+
+        # if big_endian:
+        if_is_big_endian = code_generator.convert_begin_if()
+        #   value = value[::-1]
+        code_generator.convert_array_negative_stride()
+
+        code_generator.convert_end_if(if_is_big_endian, is_internal=True)
+        # stack: signed, value
+
+        code_generator.swap_reverse_stack_items(2)
+        # if signed:
+        if_is_signed = code_generator.convert_begin_if()
+
+        code_generator.duplicate_stack_top_item()
+        code_generator.duplicate_stack_top_item()
+        code_generator.convert_builtin_method_call(Builtin.Len, is_internal=True)
+        code_generator.insert_opcode(Opcode.DEC)
+        code_generator.convert_literal(1)
+        code_generator.convert_get_substring(is_internal=True)
+        code_generator.convert_literal(0b10000000)
+        code_generator.convert_operation(BinaryOp.BitAnd)
+
+        if_last_byte_not_begins_with_1 = code_generator.convert_begin_if()
+        code_generator.change_jump(if_last_byte_not_begins_with_1, Opcode.JMPIF)
+
+        else_is_not_signed = code_generator.convert_begin_else(if_is_signed, is_internal=True)
+        #  value = value + b'\x00'
+        code_generator.convert_literal(b'\x00')
+        code_generator.convert_operation(BinaryOp.Concat)
+
+        code_generator.convert_end_if(if_last_byte_not_begins_with_1, is_internal=True)
+        code_generator.convert_end_if(else_is_not_signed, is_internal=True)
+        # stack: value
+
+        self.generate_internal_opcodes(code_generator)
 
     def generate_internal_opcodes(self, code_generator):
-        from boa3.internal.model.type.type import Type
         code_generator.convert_cast(Type.int, is_internal=True)
-
-    def push_self_first(self) -> bool:
-        return self.has_self_argument
 
     @property
     def _args_on_stack(self) -> int:
@@ -43,31 +85,12 @@ class ToIntMethod(IBuiltinMethod, ABC):
     def _body(self) -> str | None:
         return None
 
-
-class _ConvertToIntMethod(ToIntMethod):
-    def __init__(self):
-        super().__init__(None)
-
     def build(self, value: Any) -> IBuiltinMethod:
-        if isinstance(value, BytesType):
-            return BytesToIntMethod(value)
-        # if it is not a valid type, show mismatched type with bytes
-        return BytesToIntMethod()
-
-
-ToInt = _ConvertToIntMethod()
-
-
-class BytesToIntMethod(ToIntMethod):
-    def __init__(self, self_type: IType = None):
-        if not isinstance(self_type, BytesType):
-            from boa3.internal.model.type.type import Type
-            self_type = Type.bytes
-        super().__init__(self_type)
-
-    def build(self, value: Any) -> IBuiltinMethod:
-        if type(value) == type(self.args['self'].type):
+        if type(value) == type(self.args['value'].type):
             return self
         if isinstance(value, BytesType):
-            return BytesToIntMethod(value)
+            return ToIntMethod()
         return super().build(value)
+
+
+ToInt = ToIntMethod()

--- a/boa3/sc/utils/__init__.py
+++ b/boa3/sc/utils/__init__.py
@@ -344,11 +344,11 @@ def to_bytes(value: str | int, length: int = 1, big_endian: bool = True, signed:
     :type value: str | int
     :param length: available only to integer values, it represents the length of the resulting bytes
     :type length: int
-    :param big_endian: available only to integer values, it represents whether the integer is represented in big or
-    little endian
+    :param big_endian: available only to integer values, whether to represent the integer in big-endian (True) or
+    little-endian (False) byte order
     :type big_endian: bool
-    :param signed: available only to integer values, it represents whether the integer has a bit to represent a signed
-    value
+    :param signed: available only to integer values, whether to represent the integer as signed (True) or
+    unsigned (False) in bytes return
     :type signed: bool
     :return: a byte value that represents the given value
     :rtype: bytes
@@ -358,12 +358,30 @@ def to_bytes(value: str | int, length: int = 1, big_endian: bool = True, signed:
     pass
 
 
-def to_int(value: bytes) -> int:
+def to_int(value: bytes, big_endian: bool = True, signed: bool = False) -> int:
     """
     Converts a bytes value to the integer it represents.
 
     >>> to_int(b'A')
     65
+
+    >>> to_int(b'\xfa\x15')
+    64021
+
+    >>> to_int(b'\xfa\x15', False)
+    5626
+
+    >>> to_int(b'\xfa\x15', True, True)
+    -1515
+
+    :param value: value to be converted to int
+    :type value: bytes
+    :param big_endian: whether to interpret the bytes in big-endian (True) or little-endian (False) byte order
+    :type big_endian: bool
+    :param signed: whether to interpret the bytes as a signed (True) or unsigned (False) integer
+    :type signed: bool
+    :return:
+    :rtype: int
     """
     pass
 

--- a/boa3_test/test_sc/bytes_test/BytesToIntBigEndianArgs.py
+++ b/boa3_test/test_sc/bytes_test/BytesToIntBigEndianArgs.py
@@ -1,0 +1,7 @@
+from boa3.sc.compiletime import public
+from boa3.sc.utils import to_int
+
+
+@public
+def main(bytes_: bytes, big_endian: bool) -> int:
+    return to_int(bytes_, big_endian)

--- a/boa3_test/test_sc/bytes_test/BytesToIntBigEndianSignedArgs.py
+++ b/boa3_test/test_sc/bytes_test/BytesToIntBigEndianSignedArgs.py
@@ -1,0 +1,7 @@
+from boa3.sc.compiletime import public
+from boa3.sc.utils import to_int
+
+
+@public
+def main(bytes_: bytes, big_endian: bool, signed: bool) -> int:
+    return to_int(bytes_, big_endian, signed)

--- a/boa3_test/test_sc/bytes_test/BytesToIntDefaultArgs.py
+++ b/boa3_test/test_sc/bytes_test/BytesToIntDefaultArgs.py
@@ -1,0 +1,7 @@
+from boa3.sc.compiletime import public
+from boa3.sc.utils import to_int
+
+
+@public
+def main(bytes_: bytes) -> int:
+    return to_int(bytes_)

--- a/boa3_test/tests/compiler_tests/test_bytes.py
+++ b/boa3_test/tests/compiler_tests/test_bytes.py
@@ -90,7 +90,69 @@ class TestBytes(boatestcase.BoaTestCase):
         await self.set_up_contract('BytesToInt.py')
 
         result, _ = await self.call('bytes_to_int', return_type=int)
-        self.assertEqual(513, result)
+        self.assertEqual(int.from_bytes(b'\x01\x02'), result)
+
+    async def test_bytes_to_int_default_args(self):
+        await self.set_up_contract('BytesToIntDefaultArgs.py')
+
+        for x in range(0, 256):
+            bytes_value = x.to_bytes()
+            result, _ = await self.call('main', [bytes_value], return_type=int)
+            self.assertEqual(int.from_bytes(bytes_value), result)
+
+        for x in range(256, 0x10000, 100):
+            bytes_value = x.to_bytes(2)
+            result, _ = await self.call('main', [bytes_value], return_type=int)
+            self.assertEqual(int.from_bytes(bytes_value), result)
+
+        for x in range(0, 0x100000, 1000):
+            bytes_value = x.to_bytes(3)
+
+            result, _ = await self.call('main', [bytes_value], return_type=int)
+            self.assertEqual(int.from_bytes(bytes_value), result)
+
+    async def test_bytes_to_int_big_endian_args(self):
+        await self.set_up_contract('BytesToIntBigEndianArgs.py')
+
+        for x in range(0, 0x100000, 1000):
+            bytes_value = x.to_bytes(3)
+
+            result, _ = await self.call('main', [bytes_value, True], return_type=int)
+            self.assertEqual(int.from_bytes(bytes_value, 'big'), result)
+
+            result, _ = await self.call('main', [bytes_value, False], return_type=int)
+            self.assertEqual(int.from_bytes(bytes_value, 'little'), result)
+
+    async def test_bytes_to_int_big_endian_signed_args(self):
+        await self.set_up_contract('BytesToIntBigEndianSignedArgs.py')
+
+        for x in range(0, 0x100000, 1000):
+            bytes_value = x.to_bytes(3)
+
+            result, _ = await self.call('main', [bytes_value, True, True], return_type=int)
+            self.assertEqual(int.from_bytes(bytes_value, 'big', signed=True), result)
+
+            result, _ = await self.call('main', [bytes_value, False, True], return_type=int)
+            self.assertEqual(int.from_bytes(bytes_value, 'little', signed=True), result)
+
+            result, _ = await self.call('main', [bytes_value, True, False], return_type=int)
+            self.assertEqual(int.from_bytes(bytes_value, 'big', signed=False), result)
+
+            result, _ = await self.call('main', [bytes_value, False, False], return_type=int)
+            self.assertEqual(int.from_bytes(bytes_value, 'little', signed=False), result)
+
+        big_bytes_value = b'abcdef1234567890'
+        result, _ = await self.call('main', [big_bytes_value, True, True], return_type=int)
+        self.assertEqual(int.from_bytes(big_bytes_value, 'big', signed=True), result)
+
+        result, _ = await self.call('main', [big_bytes_value, False, True], return_type=int)
+        self.assertEqual(int.from_bytes(big_bytes_value, 'little', signed=True), result)
+
+        result, _ = await self.call('main', [big_bytes_value, True, False], return_type=int)
+        self.assertEqual(int.from_bytes(big_bytes_value, 'big', signed=False), result)
+
+        result, _ = await self.call('main', [big_bytes_value, False, False], return_type=int)
+        self.assertEqual(int.from_bytes(big_bytes_value, 'little', signed=False), result)
 
     def test_bytes_to_int_with_builtin(self):
         self.assertCompilerLogs(CompilerError.UnresolvedReference, 'BytesToIntWithBuiltin.py')
@@ -659,7 +721,7 @@ class TestBytes(boatestcase.BoaTestCase):
         await self.set_up_contract('BytearrayToInt.py')
 
         result, _ = await self.call('bytes_to_int', return_type=int)
-        self.assertEqual(513, result)
+        self.assertEqual(int.from_bytes(bytearray(b'\x01\x02')), result)
 
     def test_byte_array_to_int_with_builtin(self):
         self.assertCompilerLogs(CompilerError.UnresolvedReference, 'BytearrayToIntWithBuiltin.py')


### PR DESCRIPTION
**Summary or solution description**
Since, endianness and sign were added to `to_bytes` #1308, they were also added to `to_int` method

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/08c7ff9152e66f997de297a7642221718e78f5b9/boa3_test/test_sc/bytes_test/BytesToIntBigEndianSignedArgs.py#L1-L7

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/08c7ff9152e66f997de297a7642221718e78f5b9/boa3_test/tests/compiler_tests/test_bytes.py#L95-L155

**Platform:**
 - OS: MacOS Tahoe 26.0
 - Python version:  Python 3.12
