### PR TITLE
Throw compiler error when trying to assign other value to native contract hash

### DIFF
--- a/boa3/internal/analyser/moduleanalyser.py
+++ b/boa3/internal/analyser/moduleanalyser.py
@@ -14,9 +14,11 @@ from boa3.internal.analyser.model.optimizer import UndefinedType
 from boa3.internal.analyser.model.symbolscope import SymbolScope
 from boa3.internal.exception import CompilerError, CompilerWarning
 from boa3.internal.model.builtin.builtin import Builtin
+from boa3.internal.model.builtin.builtinproperty import IBuiltinProperty
 from boa3.internal.model.builtin.compile_time.neometadatatype import MetadataTypeSingleton
 from boa3.internal.model.builtin.decorator import ContractDecorator
 from boa3.internal.model.builtin.decorator.builtindecorator import IBuiltinDecorator
+from boa3.internal.model.builtin.interop.contractgethashmethod import ContractGetHashMethod
 from boa3.internal.model.builtin.interop.runtime import ScriptContainerProperty
 from boa3.internal.model.builtin.interop.runtime import NotifyMethod
 from boa3.internal.model.builtin.method.builtinmethod import IBuiltinMethod
@@ -1111,6 +1113,13 @@ class ModuleAnalyser(IAstAnalyser, ast.NodeVisitor):
         return_type = var_type
         for target in targets:
             var_id = self.visit(target)
+
+            if isinstance(var_id, IBuiltinProperty) and isinstance(var_id.getter, ContractGetHashMethod):
+                self._log_error(
+                    CompilerError.NotSupportedOperation(assign.lineno, assign.col_offset,
+                                                        'Can not change contract script hash')
+                )
+
             if not isinstance(var_id, ISymbol):
                 return_type = self.assign_value(var_id, var_type,
                                                 source_node=assign,

--- a/boa3_test/test_sc/native_test/contractmanagement/CompilerErrorOverwriteHash.py
+++ b/boa3_test/test_sc/native_test/contractmanagement/CompilerErrorOverwriteHash.py
@@ -1,0 +1,7 @@
+from boa3.sc.contracts import ContractManagement
+from boa3.sc.types import UInt160
+
+
+def main() -> UInt160:
+    ContractManagement.hash = UInt160()
+    return ContractManagement.hash

--- a/boa3_test/test_sc/native_test/cryptolib/CompilerErrorOverwriteHash.py
+++ b/boa3_test/test_sc/native_test/cryptolib/CompilerErrorOverwriteHash.py
@@ -1,0 +1,7 @@
+from boa3.sc.contracts import CryptoLib
+from boa3.sc.types import UInt160
+
+
+def main() -> UInt160:
+    CryptoLib.hash = UInt160()
+    return CryptoLib.hash

--- a/boa3_test/test_sc/native_test/gas/CompilerErrorOverwriteHash.py
+++ b/boa3_test/test_sc/native_test/gas/CompilerErrorOverwriteHash.py
@@ -1,0 +1,7 @@
+from boa3.sc.contracts import GasToken
+from boa3.sc.types import UInt160
+
+
+def main() -> UInt160:
+    GasToken.hash = UInt160()
+    return GasToken.hash

--- a/boa3_test/test_sc/native_test/ledger/CompilerErrorOverwriteHash.py
+++ b/boa3_test/test_sc/native_test/ledger/CompilerErrorOverwriteHash.py
@@ -1,0 +1,7 @@
+from boa3.sc.contracts import LedgerContract
+from boa3.sc.types import UInt160
+
+
+def main() -> UInt160:
+    LedgerContract.hash = UInt160()
+    return LedgerContract.hash

--- a/boa3_test/test_sc/native_test/neo/CompilerErrorOverwriteHash.py
+++ b/boa3_test/test_sc/native_test/neo/CompilerErrorOverwriteHash.py
@@ -1,0 +1,7 @@
+from boa3.sc.contracts import NeoToken
+from boa3.sc.types import UInt160
+
+
+def main() -> UInt160:
+    NeoToken.hash = UInt160()
+    return NeoToken.hash

--- a/boa3_test/test_sc/native_test/oracle/CompilerErrorOverwriteHash.py
+++ b/boa3_test/test_sc/native_test/oracle/CompilerErrorOverwriteHash.py
@@ -1,0 +1,7 @@
+from boa3.sc.contracts import OracleContract
+from boa3.sc.types import UInt160
+
+
+def main() -> UInt160:
+    OracleContract.hash = UInt160()
+    return OracleContract.hash

--- a/boa3_test/test_sc/native_test/policy/CompilerErrorOverwriteHash.py
+++ b/boa3_test/test_sc/native_test/policy/CompilerErrorOverwriteHash.py
@@ -1,0 +1,7 @@
+from boa3.sc.contracts import PolicyContract
+from boa3.sc.types import UInt160
+
+
+def main() -> UInt160:
+    PolicyContract.hash = UInt160()
+    return PolicyContract.hash

--- a/boa3_test/test_sc/native_test/rolemanagement/CompilerErrorOverwriteHash.py
+++ b/boa3_test/test_sc/native_test/rolemanagement/CompilerErrorOverwriteHash.py
@@ -1,0 +1,7 @@
+from boa3.sc.contracts import RoleManagement
+from boa3.sc.types import UInt160
+
+
+def main() -> UInt160:
+    RoleManagement.hash = UInt160()
+    return RoleManagement.hash

--- a/boa3_test/test_sc/native_test/stdlib/CompilerErrorOverwriteHash.py
+++ b/boa3_test/test_sc/native_test/stdlib/CompilerErrorOverwriteHash.py
@@ -1,0 +1,7 @@
+from boa3.sc.contracts import StdLib
+from boa3.sc.types import UInt160
+
+
+def main() -> UInt160:
+    StdLib.hash = UInt160()
+    return StdLib.hash

--- a/boa3_test/tests/compiler_tests/test_native/test_contract_management.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_contract_management.py
@@ -283,3 +283,6 @@ class TestContractManagementContract(boatestcase.BoaTestCase):
         self.assertEqual(gas_contract_id, result[0])  # contract id
         self.assertEqual(0, result[1])  # update counter
         self.assertEqual(types.UInt160(constants.GAS_SCRIPT), result[2])  # contract hash
+
+    def test_overwrite_hash(self):
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'CompilerErrorOverwriteHash.py')

