### PR TITLE
Stop generating constant expressions inside class that are not used

### DIFF
--- a/boa3/internal/analyser/moduleanalyser.py
+++ b/boa3/internal/analyser/moduleanalyser.py
@@ -731,6 +731,10 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
             self._current_symbol_scope.include_symbol(class_node.name, user_class)
         self._scope_stack.append(SymbolScope())
 
+        # don't evaluate constant expression - for example: string for documentation
+        class_node.body = [stmt for stmt in class_node.body
+                           if not isinstance(stmt, ast.Expr)]
+
         for stmt in class_node.body:
             self.visit(stmt)
 

--- a/boa3_test/test_sc/class_test/ExpressionInsideClass.py
+++ b/boa3_test/test_sc/class_test/ExpressionInsideClass.py
@@ -1,0 +1,26 @@
+from boa3.sc.compiletime import public
+
+
+class Example:
+    """
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris tempus accumsan imperdiet. Pellentesque vel augue
+    ipsum. Morbi at varius enim. Praesent eu elit id metus tincidunt pharetra eu pharetra diam. Cras ac imperdiet lacus.
+    Nullam dapibus tellus vel neque malesuada, non egestas orci lobortis. Curabitur et blandit lorem. Nunc luctus
+    sollicitudin elit ac molestie. Maecenas nec pulvinar justo. Vestibulum sed justo bibendum, gravida ipsum at,
+    maximus eros. Vivamus a volutpat lorem. Sed id ligula sit amet eros mollis luctus. Quisque at auctor erat.
+    Curabitur dui turpis, tincidunt a eros eu, tempor consectetur ex. In eget justo ac odio molestie pharetra id
+    feugiat leo.
+    """
+    123456
+    True
+    False
+    b'Lorem ipsum dolor sit amet, consectetur adipiscing elit'
+
+    @staticmethod
+    def return_1() -> int:
+        return 1
+
+
+@public
+def main() -> int:
+    return Example.return_1()

--- a/boa3_test/tests/compiler_tests/test_class.py
+++ b/boa3_test/tests/compiler_tests/test_class.py
@@ -2,6 +2,8 @@ from neo3.core import types
 
 from boa3.internal.exception import CompilerError
 from boa3.internal.exception.NotLoadedException import NotLoadedException
+from boa3.internal.neo.vm.opcode.Opcode import Opcode
+from boa3.internal.neo.vm.type.Integer import Integer
 from boa3.internal.neo.vm.type.String import String
 from boa3_test.tests import boatestcase
 
@@ -514,3 +516,21 @@ class TestClass(boatestcase.BoaTestCase):
 
     def test_user_class_class_method_without_return_type(self):
         self.assertCompilerLogs(CompilerError.TypeHintMissing, 'UserClassClassMethodWithoutReturnType.py')
+
+    async def test_expression_inside_class_compile(self):
+        expected_output = (
+                Opcode.CALL
+                + Integer(3).to_byte_array(min_length=1, signed=True)
+                + Opcode.RET
+                + Opcode.PUSH1
+                + Opcode.RET
+        )
+
+        output, _ = self.assertCompile('ExpressionInsideClass.py')
+        self.assertEqual(expected_output, output)
+
+    async def test_expression_inside_class(self):
+        await self.set_up_contract('ExpressionInsideClass.py')
+
+        result, _ = await self.call('main', [], return_type=int)
+        self.assertEqual(1, result)


### PR DESCRIPTION
**Summary or solution description**
Constant expressions were being added into the NEF, but were dropped in the next opcode. Now they are not being added.

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/146526ea4d14d0e6711e06aa30ae4b720c0fd084/boa3_test/test_sc/class_test/ExpressionInsideClass.py#L1-L26

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/146526ea4d14d0e6711e06aa30ae4b720c0fd084/boa3_test/tests/compiler_tests/test_class.py#L520-L536

**Platform:**
 - OS: MacOS 26.0 (25A354)
 - Python version: Python 3.13