### PR TITLE
Add short commit hash alongside the compiler version

### DIFF
--- a/boa3/internal/constants.py
+++ b/boa3/internal/constants.py
@@ -4,6 +4,7 @@ import platform
 import sys
 
 from boa3 import __version__ as _actual_boa_version
+from boa3.internal.git_helper import _get_git_commit_hash
 from boa3.internal.neo import from_hex_str
 
 ENCODING = 'utf-8'
@@ -16,7 +17,8 @@ IMPORT_WILDCARD = '*'
 
 SYS_VERSION_INFO = sys.version_info
 SYS_VERSION = platform.python_version()
-BOA_VERSION = _actual_boa_version  # for logging only
+COMMIT_HASH = _get_git_commit_hash()
+BOA_VERSION = f"{_actual_boa_version}-{COMMIT_HASH}" if COMMIT_HASH else _actual_boa_version  # for logging only
 BOA_LOGGING_NAME = 'neo3-boa-log'
 COMPILER_VERSION = BOA_VERSION
 BOA_PACKAGE_PATH = os.path.abspath(f'{__file__}/../..')

--- a/boa3/internal/git_helper.py
+++ b/boa3/internal/git_helper.py
@@ -1,0 +1,10 @@
+import subprocess
+
+
+def _get_git_commit_hash(short: bool = True) -> str | None:
+    try:
+        arg = ['git', 'rev-parse', '--short', 'HEAD'] if short else ['git', 'rev-parse', 'HEAD']
+        out = subprocess.check_output(arg, stderr=subprocess.DEVNULL, text=True).strip()
+        return out or None
+    except Exception:
+        return None

--- a/boa3_test/tests/cli_tests/test_cli.py
+++ b/boa3_test/tests/cli_tests/test_cli.py
@@ -13,6 +13,8 @@ class TestCli(BoaCliTest):
         self.assertIn('usage: neo3-boa [-h] [-v] {compile}', cli_output)
         self.assertIn(f'neo3-boa by COZ - version {constants.BOA_VERSION}', cli_output)
         self.assertIn('Write smart contracts for Neo3 in Python', cli_output)
+        self.assertIsNotNone(constants.COMMIT_HASH)
+        self.assertIn(constants.COMMIT_HASH, cli_output)
 
     @neo3_boa_cli('--version')
     def test_cli_version(self):
@@ -20,6 +22,8 @@ class TestCli(BoaCliTest):
 
         self.assertEqual(self.EXIT_CODE_SUCCESS, system_exit.exception.code)
         self.assertIn(f'neo3-boa {constants.BOA_VERSION}', cli_output)
+        self.assertIsNotNone(constants.COMMIT_HASH)
+        self.assertIn(constants.COMMIT_HASH, cli_output)
 
     @neo3_boa_cli('build')
     def test_cli_wrong_syntax(self):

--- a/boa3_test/tests/cli_tests/test_compile.py
+++ b/boa3_test/tests/cli_tests/test_compile.py
@@ -36,7 +36,9 @@ class TestCliCompile(BoaCliTest):
         logs = self.get_cli_log()
 
         self.assertEqual(3, len(logs.output))
-        self.assertTrue(f'neo3-boa v{constants.BOA_VERSION}\tPython {constants.SYS_VERSION}' in logs.output[0])
+        self.assertIn(f'neo3-boa v{constants.BOA_VERSION}\tPython {constants.SYS_VERSION}', logs.output[0])
+        self.assertIsNotNone(constants.COMMIT_HASH)
+        self.assertIn(constants.COMMIT_HASH, logs.output[0])
         self.assertTrue('Started compiling' in logs.output[1])
         self.assertTrue(f'Wrote {sc_nef_name} to ' in logs.output[-1],
                         msg=f'Something went wrong when compiling {sc_nef_name}')


### PR DESCRIPTION
**Summary or solution description**
Added the short commit hash in the logs when compiling the smart contract

**How to Reproduce**
```
$ neo3-boa compile contract.py
INFO: neo3-boa v1.4.1-4b4eceba  Python 3.13.7
```

**Platform:**
 - OS: 26.0 (25A354)
 - Python version: Python 3.13