--- a/boa3_test/tests/compiler_tests/test_native/test_cryptolib.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_cryptolib.py
@@ -404,3 +404,6 @@ class TestCryptoLibClass(boatestcase.BoaTestCase):
         public_key = bytes.fromhex('03414549fd05bfb7803ae507ff86b99becd36f8d66037a7f5ba612792841d42eb9')
         result, _ = await self.call('main', [message_hash, signature], return_type=bytes)
         self.assertEqual(public_key, result)
+
+    def test_overwrite_hash(self):
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'CompilerErrorOverwriteHash.py')

--- a/boa3_test/tests/compiler_tests/test_native/test_gas.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_gas.py
@@ -178,3 +178,6 @@ class TestGasClass(boatestcase.BoaTestCase):
         no_balance = types.UInt160.zero()
         result, _ = await self.call('main', [no_balance], return_type=int)
         self.assertEqual(0, result)
+
+    def test_overwrite_hash(self):
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'CompilerErrorOverwriteHash.py')

--- a/boa3_test/tests/compiler_tests/test_native/test_ledger.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_ledger.py
@@ -311,3 +311,6 @@ class TestLedgerContract(boatestcase.BoaTestCase):
 
         result, _ = await self.call('get_transaction_count', [], return_type=int)
         self.assertEqual(len(self.genesis_block.transactions), result)
+
+    def test_overwrite_hash(self):
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'CompilerErrorOverwriteHash.py')

--- a/boa3_test/tests/compiler_tests/test_native/test_neo.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_neo.py
@@ -590,3 +590,6 @@ class TestNeoClass(boatestcase.BoaTestCase):
         register_price = await self.get_register_price()
         result, _ = await self.call('main', [], return_type=int)
         self.assertEqual(register_price, result)
+
+    def test_overwrite_hash(self):
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'CompilerErrorOverwriteHash.py')

--- a/boa3_test/tests/compiler_tests/test_native/test_oracle.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_oracle.py
@@ -385,3 +385,6 @@ class TestOracleContract(boatestcase.BoaTestCase):
         for oracle_response_code in OracleResponseCode:
             result, _ = await self.call('main', [oracle_response_code], return_type=int)
             self.assertEqual(~oracle_response_code, result)
+
+    def test_overwrite_hash(self):
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'CompilerErrorOverwriteHash.py')

--- a/boa3_test/tests/compiler_tests/test_native/test_policy.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_policy.py
@@ -160,3 +160,6 @@ class TestPolicyContract(boatestcase.BoaTestCase):
 
         result, _ = await self.call('main', [], return_type=int)
         self.assertIsInstance(result, int)
+
+    def test_overwrite_hash(self):
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'CompilerErrorOverwriteHash.py')

--- a/boa3_test/tests/compiler_tests/test_native/test_rolemanagement.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_rolemanagement.py
@@ -84,3 +84,6 @@ class TestRoleManagementClass(boatestcase.BoaTestCase):
 
         output, _ = self.assertCompile('ImportScContractsRoleManagement.py')
         self.assertEqual(expected_output, output)
+
+    def test_overwrite_hash(self):
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'CompilerErrorOverwriteHash.py')

--- a/boa3_test/tests/compiler_tests/test_native/test_stdlib.py
+++ b/boa3_test/tests/compiler_tests/test_native/test_stdlib.py
@@ -682,3 +682,6 @@ class TestStdlibClass(boatestcase.BoaTestCase):
         string = '😀'
         result, _ = await self.call('main', [string], return_type=int)
         self.assertEqual(len(string), result)
+
+    def test_overwrite_hash(self):
+        self.assertCompilerLogs(CompilerError.NotSupportedOperation, 'CompilerErrorOverwriteHash.py')


### PR DESCRIPTION
**Summary or solution description**
When trying to assign a new value to a native contract hash, it would compile without throwing an error and produce invalid opcode

**How to Reproduce**
https://github.com/CityOfZion/neo3-boa/blob/46015725d0c409e89f6d3fe9235aff8896f21070/boa3_test/test_sc/native_test/contractmanagement/CompilerErrorOverwriteHash.py#L1-L7

**Tests**
https://github.com/CityOfZion/neo3-boa/blob/46015725d0c409e89f6d3fe9235aff8896f21070/boa3_test/tests/compiler_tests/test_native/test_contract_management.py#L287-L288

**Platform:**
 - OS: macOS 25A354
 - Python version: Python 3.14
